### PR TITLE
feedback из доработки demo "trade": 18 пунктов + 4 follow-up фикса

### DIFF
--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"strings"
 	"unicode"
 
 	"github.com/ivantit66/onebase/internal/metadata"
@@ -124,8 +125,150 @@ func (db *DB) MigrateInfoRegisters(ctx context.Context, regs []*metadata.InfoReg
 				return fmt.Errorf("migrate info register %s.%s: %w", ir.Name, f.Name, err)
 			}
 		}
+		// Замечание #23 (продолжение): фактический PK таблицы может не
+		// совпадать с pkCols(ir) — наследие старого CREATE до того как
+		// регистр стал periodic / добавили измерения. SQLite не позволяет
+		// ALTER PK, поэтому при mismatch пересоздаём таблицу через
+		// CREATE + INSERT SELECT + DROP + RENAME.
+		if err := db.fixInfoRegPK(ctx, ir); err != nil {
+			return fmt.Errorf("migrate info register %s PK: %w", ir.Name, err)
+		}
 	}
 	return nil
+}
+
+// fixInfoRegPK сверяет фактический PRIMARY KEY таблицы регистра сведений
+// с ожидаемым (pkCols(ir)). При несовпадении пересоздаёт таблицу с
+// правильным PK, копируя данные. Безопасно если в существующих строках
+// нет дубликатов по новому ключу — иначе INSERT упадёт с UNIQUE constraint,
+// и пользователь должен будет разобраться с дубликатами.
+//
+// Реализация SQLite-only — PostgreSQL поддерживает ALTER TABLE для PK
+// напрямую (но в onebase это пока не используется).
+func (db *DB) fixInfoRegPK(ctx context.Context, ir *metadata.InfoRegister) error {
+	if db.dialect.Name() != "sqlite" {
+		return nil // PG: ALTER TABLE сам разрулит, но это другой код-путь
+	}
+	table := metadata.InfoRegTableName(ir.Name)
+
+	// Снимаем фактический PK.
+	rows, err := db.Query(ctx, "PRAGMA table_info("+sqliteIdent(table)+")")
+	if err != nil {
+		return err
+	}
+	type pkCol struct {
+		name string
+		pos  int
+	}
+	var actual []pkCol
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			rows.Close()
+			return err
+		}
+		if pk > 0 {
+			actual = append(actual, pkCol{name: name, pos: pk})
+		}
+	}
+	rows.Close()
+	// Сортируем по pos
+	for i := 1; i < len(actual); i++ {
+		for j := i; j > 0 && actual[j-1].pos > actual[j].pos; j-- {
+			actual[j-1], actual[j] = actual[j], actual[j-1]
+		}
+	}
+
+	expected := pkCols(ir)
+	if len(actual) == len(expected) {
+		match := true
+		for i := range actual {
+			if actual[i].name != expected[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return nil
+		}
+	}
+
+	// PK mismatch — rebuild.
+	d := db.dialect
+	tmp := table + "_new"
+	if _, err := db.Exec(ctx, "DROP TABLE IF EXISTS "+sqliteIdent(tmp)); err != nil {
+		return err
+	}
+	createSQL := CreateInfoRegisterSQL(d, ir)
+	// Подменяем имя таблицы на _new
+	createSQL = strings.Replace(createSQL, "CREATE TABLE IF NOT EXISTS "+table, "CREATE TABLE "+tmp, 1)
+	if _, err := db.Exec(ctx, createSQL); err != nil {
+		return err
+	}
+
+	// Копируем данные — только общие колонки. Берём пересечение
+	// колонок старой и новой таблицы.
+	oldCols, err := tableColumnNames(ctx, db, table)
+	if err != nil {
+		return err
+	}
+	newCols, err := tableColumnNames(ctx, db, tmp)
+	if err != nil {
+		return err
+	}
+	var common []string
+	newSet := make(map[string]bool, len(newCols))
+	for _, c := range newCols {
+		newSet[c] = true
+	}
+	for _, c := range oldCols {
+		if newSet[c] {
+			common = append(common, c)
+		}
+	}
+	if len(common) > 0 {
+		copySQL := fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s",
+			sqliteIdent(tmp),
+			strings.Join(common, ", "),
+			strings.Join(common, ", "),
+			sqliteIdent(table))
+		if _, err := db.Exec(ctx, copySQL); err != nil {
+			// Откатимся — дропнем tmp, оставим старую.
+			_, _ = db.Exec(ctx, "DROP TABLE "+sqliteIdent(tmp))
+			return fmt.Errorf("copy data (возможно дубликаты по новому PK): %w", err)
+		}
+	}
+	if _, err := db.Exec(ctx, "DROP TABLE "+sqliteIdent(table)); err != nil {
+		return err
+	}
+	if _, err := db.Exec(ctx, "ALTER TABLE "+sqliteIdent(tmp)+" RENAME TO "+sqliteIdent(table)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// tableColumnNames возвращает имена колонок таблицы в порядке их объявления.
+func tableColumnNames(ctx context.Context, db *DB, table string) ([]string, error) {
+	rows, err := db.Query(ctx, "PRAGMA table_info("+sqliteIdent(table)+")")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return nil, err
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
 }
 
 // Migrate applies CREATE TABLE and ADD COLUMN IF NOT EXISTS for all entities.

--- a/internal/storage/migrate_inforeg_test.go
+++ b/internal/storage/migrate_inforeg_test.go
@@ -103,6 +103,65 @@ func TestMigrateInfoRegisters_AddsDimension(t *testing.T) {
 	}
 }
 
+// Замечание #23: при mismatch фактического PK (наследие старого CREATE)
+// миграция пересоздаёт таблицу с правильным PK через CREATE+INSERT SELECT+DROP+RENAME.
+func TestMigrateInfoRegisters_RebuildsPK(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Создаём «старую» неправильную таблицу — PK только по номенклатура_id.
+	_, err = db.Exec(ctx, `CREATE TABLE инфо_ценыноменклатуры (
+		номенклатура_id TEXT NOT NULL,
+		цена TEXT,
+		PRIMARY KEY (номенклатура_id)
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ir := &metadata.InfoRegister{
+		Name:     "ЦеныНоменклатуры",
+		Periodic: true,
+		Dimensions: []metadata.Field{
+			{Name: "Номенклатура", Type: "reference:Номенклатура", RefEntity: "Номенклатура"},
+			{Name: "ТипЦен", Type: "reference:ТипЦен", RefEntity: "ТипЦен"},
+		},
+		Resources: []metadata.Field{
+			{Name: "Цена", Type: "number"},
+		},
+	}
+	if err := db.MigrateInfoRegisters(ctx, []*metadata.InfoRegister{ir}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Проверим что PK теперь (period, номенклатура_id, типцен_id).
+	rows, err := db.Query(ctx, `PRAGMA table_info("инфо_ценыноменклатуры")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var pks []string
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		if pk > 0 {
+			pks = append(pks, name)
+		}
+	}
+	if len(pks) != 3 {
+		t.Errorf("ожидалось 3 колонки в PK, получили %v", pks)
+	}
+}
+
 // Добавление новых ресурсов уже работало — регресс-тест на это.
 func TestMigrateInfoRegisters_AddsResource(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
По ходу доработки демо-конфигурации `trade` до полноценной учётной
системы (поступление/реализация/списание/оприходование/перемещение/
ПКО/РКО) собрал список из 22 пунктов, чего не хватает в платформе/DSL.
В этом PR — **18 пунктов**, которые могу делать с тестами:
6 явных багов + 12 малых/средних фич. Плюс 4 follow-up фикса, которые
всплыли при тестировании на реальной БД demo.

4 архитектурных пункта (#1 МоментВремени, #2 управляемые блокировки,
#7 реквизит журнала, #14 cross-ref в predefined) **не вошли** —
там нужны решения по дизайну, могу взяться после обсуждения.

## Что закрыто

### 🟢 Баги (6)
- **#13** — в `.proc.os` видна только одна процедура → `Interpreter.LookupSiblingProc` + `Registry.GetSiblingProc`.
- **#17** — Ref-типы в измерениях регистров → resolveRefArg в storage + расширено для `*runtime.Object` (см. follow-up ниже).
- **#18** — bare-`Ссылка` в запросах → транслируется в `id` и с алиасом, и без.
- **#20/#21** — `Справочники.X.Имя` / `НайтиПоНаименованию(...)` → `CatalogsRoot`/`CatalogProxy` + storage-метод `FindCatalogByField`.
- **#22** — `Если/Иначе` теряет присваивание → код был корректен (`feae0205`), добавлен регресс-тест.

### 🟢 Малые фичи (4)
- **#3** `ПустаяСсылка(x)` — узкий ref-предикат.
- **#8** `ЧислоПрописью(сумма, валюта)` со склонением рубль/рубля/рублей, USD/EUR.
- **#12** Параметры функций по умолчанию: `Функция X(А, Б = 20)`.
- **#19а** Системные колонки регистра доступны как `Период`/`ВидДвижения`/`Регистратор`/`НомерСтроки`.

### 🟡 Средние (8)
- **#4** Атрибуты регистров доступны в outer SELECT/WHERE поверх VT через `MIN(attr_col)`.
- **#5** Синтаксис `Утилиты.Функция()` — namespaced module call.
- **#6** `numerator.scope: Организация` — отдельные счётчики для каждой организации.
- **#9** `Распределить(сумма, веса[, scale])` — гарантирует сумму долей == total.
- **#10** `.os`-форма перебивает YAML-форму с тем же именем + warning + UI-маркер в конфигураторе.
- **#11** `demo.enabled=true` требует `ONEBASE_ENV=demo`, иначе отказ запускаться.
- **#15** События ТЧ (`ПриДобавленииСтроки` и т.п.) — серверная сторона (UI-триггеры отдельно).
- **#16** `onebase run --watch` — hot reload `.yaml`/`.os` без рестарта.
- **#19б** Функции даты в DSL: `Год`/`Месяц`/`НачалоДня`/... транслируются в SQL под диалект.

### 🔧 Follow-up фиксы (4)
Всплыли при прогонe демо `trade` на SQLite, после основных правок:
- `runtime.Object` (this в проведении) теперь имеет `GetRefUUID()`+`String()`, чтобы корректно сериализоваться в колонки регистра.
- `MigrateInfoRegisters` дотягивает существующие таблицы — добавляет `period` если изменили `periodic: true`, добавляет новые измерения/ресурсы.
- `LatestPerKey` (`СрезПоследних` под SQLite) — outer SELECT использует alias-имена, не `_id` (раньше падал на `no such column`).
- UI конфигуратора: тип «перечисление» в селекторе полей справочника/документа/ТЧ.

## Качество

- **39+ unit-тестов** добавлено (новые testfn в interpreter / query / storage / runtime / launcher / cli / devserver / metadata).
- `go test ./...` зелёный по всему репо.
- `go vet ./...` чистый.
- `go build ./...` собирает бинарь.

## Что НЕ вошло

- **#1** МоментВремени у виртуальных таблиц — меняется схема query + регистр + проведение, нужно дизайн-обсуждение.
- **#2** Управляемые блокировки — нужен новый рантайм + SQL row locks.
- **#7** «Реквизит журнала» — рефакторинг journal.go и UI.
- **#14** Cross-ref в `predefined` (deferred FK) — миграции схемы.

Готов делать любой из этих пунктов отдельным PR после согласования.

---

Каждый коммит атомарен — можно ревьюить по одному. `PROGRESS.md` в корне репо суммирует.