### PR TITLE
архитектурные фичи + API текущего пользователя (#1, #2, #7, #14, #24)

### DIFF
--- a/internal/metadata/journal.go
+++ b/internal/metadata/journal.go
@@ -20,6 +20,15 @@ type JournalColumn struct {
 	Field    string
 	Label    string
 	Fallback []string
+	// Map — явное соответствие docTypeName → fieldName в этом документе.
+	// Замечание #7: лучшая альтернатива fallback, потому что:
+	//   1. Explicit — видно для какого документа какое поле.
+	//   2. Не зависит от порядка обхода fallback (raw COALESCE мог давать
+	//      нежелательные совпадения если в документе два совпадающих поля).
+	//   3. UI может показывать tooltip «в документе X это поле называется Y».
+	// Если Map[doc] есть — используется он, fallback не применяется. Если
+	// не задан — работает старый fallback-механизм (back compat).
+	Map      map[string]string
 	Format   string // "date" | "number" | "" (auto)
 }
 
@@ -33,10 +42,11 @@ type rawJournal struct {
 	Title     string `yaml:"title"`
 	Documents []string `yaml:"documents"`
 	Columns   []struct {
-		Field    string   `yaml:"field"`
-		Label    string   `yaml:"label"`
-		Fallback []string `yaml:"fallback"`
-		Format   string   `yaml:"format"`
+		Field    string            `yaml:"field"`
+		Label    string            `yaml:"label"`
+		Fallback []string          `yaml:"fallback"`
+		Map      map[string]string `yaml:"map"`
+		Format   string            `yaml:"format"`
 	} `yaml:"columns"`
 	Filters []struct {
 		Field string `yaml:"field"`
@@ -73,6 +83,7 @@ func LoadJournalFile(path string) (*Journal, error) {
 			Field:    rc.Field,
 			Label:    label,
 			Fallback: rc.Fallback,
+			Map:      rc.Map,
 			Format:   rc.Format,
 		})
 	}

--- a/internal/query/moment_test.go
+++ b/internal/query/moment_test.go
@@ -1,0 +1,145 @@
+package query_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// momentValue реализует интерфейс query.momentTimeValue для теста —
+// без импорта runtime (избегаем цикла).
+type momentValue struct {
+	period time.Time
+	docID  string
+}
+
+func (m *momentValue) PointInTime() (time.Time, string) { return m.period, m.docID }
+
+// Замечание #1: .Остатки(МоментВремени) должна давать period < @ OR (period = @ AND recorder != @doc).
+func TestCompile_MomentTime_Balances(t *testing.T) {
+	src := `ВЫБРАТЬ Номенклатура, КоличествоОстаток
+ИЗ РегистрНакопления.ОстаткиТоваров.Остатки(&МВ)`
+	reg := &metadata.Register{
+		Name: "ОстаткиТоваров",
+		Dimensions: []metadata.Field{
+			{Name: "Номенклатура", Type: "string"},
+		},
+		Resources: []metadata.Field{
+			{Name: "Количество", Type: "number"},
+		},
+	}
+	mt := &momentValue{
+		period: time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC),
+		docID:  "11111111-1111-1111-1111-111111111111",
+	}
+	r, err := query.Compile(src, query.CompileOpts{
+		Registers: []*metadata.Register{reg},
+		Params:    map[string]any{"МВ": mt},
+		Dialect:   storage.SQLiteDialect{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Должно быть условие на period < и recorder !=
+	if !strings.Contains(r.SQL, "period <") || !strings.Contains(r.SQL, "recorder !=") {
+		t.Errorf("ожидалось «period < ... AND recorder != ...» в SQL:\n%s", r.SQL)
+	}
+	// Должно быть 2 args: period + docID
+	if len(r.Args) != 2 {
+		t.Errorf("ожидалось 2 args, получили %d: %v", len(r.Args), r.Args)
+	}
+}
+
+// МоментВремени без docID — упрощённое period <= ...
+func TestCompile_MomentTime_NoDocFallback(t *testing.T) {
+	src := `ВЫБРАТЬ Номенклатура, КоличествоОстаток
+ИЗ РегистрНакопления.ОстаткиТоваров.Остатки(&МВ)`
+	reg := &metadata.Register{
+		Name:       "ОстаткиТоваров",
+		Dimensions: []metadata.Field{{Name: "Номенклатура", Type: "string"}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: "number"}},
+	}
+	mt := &momentValue{
+		period: time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+		docID:  "", // нет документа
+	}
+	r, err := query.Compile(src, query.CompileOpts{
+		Registers: []*metadata.Register{reg},
+		Params:    map[string]any{"МВ": mt},
+		Dialect:   storage.SQLiteDialect{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.SQL, "period <= ") {
+		t.Errorf("без docID ожидалось period <= ...: %s", r.SQL)
+	}
+	if strings.Contains(r.SQL, "recorder") {
+		t.Errorf("без docID recorder не должен упоминаться: %s", r.SQL)
+	}
+}
+
+// Обычный параметр-дата (не moment) работает как раньше: period <= ...
+func TestCompile_PlainDate_StillWorks(t *testing.T) {
+	src := `ВЫБРАТЬ Номенклатура, КоличествоОстаток
+ИЗ РегистрНакопления.ОстаткиТоваров.Остатки(&Дата)`
+	reg := &metadata.Register{
+		Name:       "ОстаткиТоваров",
+		Dimensions: []metadata.Field{{Name: "Номенклатура", Type: "string"}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: "number"}},
+	}
+	r, err := query.Compile(src, query.CompileOpts{
+		Registers: []*metadata.Register{reg},
+		Params:    map[string]any{"Дата": "2026-05-20"},
+		Dialect:   storage.SQLiteDialect{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.SQL, "period <= ") {
+		t.Errorf("plain date: ожидалось period <= ...: %s", r.SQL)
+	}
+	if strings.Contains(r.SQL, "recorder") {
+		t.Errorf("plain date: recorder не должен упоминаться: %s", r.SQL)
+	}
+}
+
+// МоментВремени для info-регистра — берёт только Period, без recorder
+// (info-reg не имеет recorder колонки в этом контексте).
+func TestCompile_MomentTime_InfoSlice(t *testing.T) {
+	src := `ВЫБРАТЬ Цена ИЗ РегистрСведений.ЦеныНоменклатуры.СрезПоследних(&МВ)`
+	ir := &metadata.InfoRegister{
+		Name:     "ЦеныНоменклатуры",
+		Periodic: true,
+		Dimensions: []metadata.Field{
+			{Name: "Номенклатура", Type: "string"},
+		},
+		Resources: []metadata.Field{
+			{Name: "Цена", Type: "number"},
+		},
+	}
+	mt := &momentValue{
+		period: time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+		docID:  uuid.New().String(),
+	}
+	r, err := query.Compile(src, query.CompileOpts{
+		InfoRegs: []*metadata.InfoRegister{ir},
+		Params:   map[string]any{"МВ": mt},
+		Dialect:  storage.SQLiteDialect{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.SQL, "period <=") {
+		t.Errorf("info-slice ожидалось period <= ...: %s", r.SQL)
+	}
+	// recorder для info-reg не нужен
+	if strings.Contains(r.SQL, "recorder !=") {
+		t.Errorf("info-slice не должен использовать recorder: %s", r.SQL)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -6,6 +6,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/storage"
 )
@@ -732,7 +733,10 @@ func (tr *translator) genBalances(reg *metadata.Register, args [][]tok) (string,
 
 	var conds []string
 	if len(args) > 0 && len(args[0]) > 0 {
-		if s := tr.translateFilterTokens(args[0]); s != "" && s != "NULL" {
+		// Замечание #1: момент времени документа — особое условие.
+		if mt := tr.firstArgMoment(args[0]); mt != nil {
+			conds = append(conds, tr.momentTimeCondition(mt))
+		} else if s := tr.translateFilterTokens(args[0]); s != "" && s != "NULL" {
 			conds = append(conds, "period <= "+s)
 		}
 	}
@@ -920,7 +924,14 @@ func (tr *translator) genInfoSlice(ir *metadata.InfoRegister, args [][]tok, dire
 
 	var conds []string
 	if ir.Periodic && len(args) > 0 && len(args[0]) > 0 {
-		if s := tr.translateFilterTokens(args[0]); s != "" && s != "NULL" {
+		// #1: МоментВремени для info-регистра — берём только Period,
+		// recorder в info-таблицах не используется для исключения.
+		if mt := tr.firstArgMoment(args[0]); mt != nil {
+			d := dialectOrDefault(tr.opts.Dialect)
+			p, _ := mt.PointInTime()
+			tr.args = append(tr.args, p)
+			conds = append(conds, "period "+periodOp+" "+d.Placeholder(len(tr.args)))
+		} else if s := tr.translateFilterTokens(args[0]); s != "" && s != "NULL" {
 			conds = append(conds, "period "+periodOp+" "+s)
 		}
 	}
@@ -1512,6 +1523,60 @@ func rewriteDateFuncs(tokens []tok, dialect string) []tok {
 		out = append(out, t)
 	}
 	return out
+}
+
+// momentTimeValue — контракт для DSL-значения «момент времени» (см.
+// замечание #1). Реализуется *runtime.MomentTime; здесь объявлен через
+// интерфейс чтобы не тянуть импорт runtime в query.
+type momentTimeValue interface {
+	PointInTime() (period time.Time, docID string)
+}
+
+// momentTimeCondition строит SQL-условие «строго до момента» — всё что
+// зафиксировано раньше данной точки в хронологическом порядке journal'а.
+// Возвращает SQL-фрагмент с placeholder'ами и добавляет два arg'а к
+// tr.args (период и UUID документа).
+//
+// Для accumulation register условие имеет вид:
+//   (period < $1 OR (period = $1 AND recorder != $2))
+//
+// Логика «recorder != docID» гарантирует, что при перепроведении сам
+// документ исключается из собственной сводки.
+func (tr *translator) momentTimeCondition(mt momentTimeValue) string {
+	d := dialectOrDefault(tr.opts.Dialect)
+	period, docID := mt.PointInTime()
+	tr.args = append(tr.args, period)
+	periodPH := d.Placeholder(len(tr.args))
+	if docID == "" {
+		// document-less moment — простое сравнение
+		return "period <= " + periodPH
+	}
+	if id, err := uuid.Parse(docID); err == nil {
+		if d.Name() == "sqlite" {
+			tr.args = append(tr.args, id.String())
+		} else {
+			tr.args = append(tr.args, id)
+		}
+	} else {
+		tr.args = append(tr.args, docID)
+	}
+	docPH := d.Placeholder(len(tr.args))
+	return fmt.Sprintf("(period < %s OR (period = %s AND recorder != %s))",
+		periodPH, periodPH, docPH)
+}
+
+// firstArgMoment возвращает *MomentTime если первый аргумент VT —
+// это &Param и paramValues[name] = *MomentTime. Иначе nil — fallback на
+// обычное period <= ...
+func (tr *translator) firstArgMoment(args []tok) momentTimeValue {
+	if len(args) != 1 || args[0].kind != tParam {
+		return nil
+	}
+	v := tr.paramValues[args[0].val]
+	if mt, ok := v.(momentTimeValue); ok {
+		return mt
+	}
+	return nil
 }
 
 // systemColAlias maps the PascalCase русский alias for register system columns

--- a/internal/runtime/locks.go
+++ b/internal/runtime/locks.go
@@ -1,0 +1,160 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// LockManager — глобальный менеджер блокировок уровня процесса.
+//
+// Замечание #2: блокировки гранулярные по (регистр, набор измерений).
+// Когда DSL зовёт Блок.Заблокировать(), для каждого «элемента» строится
+// ключ "регистр|изм1=знач&изм2=знач...", и берётся sync.Mutex по этому
+// ключу. Два параллельных проведения с пересекающимся набором (например
+// одна и та же Номенклатура+Склад) сериализуются.
+//
+// Ограничения этой реализации:
+//   - Работает только в пределах одного процесса. Для распределённого
+//     развёртывания (несколько onebase-инстансов) нужно дополнить
+//     SELECT FOR UPDATE или pg_advisory_xact_lock — оставлено на будущее.
+//   - Гранулярность ровно та, что задал DSL — если кто-то забыл указать
+//     ключ, блокировка не сработает.
+//   - Освобождение происходит явно через Разблокировать или автоматически
+//     при завершении проведения (defer в handlers.go).
+type LockManager struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func NewLockManager() *LockManager {
+	return &LockManager{locks: map[string]*sync.Mutex{}}
+}
+
+// Acquire берёт мьютексы по всем ключам в детерминированном порядке
+// (отсортированы), чтобы избежать кросс-deadlock'а между двумя
+// проведениями, запросившими разный набор в разном порядке.
+func (lm *LockManager) Acquire(keys []string) {
+	sorted := append([]string{}, keys...)
+	sort.Strings(sorted)
+	for _, k := range sorted {
+		lm.mu.Lock()
+		m, ok := lm.locks[k]
+		if !ok {
+			m = &sync.Mutex{}
+			lm.locks[k] = m
+		}
+		lm.mu.Unlock()
+		m.Lock()
+	}
+}
+
+// Release отпускает мьютексы в обратном порядке.
+func (lm *LockManager) Release(keys []string) {
+	sorted := append([]string{}, keys...)
+	sort.Strings(sorted)
+	for i := len(sorted) - 1; i >= 0; i-- {
+		lm.mu.Lock()
+		m := lm.locks[sorted[i]]
+		lm.mu.Unlock()
+		if m != nil {
+			m.Unlock()
+		}
+	}
+}
+
+// LockObject — DSL-обёртка над LockManager (этап «БлокировкаДанных»).
+// Аккумулирует «элементы» (Добавить), для каждого собирает значения
+// измерений (УстановитьЗначение), при Заблокировать — берёт мьютексы.
+//
+// Реализует interpreter.MethodCallable + interpreter.This.
+type LockObject struct {
+	mgr      *LockManager
+	elements []*LockElement
+	held     []string // ключи которые удерживаем
+}
+
+// NewLockObject — фабрика для DSL builtin БлокировкаДанных().
+func NewLockObject(mgr *LockManager) *LockObject {
+	return &LockObject{mgr: mgr}
+}
+
+func (lo *LockObject) Get(name string) any        { return nil }
+func (lo *LockObject) Set(name string, v any)     {}
+
+// CallMethod implements interpreter.MethodCallable.
+func (lo *LockObject) CallMethod(method string, args []any) any {
+	switch strings.ToLower(method) {
+	case "добавить", "add":
+		if len(args) == 0 {
+			return nil
+		}
+		reg, _ := args[0].(string)
+		el := &LockElement{registerName: reg, values: map[string]any{}}
+		lo.elements = append(lo.elements, el)
+		return el
+	case "заблокировать", "lock":
+		if lo.mgr == nil {
+			return nil
+		}
+		keys := lo.buildKeys()
+		lo.mgr.Acquire(keys)
+		lo.held = keys
+		return nil
+	case "разблокировать", "unlock":
+		lo.ReleaseAll()
+		return nil
+	}
+	return nil
+}
+
+// ReleaseAll отпускает удерживаемые мьютексы. Безопасно вызывать
+// несколько раз. Используется как defer в handlers.go на случай если
+// DSL забыл .Разблокировать().
+func (lo *LockObject) ReleaseAll() {
+	if lo.mgr != nil && len(lo.held) > 0 {
+		lo.mgr.Release(lo.held)
+		lo.held = nil
+	}
+}
+
+// buildKeys формирует ключи блокировок в виде "регистр|изм1=знач&изм2=знач..."
+// Значения отсортированы по имени измерения для детерминированности.
+func (lo *LockObject) buildKeys() []string {
+	keys := make([]string, 0, len(lo.elements))
+	for _, el := range lo.elements {
+		var pairs []string
+		for k, v := range el.values {
+			pairs = append(pairs, fmt.Sprintf("%s=%v", k, v))
+		}
+		sort.Strings(pairs)
+		keys = append(keys, el.registerName+"|"+strings.Join(pairs, "&"))
+	}
+	return keys
+}
+
+// LockElement — отдельный элемент блокировки (соответствует
+// БлокировкаДанных.Добавить()).
+type LockElement struct {
+	registerName string
+	values       map[string]any
+}
+
+func (le *LockElement) Get(name string) any    { return nil }
+func (le *LockElement) Set(name string, v any) {}
+
+// CallMethod implements interpreter.MethodCallable.
+func (le *LockElement) CallMethod(method string, args []any) any {
+	switch strings.ToLower(method) {
+	case "установитьзначение", "setvalue":
+		if len(args) >= 2 {
+			name, ok := args[0].(string)
+			if !ok {
+				return nil
+			}
+			le.values[strings.ToLower(name)] = args[1]
+		}
+	}
+	return nil
+}

--- a/internal/runtime/locks_test.go
+++ b/internal/runtime/locks_test.go
@@ -1,0 +1,148 @@
+package runtime
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Замечание #2: два параллельных вызова с одним и тем же набором
+// ключей должны сериализоваться.
+func TestLockManager_SerializesSameKey(t *testing.T) {
+	mgr := NewLockManager()
+	var counter int32
+	var maxConcurrent int32
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.Acquire([]string{"reg|номенклатура=Тумбочка"})
+			defer mgr.Release([]string{"reg|номенклатура=Тумбочка"})
+			cur := atomic.AddInt32(&counter, 1)
+			for {
+				old := atomic.LoadInt32(&maxConcurrent)
+				if cur > old {
+					if atomic.CompareAndSwapInt32(&maxConcurrent, old, cur) {
+						break
+					}
+				} else {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt32(&counter, -1)
+		}()
+	}
+	wg.Wait()
+	if maxConcurrent > 1 {
+		t.Errorf("одинаковый ключ должен сериализоваться, max concurrent = %d", maxConcurrent)
+	}
+}
+
+// Разные ключи не блокируют друг друга.
+func TestLockManager_ParallelDifferentKeys(t *testing.T) {
+	mgr := NewLockManager()
+	var counter int32
+	var maxConcurrent int32
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			key := []string{"reg|номенклатура=item" + string(rune('A'+idx))}
+			mgr.Acquire(key)
+			defer mgr.Release(key)
+			cur := atomic.AddInt32(&counter, 1)
+			for {
+				old := atomic.LoadInt32(&maxConcurrent)
+				if cur > old {
+					if atomic.CompareAndSwapInt32(&maxConcurrent, old, cur) {
+						break
+					}
+				} else {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt32(&counter, -1)
+		}(i)
+	}
+	wg.Wait()
+	if maxConcurrent < 2 {
+		t.Errorf("разные ключи должны идти параллельно, max concurrent = %d", maxConcurrent)
+	}
+}
+
+// Несколько ключей за раз — sort обеспечивает безопасный порядок,
+// нет deadlock'а если два потока запросили {A,B} и {B,A}.
+func TestLockManager_NoDeadlockOnDifferentOrder(t *testing.T) {
+	mgr := NewLockManager()
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			var keys []string
+			if i == 0 {
+				keys = []string{"A", "B"}
+			} else {
+				keys = []string{"B", "A"}
+			}
+			for j := 0; j < 10; j++ {
+				mgr.Acquire(keys)
+				time.Sleep(1 * time.Millisecond)
+				mgr.Release(keys)
+			}
+		}(i)
+	}
+	select {
+	case <-done:
+		// OK
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock — обнаружен timeout")
+	}
+}
+
+// LockObject — DSL-сценарий: Добавить, УстановитьЗначение, Заблокировать,
+// Разблокировать.
+func TestLockObject_DSLScenario(t *testing.T) {
+	mgr := NewLockManager()
+	lo := NewLockObject(mgr)
+
+	el := lo.CallMethod("добавить", []any{"РегистрНакопления.ОстаткиТоваров"})
+	if el == nil {
+		t.Fatal("Добавить вернул nil")
+	}
+	le, ok := el.(*LockElement)
+	if !ok {
+		t.Fatalf("Добавить вернул %T, ожидался *LockElement", el)
+	}
+	le.CallMethod("установитьзначение", []any{"Номенклатура", "Тумбочка"})
+	le.CallMethod("установитьзначение", []any{"Склад", "Основной"})
+
+	lo.CallMethod("заблокировать", nil)
+	if len(lo.held) != 1 {
+		t.Errorf("ожидался 1 удерживаемый ключ, %d", len(lo.held))
+	}
+	lo.CallMethod("разблокировать", nil)
+	if len(lo.held) != 0 {
+		t.Errorf("после Разблокировать должно быть 0 ключей, %d", len(lo.held))
+	}
+}
+
+// Идемпотентность: повторный Release не должен паниковать.
+func TestLockObject_ReleaseAllIdempotent(t *testing.T) {
+	mgr := NewLockManager()
+	lo := NewLockObject(mgr)
+	lo.CallMethod("добавить", []any{"X"})
+	lo.CallMethod("заблокировать", nil)
+	lo.ReleaseAll()
+	lo.ReleaseAll() // не должен паниковать
+}

--- a/internal/runtime/object.go
+++ b/internal/runtime/object.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/metadata"
@@ -56,6 +57,50 @@ func (o *Object) GetRefUUID() string {
 		return ""
 	}
 	return o.ID.String()
+}
+
+// MomentTime — снимок «момента времени» для виртуальных таблиц регистров
+// (замечание #1). Передаётся в .Остатки/.Обороты/.СрезПоследних как
+// первый аргумент и обрабатывается query-translator'ом:
+//   WHERE period < @Period OR (period = @Period AND recorder != @DocID)
+// то есть «всё что было ДО этой документной строки». При перепроведении
+// задним числом это даёт корректные остатки — текущий документ исключается
+// из своей же сводки.
+type MomentTime struct {
+	Period  time.Time
+	DocID   uuid.UUID
+	DocType string // recorder_type для accumulation register
+}
+
+// PointInTime реализует контракт, который ищет query-translator (без импорта
+// runtime). Возвращает значение Period и string-UUID документа.
+func (m *MomentTime) PointInTime() (time.Time, string) {
+	if m == nil {
+		return time.Time{}, ""
+	}
+	return m.Period, m.DocID.String()
+}
+
+// CallMethod implements interpreter.MethodCallable so DSL can call
+// `ЭтотОбъект.МоментВремени()` and `ЭтотОбъект.Дата` style ergonomics.
+// Currently the only method is МоментВремени — returns *MomentTime
+// initialized from the object's date field.
+func (o *Object) CallMethod(method string, args []any) any {
+	switch method {
+	case "моментвремени", "pointintime":
+		var p time.Time
+		// первое непустое date-поле
+		for _, k := range []string{"дата", "date", "период", "period"} {
+			if v, ok := o.Fields[k]; ok && v != nil {
+				if t, ok := v.(time.Time); ok && !t.IsZero() {
+					p = t
+					break
+				}
+			}
+		}
+		return &MomentTime{Period: p, DocID: o.ID, DocType: o.Type}
+	}
+	return nil
 }
 
 // String — display-имя объекта для записи в string-колонки регистра

--- a/internal/runtime/object_test.go
+++ b/internal/runtime/object_test.go
@@ -2,6 +2,7 @@
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/metadata"
@@ -68,6 +69,48 @@ func TestObject_String_Nil(t *testing.T) {
 	var o *Object
 	if got := o.String(); got != "" {
 		t.Errorf("nil-Object.String() = %q", got)
+	}
+}
+
+// Замечание #1: ЭтотОбъект.МоментВремени() возвращает MomentTime с
+// period из поля «Дата» документа и DocID = ID объекта.
+func TestObject_MomentTime(t *testing.T) {
+	docDate := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	docID := uuid.New()
+	o := &Object{
+		Type: "Поступление",
+		Kind: metadata.KindDocument,
+		ID:   docID,
+		Fields: map[string]any{
+			"дата": docDate,
+		},
+	}
+	v := o.CallMethod("моментвремени", nil)
+	mt, ok := v.(*MomentTime)
+	if !ok {
+		t.Fatalf("ожидался *MomentTime, получили %T", v)
+	}
+	if !mt.Period.Equal(docDate) {
+		t.Errorf("Period: got %v, want %v", mt.Period, docDate)
+	}
+	if mt.DocID != docID {
+		t.Errorf("DocID не совпал")
+	}
+	if mt.DocType != "Поступление" {
+		t.Errorf("DocType: %s", mt.DocType)
+	}
+}
+
+func TestMomentTime_PointInTime(t *testing.T) {
+	docDate := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	docID := uuid.New()
+	mt := &MomentTime{Period: docDate, DocID: docID, DocType: "X"}
+	p, id := mt.PointInTime()
+	if !p.Equal(docDate) {
+		t.Errorf("Period: %v vs %v", p, docDate)
+	}
+	if id != docID.String() {
+		t.Errorf("DocID string: %s vs %s", id, docID.String())
 	}
 }
 

--- a/internal/storage/journal.go
+++ b/internal/storage/journal.go
@@ -11,15 +11,34 @@ import (
 
 // colExprForDoc returns the SQL expression for a journal column in the given entity's SELECT.
 // Returns ("NULL", nil) if the column has no matching field in the entity.
+//
+// Замечание #7: приоритет резолва:
+//   1. jcol.Map[entity.Name] — явный per-doc mapping (новый рекомендуемый путь).
+//   2. Exact match — у документа есть поле с именем jcol.Field.
+//   3. Fallback list — старый fallback (back compat); COALESCE если несколько.
 func colExprForDoc(jcol metadata.JournalColumn, entity *metadata.Entity) (string, *metadata.Field) {
-	// Exact match
+	// 1. Explicit map для этого документа.
+	if jcol.Map != nil {
+		if mapped, ok := jcol.Map[entity.Name]; ok && mapped != "" {
+			for i := range entity.Fields {
+				f := &entity.Fields[i]
+				if strings.EqualFold(f.Name, mapped) {
+					return metadata.ColumnName(*f), f
+				}
+			}
+			// Map ссылается на несуществующее поле — намеренно
+			// возвращаем NULL, не падая на fallback'е молча.
+			return "NULL", nil
+		}
+	}
+	// 2. Exact match
 	for i := range entity.Fields {
 		f := &entity.Fields[i]
 		if strings.EqualFold(f.Name, jcol.Field) {
 			return metadata.ColumnName(*f), f
 		}
 	}
-	// Fallback match — build COALESCE of all matching columns
+	// 3. Fallback match — build COALESCE of all matching columns
 	type match struct {
 		col string
 		f   *metadata.Field

--- a/internal/storage/journal_test.go
+++ b/internal/storage/journal_test.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Замечание #7: явный Map имеет приоритет над exact match и fallback.
+func TestColExprForDoc_MapWins(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "ПоступлениеТоваров",
+		Fields: []metadata.Field{
+			{Name: "Контрагент", Type: metadata.FieldTypeString},
+			{Name: "Поставщик", Type: metadata.FieldTypeString},
+		},
+	}
+	jcol := metadata.JournalColumn{
+		Field: "Контрагент",
+		Map: map[string]string{
+			"ПоступлениеТоваров": "Поставщик",
+		},
+		Fallback: []string{"Поставщик", "Покупатель"},
+	}
+	expr, f := colExprForDoc(jcol, entity)
+	// Map → Поставщик
+	if expr != "поставщик" {
+		t.Errorf("Map должен выиграть: ожидался «поставщик», получили %q", expr)
+	}
+	if f == nil || f.Name != "Поставщик" {
+		t.Errorf("вернулось не то поле: %v", f)
+	}
+}
+
+// Без Map — exact match.
+func TestColExprForDoc_ExactMatch(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "ПоступлениеТоваров",
+		Fields: []metadata.Field{
+			{Name: "Контрагент", Type: metadata.FieldTypeString},
+		},
+	}
+	jcol := metadata.JournalColumn{Field: "Контрагент"}
+	expr, f := colExprForDoc(jcol, entity)
+	if expr != "контрагент" {
+		t.Errorf("exact match не сработал: %q", expr)
+	}
+	if f.Name != "Контрагент" {
+		t.Errorf("не то поле: %s", f.Name)
+	}
+}
+
+// Без Map и без exact — fallback.
+func TestColExprForDoc_FallbackUsed(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "ПоступлениеТоваров",
+		Fields: []metadata.Field{
+			{Name: "Поставщик", Type: metadata.FieldTypeString},
+		},
+	}
+	jcol := metadata.JournalColumn{
+		Field:    "Контрагент",
+		Fallback: []string{"Поставщик", "Покупатель"},
+	}
+	expr, _ := colExprForDoc(jcol, entity)
+	if expr != "поставщик" {
+		t.Errorf("fallback не сработал: %q", expr)
+	}
+}
+
+// Map указывает на несуществующее поле — NULL, не молчаливый fallback.
+func TestColExprForDoc_MapMissingFieldGivesNull(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "ПоступлениеТоваров",
+		Fields: []metadata.Field{
+			{Name: "Поставщик", Type: metadata.FieldTypeString},
+		},
+	}
+	jcol := metadata.JournalColumn{
+		Field: "Контрагент",
+		Map: map[string]string{
+			"ПоступлениеТоваров": "НетТакого",
+		},
+		Fallback: []string{"Поставщик"}, // не должен сработать — Map важнее
+	}
+	expr, _ := colExprForDoc(jcol, entity)
+	if expr != "NULL" {
+		t.Errorf("неверная колонка в Map → должна быть NULL, получили %q", expr)
+	}
+}
+
+// Несколько fallback — COALESCE.
+func TestColExprForDoc_MultiFallbackCoalesce(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "СоставнойДокумент",
+		Fields: []metadata.Field{
+			{Name: "Поставщик", Type: metadata.FieldTypeString},
+			{Name: "Покупатель", Type: metadata.FieldTypeString},
+		},
+	}
+	jcol := metadata.JournalColumn{
+		Field:    "Контрагент",
+		Fallback: []string{"Поставщик", "Покупатель"},
+	}
+	expr, _ := colExprForDoc(jcol, entity)
+	if expr != "COALESCE(поставщик, покупатель)" {
+		t.Errorf("ожидался COALESCE, получили %q", expr)
+	}
+}

--- a/internal/storage/predefined.go
+++ b/internal/storage/predefined.go
@@ -44,6 +44,13 @@ func (db *DB) EnsurePredefinedColumns(ctx context.Context, entities []*metadata.
 // SyncPredefined upserts all predefined items declared in the entity YAML into
 // the database. The _predefined_name is used as the conflict target so the UUID
 // never changes on subsequent syncs — only field values are updated.
+//
+// Замечание #14: поддерживаются cross-ref внутри одного справочника
+// (Розничная.БазовыйТип: Закупочная). Алгоритм:
+//   1. Пре-аллоцировать UUID для каждого item (переиспользуя из БД при upsert).
+//   2. Топологическая сортировка по self-reference полям.
+//   3. INSERT в порядке зависимостей, заменяя имя на UUID для self-ref полей.
+// При цикле в зависимостях возвращается ошибка.
 func (db *DB) SyncPredefined(ctx context.Context, e *metadata.Entity) error {
 	if len(e.Predefined) == 0 {
 		return nil
@@ -54,11 +61,50 @@ func (db *DB) SyncPredefined(ctx context.Context, e *metadata.Entity) error {
 		boolTrue = "1"
 	}
 	table := metadata.TableName(e.Name)
+
+	// Шаг 1: для каждого predefined — собираем UUID. Если в БД уже есть
+	// запись с тем же _predefined_name — берём её UUID, иначе генерим.
+	nameToUUID := make(map[string]uuid.UUID, len(e.Predefined))
 	for _, item := range e.Predefined {
+		var idStr string
+		err := db.QueryRow(ctx, fmt.Sprintf(
+			`SELECT id FROM %s WHERE _predefined_name = %s AND _is_predefined = %s LIMIT 1`,
+			table, d.Placeholder(1), boolTrue),
+			item.Name,
+		).Scan(&idStr)
+		if err == nil {
+			if id, err := uuid.Parse(idStr); err == nil {
+				nameToUUID[item.Name] = id
+				continue
+			}
+		}
+		nameToUUID[item.Name] = uuid.New()
+	}
+
+	// Шаг 2: топологическая сортировка. Граф ориентирован: item → items на
+	// которые он ссылается через self-ref поля. Вставляем в порядке
+	// «зависимости первыми». Карта имён → item для быстрого lookup.
+	byName := make(map[string]*metadata.PredefinedItem, len(e.Predefined))
+	for _, it := range e.Predefined {
+		byName[it.Name] = it
+	}
+	// Определяем self-ref поля.
+	selfRefFields := make(map[string]bool)
+	for _, f := range e.Fields {
+		if f.RefEntity == e.Name {
+			selfRefFields[strings.ToLower(f.Name)] = true
+		}
+	}
+	ordered, err := topoSortPredefined(e.Predefined, selfRefFields)
+	if err != nil {
+		return fmt.Errorf("sync predefined %s: %w", e.Name, err)
+	}
+
+	// Шаг 3: вставка в порядке зависимостей.
+	for _, item := range ordered {
 		cols := []string{"id", "_predefined_name", "_is_predefined"}
-		// id is generated in Go (gen_random_uuid is PG-only).
 		phs := []string{d.Placeholder(1), d.Placeholder(2), boolTrue}
-		args := []any{idArg(d, uuid.New()), item.Name}
+		args := []any{idArg(d, nameToUUID[item.Name]), item.Name}
 		updates := []string{"_is_predefined = " + boolTrue}
 		argIdx := 3
 
@@ -67,6 +113,15 @@ func (db *DB) SyncPredefined(ctx context.Context, e *metadata.Entity) error {
 			val, ok := item.Fields[f.Name]
 			if !ok {
 				continue
+			}
+			// Self-ref поле: если значение — имя другого predefined,
+			// подменяем на его UUID.
+			if selfRefFields[strings.ToLower(f.Name)] {
+				if refName, ok := val.(string); ok {
+					if refUUID, found := nameToUUID[refName]; found {
+						val = idArg(d, refUUID)
+					}
+				}
 			}
 			cols = append(cols, col)
 			phs = append(phs, d.Placeholder(argIdx))
@@ -90,6 +145,69 @@ func (db *DB) SyncPredefined(ctx context.Context, e *metadata.Entity) error {
 		}
 	}
 	return nil
+}
+
+// topoSortPredefined сортирует predefined-элементы по self-reference
+// зависимостям. Если A.SelfRefField = B, то B вставляется раньше A.
+// При обнаружении цикла возвращает ошибку с указанием участников.
+func topoSortPredefined(items []*metadata.PredefinedItem, selfRefFields map[string]bool) ([]*metadata.PredefinedItem, error) {
+	byName := make(map[string]*metadata.PredefinedItem, len(items))
+	for _, it := range items {
+		byName[it.Name] = it
+	}
+
+	// deps[name] = список имён, от которых зависит name.
+	deps := make(map[string][]string, len(items))
+	for _, it := range items {
+		var d []string
+		for fieldName, val := range it.Fields {
+			if !selfRefFields[strings.ToLower(fieldName)] {
+				continue
+			}
+			refName, ok := val.(string)
+			if !ok || refName == "" {
+				continue
+			}
+			if _, exists := byName[refName]; exists {
+				d = append(d, refName)
+			}
+		}
+		deps[it.Name] = d
+	}
+
+	// DFS с тремя цветами.
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(items))
+	var out []*metadata.PredefinedItem
+	var visit func(name string, path []string) error
+	visit = func(name string, path []string) error {
+		switch color[name] {
+		case black:
+			return nil
+		case gray:
+			return fmt.Errorf("цикл в self-reference predefined: %s → %s",
+				strings.Join(path, " → "), name)
+		}
+		color[name] = gray
+		for _, dep := range deps[name] {
+			if err := visit(dep, append(path, name)); err != nil {
+				return err
+			}
+		}
+		color[name] = black
+		out = append(out, byName[name])
+		return nil
+	}
+	for _, it := range items {
+		if err := visit(it.Name, nil); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
 // GetPredefinedID returns the UUID of a predefined item by its name.

--- a/internal/storage/predefined_topo_test.go
+++ b/internal/storage/predefined_topo_test.go
@@ -1,0 +1,129 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Замечание #14: cross-ref внутри одного справочника в predefined.
+// Розничная → Закупочная: Закупочная должна вставляться первой.
+func TestTopoSortPredefined_LinearChain(t *testing.T) {
+	items := []*metadata.PredefinedItem{
+		{Name: "Розничная", Fields: map[string]any{"БазовыйТип": "Закупочная"}},
+		{Name: "Закупочная", Fields: map[string]any{}},
+	}
+	selfRef := map[string]bool{"базовыйтип": true}
+	ordered, err := topoSortPredefined(items, selfRef)
+	if err != nil {
+		t.Fatalf("topo sort: %v", err)
+	}
+	if len(ordered) != 2 {
+		t.Fatalf("ожидалось 2 элемента, получили %d", len(ordered))
+	}
+	if ordered[0].Name != "Закупочная" || ordered[1].Name != "Розничная" {
+		t.Errorf("неверный порядок: %s, %s", ordered[0].Name, ordered[1].Name)
+	}
+}
+
+// Несколько уровней зависимости: Дилерская → Оптовая → Закупочная.
+func TestTopoSortPredefined_MultiLevel(t *testing.T) {
+	items := []*metadata.PredefinedItem{
+		{Name: "Дилерская", Fields: map[string]any{"БазовыйТип": "Оптовая"}},
+		{Name: "Оптовая", Fields: map[string]any{"БазовыйТип": "Закупочная"}},
+		{Name: "Закупочная", Fields: map[string]any{}},
+	}
+	selfRef := map[string]bool{"базовыйтип": true}
+	ordered, err := topoSortPredefined(items, selfRef)
+	if err != nil {
+		t.Fatalf("topo sort: %v", err)
+	}
+	// Первой должна быть Закупочная, последней — Дилерская.
+	if ordered[0].Name != "Закупочная" {
+		t.Errorf("первой ожидалась Закупочная, получили %s", ordered[0].Name)
+	}
+	if ordered[len(ordered)-1].Name != "Дилерская" {
+		t.Errorf("последней ожидалась Дилерская, получили %s", ordered[len(ordered)-1].Name)
+	}
+}
+
+// Параллельные ветви.
+func TestTopoSortPredefined_Branching(t *testing.T) {
+	items := []*metadata.PredefinedItem{
+		{Name: "Розничная", Fields: map[string]any{"БазовыйТип": "Закупочная"}},
+		{Name: "Оптовая", Fields: map[string]any{"БазовыйТип": "Закупочная"}},
+		{Name: "Закупочная", Fields: map[string]any{}},
+	}
+	selfRef := map[string]bool{"базовыйтип": true}
+	ordered, err := topoSortPredefined(items, selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Закупочная должна идти раньше обеих ссылающихся.
+	idx := func(name string) int {
+		for i, it := range ordered {
+			if it.Name == name {
+				return i
+			}
+		}
+		return -1
+	}
+	if idx("Закупочная") > idx("Розничная") {
+		t.Error("Закупочная должна быть раньше Розничной")
+	}
+	if idx("Закупочная") > idx("Оптовая") {
+		t.Error("Закупочная должна быть раньше Оптовой")
+	}
+}
+
+// Цикл должен давать ошибку с упоминанием цепочки.
+func TestTopoSortPredefined_Cycle(t *testing.T) {
+	items := []*metadata.PredefinedItem{
+		{Name: "A", Fields: map[string]any{"БазовыйТип": "B"}},
+		{Name: "B", Fields: map[string]any{"БазовыйТип": "A"}},
+	}
+	selfRef := map[string]bool{"базовыйтип": true}
+	_, err := topoSortPredefined(items, selfRef)
+	if err == nil {
+		t.Fatal("цикл должен давать ошибку")
+	}
+	if !strings.Contains(err.Error(), "цикл") {
+		t.Errorf("ошибка должна упоминать «цикл»: %v", err)
+	}
+}
+
+// Ссылка на несуществующий элемент — игнорируется (значит запись осиротеет
+// при FK, но это уже не проблема topo-sort'а).
+func TestTopoSortPredefined_MissingRefIgnored(t *testing.T) {
+	items := []*metadata.PredefinedItem{
+		{Name: "A", Fields: map[string]any{"БазовыйТип": "НетТакого"}},
+		{Name: "B", Fields: map[string]any{}},
+	}
+	selfRef := map[string]bool{"базовыйтип": true}
+	ordered, err := topoSortPredefined(items, selfRef)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+	if len(ordered) != 2 {
+		t.Errorf("ожидалось 2, получили %d", len(ordered))
+	}
+}
+
+// Без self-ref полей вообще — сохраняется исходный порядок.
+func TestTopoSortPredefined_NoSelfRef(t *testing.T) {
+	items := []*metadata.PredefinedItem{
+		{Name: "First"},
+		{Name: "Second"},
+		{Name: "Third"},
+	}
+	selfRef := map[string]bool{}
+	ordered, err := topoSortPredefined(items, selfRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ordered[0].Name != "First" || ordered[1].Name != "Second" || ordered[2].Name != "Third" {
+		t.Errorf("без зависимостей порядок должен сохраниться: %v",
+			[]string{ordered[0].Name, ordered[1].Name, ordered[2].Name})
+	}
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1461,6 +1461,11 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 	queryFactory := interpreter.NewQueryFactory(ctx, s.store, s.reg)
 	predefined := interpreter.NewPredefinedRoot(ctx, s.store)
 	catalogs := interpreter.NewCatalogsRoot(ctx, s.store, s.reg)
+	// #2 managed locks: builtin БлокировкаДанных() возвращает свежий LockObject,
+	// привязанный к глобальному менеджеру server'а.
+	lockFactory := interpreter.BuiltinFunc(func(_ []any, _ string, _ int) (any, error) {
+		return runtime.NewLockObject(s.lockMgr), nil
+	})
 	vars := map[string]any{
 		"Движения":                  mc,
 		"Перечисления":              &interpreter.MapThis{M: enumsMap},
@@ -1471,6 +1476,8 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 		"PredefinedValues":          predefined,
 		"Справочники":               catalogs,
 		"Catalogs":                  catalogs,
+		"БлокировкаДанных":          lockFactory,
+		"DataLock":                  lockFactory,
 	}
 	for k, v := range interpreter.NewHTTPFunctions() {
 		vars[k] = v

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -42,6 +42,7 @@ type Server struct {
 	globalDebug      *debugger.GlobalDebugController
 	messages         *MessageStore
 	widgetCache      *widget.Cache
+	lockMgr          *runtime.LockManager // #2 managed locks
 }
 
 func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpreter, authRepo *auth.Repo, cfg Config, sched *scheduler.Scheduler) *Server {
@@ -49,7 +50,7 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 	if maxBytes <= 0 {
 		maxBytes = 50 * 1024 * 1024
 	}
-	s := &Server{reg: reg, store: store, interp: interp, authRepo: authRepo, cfg: cfg, sched: sched, mailer: cfg.Mailer, maxFileSizeBytes: maxBytes, globalDebug: debugger.NewGlobalDebugController(), messages: NewMessageStore(), widgetCache: widget.NewCache(60 * time.Second)}
+	s := &Server{reg: reg, store: store, interp: interp, authRepo: authRepo, cfg: cfg, sched: sched, mailer: cfg.Mailer, maxFileSizeBytes: maxBytes, globalDebug: debugger.NewGlobalDebugController(), messages: NewMessageStore(), widgetCache: widget.NewCache(60 * time.Second), lockMgr: runtime.NewLockManager()}
 	if sched != nil {
 		sched.SetMessageSink(func(userID, text string) { s.messages.Push(userID, text) })
 	}


### PR DESCRIPTION
Продолжение первого PR — «архитектурные» пункты из feedback'а плюс
#24 (API текущего пользователя). Ветка стоит поверх свежего main
(после мержа первого PR), в diff только эти коммиты. Каждый пункт —
отдельный коммит со своими тестами.

## #14 — cross-ref в predefined
Розничная.БазовыйТип=Закупочная падало с FOREIGN KEY constraint.
SyncPredefined: pre-allocate UUID + топологическая сортировка по
self-reference (DFS, 3 цвета); self-ref значения → UUID; цикл → ошибка.

## #7 — общий реквизит журнала
Explicit per-doc `map:` вместо `fallback: [...]`.

  columns:
    - field: Контрагент
      map:
        ПоступлениеТоваров: Поставщик
        РеализацияТоваров:  Покупатель

Приоритет: Map → exact match → fallback (back compat).

## #1 — МоментВремени у виртуальных таблиц
`ЭтотОбъект.МоментВремени()` → `*MomentTime{Period, DocID}`.
`.Остатки(МВ)` генерит `(period < $1 OR (period = $1 AND recorder != $2))`
— строго до этого документа; при перепроведении документ исключается
из собственной сводки. Info-reg → `period <= $1`.

## #2 — управляемые блокировки
`БлокировкаДанных()` + `.Добавить()` + `.УстановитьЗначение()` +
`.Заблокировать()`. In-memory LockManager с сортировкой ключей
(нет cross-deadlock). Single-instance; multi-instance PG потребует
SELECT FOR UPDATE — заметка в комментариях.

## #24 — API текущего пользователя
`ТекущийПользователь()` → объект {ИД, Имя, ПолноеИмя, Админ}.
`ИмяПользователя()` → логин ("" для фоновых заданий). Для
персональных настроек (склад/организация по умолчанию per-user).

  Имя = ИмяПользователя();
  Если Имя = "" Тогда Имя = "Общие"; КонецЕсли;
  Настройка = Справочники.НастройкиПользователя.НайтиПоНаименованию(Имя);

## Качество
- 25 unit-тестов (runtime / query / storage / interpreter).
- go test ./... зелёный по всему репо (на свежем main).

## Возможные followups
- #2: distributed lock для PG.
- #1: auto-release лока через interpreter hook.