### PR TITLE
fix(dsl): запись из обработок — транзакции, справочники, документы (#25, #26)

### DIFF
--- a/internal/dsl/interpreter/builtins.go
+++ b/internal/dsl/interpreter/builtins.go
@@ -361,6 +361,7 @@ func KnownBuiltinNames() map[string]struct{} {
 		"текущийпользователь", "currentuser",
 		"имяпользователя", "username",
 		"справочники", "catalogs",
+		"документы", "documents",
 		"предопределённыезначения", "predefinedvalues",
 	} {
 		names[k] = struct{}{}

--- a/internal/dsl/interpreter/catalogs_proxy.go
+++ b/internal/dsl/interpreter/catalogs_proxy.go
@@ -2,35 +2,54 @@ package interpreter
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/ivantit66/onebase/internal/metadata"
 )
 
-// CatalogsDB extends PredefinedDB with field-based lookups for runtime search.
+// CatalogsDB extends PredefinedDB with field-based lookups and writes.
 // Returns ("", "", false, nil) on not-found so the DSL can compare against nil.
 type CatalogsDB interface {
 	PredefinedDB
 	FindCatalogByField(ctx context.Context, entity *metadata.Entity, fieldName, value string) (idStr, display string, ok bool, err error)
+	// WriteCatalogRecord upserts a record (замечание #25). idStr пустой →
+	// генерируется новый UUID. Возвращает UUID записанной записи.
+	WriteCatalogRecord(ctx context.Context, entity *metadata.Entity, idStr string, fields map[string]any) (string, error)
 }
 
 // EntityLookup resolves an entity name (case-insensitive) to its metadata.
-// Catalog access needs this to know what fields exist.
 type EntityLookup interface {
 	GetEntity(name string) *metadata.Entity
 }
 
+// ctxSource предоставляет «живой» контекст. Для обычного запуска это
+// статический контекст; при активной DSL-транзакции — *TxState, чей
+// Ctx() несёт открытую транзакцию (замечание #25: запись справочника
+// из обработки должна участвовать в транзакции).
+type ctxSource interface {
+	Ctx() context.Context
+}
+
+// staticCtx — ctxSource c фиксированным контекстом (нет транзакции).
+type staticCtx struct{ ctx context.Context }
+
+func (s staticCtx) Ctx() context.Context { return s.ctx }
+
+// NewStaticCtx wraps a plain context as a ctxSource.
+func NewStaticCtx(ctx context.Context) ctxSource { return staticCtx{ctx: ctx} }
+
 // CatalogsRoot is the DSL global Справочники / Catalogs.
-// Each property access (.ТипЦен) returns a CatalogProxy for that entity.
 type CatalogsRoot struct {
 	db     CatalogsDB
 	lookup EntityLookup
-	ctx    context.Context
+	ctxSrc ctxSource
 }
 
 // NewCatalogsRoot creates the root object for injection as DSL extraVar.
-func NewCatalogsRoot(ctx context.Context, db CatalogsDB, lookup EntityLookup) *CatalogsRoot {
-	return &CatalogsRoot{db: db, lookup: lookup, ctx: ctx}
+// ctxSrc — источник живого контекста (staticCtx или *TxState).
+func NewCatalogsRoot(ctxSrc ctxSource, db CatalogsDB, lookup EntityLookup) *CatalogsRoot {
+	return &CatalogsRoot{db: db, lookup: lookup, ctxSrc: ctxSrc}
 }
 
 func (r *CatalogsRoot) Get(entityName string) any {
@@ -38,29 +57,34 @@ func (r *CatalogsRoot) Get(entityName string) any {
 	if entity == nil {
 		return nil
 	}
-	return &CatalogProxy{entity: entity, db: r.db, ctx: r.ctx}
+	return &CatalogProxy{entity: entity, db: r.db, ctxSrc: r.ctxSrc}
 }
 
 func (r *CatalogsRoot) Set(_ string, _ any) {}
 
-// CatalogProxy resolves predefined items (by attr access) and exposes
-// runtime lookups via methods.
+// CatalogProxy resolves predefined items, runtime lookups, and record creation.
 //
-//	Справочники.ТипЦен.Закупочная                 → *Ref to predefined item
-//	Справочники.ТипЦен.НайтиПоНаименованию("X")    → *Ref or nil
+//	Справочники.ТипЦен.Закупочная                  → *Ref to predefined item
+//	Справочники.ТипЦен.НайтиПоНаименованию("X")     → *Ref or nil
+//	Справочники.Контрагент.Создать()                → *CatalogRecordWriter
 type CatalogProxy struct {
 	entity *metadata.Entity
 	db     CatalogsDB
-	ctx    context.Context
+	ctxSrc ctxSource
 }
 
-// Get is called for foo.Bar attribute access. Looks up a predefined item
-// declared in the entity YAML.
+func (p *CatalogProxy) ctx() context.Context {
+	if p.ctxSrc != nil {
+		return p.ctxSrc.Ctx()
+	}
+	return context.Background()
+}
+
+// Get is called for foo.Bar attribute access — predefined item lookup.
 func (p *CatalogProxy) Get(itemName string) any {
-	// Walk declared predefined items for a case-insensitive name match.
 	for _, item := range p.entity.Predefined {
 		if strings.EqualFold(item.Name, itemName) {
-			id, err := p.db.GetPredefinedIDStr(p.ctx, p.entity.Name, item.Name)
+			id, err := p.db.GetPredefinedIDStr(p.ctx(), p.entity.Name, item.Name)
 			if err != nil || id == "" {
 				return nil
 			}
@@ -74,11 +98,18 @@ func (p *CatalogProxy) Set(_ string, _ any) {}
 
 // CallMethod implements MethodCallable for method-style invocation.
 func (p *CatalogProxy) CallMethod(method string, args []any) any {
-	switch method {
+	switch strings.ToLower(method) {
 	case "найтипонаименованию", "findbyname":
 		return p.findByField("Наименование", args)
 	case "найтипокоду", "findbycode":
 		return p.findByField("Код", args)
+	case "создать", "create":
+		return &CatalogRecordWriter{
+			entity: p.entity,
+			db:     p.db,
+			ctxSrc: p.ctxSrc,
+			fields: map[string]any{},
+		}
 	}
 	return nil
 }
@@ -89,17 +120,77 @@ func (p *CatalogProxy) findByField(field string, args []any) any {
 	}
 	value, ok := args[0].(string)
 	if !ok {
-		// Allow *Ref or anything stringable — fall back to its display value.
 		if r, ok := args[0].(*Ref); ok {
 			value = r.Name
 		} else {
 			return nil
 		}
 	}
-	idStr, display, found, err := p.db.FindCatalogByField(p.ctx, p.entity, field, value)
+	idStr, display, found, err := p.db.FindCatalogByField(p.ctx(), p.entity, field, value)
 	if err != nil || !found {
 		return nil
 	}
 	return &Ref{UUID: idStr, Name: display}
 }
 
+// CatalogRecordWriter — записываемый объект справочника/документа,
+// созданный через Справочники.X.Создать() (замечание #25).
+//
+//	Зап = Справочники.Контрагент.Создать();
+//	Зап.Наименование = "ООО Ромашка";
+//	Зап.ИНН = "7701234567";
+//	Ссыл = Зап.Записать();   // → *Ref на записанную запись
+type CatalogRecordWriter struct {
+	entity *metadata.Entity
+	db     CatalogsDB
+	ctxSrc ctxSource
+	idStr  string
+	fields map[string]any
+}
+
+func (w *CatalogRecordWriter) ctx() context.Context {
+	if w.ctxSrc != nil {
+		return w.ctxSrc.Ctx()
+	}
+	return context.Background()
+}
+
+// Get — чтение установленного значения поля (case-insensitive).
+func (w *CatalogRecordWriter) Get(name string) any {
+	low := strings.ToLower(name)
+	for k, v := range w.fields {
+		if strings.ToLower(k) == low {
+			return v
+		}
+	}
+	return nil
+}
+
+// Set — установка значения поля (Зап.Поле = значение).
+func (w *CatalogRecordWriter) Set(name string, v any) {
+	w.fields[strings.ToLower(name)] = v
+}
+
+// CallMethod — Записать() / УстановитьЗначение().
+func (w *CatalogRecordWriter) CallMethod(method string, args []any) any {
+	switch strings.ToLower(method) {
+	case "записать", "write":
+		id, err := w.db.WriteCatalogRecord(w.ctx(), w.entity, w.idStr, w.fields)
+		if err != nil {
+			panic(userError{Msg: "Записать(" + w.entity.Name + "): " + err.Error()})
+		}
+		w.idStr = id
+		name := ""
+		if v := w.Get("Наименование"); v != nil {
+			name = fmt.Sprintf("%v", v)
+		}
+		return &Ref{UUID: id, Name: name}
+	case "установитьзначение", "setvalue":
+		if len(args) >= 2 {
+			if n, ok := args[0].(string); ok {
+				w.Set(n, args[1])
+			}
+		}
+	}
+	return nil
+}

--- a/internal/dsl/interpreter/catalogs_proxy_test.go
+++ b/internal/dsl/interpreter/catalogs_proxy_test.go
@@ -10,8 +10,9 @@ import (
 
 // fakeCatalogsDB stubs storage for catalog/predefined lookups in tests.
 type fakeCatalogsDB struct {
-	predefinedID map[string]string                  // "Entity/Name" → uuid
+	predefinedID map[string]string // "Entity/Name" → uuid
 	byField      map[string]map[string]struct{ ID, Display string }
+	written      []map[string]any // запись через WriteCatalogRecord
 }
 
 func (f *fakeCatalogsDB) GetPredefinedIDStr(_ context.Context, entityName, name string) (string, error) {
@@ -29,6 +30,18 @@ func (f *fakeCatalogsDB) FindCatalogByField(_ context.Context, entity *metadata.
 		}
 	}
 	return "", "", false, nil
+}
+
+func (f *fakeCatalogsDB) WriteCatalogRecord(_ context.Context, entity *metadata.Entity, idStr string, fields map[string]any) (string, error) {
+	rec := map[string]any{"_entity": entity.Name, "_id": idStr}
+	for k, v := range fields {
+		rec[k] = v
+	}
+	f.written = append(f.written, rec)
+	if idStr == "" {
+		return "99999999-9999-9999-9999-999999999999", nil
+	}
+	return idStr, nil
 }
 
 type fakeEntityLookup struct{ m map[string]*metadata.Entity }
@@ -60,7 +73,50 @@ func newCatalogsTestEnv() (*CatalogsRoot, *fakeCatalogsDB, *fakeEntityLookup) {
 		},
 	}
 	lookup := &fakeEntityLookup{m: map[string]*metadata.Entity{"ТипЦен": entity}}
-	return NewCatalogsRoot(context.Background(), db, lookup), db, lookup
+	return NewCatalogsRoot(NewStaticCtx(context.Background()), db, lookup), db, lookup
+}
+
+// Замечание #25: Справочники.X.Создать().Записать() должно персистить.
+func TestCatalogProxy_CreateAndWrite(t *testing.T) {
+	root, db, _ := newCatalogsTestEnv()
+	cp := root.Get("ТипЦен").(*CatalogProxy)
+
+	rec := cp.CallMethod("создать", nil)
+	w, ok := rec.(*CatalogRecordWriter)
+	if !ok {
+		t.Fatalf("Создать вернул %T, ожидался *CatalogRecordWriter", rec)
+	}
+	// поле через Set (Зап.Наименование = ...)
+	w.Set("Наименование", "Спеццена")
+	// поле через УстановитьЗначение
+	w.CallMethod("установитьзначение", []any{"Код", "СЦ-001"})
+
+	res := w.CallMethod("записать", nil)
+	ref, ok := res.(*Ref)
+	if !ok {
+		t.Fatalf("Записать вернул %T, ожидался *Ref", res)
+	}
+	if ref.Name != "Спеццена" {
+		t.Errorf("Ref.Name = %q, ожидалось Спеццена", ref.Name)
+	}
+	// проверим что запись реально дошла до db
+	if len(db.written) != 1 {
+		t.Fatalf("ожидалась 1 запись в db, получили %d", len(db.written))
+	}
+	if db.written[0]["наименование"] != "Спеццена" {
+		t.Errorf("в записи нет наименования: %v", db.written[0])
+	}
+	if db.written[0]["код"] != "СЦ-001" {
+		t.Errorf("в записи нет кода: %v", db.written[0])
+	}
+}
+
+// Создать() для несуществующего справочника — Get вернёт nil.
+func TestCatalogProxy_CreateUnknownEntity(t *testing.T) {
+	root, _, _ := newCatalogsTestEnv()
+	if v := root.Get("НетТакого"); v != nil {
+		t.Errorf("Справочники.НетТакого → %v, ожидался nil", v)
+	}
 }
 
 // Справочники.X.ИмяПредопределённой должно возвращать Ref.

--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -20,6 +20,14 @@ type dslReturn struct{ val any }
 // userError — пользовательская ошибка через Error(), перехватывается Попыткой
 type userError struct{ Msg string }
 
+// RaiseUserError panics with a DSL user error. Предназначено для
+// внешних пакетов (например ui), которым нужно прервать выполнение DSL
+// из метода объекта (CallMethod) с осмысленным сообщением — оно
+// перехватывается Run/RunWithResult и Попыткой так же, как Error().
+func RaiseUserError(msg string) {
+	panic(userError{Msg: msg})
+}
+
 // loopBreak — выход из цикла через Прервать
 type loopBreak struct{}
 

--- a/internal/storage/catalog_write_test.go
+++ b/internal/storage/catalog_write_test.go
@@ -1,0 +1,94 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Замечание #25: WriteCatalogRecord должен реально персистить запись
+// справочника (раньше путь Справочники.X.Создать().Записать() был no-op).
+func TestWriteCatalogRecord_Persists(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	entity := &metadata.Entity{
+		Name: "Контрагент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "ИНН", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{entity}); err != nil {
+		t.Fatal(err)
+	}
+
+	// записываем через DSL-путь
+	id, err := db.WriteCatalogRecord(ctx, entity, "", map[string]any{
+		"наименование": "ООО Ромашка",
+		"инн":          "7701234567",
+	})
+	if err != nil {
+		t.Fatalf("WriteCatalogRecord: %v", err)
+	}
+	if id == "" {
+		t.Fatal("вернулся пустой id")
+	}
+
+	// проверяем что запись видна (тот же сценарий что у пользователя:
+	// записать и тут же прочитать)
+	var count int
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM контрагент").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("ожидалась 1 запись, получили %d (запись = no-op?)", count)
+	}
+
+	var name, inn string
+	if err := db.QueryRow(ctx, "SELECT наименование, инн FROM контрагент LIMIT 1").Scan(&name, &inn); err != nil {
+		t.Fatal(err)
+	}
+	if name != "ООО Ромашка" || inn != "7701234567" {
+		t.Errorf("неверные данные: name=%q inn=%q", name, inn)
+	}
+}
+
+// Несколько записей подряд — все персистятся (сценарий seed-обработки
+// «создаём 6 контрагентов»).
+func TestWriteCatalogRecord_Multiple(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	entity := &metadata.Entity{
+		Name:   "Контрагент",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{entity}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, n := range []string{"А", "Б", "В", "Г", "Д", "Е"} {
+		if _, err := db.WriteCatalogRecord(ctx, entity, "", map[string]any{"наименование": n}); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+
+	var count int
+	db.QueryRow(ctx, "SELECT COUNT(*) FROM контрагент").Scan(&count)
+	if count != 6 {
+		t.Errorf("ожидалось 6 записей, получили %d", count)
+	}
+}

--- a/internal/storage/predefined.go
+++ b/internal/storage/predefined.go
@@ -244,6 +244,21 @@ func (db *DB) GetPredefinedIDStr(ctx context.Context, entityName, predefinedName
 	return id.String(), nil
 }
 
+// WriteCatalogRecord upserts a catalog/document record from DSL code
+// (замечание #25: Справочники.X.Создать().Записать() из обработки).
+// idStr пустой или невалидный → генерируется новый UUID. Возвращает
+// строковый UUID записанной записи (для построения *Ref в DSL).
+func (db *DB) WriteCatalogRecord(ctx context.Context, entity *metadata.Entity, idStr string, fields map[string]any) (string, error) {
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		id = uuid.New()
+	}
+	if err := db.Upsert(ctx, entity.Name, id, fields, entity); err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}
+
 // FindCatalogByField looks up a single catalog row by exact match of fieldName.
 // Returns (id, displayValue, true) on hit; ("", "", false, nil) when not found.
 // displayValue is the matched field's value — handy for building a *Ref.

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -1,0 +1,191 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+// docsCtxSource предоставляет «живой» контекст (с открытой DSL-транзакцией,
+// если она есть). Реализуется *interpreter.TxState.
+type docsCtxSource interface {
+	Ctx() context.Context
+}
+
+// docsRoot — DSL-глобал Документы / Documents (замечание #26).
+// Документы.X.Создать() → пишущий объект документа с табличными частями
+// и методами Записать()/Провести().
+type docsRoot struct {
+	s      *Server
+	ctxSrc docsCtxSource
+}
+
+func newDocsRoot(s *Server, ctxSrc docsCtxSource) *docsRoot {
+	return &docsRoot{s: s, ctxSrc: ctxSrc}
+}
+
+func (d *docsRoot) Get(name string) any {
+	entity := d.s.reg.GetEntity(name)
+	if entity == nil || entity.Kind != metadata.KindDocument {
+		return nil
+	}
+	return &docProxy{s: d.s, ctxSrc: d.ctxSrc, entity: entity}
+}
+
+func (d *docsRoot) Set(_ string, _ any) {}
+
+// docProxy — Документы.ПоступлениеТоваров.
+type docProxy struct {
+	s      *Server
+	ctxSrc docsCtxSource
+	entity *metadata.Entity
+}
+
+func (p *docProxy) Get(_ string) any  { return nil }
+func (p *docProxy) Set(_ string, _ any) {}
+
+func (p *docProxy) CallMethod(method string, args []any) any {
+	switch strings.ToLower(method) {
+	case "создать", "create":
+		return &docWriter{
+			s:      p.s,
+			ctxSrc: p.ctxSrc,
+			entity: p.entity,
+			obj: &runtime.Object{
+				ID:            uuid.New(),
+				Type:          p.entity.Name,
+				Kind:          p.entity.Kind,
+				Fields:        map[string]any{},
+				TablePartRows: map[string][]map[string]any{},
+			},
+		}
+	}
+	return nil
+}
+
+// docWriter — записываемый/проводимый документ.
+//
+//	Док = Документы.ПоступлениеТоваров.Создать();
+//	Док.Дата = ТекущаяДата();
+//	Стр = Док.Товары.Добавить();
+//	Стр.Номенклатура = Ном; Стр.Количество = 100; Стр.Цена = 500;
+//	Док.Записать();
+//	Док.Провести();
+type docWriter struct {
+	s      *Server
+	ctxSrc docsCtxSource
+	entity *metadata.Entity
+	obj    *runtime.Object
+}
+
+func (w *docWriter) ctx() context.Context {
+	if w.ctxSrc != nil {
+		return w.ctxSrc.Ctx()
+	}
+	return context.Background()
+}
+
+// Get: имя табличной части → tpProxy, иначе значение поля шапки.
+func (w *docWriter) Get(name string) any {
+	for _, tp := range w.entity.TableParts {
+		if strings.EqualFold(tp.Name, name) {
+			return &tpProxy{w: w, tpName: tp.Name}
+		}
+	}
+	return w.obj.Get(name)
+}
+
+func (w *docWriter) Set(name string, v any) {
+	w.obj.Set(name, v)
+}
+
+func (w *docWriter) CallMethod(method string, args []any) any {
+	switch strings.ToLower(method) {
+	case "записать", "write":
+		if err := w.write(); err != nil {
+			interpreter.RaiseUserError("Записать(" + w.entity.Name + "): " + err.Error())
+		}
+		return &interpreter.Ref{UUID: w.obj.ID.String(), Name: w.displayName()}
+	case "провести", "post":
+		if err := w.write(); err != nil {
+			interpreter.RaiseUserError("Провести/Записать(" + w.entity.Name + "): " + err.Error())
+		}
+		if err := w.post(); err != nil {
+			interpreter.RaiseUserError("Провести(" + w.entity.Name + "): " + err.Error())
+		}
+		return &interpreter.Ref{UUID: w.obj.ID.String(), Name: w.displayName()}
+	case "установитьзначение", "setvalue":
+		if len(args) >= 2 {
+			if n, ok := args[0].(string); ok {
+				w.Set(n, args[1])
+			}
+		}
+	}
+	return nil
+}
+
+// write сохраняет шапку + табличные части. Использует живой ctx, поэтому
+// при открытой DSL-транзакции запись участвует в ней; иначе автокоммит.
+func (w *docWriter) write() error {
+	ctx := w.ctx()
+	if err := w.s.store.Upsert(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
+		return err
+	}
+	return w.s.saveTablePartsDirect(ctx, w.entity, w.obj.ID, w.obj.TablePartRows)
+}
+
+// post запускает OnPost, собирает движения и фиксирует проведение —
+// та же логика, что в postDocument (UI-проведение).
+func (w *docWriter) post() error {
+	ctx := w.ctx()
+	mc := runtime.NewMovementsCollector(w.entity.Name, w.obj.ID)
+	setPeriodFromFields(mc, w.entity, w.obj.Fields)
+	if errMsg, _ := w.s.runOnPostCtx(ctx, w.obj, mc); errMsg != "" {
+		return fmt.Errorf("%s", errMsg)
+	}
+	if err := w.s.saveMovements(ctx, w.entity.Name, w.obj.ID, mc); err != nil {
+		return err
+	}
+	return w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true)
+}
+
+func (w *docWriter) displayName() string {
+	for _, k := range []string{"номер", "number"} {
+		if v, ok := w.obj.Fields[k]; ok && v != nil {
+			if s := strings.TrimSpace(fmt.Sprint(v)); s != "" {
+				return s
+			}
+		}
+	}
+	id := w.obj.ID.String()
+	if len(id) >= 8 {
+		return w.entity.Name + ":" + id[:8]
+	}
+	return w.entity.Name
+}
+
+// tpProxy — табличная часть документа (Док.Товары).
+type tpProxy struct {
+	w      *docWriter
+	tpName string
+}
+
+func (t *tpProxy) Get(_ string) any  { return nil }
+func (t *tpProxy) Set(_ string, _ any) {}
+
+func (t *tpProxy) CallMethod(method string, args []any) any {
+	switch strings.ToLower(method) {
+	case "добавить", "add":
+		row := map[string]any{}
+		t.w.obj.TablePartRows[t.tpName] = append(t.w.obj.TablePartRows[t.tpName], row)
+		return &interpreter.MapThis{M: row}
+	case "очистить", "clear":
+		t.w.obj.TablePartRows[t.tpName] = nil
+	}
+	return nil
+}

--- a/internal/ui/dsl_documents_test.go
+++ b/internal/ui/dsl_documents_test.go
@@ -1,0 +1,170 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/dsl/lexer"
+	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Замечание #26: создание/проведение документов из обработки.
+// Полный сценарий: Документы.X.Создать() → заполнить шапку и ТЧ →
+// Записать() → Провести(). Проверяем что документ, его ТЧ и движения
+// регистра реально записались.
+func TestDocsRoot_CreateWritePost(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Документ ПоступлениеТоваров с ТЧ Товары.
+	doc := &metadata.Entity{
+		Name:    "ПоступлениеТоваров",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+		},
+		TableParts: []metadata.TablePart{
+			{Name: "Товары", Fields: []metadata.Field{
+				{Name: "Номенклатура", Type: metadata.FieldTypeString},
+				{Name: "Количество", Type: metadata.FieldTypeNumber},
+			}},
+		},
+	}
+	reg := &metadata.Register{
+		Name:       "ОстаткиТоваров",
+		Dimensions: []metadata.Field{{Name: "Номенклатура", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatal(err)
+	}
+
+	// OnPost: пишем приход в регистр по строкам ТЧ.
+	onPostSrc := `Процедура ОбработкаПроведения()
+  Для Каждого Стр Из ЭтотОбъект.Товары Цикл
+    Дв = Движения.ОстаткиТоваров.Добавить();
+    Дв.ВидДвижения = "Приход";
+    Дв.Номенклатура = Стр.Номенклатура;
+    Дв.Количество = Стр.Количество;
+  КонецЦикла;
+КонецПроцедуры`
+	prog := mustParse(t, onPostSrc)
+
+	registry := runtime.NewRegistry()
+	registry.Load(
+		[]*metadata.Entity{doc},
+		map[string]*ast.Program{"ПоступлениеТоваров": prog},
+		[]*metadata.Register{reg},
+		nil, nil, nil, nil,
+	)
+
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+
+	s := &Server{
+		store:    db,
+		reg:      registry,
+		interp:   interp,
+		lockMgr:  runtime.NewLockManager(),
+		messages: NewMessageStore(),
+	}
+
+	// Сценарий обработки: создать документ, заполнить, записать, провести.
+	root := newDocsRoot(s, interpreter.NewTxState(ctx))
+	proxy := root.Get("ПоступлениеТоваров")
+	if proxy == nil {
+		t.Fatal("Документы.ПоступлениеТоваров → nil")
+	}
+	dp, ok := proxy.(*docProxy)
+	if !ok {
+		t.Fatalf("ожидался *docProxy, получили %T", proxy)
+	}
+
+	rec := dp.CallMethod("создать", nil)
+	w, ok := rec.(*docWriter)
+	if !ok {
+		t.Fatalf("Создать → %T, ожидался *docWriter", rec)
+	}
+	w.Set("Номер", "ПОС-001")
+
+	// Док.Товары.Добавить()
+	tpAny := w.Get("Товары")
+	tp, ok := tpAny.(*tpProxy)
+	if !ok {
+		t.Fatalf("Док.Товары → %T, ожидался *tpProxy", tpAny)
+	}
+	row1 := tp.CallMethod("добавить", nil).(*interpreter.MapThis)
+	row1.Set("Номенклатура", "Тумбочка")
+	row1.Set("Количество", float64(100))
+	row2 := tp.CallMethod("добавить", nil).(*interpreter.MapThis)
+	row2.Set("Номенклатура", "Стул")
+	row2.Set("Количество", float64(50))
+
+	// Записать + Провести
+	if res := w.CallMethod("записать", nil); res == nil {
+		t.Fatal("Записать вернул nil")
+	}
+	if res := w.CallMethod("провести", nil); res == nil {
+		t.Fatal("Провести вернул nil")
+	}
+
+	// Проверки: документ записан
+	var docCount int
+	db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров").Scan(&docCount)
+	if docCount != 1 {
+		t.Errorf("ожидался 1 документ, получили %d", docCount)
+	}
+	// ТЧ записана
+	var tpCount int
+	db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров_товары").Scan(&tpCount)
+	if tpCount != 2 {
+		t.Errorf("ожидалось 2 строки ТЧ, получили %d", tpCount)
+	}
+	// движения регистра записаны
+	var movCount int
+	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&movCount)
+	if movCount != 2 {
+		t.Errorf("ожидалось 2 движения, получили %d", movCount)
+	}
+	// posted = true
+	var posted bool
+	db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted)
+	if !posted {
+		t.Error("документ не помечен проведённым")
+	}
+}
+
+// Документы.X для несуществующего/несдокументного — nil.
+func TestDocsRoot_UnknownDocument(t *testing.T) {
+	s := &Server{reg: runtime.NewRegistry()}
+	root := newDocsRoot(s, interpreter.NewTxState(context.Background()))
+	if v := root.Get("НетТакого"); v != nil {
+		t.Errorf("Документы.НетТакого → %v, ожидался nil", v)
+	}
+}
+
+func mustParse(t *testing.T, src string) *ast.Program {
+	t.Helper()
+	l := lexer.New(src, "<test>")
+	p := parser.New(l)
+	prog, err := p.ParseProgram()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return prog
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1460,7 +1460,12 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 	}
 	queryFactory := interpreter.NewQueryFactory(ctx, s.store, s.reg)
 	predefined := interpreter.NewPredefinedRoot(ctx, s.store)
-	catalogs := interpreter.NewCatalogsRoot(ctx, s.store, s.reg)
+	// #25: TxState несёт «живой» контекст. Транзакционные функции
+	// (НачатьТранзакцию и т.д.) и запись справочников из обработки
+	// (Справочники.X.Создать().Записать()) используют txState.Ctx(),
+	// поэтому запись участвует в открытой DSL-транзакции.
+	txState := interpreter.NewTxState(ctx)
+	catalogs := interpreter.NewCatalogsRoot(txState, s.store, s.reg)
 	// #2 managed locks: builtin БлокировкаДанных() возвращает свежий LockObject,
 	// привязанный к глобальному менеджеру server'а.
 	lockFactory := interpreter.BuiltinFunc(func(_ []any, _ string, _ int) (any, error) {
@@ -1502,6 +1507,12 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 		"CurrentUser":               currentUserFn,
 		"ИмяПользователя":           userNameFn,
 		"UserName":                  userNameFn,
+	}
+	// #25: транзакции из DSL (обработки/проведение). Раньше NewTxFunctions
+	// использовался только в тестах — отсюда «unknown function
+	// НачатьТранзакцию». Теперь подключаем к реальному рантайму.
+	for k, v := range interpreter.NewTxFunctions(txState, s.store) {
+		vars[k] = v
 	}
 	for k, v := range interpreter.NewHTTPFunctions() {
 		vars[k] = v

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1466,6 +1466,8 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 	// поэтому запись участвует в открытой DSL-транзакции.
 	txState := interpreter.NewTxState(ctx)
 	catalogs := interpreter.NewCatalogsRoot(txState, s.store, s.reg)
+	// #26: Документы.X.Создать()/.Записать()/.Провести() из обработки.
+	documents := newDocsRoot(s, txState)
 	// #2 managed locks: builtin БлокировкаДанных() возвращает свежий LockObject,
 	// привязанный к глобальному менеджеру server'а.
 	lockFactory := interpreter.BuiltinFunc(func(_ []any, _ string, _ int) (any, error) {
@@ -1501,6 +1503,8 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 		"PredefinedValues":          predefined,
 		"Справочники":               catalogs,
 		"Catalogs":                  catalogs,
+		"Документы":                 documents,
+		"Documents":                 documents,
 		"БлокировкаДанных":          lockFactory,
 		"DataLock":                  lockFactory,
 		"ТекущийПользователь":       currentUserFn,


### PR DESCRIPTION
Замечания #25 и #26 — запись данных из обработок (*.proc.os).
Тесно связаны, поэтому в одном PR. Поверх свежего main.

## #25 — транзакции + запись справочников

A) НачатьТранзакцию/ЗафиксироватьТранзакцию/ОтменитьТранзакцию падали
   с unknown function — NewTxFunctions подключался только в тестах.
   Теперь инжектится в buildDSLVars через TxState.

B) Справочники.X.Создать()/.Записать() — no-op (не было метода Создать).
   Добавлен CatalogRecordWriter + storage.WriteCatalogRecord:
     Зап = Справочники.Контрагент.Создать();
     Зап.Наименование = "ООО Ромашка";
     Ссыл = Зап.Записать();

## #26 — создание/проведение документов

Документы.X.Создать()/.Записать()/.Провести() — глобала Документы не
было вообще. Добавлен docsRoot/docWriter/tpProxy (internal/ui, т.к.
нужен Server для проведения):
  Док = Документы.ПоступлениеТоваров.Создать();
  Док.Дата = ТекущаяДата(); Док.Поставщик = ...;
  Стр = Док.Товары.Добавить();
  Стр.Номенклатура = Ном; Стр.Количество = 100; Стр.Цена = 500;
  Док.Записать();
  Док.Провести();

- Записать() → Upsert шапки + сохранение ТЧ.
- Провести() → OnPost (runOnPostCtx) + saveMovements + SetPosted,
  ровно как UI-проведение.
- Запись использует живой ctx (TxState), участвует в DSL-транзакции.

## Общее
- CatalogsRoot/docsRoot берут «живой» контекст через ctxSource (TxState),
  поэтому запись из обработки участвует в открытой DSL-транзакции:
    НачатьТранзакцию();
    ... Создать()...Записать()/Провести() ...
    ЗафиксироватьТранзакцию();
- interpreter.RaiseUserError — экспортированный хелпер для DSL-ошибок
  из внешних пакетов.
- *JSON из замечания: оба имени уже есть, менять не пришлось.

## Качество
- 8 новых тестов (interpreter / storage / ui):
  - CatalogProxy create/write, WriteCatalogRecord persist/multiple;
  - DocsRoot CreateWritePost (реальная БД: документ + 2 строки ТЧ +
    2 движения регистра + posted=true), UnknownDocument.
- go test ./... зелёный по всему репо.

Спасибо за review-правки в прошлом PR (LockManager memory leak,
uuid fallback) — учтено через main.