### PR TITLE
fix: момент времени на SQLite (#36) + обогащение ссылок шапки при проведении (#37)

### DIFF
--- a/internal/query/moment_test.go
+++ b/internal/query/moment_test.go
@@ -1,6 +1,8 @@
 ﻿package query_test
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,85 @@ type momentValue struct {
 }
 
 func (m *momentValue) PointInTime() (time.Time, string) { return m.period, m.docID }
+
+// Исполняющий тест: момент-временной запрос реально выполняется на SQLite.
+// Именно этого не хватало раньше — старый тест проверял только len(Args)
+// и подстроки, не выполняя SQL, поэтому рассинхрон плейсхолдеров и
+// аргументов («period < ? OR period = ?» с одним arg) проскочил.
+func TestMomentTime_ExecutesOnSQLite(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	reg := &metadata.Register{
+		Name:       "ОстаткиТоваров",
+		Dimensions: []metadata.Field{{Name: "Номенклатура", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Документ A (раньше) — приход 100. Документ B (позже, наш «текущий») —
+	// приход 50. Момент времени = период B, docID = B → B исключается,
+	// остаток должен быть 100 (только от A).
+	docA := uuid.New()
+	docB := uuid.New()
+	pA := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	pB := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+
+	if err := db.WriteMovements(ctx, "ОстаткиТоваров", "ПоступлениеТоваров", docA,
+		[]map[string]any{{"ВидДвижения": "Приход", "Номенклатура": "Тумбочка", "Количество": float64(100)}},
+		reg, &pA); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.WriteMovements(ctx, "ОстаткиТоваров", "ПоступлениеТоваров", docB,
+		[]map[string]any{{"ВидДвижения": "Приход", "Номенклатура": "Тумбочка", "Количество": float64(50)}},
+		reg, &pB); err != nil {
+		t.Fatal(err)
+	}
+
+	mt := &momentValue{period: pB, docID: docB.String()}
+	r, err := query.Compile(
+		`ВЫБРАТЬ Номенклатура, КоличествоОстаток ИЗ РегистрНакопления.ОстаткиТоваров.Остатки(&МВ)`,
+		query.CompileOpts{
+			Registers: []*metadata.Register{reg},
+			Params:    map[string]any{"МВ": mt},
+			Dialect:   storage.SQLiteDialect{},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Главное: запрос выполняется без «missing argument» и т.п.
+	rows, err := db.Query(ctx, r.SQL, r.Args...)
+	if err != nil {
+		t.Fatalf("query execution failed (баг плейсхолдеров?): %v\nSQL: %s\nArgs: %v", err, r.SQL, r.Args)
+	}
+	defer rows.Close()
+
+	var total float64
+	var found bool
+	for rows.Next() {
+		var name string
+		var qty float64
+		if err := rows.Scan(&name, &qty); err != nil {
+			t.Fatal(err)
+		}
+		found = true
+		total += qty
+	}
+	if !found {
+		t.Fatal("нет строк — момент времени отфильтровал лишнее")
+	}
+	if total != 100 {
+		t.Errorf("остаток на момент B (исключая сам B) = %v, ожидалось 100", total)
+	}
+}
 
 // .Остатки(МоментВремени) должна давать period < @ OR (period = @ AND recorder != @doc).
 func TestCompile_MomentTime_Balances(t *testing.T) {
@@ -49,9 +130,11 @@ func TestCompile_MomentTime_Balances(t *testing.T) {
 	if !strings.Contains(r.SQL, "period <") || !strings.Contains(r.SQL, "recorder !=") {
 		t.Errorf("ожидалось «period < ... AND recorder != ...» в SQL:\n%s", r.SQL)
 	}
-	// Должно быть 2 args: period + docID
-	if len(r.Args) != 2 {
-		t.Errorf("ожидалось 2 args, получили %d: %v", len(r.Args), r.Args)
+	// 3 args: period (для «period <») + period (для «period =») + docID.
+	// period дублируется, т.к. SQLite-плейсхолдеры анонимные ('?') и каждый
+	// '?' требует свой позиционный аргумент.
+	if len(r.Args) != 3 {
+		t.Errorf("ожидалось 3 args, получили %d: %v", len(r.Args), r.Args)
 	}
 }
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1552,6 +1552,13 @@ func (tr *translator) momentTimeCondition(mt momentTimeValue) string {
 		// docID — невалидный UUID, безопасный fallback: только по периоду.
 		return "period <= " + periodPH
 	}
+	// period используется в SQL дважды (period < ... OR period = ...).
+	// SQLite-плейсхолдеры анонимные ('?') — каждый '?' это отдельный
+	// позиционный аргумент, поэтому period нужно добавить ВТОРЫМ аргументом
+	// под второй плейсхолдер, иначе аргументы съезжают («missing argument»).
+	// Для нумерованных диалектов ($n) лишний дубль period безвреден.
+	tr.args = append(tr.args, period)
+	periodPH2 := d.Placeholder(len(tr.args))
 	if d.Name() == "sqlite" {
 		tr.args = append(tr.args, id.String())
 	} else {
@@ -1559,7 +1566,7 @@ func (tr *translator) momentTimeCondition(mt momentTimeValue) string {
 	}
 	docPH := d.Placeholder(len(tr.args))
 	return fmt.Sprintf("(period < %s OR (period = %s AND recorder != %s))",
-		periodPH, periodPH, docPH)
+		periodPH, periodPH2, docPH)
 }
 
 // firstArgMoment возвращает *MomentTime если первый аргумент VT —

--- a/internal/ui/enrich_header_refs_test.go
+++ b/internal/ui/enrich_header_refs_test.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// П.37: ссылочные поля ШАПКИ при проведении должны обогащаться до *Ref,
+// чтобы Строка(this.Склад) давало имя, а не UUID (симметрично строкам ТЧ).
+func TestEnrichHeaderRefs_UUIDToRef(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	sklad := &metadata.Entity{
+		Name:   "Склад",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	doc := &metadata.Entity{
+		Name: "ПоступлениеТоваров",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Склад", Type: "reference:Склад", RefEntity: "Склад"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{sklad, doc}); err != nil {
+		t.Fatal(err)
+	}
+
+	// записываем склад
+	skladID := uuid.New()
+	if err := db.Upsert(ctx, "Склад", skladID, map[string]any{"Наименование": "Основной"}, sklad); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := runtime.NewRegistry()
+	registry.Load([]*metadata.Entity{sklad, doc}, nil, nil, nil, nil, nil, nil)
+	s := &Server{store: db, reg: registry}
+
+	// шапка документа: Склад приходит сырым UUID-строкой (как из формы)
+	obj := &runtime.Object{
+		ID:     uuid.New(),
+		Type:   "ПоступлениеТоваров",
+		Kind:   metadata.KindDocument,
+		Fields: map[string]any{"номер": "ПОС-1", "склад": skladID.String()},
+	}
+
+	s.enrichHeaderRefs(ctx, doc, obj)
+
+	v := obj.Get("Склад")
+	ref, ok := v.(*interpreter.Ref)
+	if !ok {
+		t.Fatalf("Склад → %T, ожидался *interpreter.Ref", v)
+	}
+	if ref.UUID != skladID.String() {
+		t.Errorf("UUID не сохранился: %s", ref.UUID)
+	}
+	if ref.Name != "Основной" {
+		t.Errorf("Name = %q, ожидалось «Основной» (Строка() дал бы имя)", ref.Name)
+	}
+	// не-ссылочное поле не трогаем
+	if obj.Get("Номер") != "ПОС-1" {
+		t.Errorf("номер изменился: %v", obj.Get("Номер"))
+	}
+}
+
+// Поле, уже являющееся *Ref (проведение из обработки), не должно
+// перезаписываться — двойной обработки нет.
+func TestEnrichHeaderRefs_SkipsExistingRef(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	sklad := &metadata.Entity{
+		Name:   "Склад",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	doc := &metadata.Entity{
+		Name: "ПоступлениеТоваров",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Склад", Type: "reference:Склад", RefEntity: "Склад"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{sklad, doc}); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load([]*metadata.Entity{sklad, doc}, nil, nil, nil, nil, nil, nil)
+	s := &Server{store: db, reg: registry}
+
+	orig := &interpreter.Ref{UUID: uuid.New().String(), Name: "ИзОбработки", Type: "Склад"}
+	obj := &runtime.Object{
+		ID:     uuid.New(),
+		Type:   "ПоступлениеТоваров",
+		Kind:   metadata.KindDocument,
+		Fields: map[string]any{"склад": orig},
+	}
+	s.enrichHeaderRefs(ctx, doc, obj)
+
+	v := obj.Get("Склад")
+	ref, ok := v.(*interpreter.Ref)
+	if !ok {
+		t.Fatalf("Склад → %T, ожидался *interpreter.Ref", v)
+	}
+	if ref != orig {
+		t.Error("существующий *Ref был перезаписан — должен пропускаться")
+	}
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1618,6 +1618,13 @@ func (s *Server) runOnPostCtx(ctx context.Context, obj *runtime.Object, mc *runt
 	if proc == nil {
 		return "", nil
 	}
+	// Симметрично табличным частям: ссылки в полях шапки из формы приходят
+	// сырыми UUID — обогащаем до *Ref{UUID,Name}, чтобы string-измерения
+	// (Склад, Касса, Контрагент) фильтровались по имени, как при проведении
+	// из обработки. См. П.37.
+	if entity := s.reg.GetEntity(obj.Type); entity != nil {
+		s.enrichHeaderRefs(ctx, entity, obj)
+	}
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)
 	if err := s.interp.Run(proc, obj, vars); err != nil {
@@ -2109,6 +2116,47 @@ func (s *Server) enrichTPRowsWithRefs(ctx context.Context, tp metadata.TablePart
 				}
 			}
 		}
+	}
+}
+
+// enrichHeaderRefs заменяет UUID-строки в ссылочных полях ШАПКИ объекта на
+// *interpreter.Ref{UUID, Name} — симметрично enrichTPRowsWithRefs для строк
+// табличных частей. Без этого ссылки шапки (например Склад) приходят в
+// ОбработкаПроведения сырым UUID, и Строка(this.Склад) даёт UUID; фильтр по
+// string-измерению (ГДЕ Склад = Строка(this.Склад)) не совпадает с движениями,
+// записанными по имени из обработок/сидов. После обогащения шапка ведёт себя
+// как при создании из обработки. Ref-параметры и reference-измерения остаются
+// корректными: unwrapArrayParams приводит *Ref к UUID. См. П.37.
+func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, obj *runtime.Object) {
+	for _, f := range entity.Fields {
+		if f.RefEntity == "" {
+			continue
+		}
+		refEntity := s.reg.GetEntity(f.RefEntity)
+		if refEntity == nil {
+			continue
+		}
+		v := obj.Get(f.Name)
+		if v == nil {
+			continue
+		}
+		if _, isRef := v.(*interpreter.Ref); isRef {
+			continue
+		}
+		idStr := fmt.Sprintf("%v", v)
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			continue
+		}
+		refRow, err := s.store.GetByID(ctx, refEntity.Name, id, refEntity)
+		if err != nil {
+			continue
+		}
+		obj.Set(f.Name, &interpreter.Ref{
+			UUID: idStr,
+			Name: firstStringField(refRow, refEntity),
+			Type: refEntity.Name,
+		})
 	}
 }
 


### PR DESCRIPTION
Два связанных фикса проведения, всплывших при первом реальном
проведении с моментом времени. Поверх свежего main.

## #36 — момент времени ломал SQL под SQLite
momentTimeCondition генерил три плейсхолдера
  (period < ? OR (period = ? AND recorder != ?))
но period добавлялся в args один раз → 2 аргумента на 3 анонимных
'?'. SQLite сопоставляет '?' позиционно → «missing argument with
index N», сдвиг аргументов. На $n-диалектах баг был скрыт ($1
переиспользовался).

Фикс: period добавляется вторым аргументом под отдельный
плейсхолдер. Старый тест проверял только len(Args)==2 и подстроки,
НЕ выполняя SQL — поэтому проскочило.

- internal/query/query.go — фикс momentTimeCondition.
- internal/query/moment_test.go — проверка 2 → 3 аргумента +
  TestMomentTime_ExecutesOnSQLite (РЕАЛЬНО выполняет момент-запрос
  на SQLite: приход 100 от A + 50 от B; момент = период B, docID = B
  → B исключается → остаток 100).

## #37 — ссылки полей ШАПКИ не обогащались при проведении
ФИФО падал «Недостаточно остатков, доступно 0»: Строка(this.Склад)
давало UUID, а движения партий записаны по имени (Склад —
string-измерение, workaround П.17).

Причина: enrichTPRowsWithRefs обогащал UUID→*Ref только для строк
ТАБЛИЧНЫХ ЧАСТЕЙ; поля ШАПКИ оставались сырым UUID из формы.
Рассинхрон: Строка.Номенклатура (ТЧ) = имя, this.Склад (шапка) =
UUID. Затрагивало также Касса, Контрагент.

Фикс: enrichHeaderRefs (симметрично enrichTPRowsWithRefs)
вызывается в runOnPostCtx — единой точке для всех путей проведения
(UI и docWriter обработок). Поля шапки → *Ref{UUID,Name,Type};
уже-*Ref пропускаются (без двойной обработки). Reference-измерения
остаются по UUID. Миграция данных не нужна.

- internal/ui/handlers.go — enrichHeaderRefs + вызов в runOnPostCtx.
- internal/ui/enrich_header_refs_test.go — UUIDToRef, SkipsExistingRef.

## Качество
go test ./... зелёный по всему репо (18 пакетов).