### PR TITLE
feat(tools): dbquery — диагностика SQLite-баз + фикс строковой даты в МоментВремени

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 onebase-gui.exe
 onebase-linux-arm64
 onebase-arm64
+dbquery.exe
 
 # Temp files
 __*.py

--- a/build_dbquery.bat
+++ b/build_dbquery.bat
@@ -1,0 +1,17 @@
+@echo off
+chcp 65001 >nul 2>&1
+setlocal
+cd /d "%~dp0"
+
+echo === dbquery build ===
+echo.
+set "CGO_ENABLED=0"
+go build -ldflags="-s -w" -o dbquery.exe ./tools/dbquery
+if %errorlevel% neq 0 (
+    echo ERROR
+    pause
+    exit /b 1
+)
+echo     OK  =^>  dbquery.exe
+echo.
+pause

--- a/internal/runtime/object.go
+++ b/internal/runtime/object.go
@@ -91,11 +91,33 @@ func (o *Object) CallMethod(method string, args []any) any {
 		var p time.Time
 		// первое непустое date-поле
 		for _, k := range []string{"дата", "date", "период", "period"} {
-			if v, ok := o.Fields[k]; ok && v != nil {
-				if t, ok := v.(time.Time); ok && !t.IsZero() {
-					p = t
-					break
+			v, ok := o.Fields[k]
+			if !ok || v == nil {
+				continue
+			}
+			switch tv := v.(type) {
+			case time.Time:
+				if !tv.IsZero() {
+					p = tv
 				}
+			case string:
+				// При загрузке документа из БД/формы дата приходит строкой.
+				// Без разбора Period остался бы нулевым и moment-фильтр
+				// (period < @) отсёк бы все движения → ФИФО «доступно 0».
+				// Layout'ы те же, что в setPeriodFromFields, плюс формат
+				// SQLite datetime с пробелом.
+				for _, layout := range []string{
+					time.RFC3339, "2006-01-02T15:04:05", "2006-01-02T15:04",
+					"2006-01-02 15:04:05", "2006-01-02",
+				} {
+					if t, err := time.ParseInLocation(layout, tv, time.Local); err == nil {
+						p = t
+						break
+					}
+				}
+			}
+			if !p.IsZero() {
+				break
 			}
 		}
 		return &MomentTime{Period: p, DocID: o.ID, DocType: o.Type}

--- a/internal/runtime/object_test.go
+++ b/internal/runtime/object_test.go
@@ -101,6 +101,30 @@ func TestObject_MomentTime(t *testing.T) {
 	}
 }
 
+// При загрузке документа из БД/формы дата приходит СТРОКОЙ. МоментВремени
+// должен её распарсить, иначе Period нулевой и moment-фильтр (period < @)
+// отсекает все движения → ФИФО «доступно 0».
+func TestObject_MomentTime_StringDate(t *testing.T) {
+	cases := []string{
+		"2026-05-20T12:00:00Z",   // RFC3339
+		"2026-05-20T12:00:00",    // без зоны
+		"2026-05-20 12:00:00",    // SQLite datetime (пробел)
+		"2026-05-20",             // только дата
+	}
+	for _, ds := range cases {
+		o := &Object{
+			Type:   "Поступление",
+			Kind:   metadata.KindDocument,
+			ID:     uuid.New(),
+			Fields: map[string]any{"дата": ds},
+		}
+		mt := o.CallMethod("моментвремени", nil).(*MomentTime)
+		if mt.Period.IsZero() {
+			t.Errorf("дата %q не распарсилась — Period нулевой (ФИФО упал бы)", ds)
+		}
+	}
+}
+
 func TestMomentTime_PointInTime(t *testing.T) {
 	docDate := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
 	docID := uuid.New()

--- a/tools/dbquery/README.md
+++ b/tools/dbquery/README.md
@@ -1,0 +1,89 @@
+# dbquery — диагностический инструмент для баз OneBase
+
+Консольная утилита для прямых SQL-запросов к SQLite-базам OneBase.
+Не требует установки — один `.exe`, никаких зависимостей.
+
+## Сборка
+
+```bat
+cd C:\Project\onebase-1
+build_dbquery.bat
+```
+
+Появится `dbquery.exe` рядом с `onebase.exe`.
+
+## Синтаксис
+
+```bat
+dbquery -db <путь_к_базе> [опции]
+```
+
+### Опции
+
+| Опция        | Описание                                  |
+|--------------|-------------------------------------------|
+| `-sql "..."` | выполнить один SQL-запрос                 |
+| `-f format`  | формат вывода: `table` (по умолч.), `csv`, `json` |
+| `--tables`   | список таблиц                             |
+| `--schema`   | полная схема (DDL)                        |
+
+### Примеры
+
+Список таблиц:
+```bat
+dbquery -db C:\Project\OneBase\basees\TradeDemo\Tradedemo.db --tables
+```
+
+Проверить period в регистре партий:
+```bat
+dbquery -db Tradedemo.db -sql "SELECT DISTINCT period FROM рег_партиитоваров"
+```
+
+Остатки по складам:
+```bat
+dbquery -db Tradedemo.db -sql "SELECT склад, SUM(количество) FROM рег_остаткитоваров GROUP BY склад"
+```
+
+SQL из файла (stdin):
+```bat
+dbquery -db Tradedemo.db -f csv < query.sql
+```
+
+Интерактивный REPL:
+```bat
+dbquery -db Tradedemo.db
+sql> \tables
+sql> \schema
+sql> \format csv
+sql> SELECT * FROM рег_партиитоваров LIMIT 5
+sql> \q
+```
+
+## Для агентов (Claude Code)
+
+```bash
+# Из bash-сессии:
+./dbquery.exe -db "C:/Project/OneBase/basees/TradeDemo/Tradedemo.db" --tables
+
+./dbquery.exe -db "C:/Project/OneBase/basees/TradeDemo/Tradedemo.db" \
+  -sql "SELECT DISTINCT period FROM рег_партиитоваров"
+```
+
+## Имена таблиц
+
+OneBase именует таблицы так (всё в нижнем регистре):
+
+| Тип                       | Правило            | Пример                       |
+|---------------------------|--------------------|------------------------------|
+| Справочник                | `<имя>`            | `номенклатура`, `склад`      |
+| Документ (шапка)          | `<имя>`            | `поступлениетоваров`         |
+| Табличная часть документа | `<документ>_<тч>`  | `поступлениетоваров_товары`  |
+| Регистр накопления        | `рег_<имя>`        | `рег_партиитоваров`          |
+| Регистр сведений          | `инфо_<имя>`       | `инфо_ценыноменклатуры`      |
+| Регистр бухгалтерии       | `акк_<имя>`        | `акк_хозрасчётный`           |
+
+Префиксов `спр_` / `док_` НЕТ — справочники и документы лежат под своим
+именем напрямую. Точный список всегда можно посмотреть через `--tables`.
+
+Системные колонки регистров накопления: `period`, `recorder`,
+`recorder_type`, `вид_движения`, `line_number`.

--- a/tools/dbquery/main.go
+++ b/tools/dbquery/main.go
@@ -1,0 +1,353 @@
+// dbquery — diagnostic tool for OneBase SQLite databases.
+//
+// Usage:
+//
+//	dbquery -db <path> -sql "SELECT ..."
+//	dbquery -db <path> < query.sql
+//	dbquery -db <path>          # interactive REPL
+//	dbquery -db <path> --tables # list tables
+//	dbquery -db <path> --schema # show full schema
+//
+// Output formats: table (default), csv, json.
+package main
+
+import (
+	"database/sql"
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	dbPath := flag.String("db", "", "path to .db file")
+	sqlStmt := flag.String("sql", "", "SQL query to execute")
+	format := flag.String("f", "table", "output format: table, csv, json")
+	listTables := flag.Bool("tables", false, "list all tables")
+	showSchema := flag.Bool("schema", false, "show full schema")
+	flag.Parse()
+
+	if *dbPath == "" {
+		fmt.Fprintln(os.Stderr, "Usage: dbquery -db <path> [-sql <query>] [-f table|csv|json] [--tables] [--schema]")
+		os.Exit(1)
+	}
+
+	db, err := sql.Open("sqlite", *dbPath)
+	if err != nil {
+		fatal("open db: %v", err)
+	}
+	defer db.Close()
+
+	if *listTables {
+		printTables(db, *format)
+		return
+	}
+	if *showSchema {
+		printSchema(db)
+		return
+	}
+
+	query := strings.TrimSpace(*sqlStmt)
+	if query == "" {
+		// read from stdin if piped, else enter REPL
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				fatal("read stdin: %v", err)
+			}
+			query = strings.TrimSpace(string(data))
+		}
+	}
+
+	if query != "" {
+		execAndPrint(db, query, *format)
+		return
+	}
+
+	// interactive REPL
+	repl(db, *format)
+}
+
+func printTables(db *sql.DB, format string) {
+	rows, err := db.Query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+	if err != nil {
+		fatal("query tables: %v", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var n string
+		rows.Scan(&n)
+		names = append(names, n)
+	}
+
+	switch format {
+	case "csv":
+		w := csv.NewWriter(os.Stdout)
+		w.Write([]string{"table"})
+		for _, n := range names {
+			w.Write([]string{n})
+		}
+		w.Flush()
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		enc.Encode(names)
+	default:
+		for _, n := range names {
+			fmt.Println(n)
+		}
+	}
+}
+
+func printSchema(db *sql.DB) {
+	rows, err := db.Query("SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name")
+	if err != nil {
+		fatal("query schema: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var s string
+		rows.Scan(&s)
+		fmt.Println(s)
+		fmt.Println()
+	}
+}
+
+func execAndPrint(db *sql.DB, query, format string) {
+	// split by ; for multiple statements
+	stmts := splitStmts(query)
+	if len(stmts) == 0 {
+		return
+	}
+	// only last statement produces output
+	for i, s := range stmts {
+		if i < len(stmts)-1 {
+			_, err := db.Exec(s)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "stmt %d: %v\n", i+1, err)
+			}
+			continue
+		}
+		printQuery(db, s, format)
+	}
+}
+
+func printQuery(db *sql.DB, query, format string) {
+	rows, err := db.Query(query)
+	if err != nil {
+		fatal("query: %v", err)
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		fatal("columns: %v", err)
+	}
+
+	var allRows [][]any
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			fatal("scan: %v", err)
+		}
+		allRows = append(allRows, vals)
+	}
+
+	switch format {
+	case "csv":
+		printCSV(cols, allRows)
+	case "json":
+		printJSON(cols, allRows)
+	default:
+		printTable(cols, allRows)
+	}
+}
+
+func printTable(cols []string, rows [][]any) {
+	strRows := make([][]string, len(rows)+1)
+	strRows[0] = cols
+
+	widths := make([]int, len(cols))
+	for i, c := range cols {
+		widths[i] = len(c)
+	}
+
+	for ri, row := range rows {
+		sr := make([]string, len(cols))
+		for ci, v := range row {
+			s := formatVal(v)
+			sr[ci] = s
+			if len(s) > widths[ci] {
+				widths[ci] = len(s)
+			}
+		}
+		strRows[ri+1] = sr
+	}
+
+	// header
+	for i, c := range cols {
+		if i > 0 {
+			fmt.Print(" | ")
+		}
+		fmt.Printf("%-*s", widths[i], c)
+	}
+	fmt.Println()
+
+	// separator
+	for i, w := range widths {
+		if i > 0 {
+			fmt.Print("-+-")
+		}
+		fmt.Print(strings.Repeat("-", w))
+	}
+	fmt.Println()
+
+	// data
+	for _, sr := range strRows[1:] {
+		for i, s := range sr {
+			if i > 0 {
+				fmt.Print(" | ")
+			}
+			fmt.Printf("%-*s", widths[i], s)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("(%d rows)\n", len(rows))
+}
+
+func printCSV(cols []string, rows [][]any) {
+	w := csv.NewWriter(os.Stdout)
+	w.Write(cols)
+	for _, row := range rows {
+		sr := make([]string, len(cols))
+		for i, v := range row {
+			sr[i] = formatVal(v)
+		}
+		w.Write(sr)
+	}
+	w.Flush()
+}
+
+func printJSON(cols []string, rows [][]any) {
+	result := make([]map[string]any, len(rows))
+	for ri, row := range rows {
+		m := make(map[string]any, len(cols))
+		for ci, col := range cols {
+			m[col] = jsonVal(row[ci])
+		}
+		result[ri] = m
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(result)
+}
+
+func formatVal(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "NULL"
+	case time.Time:
+		return t.Format("2006-01-02 15:04:05")
+	case []byte:
+		return string(t)
+	case float64:
+		if t == float64(int64(t)) {
+			return fmt.Sprintf("%d", int64(t))
+		}
+		return fmt.Sprintf("%g", t)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func jsonVal(v any) any {
+	switch t := v.(type) {
+	case []byte:
+		return string(t)
+	default:
+		return t
+	}
+}
+
+func repl(db *sql.DB, format string) {
+	fmt.Println("dbquery — type SQL or \\q to quit, \\tables, \\schema, \\format table|csv|json")
+	fmt.Println()
+
+	for {
+		fmt.Print("sql> ")
+		var line string
+		if _, err := fmt.Scanln(&line); err != nil {
+			break
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if line == "\\q" || line == "quit" || line == "exit" {
+			break
+		}
+		if line == "\\tables" {
+			printTables(db, format)
+			continue
+		}
+		if line == "\\schema" {
+			printSchema(db)
+			continue
+		}
+		if strings.HasPrefix(line, "\\format") {
+			f := strings.TrimSpace(strings.TrimPrefix(line, "\\format"))
+			if f == "table" || f == "csv" || f == "json" {
+				format = f
+				fmt.Println("format:", format)
+			} else {
+				fmt.Println("formats: table, csv, json")
+			}
+			continue
+		}
+		execAndPrint(db, line, format)
+	}
+}
+
+func splitStmts(s string) []string {
+	var stmts []string
+	var cur strings.Builder
+	inStr := false
+	for _, ch := range s {
+		if ch == '\'' {
+			inStr = !inStr
+		}
+		if ch == ';' && !inStr {
+			t := strings.TrimSpace(cur.String())
+			if t != "" {
+				stmts = append(stmts, t)
+			}
+			cur.Reset()
+			continue
+		}
+		cur.WriteRune(ch)
+	}
+	t := strings.TrimSpace(cur.String())
+	if t != "" {
+		stmts = append(stmts, t)
+	}
+	return stmts
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "ERROR: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## tools/dbquery — диагностический инструмент
Консольная утилита для прямых SQL-запросов к SQLite-базам OneBase.
Один .exe без зависимостей. Пригодилась при отладке проведения —
смотреть остатки, движения, period в регистрах напрямую.

- `tools/dbquery/main.go` — `-db`, `-sql`, `-f table|csv|json`,
  `--tables`, `--schema`, чтение из stdin, интерактивный REPL.
- `tools/dbquery/README.md` — синтаксис, примеры и РЕАЛЬНЫЕ правила
  именования таблиц (проверены на живой базе через `--tables`):
  справочники/документы лежат под своим именем БЕЗ префиксов
  `спр_`/`док_`; ТЧ как `<документ>_<тч>`; регистры — `рег_`/`инфо_`/`акк_`.
- `build_dbquery.bat` — сборка; `.gitignore` — `dbquery.exe` не коммитим.

## fix: МоментВремени разбирает строковую дату
Сопутствующий фикс, найденный этим же инструментом. При загрузке
документа из БД/формы поле даты приходит СТРОКОЙ, не time.Time.
`МоментВремени()` парсил только time.Time → Period оставался нулевым →
moment-фильтр (period < @) отсекал все движения → ФИФО
«Недостаточно остатков, доступно 0».

Фикс (internal/runtime/object.go): разбор строки по тем же layout'ам,
что в setPeriodFromFields, плюс SQLite datetime с пробелом.
Тест TestObject_MomentTime_StringDate (4 формата).

go test ./... зелёный (19 пакетов).