### PR TITLE
fix(ui/storage): резолв ссылок в регистрах + обогащение шапки ПриЗаписи + время аудита на SQLite

### DIFF
--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -291,13 +291,19 @@ func scanAuditRows(rows auditRowsScanner) ([]*AuditEntry, error) {
 		var userID, recordID *uuid.UUID
 		var auditID uuid.UUID
 		var oldVal, newVal []byte
+		// at сканируем в any: PostgreSQL (TIMESTAMPTZ) отдаёт time.Time,
+		// SQLite хранит timestamp как TEXT (ISO 8601) и драйвер не
+		// конвертирует строку → time.Time автоматически. Раньше прямое
+		// сканирование в time.Time падало/давало нулевое время на SQLite.
+		var at any
 		if err := rows.Scan(
 			&auditID, &userID, &e.UserLogin, &e.Action,
 			&e.EntityKind, &e.EntityName, &recordID,
-			&e.Field, &oldVal, &newVal, &e.IP, &e.At,
+			&e.Field, &oldVal, &newVal, &e.IP, &at,
 		); err != nil {
 			return nil, err
 		}
+		e.At = parseAuditTime(at)
 		e.ID = auditID.String()
 		if userID != nil {
 			e.UserID = userID.String()
@@ -314,6 +320,40 @@ func scanAuditRows(rows auditRowsScanner) ([]*AuditEntry, error) {
 		entries = append(entries, e)
 	}
 	return entries, rows.Err()
+}
+
+// parseAuditTime нормализует значение колонки at к time.Time независимо
+// от диалекта: PostgreSQL отдаёт time.Time, SQLite — строку (или []byte)
+// в формате ISO 8601 / "2006-01-02 15:04:05" (как datetime('now')).
+func parseAuditTime(v any) time.Time {
+	switch t := v.(type) {
+	case time.Time:
+		return t
+	case string:
+		return parseTimeStr(t)
+	case []byte:
+		return parseTimeStr(string(t))
+	}
+	return time.Time{}
+}
+
+func parseTimeStr(s string) time.Time {
+	for _, layout := range []string{
+		time.RFC3339Nano, time.RFC3339,
+		// pg text-формат timestamptz: смещение как ±NN (часто) или ±NN:NN
+		"2006-01-02 15:04:05.999999999-07",
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05-07",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05", // SQLite datetime('now')
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 // execAudit runs a statement on the pool directly (audit inserts bypass tx).

--- a/internal/storage/audit_time_test.go
+++ b/internal/storage/audit_time_test.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+// parseAuditTime должен нормализовать значение колонки at независимо от
+// диалекта: PostgreSQL отдаёт time.Time, SQLite — строку/[]byte.
+func TestParseAuditTime_TimeTime(t *testing.T) {
+	want := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	if got := parseAuditTime(want); !got.Equal(want) {
+		t.Errorf("time.Time: got %v, want %v", got, want)
+	}
+}
+
+func TestParseAuditTime_SQLiteString(t *testing.T) {
+	// формат datetime('now') в SQLite
+	got := parseAuditTime("2026-05-21 12:30:45")
+	if got.IsZero() {
+		t.Fatal("SQLite-строка не распарсилась")
+	}
+	if got.Year() != 2026 || got.Month() != 5 || got.Day() != 21 ||
+		got.Hour() != 12 || got.Minute() != 30 || got.Second() != 45 {
+		t.Errorf("неверный разбор: %v", got)
+	}
+}
+
+func TestParseAuditTime_RFC3339(t *testing.T) {
+	got := parseAuditTime("2026-05-21T12:30:45Z")
+	if got.IsZero() {
+		t.Fatal("RFC3339 не распарсился")
+	}
+}
+
+func TestParseAuditTime_Bytes(t *testing.T) {
+	// SQLite-драйвер может вернуть TEXT как []byte
+	got := parseAuditTime([]byte("2026-05-21 12:30:45"))
+	if got.IsZero() {
+		t.Fatal("[]byte-строка не распарсилась")
+	}
+}
+
+func TestParseAuditTime_PGTextTZ(t *testing.T) {
+	// текстовый формат timestamptz из pgx
+	got := parseAuditTime("2026-05-21 12:30:45+00")
+	if got.IsZero() {
+		t.Fatal("pg text timestamptz не распарсился")
+	}
+}
+
+func TestParseAuditTime_Garbage(t *testing.T) {
+	if got := parseAuditTime("не дата"); !got.IsZero() {
+		t.Errorf("мусор → должно быть нулевое время, got %v", got)
+	}
+	if got := parseAuditTime(nil); !got.IsZero() {
+		t.Errorf("nil → нулевое время, got %v", got)
+	}
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -1603,6 +1603,12 @@ func (s *Server) runOnWriteCtx(ctx context.Context, obj *runtime.Object, mc *run
 	if proc == nil {
 		return "", nil
 	}
+	// Симметрично runOnPostCtx: ссылки в полях шапки из формы приходят
+	// сырыми UUID — обогащаем до *Ref{UUID,Name}, чтобы ЗначениеРеквизитаОбъекта
+	// и Строка(ref) работали в ПриЗаписи так же, как при проведении.
+	if entity := s.reg.GetEntity(obj.Type); entity != nil {
+		s.enrichHeaderRefs(ctx, entity, obj)
+	}
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)
 	if err := s.interp.Run(proc, obj, vars); err != nil {
@@ -1827,37 +1833,72 @@ func (s *Server) resolveRegisterRows(ctx context.Context, rows []map[string]any,
 	// Резолвим UUID и в измерениях, и в атрибутах: reference-атрибут
 	// (например Организация) тоже хранит UUID и должен показываться именем.
 	refFields := append(append([]metadata.Field{}, reg.Dimensions...), reg.Attributes...)
-	// collect all UUID-looking strings in dimension/attribute fields
-	uuidToLabel := make(map[string]string)
+
+	// Build lookup: RefEntity → set of UUIDs to resolve
+	entityUUIDs := make(map[string]map[string]string) // entityName → {uuid: label}
 	for _, row := range rows {
 		for _, f := range refFields {
-			if v, ok := row[f.Name].(string); ok {
-				if _, err := uuid.Parse(v); err == nil {
-					uuidToLabel[v] = "" // mark for lookup
+			if f.RefEntity == "" {
+				// Для не-reference полей тоже проверим — вдруг там UUID
+				// (legacy string-измерения, хранящие UUID).
+				v := asString(row[f.Name])
+				if v != "" {
+					if _, err := uuid.Parse(v); err == nil {
+						if entityUUIDs[""] == nil {
+							entityUUIDs[""] = make(map[string]string)
+						}
+						entityUUIDs[""][v] = ""
+					}
 				}
+				continue
 			}
+			v := asString(row[f.Name])
+			if v == "" {
+				continue
+			}
+			if _, err := uuid.Parse(v); err != nil {
+				continue
+			}
+			entName := f.RefEntity
+			if entityUUIDs[entName] == nil {
+				entityUUIDs[entName] = make(map[string]string)
+			}
+			entityUUIDs[entName][v] = ""
 		}
 	}
-	// resolve UUIDs by scanning all entities
-	if len(uuidToLabel) > 0 {
-		for _, entity := range s.reg.Entities() {
-			for idStr, label := range uuidToLabel {
-				if label != "" {
-					continue // already resolved
-				}
-				id, _ := uuid.Parse(idStr)
+
+	// Resolve UUIDs: for known RefEntity — targeted lookup; for unknown — scan all.
+	uuidToLabel := make(map[string]string)
+	for entName, uuids := range entityUUIDs {
+		var entities []*metadata.Entity
+		if entName != "" {
+			if e := s.reg.GetEntity(entName); e != nil {
+				entities = []*metadata.Entity{e}
+			}
+		}
+		if len(entities) == 0 {
+			entities = s.reg.Entities()
+		}
+		for idStr := range uuids {
+			if _, done := uuidToLabel[idStr]; done {
+				continue
+			}
+			id, _ := uuid.Parse(idStr)
+			for _, entity := range entities {
 				refRow, err := s.store.GetByID(ctx, entity.Name, id, entity)
 				if err == nil {
 					uuidToLabel[idStr] = firstStringField(refRow, entity)
+					break
 				}
 			}
 		}
 	}
+
 	// enrich each row
 	for _, row := range rows {
 		// recorder label
 		recType, _ := row["recorder_type"].(string)
-		recIDStr, _ := row["recorder"].(string)
+		recIDStr := asString(row["recorder"])
 		if recType != "" && recIDStr != "" {
 			if recID, err := uuid.Parse(recIDStr); err == nil {
 				if entity := s.reg.GetEntityBySlug(recType); entity != nil {
@@ -1871,13 +1912,27 @@ func (s *Server) resolveRegisterRows(ctx context.Context, rows []map[string]any,
 		}
 		// dimension/attribute UUID → name
 		for _, f := range refFields {
-			if v, ok := row[f.Name].(string); ok {
-				if label, found := uuidToLabel[v]; found && label != "" {
-					row[f.Name] = label
-				}
+			v := asString(row[f.Name])
+			if v == "" {
+				continue
+			}
+			if label, found := uuidToLabel[v]; found && label != "" {
+				row[f.Name] = label
 			}
 		}
 	}
+}
+
+// asString returns a string from row values that may be string or []byte
+// (SQLite drivers differ in what they return for TEXT columns).
+func asString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	}
+	return ""
 }
 
 func regFmtDate(v any) string {

--- a/internal/ui/resolve_register_rows_test.go
+++ b/internal/ui/resolve_register_rows_test.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func TestAsString(t *testing.T) {
+	if asString("привет") != "привет" {
+		t.Error("string не прошёл")
+	}
+	if asString([]byte("байты")) != "байты" {
+		t.Error("[]byte не сконвертировался")
+	}
+	if asString(nil) != "" {
+		t.Error("nil → не пустая строка")
+	}
+	if asString(42) != "" {
+		t.Error("число → должна быть пустая строка")
+	}
+}
+
+// resolveRegisterRows: UUID в измерении (reference) и атрибуте → имя,
+// причём целевым поиском по RefEntity, и поддержка []byte от SQLite-драйвера.
+func TestResolveRegisterRows_RefAndBytes(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	nom := &metadata.Entity{
+		Name:   "Номенклатура",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	org := &metadata.Entity{
+		Name:   "Организация",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{nom, org}); err != nil {
+		t.Fatal(err)
+	}
+	nomID := uuid.New()
+	orgID := uuid.New()
+	if err := db.Upsert(ctx, "Номенклатура", nomID, map[string]any{"Наименование": "Тумбочка"}, nom); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Upsert(ctx, "Организация", orgID, map[string]any{"Наименование": "ООО Ромашка"}, org); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := runtime.NewRegistry()
+	registry.Load([]*metadata.Entity{nom, org}, nil, nil, nil, nil, nil, nil)
+	s := &Server{store: db, reg: registry}
+
+	reg := &metadata.Register{
+		Name: "ОстаткиТоваров",
+		Dimensions: []metadata.Field{
+			{Name: "Номенклатура", Type: "reference:Номенклатура", RefEntity: "Номенклатура"},
+		},
+		Attributes: []metadata.Field{
+			{Name: "Организация", Type: "reference:Организация", RefEntity: "Организация"},
+		},
+	}
+
+	rows := []map[string]any{
+		// измерение — строка-UUID, атрибут — []byte-UUID (как может вернуть SQLite)
+		{"Номенклатура": nomID.String(), "Организация": []byte(orgID.String())},
+	}
+	s.resolveRegisterRows(ctx, rows, reg)
+
+	if rows[0]["Номенклатура"] != "Тумбочка" {
+		t.Errorf("измерение не резолвнулось: %v", rows[0]["Номенклатура"])
+	}
+	if rows[0]["Организация"] != "ООО Ромашка" {
+		t.Errorf("атрибут ([]byte UUID) не резолвнулся: %v", rows[0]["Организация"])
+	}
+}
+
+// Legacy string-измерение, хранящее UUID без RefEntity, тоже резолвится
+// (через скан всех сущностей как fallback).
+func TestResolveRegisterRows_LegacyStringUUID(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	skl := &metadata.Entity{
+		Name:   "Склад",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{skl}); err != nil {
+		t.Fatal(err)
+	}
+	sklID := uuid.New()
+	if err := db.Upsert(ctx, "Склад", sklID, map[string]any{"Наименование": "Основной"}, skl); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load([]*metadata.Entity{skl}, nil, nil, nil, nil, nil, nil)
+	s := &Server{store: db, reg: registry}
+
+	reg := &metadata.Register{
+		Name: "ОстаткиТоваров",
+		// Склад как string (workaround П.17), но хранит UUID
+		Dimensions: []metadata.Field{{Name: "Склад", Type: metadata.FieldTypeString}},
+	}
+	rows := []map[string]any{{"Склад": sklID.String()}}
+	s.resolveRegisterRows(ctx, rows, reg)
+
+	if rows[0]["Склад"] != "Основной" {
+		t.Errorf("legacy string-UUID не резолвнулся: %v", rows[0]["Склад"])
+	}
+}


### PR DESCRIPTION
Три связанных фикса вокруг отображения ссылок/времени (UUID→имя,
кросс-диалектность SQLite/PG).

## 1. resolveRegisterRows — точечный резолв вместо слепого перебора
Раньше для каждого UUID в измерениях/атрибутах перебирались ВСЕ
сущности — медленно и возможно ложное совпадение.
- UUID группируются по RefEntity → точечный GetByID. Для
  не-reference полей (legacy string-измерения с UUID) — fallback-скан.
- asString(): значения колонок приходят string ИЛИ []byte (SQLite
  драйверы различаются для TEXT); раньше []byte-UUID молча не
  резолвился → сырой UUID в списке движений.

## 2. enrichHeaderRefs в runOnWriteCtx
Симметрично проведению (#37): ссылки полей шапки из формы приходят
сырыми UUID — обогащаем до *Ref{UUID,Name} перед ПриЗаписи, чтобы
ЗначениеРеквизитаОбъекта / Строка(ref) работали как при проведении.

## 3. Время в журнале аудита на SQLite
scanAuditRows сканировала at напрямую в time.Time. PostgreSQL
(TIMESTAMPTZ) ок, но SQLite хранит timestamp как TEXT — драйвер не
конвертирует строку → time.Time, записи получали нулевое время.
Фикс: at → any, parseAuditTime() нормализует time.Time / string /
[]byte по набору layout'ов (RFC3339, pg text timestamptz, SQLite
datetime). Кросс-диалектно — PG не ломается.

## Тесты
- resolve_register_rows_test.go: asString, ref+[]byte, legacy string-UUID.
- audit_time_test.go: time.Time, SQLite-строка, RFC3339, []byte, pg +00, мусор.

go test ./... зелёный (19 пакетов).