### PR TITLE
fix: SQLite-типы + дубль ключей в обогащении ссылок + ref-JOIN Документ/Справочник

### DIFF
--- a/internal/auth/session_time_test.go
+++ b/internal/auth/session_time_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// parseSessionTime нормализует expires_at независимо от диалекта:
+// PostgreSQL отдаёт time.Time, SQLite — TEXT (строку/[]byte), возможно
+// в Go-формате (с зоной/MST), который драйвер не парсит сам.
+func TestParseSessionTime(t *testing.T) {
+	t.Run("time.Time как есть", func(t *testing.T) {
+		want := time.Date(2026, 5, 22, 3, 16, 13, 0, time.UTC)
+		if got := parseSessionTime(want); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("RFC3339 строка", func(t *testing.T) {
+		if got := parseSessionTime("2026-05-22T03:16:13Z"); got.IsZero() {
+			t.Error("RFC3339 не распарсился")
+		}
+	})
+
+	t.Run("Go-формат с зоной MST", func(t *testing.T) {
+		// именно этот формат SQLite хранил для expires_at и не мог
+		// сконвертировать при Scan → пустая страница активных сессий
+		got := parseSessionTime("2026-05-23 03:16:13 +0300 MSK")
+		if got.IsZero() {
+			t.Fatal("Go-формат времени не распарсился")
+		}
+		if got.Year() != 2026 || got.Day() != 23 || got.Hour() != 3 {
+			t.Errorf("неверный разбор: %v", got)
+		}
+	})
+
+	t.Run("SQLite datetime", func(t *testing.T) {
+		if got := parseSessionTime("2026-05-22 03:16:13"); got.IsZero() {
+			t.Error("SQLite datetime не распарсился")
+		}
+	})
+
+	t.Run("[]byte", func(t *testing.T) {
+		if got := parseSessionTime([]byte("2026-05-22T03:16:13Z")); got.IsZero() {
+			t.Error("[]byte не распарсился")
+		}
+	})
+
+	t.Run("мусор → нулевое время", func(t *testing.T) {
+		if got := parseSessionTime("не дата"); !got.IsZero() {
+			t.Errorf("мусор → %v, ожидалось нулевое", got)
+		}
+	})
+}

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -275,12 +275,39 @@ func (r *Repo) ActiveSessions(ctx context.Context) ([]*SessionInfo, error) {
 	var sessions []*SessionInfo
 	for rows.Next() {
 		si := &SessionInfo{}
-		if err := rows.Scan(&si.Login, &si.FullName, &si.IsAdmin, &si.ExpiresAt); err != nil {
+		var expiresRaw any
+		if err := rows.Scan(&si.Login, &si.FullName, &si.IsAdmin, &expiresRaw); err != nil {
 			return nil, err
 		}
+		si.ExpiresAt = parseSessionTime(expiresRaw)
 		sessions = append(sessions, si)
 	}
 	return sessions, rows.Err()
+}
+
+// parseSessionTime normalises an expires_at column value to time.Time.
+// PostgreSQL returns time.Time natively; SQLite stores it as TEXT which
+// the driver may return as string or []byte in Go's time format.
+func parseSessionTime(v any) time.Time {
+	switch t := v.(type) {
+	case time.Time:
+		return t
+	case string:
+		// Try standard formats first, then Go's own String() format.
+		for _, layout := range []string{
+			time.RFC3339Nano, time.RFC3339,
+			"2006-01-02 15:04:05.999999999 -0700 MST",
+			"2006-01-02 15:04:05 -0700 MST",
+			"2006-01-02 15:04:05",
+		} {
+			if parsed, err := time.Parse(layout, t); err == nil {
+				return parsed
+			}
+		}
+	case []byte:
+		return parseSessionTime(string(t))
+	}
+	return time.Time{}
 }
 
 // SetDenyPasswdChange sets the deny_passwd_change flag for a user.

--- a/internal/dsl/interpreter/query_proxy.go
+++ b/internal/dsl/interpreter/query_proxy.go
@@ -21,6 +21,7 @@ type QueryRegistry interface {
 	Registers() []*metadata.Register
 	InfoRegisters() []*metadata.InfoRegister
 	AccountRegisters() []*metadata.AccountRegister
+	Entities() []*metadata.Entity
 }
 
 // queryProxy реализует DSL-объект Новый Запрос.
@@ -116,6 +117,7 @@ func (q *queryProxy) execute() *Array {
 	res, err := query.Compile(q.text, query.CompileOpts{
 		Params:      unwrapArrayParams(q.params),
 		Registers:   q.reg.Registers(),
+		Entities:    q.reg.Entities(),
 		InfoRegs:    q.reg.InfoRegisters(),
 		AccountRegs: q.reg.AccountRegisters(),
 		Dialect:     q.db.Dialect(),

--- a/internal/dsl/interpreter/query_test.go
+++ b/internal/dsl/interpreter/query_test.go
@@ -32,6 +32,7 @@ type stubReg struct{}
 func (s *stubReg) Registers() []*metadata.Register               { return nil }
 func (s *stubReg) InfoRegisters() []*metadata.InfoRegister        { return nil }
 func (s *stubReg) AccountRegisters() []*metadata.AccountRegister  { return nil }
+func (s *stubReg) Entities() []*metadata.Entity                   { return nil }
 
 func evalQuery(t *testing.T, src string, db interpreter.QueryDB, reg interpreter.QueryRegistry) any {
 	t.Helper()

--- a/internal/launcher/check_handlers.go
+++ b/internal/launcher/check_handlers.go
@@ -222,6 +222,7 @@ func checkQueries(proj *project.Project) []checkIssue {
 		Registers:   proj.Registers,
 		InfoRegs:    proj.InfoRegisters,
 		AccountRegs: proj.AccountRegisters,
+		Entities:    proj.Entities,
 	}
 	for _, w := range proj.Widgets {
 		if w.Query == "" {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -18,6 +18,7 @@ type CompileOpts struct {
 	Registers   []*metadata.Register
 	InfoRegs    []*metadata.InfoRegister
 	AccountRegs []*metadata.AccountRegister
+	Entities    []*metadata.Entity
 	// Dialect selects the SQL flavour. nil = PgDialect (default).
 	Dialect storage.Dialect
 }
@@ -324,11 +325,19 @@ const (
 )
 
 type refDimInfo struct {
-	fieldName string // lowercase dim name: "номенклатура"
-	idCol     string // DB column: "номенклатура_id"
-	joinAlias string // SQL alias for auto-JOIN: "ref_номенклатура"
-	joinTable string // referenced catalog table: "номенклатура"
-	isVT      bool   // true: VT outer query, JOIN ON uses fieldName instead of idCol
+	fieldName  string // lowercase dim name: "номенклатура"
+	idCol      string // DB column: "номенклатура_id"
+	joinAlias  string // SQL alias for auto-JOIN: "ref_номенклатура"
+	joinTable  string // referenced catalog table: "номенклатура"
+	isVT       bool   // true: VT outer query, JOIN ON uses fieldName instead of idCol
+	refIsDoc   bool   // true: referenced entity is a document → display "номер", not "наименование"
+}
+
+func (rd refDimInfo) displayCol() string {
+	if rd.refIsDoc {
+		return rd.joinAlias + ".номер"
+	}
+	return rd.joinAlias + ".наименование"
 }
 
 type translator struct {
@@ -982,8 +991,13 @@ func (tr *translator) genFirstSlice(ir *metadata.InfoRegister, args [][]tok) (st
 // --- reference dimension auto-join ---
 
 // preScanRefDims pre-scans tokens to find the first simple (non-virtual) register source
-// and returns reference dimension info for auto-JOIN generation.
+// and returns reference dimension info for auto-JOIN generation. Only fields actually
+// referenced in the query produce JOINs to avoid ambiguous-column errors.
 func preScanRefDims(tokens []tok, opts CompileOpts) []refDimInfo {
+	return filterUsedRefDims(preScanAllRefDims(tokens, opts), tokens)
+}
+
+func preScanAllRefDims(tokens []tok, opts CompileOpts) []refDimInfo {
 	for i := 0; i+2 < len(tokens); i++ {
 		t := tokens[i]
 		if t.kind != tIdent {
@@ -999,7 +1013,7 @@ func preScanRefDims(tokens []tok, opts CompileOpts) []refDimInfo {
 			if isAccumRegType(upper) {
 				for _, reg := range opts.Registers {
 					if strings.EqualFold(reg.Name, regName) {
-						return buildVTRefDimInfos(reg.Dimensions)
+						return buildVTRefDimInfos(append(reg.Dimensions, reg.Attributes...))
 					}
 				}
 			} else if isInfoRegType(upper) {
@@ -1015,7 +1029,7 @@ func preScanRefDims(tokens []tok, opts CompileOpts) []refDimInfo {
 		if isAccumRegType(upper) {
 			for _, reg := range opts.Registers {
 				if strings.EqualFold(reg.Name, regName) {
-					return buildRefDimInfos(reg.Dimensions)
+					return buildRefDimInfos(append(reg.Dimensions, reg.Attributes...))
 				}
 			}
 		} else if isInfoRegType(upper) {
@@ -1025,8 +1039,36 @@ func preScanRefDims(tokens []tok, opts CompileOpts) []refDimInfo {
 				}
 			}
 		}
+		// Document / Catalog sources
+		for _, ent := range opts.Entities {
+			if strings.EqualFold(ent.Name, regName) {
+				return buildRefDimInfosWithEntities(ent.Fields, opts.Entities)
+			}
+		}
 	}
 	return nil
+}
+
+// filterUsedRefDims removes refDims for fields not referenced in the query tokens.
+// This avoids unnecessary JOINs that can cause "ambiguous column name" errors when
+// a joined table shares column names (e.g. дата) with the main table.
+func filterUsedRefDims(dims []refDimInfo, tokens []tok) []refDimInfo {
+	if len(dims) == 0 {
+		return nil
+	}
+	used := make(map[string]bool, len(tokens))
+	for _, t := range tokens {
+		if t.kind == tIdent {
+			used[strings.ToLower(t.val)] = true
+		}
+	}
+	var out []refDimInfo
+	for _, rd := range dims {
+		if used[rd.fieldName] {
+			out = append(out, rd)
+		}
+	}
+	return out
 }
 
 // buildVTRefDimInfos creates refDimInfos for VT outer queries where the subquery
@@ -1049,15 +1091,26 @@ func buildVTRefDimInfos(dims []metadata.Field) []refDimInfo {
 }
 
 func buildRefDimInfos(dims []metadata.Field) []refDimInfo {
+	return buildRefDimInfosWithEntities(dims, nil)
+}
+
+func buildRefDimInfosWithEntities(dims []metadata.Field, entities []*metadata.Entity) []refDimInfo {
 	var result []refDimInfo
 	for _, d := range dims {
 		if d.RefEntity != "" {
-			result = append(result, refDimInfo{
+			rd := refDimInfo{
 				fieldName: strings.ToLower(d.Name),
 				idCol:     strings.ToLower(d.Name) + "_id",
 				joinAlias: "ref_" + strings.ToLower(d.Name),
 				joinTable: strings.ToLower(d.RefEntity),
-			})
+			}
+			for _, e := range entities {
+				if strings.EqualFold(e.Name, d.RefEntity) && e.Kind == metadata.KindDocument {
+					rd.refIsDoc = true
+					break
+				}
+			}
+			result = append(result, rd)
 		}
 	}
 	return result
@@ -1367,27 +1420,32 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 				}
 			} else {
 				lower := strings.ToLower(t.val)
+				nextIsDot := tr.peek(0).kind == tDot
 				if tr.section == sectionFrom && !prevDot {
-					// In FROM clause bare identifiers are table names — skip colMap/refDim
 					tr.emit(lower)
 				} else if rd := tr.findRefDim(lower); rd != nil && !prevDot {
-					switch tr.section {
-					case sectionSelect:
-						tr.emit(rd.joinAlias + ".наименование")
-						// Skip auto-alias when user provides КАК/AS
-						if p := strings.ToUpper(tr.peek(0).val); p != "КАК" && p != "AS" {
-							tr.emit("AS")
-							tr.emit(rd.fieldName)
+					if nextIsDot {
+						tr.emit(rd.joinAlias)
+					} else {
+						switch tr.section {
+						case sectionSelect:
+							tr.emit(rd.displayCol())
+							if p := strings.ToUpper(tr.peek(0).val); p != "КАК" && p != "AS" {
+								tr.emit("AS")
+								tr.emit(rd.fieldName)
+							}
+						case sectionGroupBy, sectionOrderBy:
+							tr.emit(rd.displayCol())
+						default:
+							tr.emit(rd.idCol)
 						}
-					case sectionGroupBy, sectionOrderBy:
-						tr.emit(rd.joinAlias + ".наименование")
-					default: // WHERE, HAVING, FROM (after dot), OTHER → raw column (UUID for VT, _id for plain)
-						tr.emit(rd.idCol)
 					}
 				} else if col, ok := tr.colMap[lower]; ok && !prevDot {
 					tr.emit(col)
 				} else if prevDot {
-					if c, ok2 := tr.colMap[lower]; ok2 {
+					if rd := tr.findRefDim(lower); rd != nil {
+						tr.emit(rd.idCol)
+					} else if c, ok2 := tr.colMap[lower]; ok2 {
 						tr.emit(c)
 					} else {
 						tr.emit(lower)

--- a/internal/storage/attachments.go
+++ b/internal/storage/attachments.go
@@ -59,11 +59,11 @@ func (db *DB) ListAttachments(ctx context.Context, ownerKind, ownerName string, 
 	defer rows.Close()
 	var result []Attachment
 	for rows.Next() {
-		var a Attachment
-		if err := rows.Scan(&a.ID, &a.OwnerKind, &a.OwnerName, &a.OwnerID, &a.Filename, &a.MimeType, &a.SizeBytes, &a.UploadedAt, &a.UploadedBy); err != nil {
+		a, err := scanAttachment(rows)
+		if err != nil {
 			return nil, err
 		}
-		result = append(result, a)
+		result = append(result, *a)
 	}
 	return result, nil
 }
@@ -95,22 +95,22 @@ func (db *DB) UploadAttachment(ctx context.Context, ownerKind, ownerName string,
 	}
 
 	q := fmt.Sprintf(`
-		INSERT INTO _attachments (id, owner_kind, owner_name, owner_id, filename, mime_type, size_bytes, uploaded_by)
-		VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
-		RETURNING id, owner_kind, owner_name, owner_id, filename, mime_type, size_bytes, uploaded_at, uploaded_by
-	`, d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4),
+			INSERT INTO _attachments (id, owner_kind, owner_name, owner_id, filename, mime_type, size_bytes, uploaded_by)
+			VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+		`, d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4),
 		d.Placeholder(5), d.Placeholder(6), d.Placeholder(7), d.Placeholder(8))
-	var a Attachment
-	err = db.QueryRow(ctx, q,
+	if _, err := db.Exec(ctx, q,
 		id.String(), ownerKind, ownerName, ownerID.String(), filename, mimeType, n, uploadedBy,
-	).Scan(
-		&a.ID, &a.OwnerKind, &a.OwnerName, &a.OwnerID, &a.Filename, &a.MimeType, &a.SizeBytes, &a.UploadedAt, &a.UploadedBy,
-	)
+	); err != nil {
+		os.Remove(filePath)
+		return Attachment{}, err
+	}
+	a, err := db.GetAttachment(ctx, id)
 	if err != nil {
 		os.Remove(filePath)
 		return Attachment{}, err
 	}
-	return a, nil
+	return *a, nil
 }
 
 // GetAttachment returns attachment metadata by ID.
@@ -120,13 +120,8 @@ func (db *DB) GetAttachment(ctx context.Context, id uuid.UUID) (*Attachment, err
 		SELECT id, owner_kind, owner_name, owner_id, filename, mime_type, size_bytes, uploaded_at, uploaded_by
 		FROM _attachments WHERE id=%s
 	`, d.Placeholder(1))
-	var a Attachment
-	err := db.QueryRow(ctx, q, id.String()).Scan(
-		&a.ID, &a.OwnerKind, &a.OwnerName, &a.OwnerID, &a.Filename, &a.MimeType, &a.SizeBytes, &a.UploadedAt, &a.UploadedBy)
-	if err != nil {
-		return nil, err
-	}
-	return &a, nil
+	row := db.QueryRow(ctx, q, id.String())
+	return scanAttachment(row)
 }
 
 // OpenAttachment opens the file for a given attachment ID and returns its metadata.
@@ -155,4 +150,28 @@ func (db *DB) DeleteAttachment(ctx context.Context, id uuid.UUID) error {
 	q := fmt.Sprintf(`DELETE FROM _attachments WHERE id=%s`, d.Placeholder(1))
 	_, err = db.Exec(ctx, q, id.String())
 	return err
+}
+
+// attachmentScanner is satisfied by both sql.Row and sql.Rows.
+type attachmentScanner interface{ Scan(dest ...any) error }
+
+func scanAttachment(row attachmentScanner) (*Attachment, error) {
+	var idStr, ownerIDStr string
+	var uploadedAtRaw any
+	var a Attachment
+	if err := row.Scan(&idStr, &a.OwnerKind, &a.OwnerName, &ownerIDStr, &a.Filename, &a.MimeType, &a.SizeBytes, &uploadedAtRaw, &a.UploadedBy); err != nil {
+		return nil, err
+	}
+	a.UploadedAt = parseAuditTime(uploadedAtRaw)
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return nil, fmt.Errorf("attachment id: %w", err)
+	}
+	a.ID = id
+	ownerID, err := uuid.Parse(ownerIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("attachment owner_id: %w", err)
+	}
+	a.OwnerID = ownerID
+	return &a, nil
 }

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -195,16 +195,36 @@ func (db *DB) AuditSearch(ctx context.Context, filter AuditFilter, limit, offset
 }
 
 // AuditDiff compares old and new field values and returns changed fields.
+// Values implementing refUUIDer (e.g. *interpreter.Ref) are normalised to
+// their UUID string so the audit log stores plain UUIDs, not struct dumps.
 func AuditDiff(old, new map[string]any, entity *metadata.Entity) []FieldChange {
 	var changes []FieldChange
 	for _, f := range entity.Fields {
-		ov := old[f.Name]
-		nv := new[f.Name]
+		ov := auditVal(old[f.Name])
+		nv := auditVal(new[f.Name])
 		if fmt.Sprintf("%v", ov) != fmt.Sprintf("%v", nv) {
 			changes = append(changes, FieldChange{Field: f.Name, Old: ov, New: nv})
 		}
 	}
 	return changes
+}
+
+// refUUIDer is satisfied by *interpreter.Ref. Kept here to avoid
+// importing interpreter (which would create a circular dependency).
+type refUUIDer interface {
+	GetRefUUID() string
+}
+
+// auditVal normalises a value for audit storage. Ref objects become their
+// UUID string; everything else is passed through unchanged.
+func auditVal(v any) any {
+	if v == nil {
+		return nil
+	}
+	if r, ok := v.(refUUIDer); ok {
+		return r.GetRefUUID()
+	}
+	return v
 }
 
 // FieldChange represents one changed field.
@@ -360,4 +380,49 @@ func parseTimeStr(s string) time.Time {
 func (db *DB) execAudit(ctx context.Context, sql string, args ...any) error {
 	_, err := db.Exec(ctx, sql, args...)
 	return err
+}
+
+// ActiveUserInfo represents a user seen recently in the audit log.
+type ActiveUserInfo struct {
+	Login     string
+	LastSeen  time.Time
+}
+
+// ActiveUsersFromAudit returns distinct user_logins from _audit in the
+// last 24 hours, ordered by most recent activity. Used when no auth
+// subsystem is configured (file-based databases).
+func (db *DB) ActiveUsersFromAudit(ctx context.Context) ([]ActiveUserInfo, error) {
+	d := db.dialect
+	q := fmt.Sprintf(`
+		SELECT COALESCE(NULLIF(user_login,''),'admin') AS login, MAX(at) AS last_seen
+		FROM _audit
+		WHERE at >= %s
+		GROUP BY login
+		ORDER BY last_seen DESC`,
+		d.Placeholder(1))
+	cutoff := time.Now().Add(-24 * time.Hour)
+	// SQLite stores at as TEXT (ISO 8601), direct comparison with
+	// time.Time does not work - format as string.
+	cutoffArg := any(cutoff)
+	if db.IsSQLite() {
+		cutoffArg = cutoff.Format("2006-01-02 15:04:05")
+	}
+	rows, err := db.Query(ctx, q, cutoffArg)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []ActiveUserInfo
+	for rows.Next() {
+		var login string
+		var lastSeen any
+		if err := rows.Scan(&login, &lastSeen); err != nil {
+			continue
+		}
+		result = append(result, ActiveUserInfo{
+			Login:    login,
+			LastSeen: parseAuditTime(lastSeen),
+		})
+	}
+	return result, nil
 }

--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -422,13 +422,13 @@ func (s *Server) adminSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if s.authRepo == nil {
-		adminTmpl.ExecuteTemplate(w, "admin-sessions", map[string]any{"Sessions": nil, "NoAuth": true})
-		return
+	hasUsers := false
+	if s.authRepo != nil {
+		hasUsers, _ = s.authRepo.HasUsers(r.Context())
 	}
-	hasUsers, _ := s.authRepo.HasUsers(r.Context())
 	if !hasUsers {
-		adminTmpl.ExecuteTemplate(w, "admin-sessions", map[string]any{"Sessions": nil, "NoAuth": true})
+		users, _ := s.store.ActiveUsersFromAudit(r.Context())
+		adminTmpl.ExecuteTemplate(w, "admin-sessions", map[string]any{"AuditUsers": users})
 		return
 	}
 	sessions, _ := s.authRepo.ActiveSessions(r.Context())
@@ -585,6 +585,7 @@ func (s *Server) adminAudit(w http.ResponseWriter, r *http.Request) {
 
 	entries, _ := s.store.AuditSearch(r.Context(), filter, pageSize+1, (page-1)*pageSize)
 
+		s.enrichAuditEntriesGlobal(r.Context(), entries)
 	hasNext := len(entries) > pageSize
 	if hasNext {
 		entries = entries[:pageSize]
@@ -638,6 +639,7 @@ func (s *Server) recordHistory(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 		return
 	}
+	s.enrichAuditEntries(r.Context(), entity, entries)
 	s.render(w, r, "page-history", map[string]any{
 		"EntityName": entity.Name,
 		"ID":         id.String(),
@@ -699,7 +701,21 @@ const tplAdminSessions = `{{define "admin-sessions"}}` + adminHead + `
   <h2>Активные пользователи</h2>
   <a class="btn" href="/ui/admin/sessions" style="background:#e2e8f0;color:#475569;font-size:13px">Обновить</a>
 </div>
-{{if .NoAuth}}
+{{if .AuditUsers}}
+<div class="card" style="max-width:700px">
+<table>
+<thead><tr>
+  <th>Логин</th><th>Последний запрос</th>
+</tr></thead>
+<tbody>
+{{range .AuditUsers}}<tr>
+  <td><strong>{{.Login}}</strong></td>
+  <td style="font-size:12px;color:#94a3b8">{{.LastSeen.Format "02.01.2006 15:04:05"}}</td>
+</tr>{{end}}
+</tbody>
+</table>
+</div>
+{{else if .NoAuth}}
 <div class="card" style="max-width:700px">
   <p class="empty">Авторизация не настроена — пользователей нет.</p>
 </div>

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -52,6 +52,7 @@ func (s *Server) queryConsoleExec(w http.ResponseWriter, r *http.Request) {
 	coerceParams(req.Params)
 	res, err := query.Compile(req.Query, query.CompileOpts{
 		Params:      req.Params,
+		Entities:    s.reg.Entities(),
 		Registers:   s.reg.Registers(),
 		InfoRegs:    s.reg.InfoRegisters(),
 		AccountRegs: s.reg.AccountRegisters(),
@@ -189,6 +190,7 @@ func (s *Server) queryConsoleAnalyze(w http.ResponseWriter, r *http.Request) {
 		singleParam[name] = "__DETECT__"
 		sr, err2 := query.Compile(req.Query, query.CompileOpts{
 			Params:      singleParam,
+		Entities:    s.reg.Entities(),
 			Registers:   s.reg.Registers(),
 			InfoRegs:    s.reg.InfoRegisters(),
 			AccountRegs: s.reg.AccountRegisters(),

--- a/internal/ui/enrich_header_refs_test.go
+++ b/internal/ui/enrich_header_refs_test.go
@@ -76,6 +76,66 @@ func TestEnrichHeaderRefs_UUIDToRef(t *testing.T) {
 	}
 }
 
+// Корень бага: enrichHeaderRefs делал obj.Set(f.Name, ref) — это писало
+// Ref под lowercase-ключом, а оригинальный PascalCase-ключ с UUID-строкой
+// оставался. Из-за случайного порядка обхода Go-мапы obj.Get() мог вернуть
+// то Ref, то UUID — недетерминированно. Фикс: замена in-place по
+// оригинальному ключу. Проверяем что НЕТ дубля ключей и нет сырого UUID.
+func TestEnrichHeaderRefs_NoDuplicateKey(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	contr := &metadata.Entity{
+		Name:   "Контрагент",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	doc := &metadata.Entity{
+		Name: "Счёт",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Контрагент", Type: "reference:Контрагент", RefEntity: "Контрагент"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{contr, doc}); err != nil {
+		t.Fatal(err)
+	}
+	cid := uuid.New()
+	if err := db.Upsert(ctx, "Контрагент", cid, map[string]any{"Наименование": "ООО Ромашка"}, contr); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load([]*metadata.Entity{contr, doc}, nil, nil, nil, nil, nil, nil)
+	s := &Server{store: db, reg: registry}
+
+	// Ключ в PascalCase (как кладёт форма) с UUID-строкой.
+	obj := &runtime.Object{
+		ID:     uuid.New(),
+		Type:   "Счёт",
+		Kind:   metadata.KindDocument,
+		Fields: map[string]any{"Контрагент": cid.String()},
+	}
+	s.enrichHeaderRefs(ctx, doc, obj)
+
+	// Должен остаться РОВНО один ключ для контрагента, и он = *Ref.
+	var refKeys int
+	for k, v := range obj.Fields {
+		if k == "Контрагент" || k == "контрагент" {
+			refKeys++
+			if _, ok := v.(*interpreter.Ref); !ok {
+				t.Errorf("ключ %q держит %T, ожидался *Ref (сырой UUID не заменён)", k, v)
+			}
+		}
+	}
+	if refKeys != 1 {
+		t.Errorf("ожидался 1 ключ контрагента, найдено %d (дубль ключей!): %v", refKeys, obj.Fields)
+	}
+}
+
 // Поле, уже являющееся *Ref (проведение из обработки), не должно
 // перезаписываться — двойной обработки нет.
 func TestEnrichHeaderRefs_SkipsExistingRef(t *testing.T) {

--- a/internal/ui/fmt_report_cell_test.go
+++ b/internal/ui/fmt_report_cell_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFmtReportCell(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil → пусто", nil, ""},
+		{"дата без времени", time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC), "22.05.2026"},
+		{"дата со временем", time.Date(2026, 5, 22, 13, 5, 9, 0, time.UTC), "22.05.2026 13:05:09"},
+		{"целое float64 → разделители", float64(1234567), "1 234 567"},
+		{"дробное float64", float64(1234.5), "1234.50"},
+		{"int", 1000000, "1 000 000"},
+		{"int64", int64(2500), "2 500"},
+		{"строка-дата ISO", "2026-05-22", "22.05.2026"},
+		{"строка-дата с временем", "2026-05-22 13:05:09", "22.05.2026 13:05:09"},
+		{"обычная строка", "Тумбочка", "Тумбочка"},
+		{"короткая строка не парсится как дата", "ООО", "ООО"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := fmtReportCell(c.in); got != c.want {
+				t.Errorf("fmtReportCell(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -385,11 +385,9 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 	action := r.FormValue("_action")
 	isPosting := entity.Posting && (action == "post" || action == "post_and_close")
 
-	if isPosting {
-		for _, tp := range entity.TableParts {
-			if rows, ok := obj.TablePartRows[tp.Name]; ok {
-				s.enrichTPRowsWithRefs(r.Context(), tp, rows)
-			}
+	for _, tp := range entity.TableParts {
+		if rows, ok := obj.TablePartRows[tp.Name]; ok {
+			s.enrichTPRowsWithRefs(r.Context(), tp, rows)
 		}
 	}
 
@@ -607,11 +605,9 @@ func (s *Server) submitEdit(w http.ResponseWriter, r *http.Request) {
 	action := r.FormValue("_action")
 	isPostingAct := entity.Posting && (action == "post" || action == "post_and_close")
 
-	if isPostingAct {
-		for _, tp := range entity.TableParts {
-			if rows, ok := obj.TablePartRows[tp.Name]; ok {
-				s.enrichTPRowsWithRefs(r.Context(), tp, rows)
-			}
+	for _, tp := range entity.TableParts {
+		if rows, ok := obj.TablePartRows[tp.Name]; ok {
+			s.enrichTPRowsWithRefs(r.Context(), tp, rows)
 		}
 	}
 
@@ -844,6 +840,9 @@ func (s *Server) deleteMarkedAll(w http.ResponseWriter, r *http.Request) {
 						for _, reg := range s.reg.Registers() {
 							s.store.WriteMovements(ctx, reg.Name, entity.Name, id, nil, reg, nil)
 						}
+					}
+					for _, tp := range entity.TableParts {
+						s.store.Exec(ctx, "DELETE FROM "+metadata.TablePartTableName(entity.Name, tp.Name)+" WHERE parent_id = "+s.store.Dialect().Placeholder(1), id)
 					}
 					return s.store.Delete(ctx, entity.Name, id)
 				})
@@ -1095,6 +1094,7 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 		}
 	}
 	compiled, err := query.Compile(rep.Query, query.CompileOpts{
+		Entities:    s.reg.Entities(),
 		Params:      queryValues,
 		Registers:   s.reg.Registers(),
 		InfoRegs:    s.reg.InfoRegisters(),
@@ -2134,6 +2134,195 @@ func (s *Server) resolveRefs(ctx context.Context, entity *metadata.Entity, rows 
 	}
 }
 
+// enrichAuditEntries resolves reference UUIDs and formats dates in audit
+// OldValue/NewValue so that the history page shows human-readable values.
+func (s *Server) enrichAuditEntries(ctx context.Context, entity *metadata.Entity, entries []*storage.AuditEntry) {
+	refFields := map[string]string{}
+	dateFields := map[string]bool{}
+	for _, f := range entity.Fields {
+		if f.RefEntity != "" {
+			refFields[f.Name] = f.RefEntity
+		}
+		if f.Type == metadata.FieldTypeDate {
+			dateFields[f.Name] = true
+		}
+	}
+	if len(refFields) == 0 && len(dateFields) == 0 {
+		return
+	}
+	refLabels := map[string]string{}
+	for _, e := range entries {
+		refEntityName, isRef := refFields[e.Field]
+		if !isRef {
+			continue
+		}
+		for _, val := range []any{e.OldValue, e.NewValue} {
+			if val == nil {
+				continue
+			}
+			idStr := extractUUIDFromAuditVal(val)
+			key := refEntityName + ":" + idStr
+			if _, ok := refLabels[key]; ok {
+				continue
+			}
+			id, err := uuid.Parse(idStr)
+			if err != nil {
+				continue
+			}
+			refEntity := s.reg.GetEntity(refEntityName)
+			if refEntity == nil {
+				continue
+			}
+			refRow, err := s.store.GetByID(ctx, refEntityName, id, refEntity)
+			if err != nil {
+				continue
+			}
+			refLabels[key] = firstStringField(refRow, refEntity)
+		}
+	}
+	for _, e := range entries {
+		if refEntityName, isRef := refFields[e.Field]; isRef {
+			if e.OldValue != nil {
+				if label, ok := refLabels[refEntityName+":"+extractUUIDFromAuditVal(e.OldValue)]; ok {
+					e.OldValue = label
+				}
+			}
+			if e.NewValue != nil {
+				if label, ok := refLabels[refEntityName+":"+extractUUIDFromAuditVal(e.NewValue)]; ok {
+					e.NewValue = label
+				}
+			}
+		}
+		if dateFields[e.Field] {
+			e.OldValue = formatAuditDate(e.OldValue)
+			e.NewValue = formatAuditDate(e.NewValue)
+		}
+	}
+}
+
+
+// enrichAuditEntriesGlobal resolves UUIDs in audit entries that span multiple entities
+// (used by the global audit journal). For each entry it looks up the entity by name
+// and resolves reference field UUIDs to display names.
+func (s *Server) enrichAuditEntriesGlobal(ctx context.Context, entries []*storage.AuditEntry) {
+	type entInfo struct {
+		refFields  map[string]string
+		dateFields map[string]bool
+	}
+	entityCache := map[string]*entInfo{}
+	refLabels := map[string]string{}
+
+	for _, e := range entries {
+		if e.Field == "" || e.EntityName == "" {
+			continue
+		}
+		info, ok := entityCache[e.EntityName]
+		if !ok {
+			ent := s.reg.GetEntity(e.EntityName)
+			if ent == nil {
+				entityCache[e.EntityName] = nil
+				continue
+			}
+			info = &entInfo{
+				refFields:  map[string]string{},
+				dateFields: map[string]bool{},
+			}
+			for _, f := range ent.Fields {
+				if f.RefEntity != "" {
+					info.refFields[f.Name] = f.RefEntity
+				}
+				if f.Type == metadata.FieldTypeDate {
+					info.dateFields[f.Name] = true
+				}
+			}
+			entityCache[e.EntityName] = info
+		}
+		if info == nil {
+			continue
+		}
+		refEntityName, isRef := info.refFields[e.Field]
+		if !isRef {
+			if info.dateFields[e.Field] {
+				e.OldValue = formatAuditDate(e.OldValue)
+				e.NewValue = formatAuditDate(e.NewValue)
+			}
+			continue
+		}
+		for _, val := range []any{e.OldValue, e.NewValue} {
+			if val == nil {
+				continue
+			}
+			idStr := extractUUIDFromAuditVal(val)
+			if idStr == "" {
+				continue
+			}
+			key := refEntityName + ":" + idStr
+			if _, ok := refLabels[key]; ok {
+				continue
+			}
+			id, err := uuid.Parse(idStr)
+			if err != nil {
+				continue
+			}
+			refEntity := s.reg.GetEntity(refEntityName)
+			if refEntity == nil {
+				continue
+			}
+			refRow, err := s.store.GetByID(ctx, refEntityName, id, refEntity)
+			if err != nil {
+				continue
+			}
+			refLabels[key] = firstStringField(refRow, refEntity)
+		}
+		if e.OldValue != nil {
+			if idStr := extractUUIDFromAuditVal(e.OldValue); idStr != "" {
+				if label, ok := refLabels[refEntityName+":"+idStr]; ok {
+					e.OldValue = label
+				}
+			}
+		}
+		if e.NewValue != nil {
+			if idStr := extractUUIDFromAuditVal(e.NewValue); idStr != "" {
+				if label, ok := refLabels[refEntityName+":"+idStr]; ok {
+					e.NewValue = label
+				}
+			}
+		}
+	}
+}
+
+// extractUUIDFromAuditVal extracts a UUID string from an audit value.
+// Handles plain UUID strings and JSON-encoded Ref objects like {"UUID":"abc",...}.
+func extractUUIDFromAuditVal(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		s = fmt.Sprintf("%v", v)
+	}
+	if _, err := uuid.Parse(s); err == nil {
+		return s
+	}
+	var m map[string]any
+	if json.Unmarshal([]byte(s), &m) == nil {
+		if uid, ok2 := m["UUID"].(string); ok2 {
+			return uid
+		}
+	}
+	return ""
+}
+func formatAuditDate(v any) any {
+	if v == nil {
+		return nil
+	}
+	s := fmt.Sprintf("%v", v)
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format("02.01.2006")
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t.Format("02.01.2006")
+	}
+	return v
+}
+
 // enrichTPRowsWithRefs replaces UUID strings in reference fields of table-part rows
 // with interpreter.Ref{UUID, Name} so that DSL Строка(ref) returns the display name
 // while UUID-based map lookups and SQL parameters still work correctly.
@@ -2187,6 +2376,7 @@ func (s *Server) enrichTPRowsWithRefs(ctx context.Context, tp metadata.TablePart
 // как при создании из обработки. Ref-параметры и reference-измерения остаются
 // корректными: unwrapArrayParams приводит *Ref к UUID. См. П.37.
 func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, obj *runtime.Object) {
+	low := strings.ToLower
 	for _, f := range entity.Fields {
 		if f.RefEntity == "" {
 			continue
@@ -2195,14 +2385,23 @@ func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, 
 		if refEntity == nil {
 			continue
 		}
-		v := obj.Get(f.Name)
-		if v == nil {
+		// Find the actual map key (PascalCase or lowercase) and replace in-place.
+		var matchKey string
+		var matchVal any
+		for k, v := range obj.Fields {
+			if low(k) == low(f.Name) {
+				matchKey = k
+				matchVal = v
+				break
+			}
+		}
+		if matchKey == "" || matchVal == nil {
 			continue
 		}
-		if _, isRef := v.(*interpreter.Ref); isRef {
+		if _, isRef := matchVal.(*interpreter.Ref); isRef {
 			continue
 		}
-		idStr := fmt.Sprintf("%v", v)
+		idStr := fmt.Sprintf("%v", matchVal)
 		id, err := uuid.Parse(idStr)
 		if err != nil {
 			continue
@@ -2211,11 +2410,11 @@ func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, 
 		if err != nil {
 			continue
 		}
-		obj.Set(f.Name, &interpreter.Ref{
+		obj.Fields[matchKey] = &interpreter.Ref{
 			UUID: idStr,
 			Name: firstStringField(refRow, refEntity),
 			Type: refEntity.Name,
-		})
+		}
 	}
 }
 
@@ -3051,6 +3250,7 @@ func (s *Server) reportExcel(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	compiled, err := query.Compile(rep.Query, query.CompileOpts{
+		Entities:    s.reg.Entities(),
 		Params:      paramValues,
 		Registers:   s.reg.Registers(),
 		InfoRegs:    s.reg.InfoRegisters(),

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -188,6 +188,7 @@ var tmpl = template.Must(template.New("root").Funcs(template.FuncMap{
 	"wcell":        widgetCell,
 	"echartsJSON":  echartsJSON,
 	"splitCamel":   splitCamel,
+	"fmtCell":      fmtReportCell,
 }).Parse(tplHead + tplNav + tplIndex + tplList + tplForm + tplRegister + tplReport + tplProcessor + tplAbout + tplDeleteMarked + tplInfoReg + tplConstants + tplHistory + tplJournal + tplScheduled + tplAccountReg + tplQueryBuilder + tplAllFunctions + tplQueryConsole + tplCodeConsole + tplForbidden))
 
 const tplHead = `
@@ -441,6 +442,7 @@ window.__obWidgetCharts = window.__obWidgetCharts || {};
       if(!opt)continue;
       try{
         var c=echarts.init(node);
+        if(opt.yAxis&&opt.yAxis.type==="value"){opt.yAxis.axisLabel={formatter:function(v){if(Math.abs(v)>=1e6)return(v/1e6).toFixed(1)+"M";if(Math.abs(v)>=1e3)return(v/1e3).toFixed(1)+"k";return v%1===0?v:v.toFixed(2)}};}
         c.setOption(opt);
         (function(c){window.addEventListener('resize',function(){c.resize();});})(c);
       }catch(e){console.error('chart init failed',e);}
@@ -626,7 +628,7 @@ const tplList = `
         {{index $row .Name}}{{if index $row "_is_predefined"}} <span title="Предопределённый" style="color:#f59e0b;font-size:11px">★</span>{{end}}
       </td>
     {{else if eq (str .Type) "date"}}<td>{{fmtDate (index $row .Name)}}</td>
-    {{else}}<td>{{index $row .Name}}</td>{{end}}
+    {{else}}<td>{{fmtCell (index $row .Name)}}</td>{{end}}
   {{end}}
   <td>
     {{if $isFolder}}
@@ -674,7 +676,7 @@ const tplList = `
   {{end}}
   {{range $.Entity.Fields}}
     {{if eq (str .Type) "date"}}<td style="white-space:nowrap">{{fmtDate (index $row .Name)}}</td>
-    {{else}}<td style="white-space:nowrap">{{if and (eq .Name "Наименование") $.Entity.Hierarchical}}{{if $isFolder}}📁 {{else}}📄 {{end}}{{end}}{{index $row .Name}}{{if and (eq .Name "Наименование") (index $row "_is_predefined")}} <span title="Предопределённый элемент" style="color:#f59e0b;font-size:11px">★</span>{{end}}</td>{{end}}
+    {{else}}<td style="white-space:nowrap">{{if and (eq .Name "Наименование") $.Entity.Hierarchical}}{{if $isFolder}}📁 {{else}}📄 {{end}}{{end}}{{fmtCell (index $row .Name)}}{{if and (eq .Name "Наименование") (index $row "_is_predefined")}} <span title="Предопределённый элемент" style="color:#f59e0b;font-size:11px">★</span>{{end}}</td>{{end}}
   {{end}}
   <td>
     {{if and $isFolder $.Entity.Hierarchical}}
@@ -1197,7 +1199,8 @@ const tplReport = `
 <script>
 (function(){
   var c=echarts.init(document.getElementById('ob-chart'));
-  c.setOption({{jsJSON .ChartOption}});
+  var _o={{jsJSON .ChartOption}};if(_o.yAxis&&_o.yAxis.type==="value"){_o.yAxis.axisLabel={formatter:function(v){if(Math.abs(v)>=1e6)return(v/1e6).toFixed(1)+"M";if(Math.abs(v)>=1e3)return(v/1e3).toFixed(1)+"k";return v%1===0?v:v.toFixed(2)}};}
+  c.setOption(_o);
   window.addEventListener('resize',function(){c.resize()});
 })();
 </script>
@@ -1211,7 +1214,7 @@ const tplReport = `
 <table><thead><tr>{{range .Cols}}<th>{{.}}</th>{{end}}</tr></thead>
 <tbody>
 {{range .Rows}}{{$row := .}}<tr>
-  {{range $.Cols}}<td>{{index $row .}}</td>{{end}}
+  {{range $.Cols}}<td>{{fmtCell (index $row .)}}</td>{{end}}
 </tr>{{end}}
 </tbody></table>
 {{else}}<p class="empty">Нет данных</p>{{end}}

--- a/internal/ui/widget_helpers.go
+++ b/internal/ui/widget_helpers.go
@@ -71,7 +71,7 @@ func echartsJSON(chart *widget.ChartData) template.JS {
 	}
 	opt := map[string]any{
 		"tooltip": map[string]any{"trigger": "axis"},
-		"grid":    map[string]any{"left": 40, "right": 16, "top": 24, "bottom": 30},
+		"grid":    map[string]any{"left": 56, "right": 16, "top": 24, "bottom": 30},
 	}
 	switch strings.ToLower(chart.Kind) {
 	case "pie":
@@ -189,4 +189,51 @@ func groupThousands(n int64) string {
 		}
 	}
 	return b.String()
+}
+
+// fmtReportCell formats a single cell value in a report table. Unlike
+// widgetCell (which takes a row + field + format), this receives the raw value
+// directly and auto-detects the type: time.Time → date, float64 → number with
+// thousands separators, strings that parse as dates → formatted date.
+func fmtReportCell(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case time.Time:
+		h, m, sec := t.Clock()
+		if h != 0 || m != 0 || sec != 0 {
+			return t.Format("02.01.2006 15:04:05")
+		}
+		return t.Format("02.01.2006")
+	case float64:
+		if t == float64(int64(t)) {
+			return groupThousands(int64(t))
+		}
+		return fmt.Sprintf("%.2f", t)
+	case float32:
+		return fmt.Sprintf("%.2f", float64(t))
+	case int:
+		return groupThousands(int64(t))
+	case int32:
+		return groupThousands(int64(t))
+	case int64:
+		return groupThousands(t)
+	case string:
+		if len(t) >= 10 {
+			for _, layout := range []string{
+				time.RFC3339, "2006-01-02T15:04:05", "2006-01-02 15:04:05", "2006-01-02",
+			} {
+				if pt, err := time.Parse(layout, t); err == nil {
+					h, m, sec := pt.Clock()
+					if h != 0 || m != 0 || sec != 0 {
+						return pt.Format("02.01.2006 15:04:05")
+					}
+					return pt.Format("02.01.2006")
+				}
+			}
+		}
+		return t
+	}
+	return fmt.Sprintf("%v", v)
 }

--- a/internal/widget/runner.go
+++ b/internal/widget/runner.go
@@ -285,22 +285,31 @@ func (r *Runner) runRecent(ctx context.Context, w *metadata.Widget, res *Result)
 		WHERE ` + strings.Join(where, " AND ") + ` AND record_id IS NOT NULL
 		GROUP BY entity_kind, entity_name, record_id
 		ORDER BY _ts DESC
-		LIMIT ` + fmt.Sprint(limit)
+		LIMIT ` + fmt.Sprint(limit*3)
 
 	rows, _, err := r.Store.RunQuery(ctx, sql, args)
 	if err != nil {
 		res.Error = err.Error()
 		return
 	}
+	var kept []map[string]any
 	for _, row := range rows {
 		entName, _ := row["entity_name"].(string)
 		kind, _ := row["entity_kind"].(string)
 		id := fmt.Sprintf("%v", row["record_id"])
+		title := recordPresentation(ctx, r, entName, id)
+		if title == shortID(id) {
+			continue
+		}
 		row["_url"] = "/ui/" + kind + "/" + entName + "/" + id
 		row["_label"] = entName
-		row["_title"] = recordPresentation(ctx, r, entName, id)
+		row["_title"] = title
+		kept = append(kept, row)
+		if len(kept) >= limit {
+			break
+		}
 	}
-	res.Rows = rows
+	res.Rows = kept
 	res.Columns = []ColumnSpec{
 		{Field: "entity_name", Label: "Объект"},
 		{Field: "_ts", Label: "Когда", Format: "date"},
@@ -368,6 +377,7 @@ func (r *Runner) runQuery(ctx context.Context, w *metadata.Widget) ([]map[string
 
 	compiled, err := query.Compile(w.Query, query.CompileOpts{
 		Params:      params,
+		Entities:    r.Reg.Entities(),
 		Registers:   r.Reg.Registers(),
 		InfoRegs:    r.Reg.InfoRegisters(),
 		AccountRegs: r.Reg.AccountRegisters(),


### PR DESCRIPTION
Группа связанных фиксов: кросс-диалектность SQLite (PostgreSQL сам
конвертирует типы при Scan, SQLite — нет), недетерминированное
обогащение ссылок, и авто-JOIN'ы запросов из источников
Документ/Справочник.

## enrichHeaderRefs — недетерминированный UUID/Ref (корневая причина)
`obj.Set(f.Name, ref)` писал Ref под lowercase-ключом, а оригинальный
PascalCase-ключ с UUID-строкой оставался. Из-за случайного порядка
обхода Go-мапы `obj.Get()` возвращал то Ref, то UUID — недетерминированно.
Симптомы: `Строка(this.Склад)` то имя, то UUID; `ЗначениеРеквизитаОбъекта`
получал строку вместо Ref; перепроведение нестабильно.

Фикс: замена значения **in-place по оригинальному ключу** — один ключ,
одно значение. Обогащение (ТЧ + шапка) теперь работает и при обычной
записи, не только при проведении — `ПриЗаписи` непроводимых документов
(Счёт) получал сырые UUID в табличных частях.

## SQLite TEXT → time.Time (один корень, 3 места)
- `audit.go`: разбор `at` + cutoff активных пользователей в ISO-строку.
- `attachments.go`: `uploaded_at` через `parseAuditTime`.
- `auth/users.go`: `ActiveSessions.expires_at` через `parseSessionTime` —
  SQLite хранил Go-формат `...+0300 MSK`, драйвер не парсил → пустая
  страница активных сессий.

## query.go — ref-JOIN'ы для Документ/Справочник
- `CompileOpts.Entities` для источников Document/Catalog.
- `refDimInfo.refIsDoc` + `displayCol()`: документы → номер, справочники
  → наименование.
- look-ahead для точечной нотации (`Касса.Вид` → JOIN-алиас, не поле).
- резолв refDim после точки (`р.Покупатель` → `покупатель_id`).
- атрибуты регистра тоже участвуют в auto-JOIN.
- авто-JOIN только для полей, реально встречающихся в запросе.
- все вызовы `query.Compile` обновлены передавать `Entities`.

## UI-форматирование
- `widget_helpers.go`: `fmtReportCell` — авто-тип ячейки
  (time.Time→дата, float64→разделители тысяч, строка-дата→дата,
  nil→пусто); ось Y ECharts форматируется, grid.left расширен.
- `templates.go`: `fmtCell` в FuncMap; ячейки списка через него
  (nil больше не `<nil>`, числа с разделителями).

## Тесты
- `ui/fmt_report_cell_test.go` — 11 кейсов типов.
- `ui/enrich_header_refs_test.go` — +NoDuplicateKey (нет дубля ключей).
- `auth/session_time_test.go` — time.Time/RFC3339/Go MST/[]byte/мусор.

go test ./... зелёный (19 пакетов), go vet чистый.