### PR TITLE
feat: Gengen — генерация конфигурации из промпта

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/ivantit66/onebase/internal/gengen"
+)
+
+var (
+	genPrompt   string
+	genOutput   string
+	genDomain   string
+	genList     bool
+	genAddons   []string
+)
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate a new project from a natural-language prompt",
+	Long: `Создаёт новый проект OneBase по описанию на естественном языке.
+
+Примеры:
+  onebase generate --prompt "оптовые продажи, склад, контрагенты"
+  onebase generate --prompt "учёт задач и проектов" --output ./my-tasks
+  onebase generate --prompt "тексты и переводы" --domain texts
+  onebase generate --list   # показать доступные домены`,
+	RunE: runGenerate,
+}
+
+func init() {
+	generateCmd.Flags().StringVar(&genPrompt, "prompt", "", "описание проекта на естественном языке")
+	generateCmd.Flags().StringVar(&genOutput, "output", "", "директория для вывода (по умолчанию = имя домена)")
+	generateCmd.Flags().StringVar(&genDomain, "domain", "", "явно указать домен (trade, crm, tasks, ...)")
+	generateCmd.Flags().StringSliceVar(&genAddons, "addon", nil, "дополнительные модули (через запятую)")
+	generateCmd.Flags().BoolVar(&genList, "list", false, "показать доступные домены и выйти")
+}
+
+func runGenerate(cmd *cobra.Command, args []string) error {
+	if genList {
+		fmt.Fprintln(os.Stdout, "Доступные домены:")
+		domains := gengen.AvailableDomains()
+		for name, keywords := range domains {
+			fmt.Fprintf(os.Stdout, "  %-14s %s\n", name, keywords[0]+", "+keywords[1])
+		}
+		return nil
+	}
+
+	if genPrompt == "" && genDomain == "" {
+		return fmt.Errorf("укажите --prompt \"описание\" или --domain <имя>\n\nИспользуйте --list для просмотра доступных доменов")
+	}
+
+	// 1. Analyze
+	var result *gengen.AnalyzeResult
+	if genDomain != "" {
+		// Direct domain override
+		result = &gengen.AnalyzeResult{
+			Domain:    genDomain,
+			Confident: true,
+		}
+	} else {
+		result = gengen.Analyze(genPrompt)
+	}
+
+	if result.Domain == "unknown" {
+		fmt.Fprintf(os.Stderr, "⚠ Домен не определён по промпту.\n\n")
+		fmt.Fprintf(os.Stderr, "Попробуйте:\n")
+		fmt.Fprintf(os.Stderr, "  1. Указать домен явно: --domain trade\n")
+		fmt.Fprintf(os.Stderr, "  2. Использовать другие ключевые слова\n\n")
+		fmt.Fprintf(os.Stderr, "Доступные домены:\n")
+		for name := range gengen.AvailableDomains() {
+			fmt.Fprintf(os.Stderr, "  %s\n", name)
+		}
+		return fmt.Errorf("domain detection failed")
+	}
+
+	if !result.Confident {
+		fmt.Fprintf(os.Stderr, "⚠ Амбигуозный результат, возможны варианты: %v\n", result.Ambiguous)
+		fmt.Fprintf(os.Stderr, "  Выбран: %s (уточните --domain для явного выбора)\n\n", result.Domain)
+	}
+
+	// 2. Resolve template
+	if result.Template == "" {
+		// Try to find template by domain name
+		candidates := []string{
+			"examples/" + result.Domain,
+			"templates/" + result.Domain,
+		}
+		for _, t := range candidates {
+			if dirExists(t) {
+				result.Template = t
+				break
+			}
+		}
+	}
+
+	if result.Template == "" {
+		return fmt.Errorf("нет шаблона для домена %q (искали: examples/%s, templates/%s)",
+			result.Domain, result.Domain, result.Domain)
+	}
+
+	// 3. Determine output directory
+	outDir := genOutput
+	if outDir == "" {
+		outDir = gengen.SanitizePrompt(genPrompt)
+		if outDir == "" {
+			outDir = result.Domain
+		}
+	}
+
+	// 4. Generate
+	gen := &gengen.Generator{OutputDir: outDir}
+	if err := gen.Generate(result.Template, genAddons); err != nil {
+		return err
+	}
+
+	// 5. Success
+	fmt.Fprintf(os.Stdout, "✓ Проект сгенерирован в %s\n", outDir)
+	fmt.Fprintf(os.Stdout, "  Домен: %s\n", result.Domain)
+	fmt.Fprintf(os.Stdout, "  Шаблон: %s\n", result.Template)
+	if len(genAddons) > 0 {
+		fmt.Fprintf(os.Stdout, "  Аддоны: %v\n", genAddons)
+	}
+	fmt.Fprintf(os.Stdout, "\nЗапуск:\n")
+	absPath, _ := filepath.Abs(outDir)
+	fmt.Fprintf(os.Stdout, "  onebase run --project %s --sqlite %s.db\n", absPath, result.Domain)
+
+	return nil
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -15,6 +15,7 @@ var (
 	genDomain   string
 	genList     bool
 	genAddons   []string
+	genMerge    bool
 )
 
 var generateCmd = &cobra.Command{
@@ -26,6 +27,7 @@ var generateCmd = &cobra.Command{
   onebase generate --prompt "оптовые продажи, склад, контрагенты"
   onebase generate --prompt "учёт задач и проектов" --output ./my-tasks
   onebase generate --prompt "тексты и переводы" --domain texts
+  onebase generate --prompt "добавить документ Сделка" --merge --output ./trade
   onebase generate --list   # показать доступные домены`,
 	RunE: runGenerate,
 }
@@ -36,6 +38,7 @@ func init() {
 	generateCmd.Flags().StringVar(&genDomain, "domain", "", "явно указать домен (trade, crm, tasks, ...)")
 	generateCmd.Flags().StringSliceVar(&genAddons, "addon", nil, "дополнительные модули (через запятую)")
 	generateCmd.Flags().BoolVar(&genList, "list", false, "показать доступные домены и выйти")
+	generateCmd.Flags().BoolVar(&genMerge, "merge", false, "добавить сущности в существующий проект (не затирать)")
 }
 
 func runGenerate(cmd *cobra.Command, args []string) error {
@@ -110,7 +113,12 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// 4. Generate
+	// 4. Generate (with or without merge)
+	if genMerge {
+		return runGenerateMerge(outDir, result)
+	}
+
+	// Normal: create new project
 	gen := &gengen.Generator{OutputDir: outDir}
 	if err := gen.Generate(result.Template, genAddons); err != nil {
 		return err
@@ -128,6 +136,110 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "  onebase run --project %s --sqlite %s.db\n", absPath, result.Domain)
 
 	return nil
+}
+
+// runGenerateMerge adds entities from a template to an existing project.
+func runGenerateMerge(outDir string, result *gengen.AnalyzeResult) error {
+	// Check that the project directory exists
+	if !dirExists(outDir) {
+		return fmt.Errorf("проект %q не найден — нельзя добавить в несуществующий проект\nСоздайте проект: onebase generate --prompt \"...\" --output %s", outDir, outDir)
+	}
+
+	// 1. Scan existing project
+	existing, err := gengen.ScanProjectFromFiles(outDir)
+	if err != nil {
+		return fmt.Errorf("сканирование проекта: %w", err)
+	}
+
+	// 2. Generate (copyDir skips existing files — merge-safe by design)
+	gen := &gengen.Generator{OutputDir: outDir}
+	if err := gen.Generate(result.Template, genAddons); err != nil {
+		return err
+	}
+
+	// 3. Scan again to see what was added
+	after, err := gengen.ScanProjectFromFiles(outDir)
+	if err != nil {
+		return fmt.Errorf("сканирование после генерации: %w", err)
+	}
+
+	// 4. Build a ResolvedManifest from the "after" state and compute delta
+	//    This is a simplified approach — we compare before vs after
+	//    to show what was actually added.
+	reportMergeDiff(existing, after, result, outDir)
+
+	return nil
+}
+
+// reportMergeDiff compares two manifests and prints what was added.
+func reportMergeDiff(before, after *gengen.ExistingManifest, result *gengen.AnalyzeResult, outDir string) {
+	fmt.Fprintf(os.Stdout, "✓ Сущности добавлены в %s\n", result.Domain)
+	fmt.Fprintf(os.Stdout, "  Домен: %s\n\n", result.Domain)
+
+	// New catalogs
+	for name := range after.Catalogs {
+		if _, ok := before.Catalogs[name]; !ok {
+			fmt.Fprintf(os.Stdout, "  + Справочник: %s\n", name)
+		}
+	}
+
+	// New documents
+	for name := range after.Documents {
+		if _, ok := before.Documents[name]; !ok {
+			fmt.Fprintf(os.Stdout, "  + Документ: %s\n", name)
+		}
+	}
+
+	// New enums
+	for name := range after.Enums {
+		if _, ok := before.Enums[name]; !ok {
+			fmt.Fprintf(os.Stdout, "  + Перечисление: %s\n", name)
+		}
+	}
+
+	// New DSL files
+	for path := range after.DSLFiles {
+		if _, ok := before.DSLFiles[path]; !ok {
+			fmt.Fprintf(os.Stdout, "  + DSL: %s\n", path)
+		}
+	}
+
+	// New fields in existing entities
+	for catName, afterCat := range after.Catalogs {
+		beforeCat, ok := before.Catalogs[catName]
+		if !ok {
+			continue
+		}
+		beforeFields := make(map[string]bool)
+		for _, f := range beforeCat.Fields {
+			beforeFields[f.Name] = true
+		}
+		for _, f := range afterCat.Fields {
+			if !beforeFields[f.Name] {
+				fmt.Fprintf(os.Stdout, "  + Поле %s → %s\n", catName, f.Name)
+			}
+		}
+	}
+
+	for docName, afterDoc := range after.Documents {
+		beforeDoc, ok := before.Documents[docName]
+		if !ok {
+			continue
+		}
+		beforeFields := make(map[string]bool)
+		for _, f := range beforeDoc.Fields {
+			beforeFields[f.Name] = true
+		}
+		for _, f := range afterDoc.Fields {
+			if !beforeFields[f.Name] {
+				fmt.Fprintf(os.Stdout, "  + Поле %s → %s\n", docName, f.Name)
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, "\nЗапуск:\n")
+	absPath, _ := filepath.Abs(outDir)
+	fmt.Fprintf(os.Stdout, "  onebase run --project %s\n", absPath)
 }
 
 func dirExists(path string) bool {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,5 +26,5 @@ func init() {
 	rootCmd.SilenceErrors = true
 	rootCmd.PersistentFlags().BoolVar(&noGUI, "no-gui", false,
 		"не показывать модальные окна с ошибками — для скриптов и CI (также ONEBASE_NO_GUI=1)")
-	rootCmd.AddCommand(initCmd, devCmd, runCmd, migrateCmd, buildCmd, startCmd, ibasesCmd, convertCmd, backupCmd, restoreCmd, deployCmd, serviceCmd)
+	rootCmd.AddCommand(initCmd, devCmd, runCmd, migrateCmd, buildCmd, startCmd, ibasesCmd, convertCmd, backupCmd, restoreCmd, deployCmd, serviceCmd, generateCmd)
 }

--- a/internal/gengen/analyzer.go
+++ b/internal/gengen/analyzer.go
@@ -1,0 +1,136 @@
+package gengen
+
+import (
+	"os"
+	"strings"
+)
+
+// domainRules maps domain names to their keyword sets and template paths.
+// Keywords are stored in lowercase; matching is case-insensitive.
+var domainRules = map[string]DomainRule{
+	"trade": {
+		Keywords: []string{
+			"продаж", "опт", "розниц", "клиент", "контрагент",
+			"отгрузк", "реализаци", "счет-фактур", "заказ", "склад", "остатк",
+			"товар", "номенклатур", "поставщик", "закупк",
+		},
+		Templates: []string{"examples/trade", "templates/trade"},
+	},
+	"warehouse": {
+		Keywords: []string{
+			"склад", "остатк", "товар", "ячейк", "адресн",
+			"инвентаризаци", "перемещен", "приход", "расход",
+		},
+		Templates: []string{"templates/warehouse"},
+	},
+	"crm": {
+		Keywords: []string{
+			"клиент", "сделк", "воронк", "лид", "звонк",
+			"менеджер", "контакт", "коммерческ",
+		},
+		Templates: []string{"templates/crm"},
+	},
+	"finance": {
+		Keywords: []string{
+			"финанс", "бюджет", "счет", "доход", "расход",
+			"категор", "долг", "прибыл", "убыток",
+		},
+		Templates: []string{"templates/finance"},
+	},
+	"tasks": {
+		Keywords: []string{
+			"задач", "проект", "исполнител", "дедлайн",
+			"приоритет", "статус",
+		},
+		Templates: []string{"templates/tasks"},
+	},
+	"accounting": {
+		Keywords: []string{
+			"бухгалтер", "план счетов", "проводк", "дебет",
+			"кредит", "оборотн", "сальдо", "основн средств", "амортизаци",
+		},
+		Templates: []string{"examples/accounting", "templates/accounting"},
+	},
+	"texts": {
+		Keywords: []string{
+			"текст", "перевод", "язык", "событие",
+			"перевод текст", "текст и перевод",
+		},
+		Templates: []string{"templates/texts"},
+	},
+}
+
+// Analyze parses a natural-language prompt and returns an AnalyzeResult.
+// It uses keyword matching against known domain rules.
+//
+// Algorithm:
+//  1. Lowercase the prompt.
+//  2. For each domain, count keyword matches (substring search).
+//  3. Pick the domain with the highest count.
+//  4. If tied, set Confident=false and list ambiguous domains.
+//  5. Resolve the template path (first existing dir from Templates list).
+func Analyze(prompt string) *AnalyzeResult {
+	prompt = strings.ToLower(prompt)
+
+	type score struct {
+		domain string
+		count  int
+	}
+	var best score
+	var ties []string
+
+	for name, rule := range domainRules {
+		count := 0
+		for _, kw := range rule.Keywords {
+			if strings.Contains(prompt, kw) {
+				count++
+			}
+		}
+		if count > best.count {
+			best.count = count
+			best.domain = name
+			ties = nil
+		} else if count == best.count && count > 0 {
+			ties = append(ties, name)
+		}
+	}
+
+	if best.count == 0 {
+		return &AnalyzeResult{Domain: "unknown"}
+	}
+
+	result := &AnalyzeResult{
+		Domain:    best.domain,
+		Confident: len(ties) == 0,
+		Ambiguous: ties,
+	}
+
+	// Resolve template path
+	rule := domainRules[best.domain]
+	for _, t := range rule.Templates {
+		if dirExists(t) {
+			result.Template = t
+			break
+		}
+	}
+
+	return result
+}
+
+// AvailableDomains returns all known domain names and their keyword counts.
+func AvailableDomains() map[string][]string {
+	out := make(map[string][]string, len(domainRules))
+	for name, rule := range domainRules {
+		out[name] = append([]string(nil), rule.Keywords...)
+	}
+	return out
+}
+
+// dirExists checks if a directory exists on the filesystem.
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/internal/gengen/analyzer_test.go
+++ b/internal/gengen/analyzer_test.go
@@ -1,0 +1,196 @@
+package gengen
+
+import "testing"
+
+// ─── Trade domain ─────────────────────────────────────────────────────────────
+
+func TestAnalyze_Trade(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"хочу склад и продажи"},
+		{"система оптовых продаж"},
+		{"клиенты, контрагенты, отгрузки"},
+		{"нужна реализация товаров со склада"},
+		{"учёт продаж и закупок"},
+		{"оптовая торговля с контрагентами"},
+		{"розничные продажи номенклатуры"},
+		{"заказ поставщика и отгрузка товара"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "trade" {
+				t.Errorf("Analyze(%q) = %q, want trade", tt.prompt, r.Domain)
+			}
+		})
+	}
+}
+
+// ─── Warehouse domain ─────────────────────────────────────────────────────────
+
+func TestAnalyze_Warehouse(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"складской учёт без продаж"},
+		{"адресное хранение товаров"},
+		{"инвентаризация склада"},
+		{"приход и расход товаров"},
+		{"перемещение между ячейками"},
+		{"учёт остатков на складах"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "warehouse" {
+				t.Errorf("Analyze(%q) = %q, want warehouse", tt.prompt, r.Domain)
+			}
+		})
+	}
+}
+
+// ─── CRM domain ───────────────────────────────────────────────────────────────
+
+func TestAnalyze_CRM(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"управление клиентами и сделками"},
+		{"воронка продаж с лидами"},
+		{"менеджер звонит контактам"},
+		{"коммерческие предложения клиентам"},
+		{"crm система для отдела продаж"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "crm" {
+				t.Errorf("Analyze(%q) = %q, want crm", tt.prompt, r.Domain)
+			}
+		})
+	}
+}
+
+// ─── Finance domain ───────────────────────────────────────────────────────────
+
+func TestAnalyze_Finance(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"домашние финансы и бюджет"},
+		{"учёт доходов и расходов"},
+		{"категории расходов"},
+		{"долги и прибыль"},
+		{"финансовый учёт по счетам"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "finance" {
+				t.Errorf("Analyze(%q) = %q, want finance", tt.prompt, r.Domain)
+			}
+		})
+	}
+}
+
+// ─── Tasks domain ─────────────────────────────────────────────────────────────
+
+func TestAnalyze_Tasks(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"трекер задач и проектов"},
+		{"исполнители и дедлайны"},
+		{"приоритет и статус задачи"},
+		{"управление проектами"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "tasks" {
+				t.Errorf("Analyze(%q) = %q, want tasks", tt.prompt, r.Domain)
+			}
+		})
+	}
+}
+
+// ─── Accounting domain ────────────────────────────────────────────────────────
+
+func TestAnalyze_Accounting(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"бухгалтерия с планом счетов"},
+		{"проводки дебет кредит"},
+		{"оборотная ведомость и сальдо"},
+		{"учёт основных средств и амортизация"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "accounting" {
+				t.Errorf("Analyze(%q) = %q, want accounting", tt.prompt, r.Domain)
+			}
+		})
+	}
+}
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+func TestAnalyze_Unknown(t *testing.T) {
+	r := Analyze("абракадабра ничего не понятно")
+	if r.Domain != "unknown" {
+		t.Errorf("Analyze(unknown) = %q, want unknown", r.Domain)
+	}
+}
+
+func TestAnalyze_Empty(t *testing.T) {
+	r := Analyze("")
+	if r.Domain != "unknown" {
+		t.Errorf("Analyze(empty) = %q, want unknown", r.Domain)
+	}
+}
+
+func TestAnalyze_Confidence(t *testing.T) {
+	// Clear single match → confident
+	r := Analyze("хочу склад и продажи товаров")
+	if !r.Confident {
+		t.Error("expected Confident=true for clear trade match")
+	}
+	if len(r.Ambiguous) != 0 {
+		t.Errorf("expected no Ambiguous, got %v", r.Ambiguous)
+	}
+}
+
+func TestAnalyze_AvailableDomains(t *testing.T) {
+	domains := AvailableDomains()
+	expected := []string{"trade", "warehouse", "crm", "finance", "tasks", "accounting", "texts"}
+	for _, d := range expected {
+		if _, ok := domains[d]; !ok {
+			t.Errorf("AvailableDomains() missing %q", d)
+		}
+	}
+}
+
+// ─── Texts domain ─────────────────────────────────────────────────────────────
+
+func TestAnalyze_Texts(t *testing.T) {
+	tests := []struct {
+		prompt string
+	}{
+		{"тексты и переводы"},
+		{"учёт текстов и переводов"},
+		{"текст содержит ссылку на событие, перевод содержит язык"},
+		{"перевод текста на разные языки"},
+		{"хранение текстов событий и их переводов"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prompt, func(t *testing.T) {
+			r := Analyze(tt.prompt)
+			if r.Domain != "texts" {
+				t.Errorf("Analyze(%q) = %q, want texts", tt.prompt, r.Domain)
+			}
+		})
+	}
+}

--- a/internal/gengen/delta.go
+++ b/internal/gengen/delta.go
@@ -1,0 +1,248 @@
+package gengen
+
+import "fmt"
+
+// ComputeDelta computes the difference between the requested manifest and the
+// existing project manifest. It returns a DeltaManifest describing what needs
+// to be created, extended, or skipped.
+func ComputeDelta(requested *ResolvedManifest, existing *ExistingManifest) *DeltaManifest {
+	delta := &DeltaManifest{
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	// 1. New catalogs + field diffs for existing
+	for _, cat := range requested.Catalogs {
+		if _, exists := existing.Catalogs[cat.Name]; !exists {
+			delta.NewCatalogs = append(delta.NewCatalogs, cat)
+		} else {
+			// Existing catalog: check for new fields and table parts
+			checkEntityDelta(cat, existing.Catalogs[cat.Name].Fields, existing.Catalogs[cat.Name].TableParts, delta)
+		}
+	}
+
+	// 2. New documents + field diffs for existing
+	for _, doc := range requested.Documents {
+		if _, exists := existing.Documents[doc.Name]; !exists {
+			delta.NewDocuments = append(delta.NewDocuments, doc)
+		} else {
+			checkEntityDelta(doc, existing.Documents[doc.Name].Fields, existing.Documents[doc.Name].TableParts, delta)
+		}
+	}
+
+	// 3. New registers
+	for _, reg := range requested.Registers {
+		if _, exists := existing.Registers[reg.Name]; !exists {
+			delta.NewRegisters = append(delta.NewRegisters, reg)
+		} else {
+			// Check dimensions and resources
+			existingReg := existing.Registers[reg.Name]
+			existingFields := make(map[string]bool)
+			for _, f := range existingReg.Dimensions {
+				existingFields[f.Name] = true
+			}
+			for _, f := range existingReg.Resources {
+				existingFields[f.Name] = true
+			}
+			for _, f := range reg.Fields {
+				if !existingFields[f.Name] {
+					delta.NewFields[reg.Name] = append(delta.NewFields[reg.Name], f)
+				}
+			}
+		}
+	}
+
+	// 4. New enums
+	for _, enum := range requested.Enums {
+		if _, exists := existing.Enums[enum.Name]; !exists {
+			delta.NewEnums = append(delta.NewEnums, enum)
+		}
+		// Note: enum value changes are not tracked in MVP
+	}
+
+	// 5. DSL files: only new ones
+	for path, content := range requested.DSLFiles {
+		if _, exists := existing.DSLFiles[path]; !exists {
+			delta.NewDSLFiles[path] = content
+		}
+	}
+
+	// 6. Detect conflicts (requested entities with same name but different kind)
+	detectConflicts(requested, existing, delta)
+
+	return delta
+}
+
+// checkEntityDelta compares an entity spec with existing fields/table parts
+// and populates delta.NewFields and delta.NewTableParts.
+func checkEntityDelta(spec EntitySpec, existingFields []FieldInfo, existingTPs []TablePartInfo, delta *DeltaManifest) {
+	// Build set of existing field names
+	existingFieldNames := make(map[string]bool)
+	for _, f := range existingFields {
+		existingFieldNames[f.Name] = true
+	}
+
+	// Find new fields
+	for _, f := range spec.Fields {
+		if !existingFieldNames[f.Name] {
+			delta.NewFields[spec.Name] = append(delta.NewFields[spec.Name], f)
+		}
+	}
+
+	// Build set of existing table part names
+	existingTPNames := make(map[string]bool)
+	for _, tp := range existingTPs {
+		existingTPNames[tp.Name] = true
+	}
+
+	// Find new table parts
+	for _, tp := range spec.TableParts {
+		if !existingTPNames[tp.Name] {
+			delta.NewTableParts[spec.Name] = append(delta.NewTableParts[spec.Name], tp)
+		} else {
+			// Existing TP: check for new fields inside it
+			for _, existingTP := range existingTPs {
+				if existingTP.Name == tp.Name {
+					existingTPFieldNames := make(map[string]bool)
+					for _, f := range existingTP.Fields {
+						existingTPFieldNames[f.Name] = true
+					}
+					for _, f := range tp.Fields {
+						if !existingTPFieldNames[f.Name] {
+							// Mark as new field in the TP
+							tpWithNewFields := TablePartSpec{
+								Name:   tp.Name,
+								Fields: []FieldSpec{f},
+							}
+							delta.NewTableParts[spec.Name] = append(delta.NewTableParts[spec.Name], tpWithNewFields)
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+}
+
+// detectConflicts finds cases where a requested entity name collides with an
+// existing entity of a different kind.
+func detectConflicts(requested *ResolvedManifest, existing *ExistingManifest, delta *DeltaManifest) {
+	// Check catalogs
+	for _, cat := range requested.Catalogs {
+		if _, ok := existing.Documents[cat.Name]; ok {
+			delta.Conflicts = append(delta.Conflicts, Conflict{
+				Kind:    "catalog",
+				Name:    cat.Name,
+				Message: fmt.Sprintf("«%s» уже существует как документ, нельзя создать справочник с тем же именем", cat.Name),
+			})
+		}
+		if _, ok := existing.Registers[cat.Name]; ok {
+			delta.Conflicts = append(delta.Conflicts, Conflict{
+				Kind:    "catalog",
+				Name:    cat.Name,
+				Message: fmt.Sprintf("«%s» уже существует как регистр, нельзя создать справочник с тем же именем", cat.Name),
+			})
+		}
+	}
+
+	// Check documents
+	for _, doc := range requested.Documents {
+		if _, ok := existing.Catalogs[doc.Name]; ok {
+			delta.Conflicts = append(delta.Conflicts, Conflict{
+				Kind:    "document",
+				Name:    doc.Name,
+				Message: fmt.Sprintf("«%s» уже существует как справочник, нельзя создать документ с тем же именем", doc.Name),
+			})
+		}
+		if _, ok := existing.Registers[doc.Name]; ok {
+			delta.Conflicts = append(delta.Conflicts, Conflict{
+				Kind:    "document",
+				Name:    doc.Name,
+				Message: fmt.Sprintf("«%s» уже существует как регистр, нельзя создать документ с тем же именем", doc.Name),
+			})
+		}
+	}
+
+	// Check enums
+	for _, enum := range requested.Enums {
+		if _, ok := existing.Catalogs[enum.Name]; ok {
+			delta.Conflicts = append(delta.Conflicts, Conflict{
+				Kind:    "enum",
+				Name:    enum.Name,
+				Message: fmt.Sprintf("«%s» уже существует как справочник, нельзя создать перечисление с тем же именем", enum.Name),
+			})
+		}
+	}
+}
+
+// HasChanges returns true if the delta contains any new entities, fields, or files.
+func (d *DeltaManifest) HasChanges() bool {
+	return len(d.NewCatalogs) > 0 ||
+		len(d.NewDocuments) > 0 ||
+		len(d.NewRegisters) > 0 ||
+		len(d.NewEnums) > 0 ||
+		len(d.NewFields) > 0 ||
+		len(d.NewTableParts) > 0 ||
+		len(d.NewDSLFiles) > 0
+}
+
+// Summary returns a human-readable summary of the delta.
+func (d *DeltaManifest) Summary() string {
+	parts := []string{}
+	if len(d.NewCatalogs) > 0 {
+		names := make([]string, len(d.NewCatalogs))
+		for i, c := range d.NewCatalogs {
+			names[i] = c.Name
+		}
+		parts = append(parts, fmt.Sprintf("+%d справочник(ов): %v", len(d.NewCatalogs), names))
+	}
+	if len(d.NewDocuments) > 0 {
+		names := make([]string, len(d.NewDocuments))
+		for i, c := range d.NewDocuments {
+			names[i] = c.Name
+		}
+		parts = append(parts, fmt.Sprintf("+%d документ(ов): %v", len(d.NewDocuments), names))
+	}
+	if len(d.NewRegisters) > 0 {
+		names := make([]string, len(d.NewRegisters))
+		for i, c := range d.NewRegisters {
+			names[i] = c.Name
+		}
+		parts = append(parts, fmt.Sprintf("+%d регистр(ов): %v", len(d.NewRegisters), names))
+	}
+	if len(d.NewEnums) > 0 {
+		names := make([]string, len(d.NewEnums))
+		for i, c := range d.NewEnums {
+			names[i] = c.Name
+		}
+		parts = append(parts, fmt.Sprintf("+%d перечисление(ий): %v", len(d.NewEnums), names))
+	}
+	if len(d.NewFields) > 0 {
+		parts = append(parts, fmt.Sprintf("+%d сущностей с новыми полями", len(d.NewFields)))
+	}
+	if len(d.NewTableParts) > 0 {
+		parts = append(parts, fmt.Sprintf("+%d сущностей с новыми ТЧ", len(d.NewTableParts)))
+	}
+	if len(d.NewDSLFiles) > 0 {
+		names := make([]string, 0, len(d.NewDSLFiles))
+		for k := range d.NewDSLFiles {
+			names = append(names, k)
+		}
+		parts = append(parts, fmt.Sprintf("+%d DSL-файл(ов): %v", len(d.NewDSLFiles), names))
+	}
+	if len(d.Conflicts) > 0 {
+		parts = append(parts, fmt.Sprintf("⚠ %d конфликт(ов)", len(d.Conflicts)))
+	}
+	if len(parts) == 0 {
+		return "Нет изменений — всё уже существует"
+	}
+	result := ""
+	for i, p := range parts {
+		if i > 0 {
+			result += "\n"
+		}
+		result += p
+	}
+	return result
+}

--- a/internal/gengen/delta_test.go
+++ b/internal/gengen/delta_test.go
@@ -1,0 +1,217 @@
+package gengen
+
+import "testing"
+
+func TestComputeDelta_NewCatalog(t *testing.T) {
+	requested := &ResolvedManifest{
+		Catalogs: []EntitySpec{
+			{Name: "Контрагент", Fields: []FieldSpec{{Name: "Наименование", Type: "string"}}},
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if len(delta.NewCatalogs) != 1 {
+		t.Fatalf("expected 1 new catalog, got %d", len(delta.NewCatalogs))
+	}
+	if delta.NewCatalogs[0].Name != "Контрагент" {
+		t.Errorf("expected Контрагент, got %s", delta.NewCatalogs[0].Name)
+	}
+}
+
+func TestComputeDelta_ExistingCatalog_NewFields(t *testing.T) {
+	requested := &ResolvedManifest{
+		Catalogs: []EntitySpec{
+			{
+				Name: "Контрагент",
+				Fields: []FieldSpec{
+					{Name: "Наименование", Type: "string"},
+					{Name: "ИНН", Type: "string"},
+					{Name: "КПП", Type: "string"},
+				},
+			},
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs: map[string]CatalogInfo{
+			"Контрагент": {
+				Name: "Контрагент",
+				Fields: []FieldInfo{
+					{Name: "Наименование", Type: "string"},
+					{Name: "ИНН", Type: "string"},
+				},
+			},
+		},
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if len(delta.NewCatalogs) != 0 {
+		t.Errorf("expected 0 new catalogs, got %d", len(delta.NewCatalogs))
+	}
+
+	newFields, ok := delta.NewFields["Контрагент"]
+	if !ok {
+		t.Fatal("expected new fields for Контрагент")
+	}
+	if len(newFields) != 1 {
+		t.Fatalf("expected 1 new field, got %d", len(newFields))
+	}
+	if newFields[0].Name != "КПП" {
+		t.Errorf("expected КПП, got %s", newFields[0].Name)
+	}
+}
+
+func TestComputeDelta_NewDocument(t *testing.T) {
+	requested := &ResolvedManifest{
+		Documents: []EntitySpec{
+			{Name: "РеализацияТоваров", Fields: []FieldSpec{{Name: "Дата", Type: "date"}}},
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if len(delta.NewDocuments) != 1 {
+		t.Fatalf("expected 1 new document, got %d", len(delta.NewDocuments))
+	}
+}
+
+func TestComputeDelta_NewEnum(t *testing.T) {
+	requested := &ResolvedManifest{
+		Enums: []EnumSpec{
+			{Name: "СтавкиНДС", Values: []string{"БезНДС", "20%"}},
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if len(delta.NewEnums) != 1 {
+		t.Fatalf("expected 1 new enum, got %d", len(delta.NewEnums))
+	}
+}
+
+func TestComputeDelta_NewDSLFile(t *testing.T) {
+	requested := &ResolvedManifest{
+		DSLFiles: map[string]string{
+			"отчёт_продажи.os": "Процедура Сформировать()\nКонецПроцедуры\n",
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if len(delta.NewDSLFiles) != 1 {
+		t.Fatalf("expected 1 new DSL file, got %d", len(delta.NewDSLFiles))
+	}
+}
+
+func TestComputeDelta_NoChanges(t *testing.T) {
+	requested := &ResolvedManifest{
+		Catalogs: []EntitySpec{
+			{Name: "Контрагент", Fields: []FieldSpec{{Name: "Наименование", Type: "string"}}},
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs: map[string]CatalogInfo{
+			"Контрагент": {
+				Name:   "Контрагент",
+				Fields: []FieldInfo{{Name: "Наименование", Type: "string"}},
+			},
+		},
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if delta.HasChanges() {
+		t.Error("expected no changes")
+	}
+}
+
+func TestComputeDelta_Conflict(t *testing.T) {
+	requested := &ResolvedManifest{
+		Catalogs: []EntitySpec{
+			{Name: "РеализацияТоваров", Fields: []FieldSpec{{Name: "Дата", Type: "date"}}},
+		},
+	}
+	existing := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: map[string]DocumentInfo{
+			"РеализацияТоваров": {Name: "РеализацияТоваров"},
+		},
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	delta := ComputeDelta(requested, existing)
+
+	if len(delta.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(delta.Conflicts))
+	}
+	if delta.Conflicts[0].Name != "РеализацияТоваров" {
+		t.Errorf("expected conflict name = РеализацияТоваров, got %s", delta.Conflicts[0].Name)
+	}
+}
+
+func TestDeltaManifest_Summary(t *testing.T) {
+	delta := &DeltaManifest{
+		NewCatalogs: []EntitySpec{{Name: "Контрагент"}},
+		NewDocuments: []EntitySpec{{Name: "РеализацияТоваров"}},
+		NewFields: map[string][]FieldSpec{
+			"Контрагент": {{Name: "КПП", Type: "string"}},
+		},
+	}
+
+	summary := delta.Summary()
+	if summary == "" {
+		t.Fatal("expected non-empty summary")
+	}
+}
+
+func TestDeltaManifest_Summary_NoChanges(t *testing.T) {
+	delta := &DeltaManifest{
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	summary := delta.Summary()
+	if summary != "Нет изменений — всё уже существует" {
+		t.Errorf("unexpected summary: %s", summary)
+	}
+}

--- a/internal/gengen/generator.go
+++ b/internal/gengen/generator.go
@@ -1,0 +1,124 @@
+package gengen
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Generator creates a project by copying a domain template to the output directory.
+type Generator struct {
+	OutputDir string
+}
+
+// Generate copies the resolved template directory to OutputDir and patches app.yaml.
+func (g *Generator) Generate(templateDir string, addons []string) error {
+	if templateDir == "" {
+		return fmt.Errorf("no template directory resolved for this domain")
+	}
+
+	// 1. Copy template directory
+	if err := copyDir(templateDir, g.OutputDir); err != nil {
+		return fmt.Errorf("copy template: %w", err)
+	}
+
+	// 2. Apply addons (each addon overlays its files on top of the base template)
+	for _, addon := range addons {
+		addonDir := filepath.Join(templateDir, "addons", addon)
+		if !dirExists(addonDir) {
+			continue
+		}
+		if err := copyDir(addonDir, g.OutputDir); err != nil {
+			return fmt.Errorf("apply addon %s: %w", addon, err)
+		}
+	}
+
+	// 3. Patch config/app.yaml if it exists
+	appYAML := filepath.Join(g.OutputDir, "config", "app.yaml")
+	if fileExists(appYAML) {
+		if err := patchAppYAML(appYAML, addons); err != nil {
+			return fmt.Errorf("patch app.yaml: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// copyDir recursively copies srcDir to dstDir.
+// Existing files are NOT overwritten (safe for merge mode).
+func copyDir(srcDir, dstDir string) error {
+	return filepath.WalkDir(srcDir, func(srcPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(srcDir, srcPath)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dstDir, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+
+		// Skip if destination already exists (merge-safe)
+		if fileExists(dstPath) {
+			return nil
+		}
+
+		return copyFile(srcPath, dstPath)
+	})
+}
+
+// copyFile copies a single file from src to dst.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}
+
+// patchAppYAML updates config/app.yaml with addon references.
+// In MVP this is a no-op; full implementation would parse and merge YAML.
+func patchAppYAML(path string, addons []string) error {
+	if len(addons) == 0 {
+		return nil
+	}
+	// TODO: parse YAML, append addon references, write back
+	// For MVP, app.yaml is copied as-is from the template.
+	return nil
+}
+
+// fileExists checks if a file exists on the filesystem.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// SanitizePrompt extracts a project name from the prompt for directory naming.
+func SanitizePrompt(prompt string) string {
+	// Take first 3 words, lowercase, replace spaces with dashes
+	words := strings.Fields(prompt)
+	if len(words) > 3 {
+		words = words[:3]
+	}
+	name := strings.Join(words, "-")
+	// Remove non-alphanumeric (keep cyrillic, latin, dashes)
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r >= 0x0400 {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/gengen/generator_test.go
+++ b/internal/gengen/generator_test.go
@@ -1,0 +1,93 @@
+package gengen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyDir(t *testing.T) {
+	// Create a temporary source directory with files
+	src := t.TempDir()
+	os.MkdirAll(filepath.Join(src, "config"), 0o755)
+	os.WriteFile(filepath.Join(src, "config", "app.yaml"), []byte("name: test\n"), 0o644)
+	os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0o644)
+
+	dst := t.TempDir()
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir() error: %v", err)
+	}
+
+	// Verify files were copied
+	if _, err := os.Stat(filepath.Join(dst, "config", "app.yaml")); err != nil {
+		t.Error("config/app.yaml was not copied")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "README.md")); err != nil {
+		t.Error("README.md was not copied")
+	}
+}
+
+func TestCopyDir_NoOverwrite(t *testing.T) {
+	src := t.TempDir()
+	os.WriteFile(filepath.Join(src, "existing.txt"), []byte("original\n"), 0o644)
+
+	dst := t.TempDir()
+	existingContent := []byte("do not overwrite\n")
+	os.WriteFile(filepath.Join(dst, "existing.txt"), existingContent, 0o644)
+
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir() error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dst, "existing.txt"))
+	if string(data) != "do not overwrite\n" {
+		t.Error("existing file was overwritten!")
+	}
+}
+
+func TestSanitizePrompt(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"тексты и переводы", "тексты-и-переводы"},
+		{"оптовые продажи товаров", "оптовые-продажи-товаров"},
+		{"очень длинный промпт который обрезается", "очень-длинный-промпт"},
+		{"hello world", "hello-world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := SanitizePrompt(tt.input)
+			if got != tt.expected {
+				t.Errorf("SanitizePrompt(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerator_Generate_NoTemplate(t *testing.T) {
+	g := &Generator{OutputDir: t.TempDir()}
+	err := g.Generate("", nil)
+	if err == nil {
+		t.Error("expected error for empty template")
+	}
+}
+
+func TestGenerator_Generate_WithTemplate(t *testing.T) {
+	// Create a mock template
+	src := t.TempDir()
+	os.MkdirAll(filepath.Join(src, "config"), 0o755)
+	os.WriteFile(filepath.Join(src, "config", "app.yaml"), []byte("name: test\n"), 0o644)
+
+	dst := t.TempDir()
+	g := &Generator{OutputDir: dst}
+
+	if err := g.Generate(src, nil); err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, "config", "app.yaml")); err != nil {
+		t.Error("template was not generated")
+	}
+}

--- a/internal/gengen/integration_test.go
+++ b/internal/gengen/integration_test.go
@@ -1,0 +1,50 @@
+package gengen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerator_Generate_TextsTemplate(t *testing.T) {
+	// This test verifies the texts template generates correctly.
+	// It uses the real templates/texts/ directory.
+	templateDir := "../../templates/texts"
+	if !dirExists(templateDir) {
+		t.Skip("templates/texts/ not found (run from repo root)")
+	}
+
+	dst := t.TempDir()
+	g := &Generator{OutputDir: dst}
+
+	if err := g.Generate(templateDir, nil); err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+
+	// Verify expected files
+	expected := []string{
+		"config/app.yaml",
+		"catalogs/события.yaml",
+		"documents/текст.yaml",
+		"documents/перевод_текста.yaml",
+	}
+	for _, f := range expected {
+		path := filepath.Join(dst, f)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected file %s not found", f)
+		}
+	}
+}
+
+func TestAnalyze_TextsTemplate(t *testing.T) {
+	r := Analyze("тексты и переводы")
+	if r.Domain != "texts" {
+		t.Fatalf("Analyze() = %q, want texts", r.Domain)
+	}
+	if r.Template == "" {
+		t.Fatal("Analyze() returned empty template")
+	}
+	if !dirExists(r.Template) {
+		t.Fatalf("template dir %q does not exist", r.Template)
+	}
+}

--- a/internal/gengen/merge_generator.go
+++ b/internal/gengen/merge_generator.go
@@ -1,0 +1,377 @@
+package gengen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MergeGenerator applies a DeltaManifest to an existing project directory,
+// creating only new entities, fields, and files.
+type MergeGenerator struct {
+	ProjectDir string
+}
+
+// Merge applies the delta to the project directory.
+func (mg *MergeGenerator) Merge(delta *DeltaManifest) error {
+	if !delta.HasChanges() {
+		return nil
+	}
+
+	// 1. Create new catalogs
+	for _, cat := range delta.NewCatalogs {
+		if err := mg.createEntity("catalogs", cat); err != nil {
+			return fmt.Errorf("create catalog %s: %w", cat.Name, err)
+		}
+	}
+
+	// 2. Create new documents
+	for _, doc := range delta.NewDocuments {
+		if err := mg.createEntity("documents", doc); err != nil {
+			return fmt.Errorf("create document %s: %w", doc.Name, err)
+		}
+	}
+
+	// 3. Create new registers (stored as YAML in registers/ dir)
+	for _, reg := range delta.NewRegisters {
+		if err := mg.createEntity("registers", reg); err != nil {
+			return fmt.Errorf("create register %s: %w", reg.Name, err)
+		}
+	}
+
+	// 4. Create new enums
+	for _, enum := range delta.NewEnums {
+		if err := mg.createEnum(enum); err != nil {
+			return fmt.Errorf("create enum %s: %w", enum.Name, err)
+		}
+	}
+
+	// 5. Add new fields to existing entities
+	for entityName, fields := range delta.NewFields {
+		if err := mg.addFieldsToEntity(entityName, fields); err != nil {
+			return fmt.Errorf("add fields to %s: %w", entityName, err)
+		}
+	}
+
+	// 6. Add new table parts to existing entities
+	for entityName, tps := range delta.NewTableParts {
+		if err := mg.addTablePartsToEntity(entityName, tps); err != nil {
+			return fmt.Errorf("add table parts to %s: %w", entityName, err)
+		}
+	}
+
+	// 7. Create new DSL files
+	for relPath, content := range delta.NewDSLFiles {
+		fullPath := filepath.Join(mg.ProjectDir, "src", relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(fullPath), err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", fullPath, err)
+		}
+	}
+
+	return nil
+}
+
+// createEntity creates a new entity YAML file.
+func (mg *MergeGenerator) createEntity(kindDir string, spec EntitySpec) error {
+	dir := filepath.Join(mg.ProjectDir, kindDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	filename := sanitizeFilename(spec.Name) + ".yaml"
+	path := filepath.Join(dir, filename)
+
+	// Don't overwrite existing files
+	if fileExists(path) {
+		return nil
+	}
+
+	raw := buildRawEntity(spec)
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+// createEnum creates a new enum YAML file.
+func (mg *MergeGenerator) createEnum(spec EnumSpec) error {
+	dir := filepath.Join(mg.ProjectDir, "enums")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	filename := sanitizeFilename(spec.Name) + ".yaml"
+	path := filepath.Join(dir, filename)
+
+	if fileExists(path) {
+		return nil
+	}
+
+	raw := map[string]interface{}{
+		"name":   spec.Name,
+		"values": spec.Values,
+	}
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+// addFieldsToEntity finds an existing entity YAML file and appends new fields.
+func (mg *MergeGenerator) addFieldsToEntity(entityName string, fields []FieldSpec) error {
+	path := mg.findEntityFile(entityName)
+	if path == "" {
+		return fmt.Errorf("entity %s not found", entityName)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return err
+	}
+
+	// Find the "fields" key node
+	fieldsNode := findMapKey(&node, "fields")
+	if fieldsNode == nil {
+		// No fields key yet — create it
+		fieldsNode = &yaml.Node{
+			Kind:  yaml.SequenceNode,
+			Tag:   "!!seq",
+			Style: yaml.FlowStyle,
+		}
+		// Append to root mapping
+		if len(node.Content) > 0 && node.Content[0].Kind == yaml.MappingNode {
+			root := node.Content[0]
+			root.Content = append(root.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: "fields", Tag: "!!str"})
+			root.Content = append(root.Content, fieldsNode)
+		}
+	}
+
+	// Append new field nodes
+	for _, f := range fields {
+		fieldNode := buildFieldNode(f)
+		fieldsNode.Content = append(fieldsNode.Content, fieldNode)
+	}
+
+	// Write back
+	out, err := yaml.Marshal(&node)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, out, 0o644)
+}
+
+// addTablePartsToEntity finds an existing entity YAML file and appends new table parts.
+func (mg *MergeGenerator) addTablePartsToEntity(entityName string, tps []TablePartSpec) error {
+	path := mg.findEntityFile(entityName)
+	if path == "" {
+		return fmt.Errorf("entity %s not found", entityName)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return err
+	}
+
+	// Find the "tableparts" key node
+	tpNode := findMapKey(&node, "tableparts")
+	if tpNode == nil {
+		tpNode = &yaml.Node{
+			Kind:  yaml.SequenceNode,
+			Tag:   "!!seq",
+			Style: yaml.FlowStyle,
+		}
+		if len(node.Content) > 0 && node.Content[0].Kind == yaml.MappingNode {
+			root := node.Content[0]
+			root.Content = append(root.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: "tableparts", Tag: "!!str"})
+			root.Content = append(root.Content, tpNode)
+		}
+	}
+
+	// Group TPs by name (in case multiple TPs have new fields for the same TP)
+	tpByName := make(map[string]*yaml.Node)
+	for _, tp := range tps {
+		existing := tpByName[tp.Name]
+		if existing == nil {
+			existing = buildTablePartNode(tp)
+			tpNode.Content = append(tpNode.Content, existing)
+			tpByName[tp.Name] = existing
+		} else {
+			// Add fields to existing TP
+			fieldsNode := findMapKeyInNode(existing, "fields")
+			if fieldsNode == nil {
+				fieldsNode = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Style: yaml.FlowStyle}
+				existing.Content = append(existing.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: "fields", Tag: "!!str"})
+				existing.Content = append(existing.Content, fieldsNode)
+			}
+			for _, f := range tp.Fields {
+				fieldsNode.Content = append(fieldsNode.Content, buildFieldNode(f))
+			}
+		}
+	}
+
+	out, err := yaml.Marshal(&node)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, out, 0o644)
+}
+
+// findEntityFile searches for an entity YAML file across known directories.
+func (mg *MergeGenerator) findEntityFile(entityName string) string {
+	dirs := []string{"catalogs", "documents", "registers"}
+	for _, dir := range dirs {
+		path := filepath.Join(mg.ProjectDir, dir, sanitizeFilename(entityName)+".yaml")
+		if fileExists(path) {
+			return path
+		}
+	}
+	return ""
+}
+
+// findMapKey finds a value node for a given key in a YAML document node.
+func findMapKey(doc *yaml.Node, key string) *yaml.Node {
+	if len(doc.Content) == 0 {
+		return nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		if root.Content[i].Value == key {
+			return root.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// findMapKeyInNode finds a value node for a given key inside a mapping node.
+func findMapKeyInNode(node *yaml.Node, key string) *yaml.Node {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// buildRawEntity converts an EntitySpec to a map suitable for YAML marshalling.
+func buildRawEntity(spec EntitySpec) map[string]interface{} {
+	raw := map[string]interface{}{
+		"name": spec.Name,
+	}
+
+	if len(spec.Fields) > 0 {
+		fields := make([]map[string]interface{}, len(spec.Fields))
+		for i, f := range spec.Fields {
+			fields[i] = buildFieldMap(f)
+		}
+		raw["fields"] = fields
+	}
+
+	if len(spec.TableParts) > 0 {
+		tps := make([]map[string]interface{}, len(spec.TableParts))
+		for i, tp := range spec.TableParts {
+			fields := make([]map[string]interface{}, len(tp.Fields))
+			for j, f := range tp.Fields {
+				fields[j] = buildFieldMap(f)
+			}
+			tps[i] = map[string]interface{}{
+				"name":   tp.Name,
+				"fields": fields,
+			}
+		}
+		raw["tableparts"] = tps
+	}
+
+	if spec.Posting {
+		raw["posting"] = true
+	}
+
+	return raw
+}
+
+// buildFieldMap converts a FieldSpec to a map for YAML.
+func buildFieldMap(f FieldSpec) map[string]interface{} {
+	m := map[string]interface{}{
+		"name": f.Name,
+		"type": f.Type,
+	}
+	return m
+}
+
+// buildFieldNode creates a YAML mapping node for a field.
+func buildFieldNode(f FieldSpec) *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "name", Tag: "!!str"},
+			{Kind: yaml.ScalarNode, Value: f.Name, Tag: "!!str"},
+			{Kind: yaml.ScalarNode, Value: "type", Tag: "!!str"},
+			{Kind: yaml.ScalarNode, Value: f.Type, Tag: "!!str"},
+		},
+	}
+}
+
+// buildTablePartNode creates a YAML mapping node for a table part.
+func buildTablePartNode(tp TablePartSpec) *yaml.Node {
+	fieldsContent := make([]*yaml.Node, 0, len(tp.Fields)*2)
+	for _, f := range tp.Fields {
+		fieldsContent = append(fieldsContent,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "name", Tag: "!!str"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: f.Name, Tag: "!!str"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "type", Tag: "!!str"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: f.Type, Tag: "!!str"},
+		)
+	}
+
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Tag:  "!!map",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "name", Tag: "!!str"},
+			{Kind: yaml.ScalarNode, Value: tp.Name, Tag: "!!str"},
+			{Kind: yaml.ScalarNode, Value: "fields", Tag: "!!str"},
+			{Kind: yaml.SequenceNode, Tag: "!!seq", Content: fieldsContent},
+		},
+	}
+}
+
+// sanitizeFilename converts an entity name to a safe filename.
+func sanitizeFilename(name string) string {
+	// For now, just lowercase. Cyrillic is fine in filenames on Linux.
+	result := ""
+	for _, r := range name {
+		if r >= 'A' && r <= 'Z' {
+			result += string(r + 32)
+		} else {
+			result += string(r)
+		}
+	}
+	return result
+}

--- a/internal/gengen/merge_generator_test.go
+++ b/internal/gengen/merge_generator_test.go
@@ -1,0 +1,211 @@
+package gengen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMergeGenerator_CreateNewCatalog(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755)
+
+	delta := &DeltaManifest{
+		NewCatalogs: []EntitySpec{
+			{
+				Name: "Контрагент",
+				Fields: []FieldSpec{
+					{Name: "Наименование", Type: "string"},
+					{Name: "ИНН", Type: "string"},
+				},
+			},
+		},
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	mg := &MergeGenerator{ProjectDir: dir}
+	if err := mg.Merge(delta); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+
+	path := filepath.Join(dir, "catalogs", "контрагент.yaml")
+	if !fileExists(path) {
+		t.Fatal("expected контрагент.yaml to be created")
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if len(content) == 0 {
+		t.Error("expected non-empty YAML file")
+	}
+}
+
+func TestMergeGenerator_CreateNewDocument(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "documents"), 0o755)
+
+	delta := &DeltaManifest{
+		NewDocuments: []EntitySpec{
+			{
+				Name: "РеализацияТоваров",
+				Fields: []FieldSpec{
+					{Name: "Контрагент", Type: "reference:Контрагент"},
+					{Name: "Дата", Type: "date"},
+				},
+				TableParts: []TablePartSpec{
+					{
+						Name: "Товары",
+						Fields: []FieldSpec{
+							{Name: "Номенклатура", Type: "reference:Номенклатура"},
+							{Name: "Количество", Type: "number"},
+						},
+					},
+				},
+			},
+		},
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	mg := &MergeGenerator{ProjectDir: dir}
+	if err := mg.Merge(delta); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+
+	path := filepath.Join(dir, "documents", "реализациятоваров.yaml")
+	if !fileExists(path) {
+		t.Fatal("expected реализациятоваров.yaml to be created")
+	}
+}
+
+func TestMergeGenerator_AddFieldsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755)
+
+	// Create existing catalog
+	existingYAML := `name: Контрагент
+fields:
+  - name: Наименование
+    type: string
+  - name: ИНН
+    type: string
+`
+	os.WriteFile(filepath.Join(dir, "catalogs", "контрагент.yaml"), []byte(existingYAML), 0o644)
+
+	delta := &DeltaManifest{
+		NewFields: map[string][]FieldSpec{
+			"Контрагент": {
+				{Name: "КПП", Type: "string"},
+				{Name: "ЮрАдрес", Type: "string"},
+			},
+		},
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	mg := &MergeGenerator{ProjectDir: dir}
+	if err := mg.Merge(delta); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+
+	// Verify the file was modified
+	data, _ := os.ReadFile(filepath.Join(dir, "catalogs", "контрагент.yaml"))
+	content := string(data)
+
+	// Check that new fields are present
+	if !containsStr(content, "КПП") {
+		t.Error("expected КПП field in modified YAML")
+	}
+	if !containsStr(content, "ЮрАдрес") {
+		t.Error("expected ЮрАдрес field in modified YAML")
+	}
+	// Check that existing fields are preserved
+	if !containsStr(content, "Наименование") {
+		t.Error("expected Наименование field to be preserved")
+	}
+	if !containsStr(content, "ИНН") {
+		t.Error("expected ИНН field to be preserved")
+	}
+}
+
+func TestMergeGenerator_CreateEnum(t *testing.T) {
+	dir := t.TempDir()
+
+	delta := &DeltaManifest{
+		NewEnums: []EnumSpec{
+			{Name: "СтавкиНДС", Values: []string{"БезНДС", "0%", "10%", "20%"}},
+		},
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	mg := &MergeGenerator{ProjectDir: dir}
+	if err := mg.Merge(delta); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+
+	path := filepath.Join(dir, "enums", "ставкиндс.yaml")
+	if !fileExists(path) {
+		t.Fatal("expected ставкиндс.yaml to be created")
+	}
+}
+
+func TestMergeGenerator_CreateDSLFile(t *testing.T) {
+	dir := t.TempDir()
+
+	delta := &DeltaManifest{
+		NewDSLFiles: map[string]string{
+			"отчёт_продажи.os": "Процедура Сформировать()\n  Сообщить(\"Готово\")\nКонецПроцедуры\n",
+		},
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+	}
+
+	mg := &MergeGenerator{ProjectDir: dir}
+	if err := mg.Merge(delta); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+
+	path := filepath.Join(dir, "src", "отчёт_продажи.os")
+	if !fileExists(path) {
+		t.Fatal("expected DSL file to be created")
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !containsStr(content, "Сформировать") {
+		t.Error("expected DSL content to contain Сформировать")
+	}
+}
+
+func TestMergeGenerator_NoChanges(t *testing.T) {
+	dir := t.TempDir()
+
+	delta := &DeltaManifest{
+		NewFields:     make(map[string][]FieldSpec),
+		NewTableParts: make(map[string][]TablePartSpec),
+		NewDSLFiles:   make(map[string]string),
+	}
+
+	mg := &MergeGenerator{ProjectDir: dir}
+	if err := mg.Merge(delta); err != nil {
+		t.Fatalf("Merge() error: %v", err)
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || (len(s) > len(substr) && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gengen/scanner.go
+++ b/internal/gengen/scanner.go
@@ -1,0 +1,278 @@
+package gengen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/project"
+)
+
+// ExistingManifest describes what entities already exist in a project.
+type ExistingManifest struct {
+	Catalogs  map[string]CatalogInfo
+	Documents map[string]DocumentInfo
+	Registers map[string]RegisterInfo
+	Enums     map[string]EnumInfo
+	DSLFiles  map[string]string // relative path → content
+}
+
+// CatalogInfo summarizes a catalog's structure.
+type CatalogInfo struct {
+	Name       string
+	Fields     []FieldInfo
+	TableParts []TablePartInfo
+	Posting    bool
+}
+
+// DocumentInfo summarizes a document's structure.
+type DocumentInfo struct {
+	Name       string
+	Fields     []FieldInfo
+	TableParts []TablePartInfo
+	Posting    bool
+}
+
+// RegisterInfo summarizes a register's structure.
+type RegisterInfo struct {
+	Name       string
+	Dimensions []FieldInfo
+	Resources  []FieldInfo
+}
+
+// EnumInfo summarizes an enum's values.
+type EnumInfo struct {
+	Name   string
+	Values []string
+}
+
+// FieldInfo is a lightweight field descriptor for comparison.
+type FieldInfo struct {
+	Name      string
+	Type      string
+	RefEntity string
+	EnumName  string
+}
+
+// TablePartInfo summarizes a table part.
+type TablePartInfo struct {
+	Name   string
+	Fields []FieldInfo
+}
+
+// ScanProject reads an existing project directory and builds an ExistingManifest.
+func ScanProject(dir string) (*ExistingManifest, error) {
+	proj, err := project.Load(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer proj.Close()
+
+	manifest := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	// Catalogs
+	for _, e := range proj.Entities {
+		if e.Kind == metadata.KindCatalog {
+			manifest.Catalogs[e.Name] = CatalogInfo{
+				Name:       e.Name,
+				Fields:     extractFields(e.Fields),
+				TableParts: extractTableParts(e.TableParts),
+				Posting:    e.Posting,
+			}
+		}
+	}
+
+	// Documents
+	for _, e := range proj.Entities {
+		if e.Kind == metadata.KindDocument {
+			manifest.Documents[e.Name] = DocumentInfo{
+				Name:       e.Name,
+				Fields:     extractFields(e.Fields),
+				TableParts: extractTableParts(e.TableParts),
+				Posting:    e.Posting,
+			}
+		}
+	}
+
+	// Registers
+	for _, reg := range proj.Registers {
+		manifest.Registers[reg.Name] = RegisterInfo{
+			Name:       reg.Name,
+			Dimensions: extractFields(reg.Dimensions),
+			Resources:  extractFields(reg.Resources),
+		}
+	}
+
+	// Enums
+	for _, enum := range proj.Enums {
+		manifest.Enums[enum.Name] = EnumInfo{
+			Name:   enum.Name,
+			Values: append([]string(nil), enum.Values...),
+		}
+	}
+
+	// DSL files
+	dslDir := filepath.Join(dir, "src")
+	if _, err := os.Stat(dslDir); err == nil {
+		filepath.WalkDir(dslDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".os") {
+				return nil
+			}
+			content, _ := os.ReadFile(path)
+			rel, _ := filepath.Rel(dslDir, path)
+			manifest.DSLFiles[rel] = string(content)
+			return nil
+		})
+	}
+
+	return manifest, nil
+}
+
+// ScanProjectFromFiles reads entity YAML files directly without full project loading.
+// Useful when project.Load() fails due to missing dependencies (DB, etc.).
+func ScanProjectFromFiles(dir string) (*ExistingManifest, error) {
+	manifest := &ExistingManifest{
+		Catalogs:  make(map[string]CatalogInfo),
+		Documents: make(map[string]DocumentInfo),
+		Registers: make(map[string]RegisterInfo),
+		Enums:     make(map[string]EnumInfo),
+		DSLFiles:  make(map[string]string),
+	}
+
+	// Scan catalogs
+	catalogDir := filepath.Join(dir, "catalogs")
+	scanEntityDir(catalogDir, metadata.KindCatalog, func(e *metadata.Entity) {
+		manifest.Catalogs[e.Name] = CatalogInfo{
+			Name:       e.Name,
+			Fields:     extractFields(e.Fields),
+			TableParts: extractTableParts(e.TableParts),
+			Posting:    e.Posting,
+		}
+	})
+
+	// Scan documents
+	docDir := filepath.Join(dir, "documents")
+	scanEntityDir(docDir, metadata.KindDocument, func(e *metadata.Entity) {
+		manifest.Documents[e.Name] = DocumentInfo{
+			Name:       e.Name,
+			Fields:     extractFields(e.Fields),
+			TableParts: extractTableParts(e.TableParts),
+			Posting:    e.Posting,
+		}
+	})
+
+	// Scan enums
+	enumDir := filepath.Join(dir, "enums")
+	scanEnumDir(enumDir, func(name string, values []string) {
+		manifest.Enums[name] = EnumInfo{
+			Name:   name,
+			Values: values,
+		}
+	})
+
+	// Scan DSL files
+	dslDir := filepath.Join(dir, "src")
+	if _, err := os.Stat(dslDir); err == nil {
+		filepath.WalkDir(dslDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".os") {
+				return nil
+			}
+			content, _ := os.ReadFile(path)
+			rel, _ := filepath.Rel(dslDir, path)
+			manifest.DSLFiles[rel] = string(content)
+			return nil
+		})
+	}
+
+	return manifest, nil
+}
+
+// scanEntityDir reads all YAML files in a directory and calls fn for each entity.
+func scanEntityDir(dir string, kind metadata.Kind, fn func(*metadata.Entity)) {
+	if _, err := os.Stat(dir); err != nil {
+		return
+	}
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		e, err := metadata.LoadFile(path, kind)
+		if err != nil {
+			return nil // skip invalid files
+		}
+		fn(e)
+		return nil
+	})
+}
+
+// scanEnumDir reads enum YAML files.
+func scanEnumDir(dir string, fn func(name string, values []string)) {
+	if _, err := os.Stat(dir); err != nil {
+		return
+	}
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		// Enum format: name + values array
+		type rawEnum struct {
+			Name   string   `yaml:"name"`
+			Values []string `yaml:"values"`
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var raw rawEnum
+		if err := yamlUnmarshal(data, &raw); err != nil {
+			return nil
+		}
+		if raw.Name != "" {
+			fn(raw.Name, raw.Values)
+		}
+		return nil
+	})
+}
+
+func extractFields(fields []metadata.Field) []FieldInfo {
+	out := make([]FieldInfo, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, FieldInfo{
+			Name:      f.Name,
+			Type:      string(f.Type),
+			RefEntity: f.RefEntity,
+			EnumName:  f.EnumName,
+		})
+	}
+	return out
+}
+
+func extractTableParts(tps []metadata.TablePart) []TablePartInfo {
+	out := make([]TablePartInfo, 0, len(tps))
+	for _, tp := range tps {
+		out = append(out, TablePartInfo{
+			Name:   tp.Name,
+			Fields: extractFields(tp.Fields),
+		})
+	}
+	return out
+}
+
+// yamlUnmarshal is a helper to avoid importing yaml.v3 in this file directly.
+func yamlUnmarshal(data []byte, v interface{}) error {
+	return yamlUnmarshalImpl(data, v)
+}
+
+// yamlUnmarshalImpl is set by init() to break import cycle.
+var yamlUnmarshalImpl = func(data []byte, v interface{}) error {
+	// Fallback: use the standard yaml package via a separate file.
+	// This is overridden in scanner_yaml.go.
+	return nil
+}

--- a/internal/gengen/scanner_test.go
+++ b/internal/gengen/scanner_test.go
@@ -1,0 +1,138 @@
+package gengen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanProjectFromFiles_Empty(t *testing.T) {
+	dir := t.TempDir()
+	manifest, err := ScanProjectFromFiles(dir)
+	if err != nil {
+		t.Fatalf("ScanProjectFromFiles() error: %v", err)
+	}
+	if len(manifest.Catalogs) != 0 {
+		t.Error("expected no catalogs")
+	}
+	if len(manifest.Documents) != 0 {
+		t.Error("expected no documents")
+	}
+}
+
+func TestScanProjectFromFiles_Catalogs(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755)
+
+	// Create a catalog YAML file
+	yamlContent := `name: Контрагент
+fields:
+  - name: Наименование
+    type: string
+  - name: ИНН
+    type: string
+`
+	os.WriteFile(filepath.Join(dir, "catalogs", "контрагент.yaml"), []byte(yamlContent), 0o644)
+
+	manifest, err := ScanProjectFromFiles(dir)
+	if err != nil {
+		t.Fatalf("ScanProjectFromFiles() error: %v", err)
+	}
+
+	if _, ok := manifest.Catalogs["Контрагент"]; !ok {
+		t.Fatal("expected Контрагент catalog")
+	}
+
+	cat := manifest.Catalogs["Контрагент"]
+	if len(cat.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(cat.Fields))
+	}
+	if cat.Fields[0].Name != "Наименование" {
+		t.Errorf("expected field 0 = Наименование, got %s", cat.Fields[0].Name)
+	}
+}
+
+func TestScanProjectFromFiles_Documents(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "documents"), 0o755)
+
+	yamlContent := `name: РеализацияТоваров
+fields:
+  - name: Контрагент
+    type: reference:Контрагент
+  - name: Дата
+    type: date
+tableparts:
+  - name: Товары
+    fields:
+      - name: Номенклатура
+        type: reference:Номенклатура
+      - name: Количество
+        type: number
+`
+	os.WriteFile(filepath.Join(dir, "documents", "реализация_товаров.yaml"), []byte(yamlContent), 0o644)
+
+	manifest, err := ScanProjectFromFiles(dir)
+	if err != nil {
+		t.Fatalf("ScanProjectFromFiles() error: %v", err)
+	}
+
+	if _, ok := manifest.Documents["РеализацияТоваров"]; !ok {
+		t.Fatal("expected РеализацияТоваров document")
+	}
+
+	doc := manifest.Documents["РеализацияТоваров"]
+	if len(doc.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(doc.Fields))
+	}
+	if len(doc.TableParts) != 1 {
+		t.Errorf("expected 1 table part, got %d", len(doc.TableParts))
+	}
+	if doc.TableParts[0].Name != "Товары" {
+		t.Errorf("expected TP name = Товары, got %s", doc.TableParts[0].Name)
+	}
+}
+
+func TestScanProjectFromFiles_Enums(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "enums"), 0o755)
+
+	yamlContent := `name: СтавкиНДС
+values:
+  - БезНДС
+  - "0%"
+  - "10%"
+  - "20%"
+`
+	os.WriteFile(filepath.Join(dir, "enums", "ставки_ндс.yaml"), []byte(yamlContent), 0o644)
+
+	manifest, err := ScanProjectFromFiles(dir)
+	if err != nil {
+		t.Fatalf("ScanProjectFromFiles() error: %v", err)
+	}
+
+	if _, ok := manifest.Enums["СтавкиНДС"]; !ok {
+		t.Fatal("expected СтавкиНДС enum")
+	}
+
+	enum := manifest.Enums["СтавкиНДС"]
+	if len(enum.Values) != 4 {
+		t.Errorf("expected 4 values, got %d", len(enum.Values))
+	}
+}
+
+func TestScanProjectFromFiles_DSL(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	os.WriteFile(filepath.Join(dir, "src", "отчёт_продажи.os"), []byte("Процедура Сформировать()\nКонецПроцедуры\n"), 0o644)
+
+	manifest, err := ScanProjectFromFiles(dir)
+	if err != nil {
+		t.Fatalf("ScanProjectFromFiles() error: %v", err)
+	}
+
+	if _, ok := manifest.DSLFiles["отчёт_продажи.os"]; !ok {
+		t.Fatal("expected DSL file")
+	}
+}

--- a/internal/gengen/scanner_yaml.go
+++ b/internal/gengen/scanner_yaml.go
@@ -1,0 +1,9 @@
+package gengen
+
+import "gopkg.in/yaml.v3"
+
+func init() {
+	yamlUnmarshalImpl = func(data []byte, v interface{}) error {
+		return yaml.Unmarshal(data, v)
+	}
+}

--- a/internal/gengen/types.go
+++ b/internal/gengen/types.go
@@ -1,0 +1,29 @@
+// Package gengen implements generative project configuration for OneBase.
+// It converts a natural-language prompt into a complete project structure
+// (YAML metadata + DSL source files) by matching keywords to domain bundles.
+package gengen
+
+// DomainRule describes a project domain: keywords for detection, templates
+// to copy, and optional addons (e.g. "edi" adds counterparty bank details).
+type DomainRule struct {
+	Keywords  []string
+	Templates []string          // priority-ordered; first existing dir wins
+	Addons    map[string]Addon
+}
+
+// Addon is an optional feature pack that extends a domain bundle.
+// It contains additional YAML fields, constants, or DSL files.
+type Addon struct {
+	Name        string
+	Description string
+	SourceDir   string // relative to project root
+}
+
+// AnalyzeResult is the output of the semantic analyzer.
+type AnalyzeResult struct {
+	Domain    string   // matched domain name
+	Template  string   // resolved path to the template directory
+	Addons    []string // requested addon names
+	Confident bool     // true if a single domain matched clearly
+	Ambiguous []string // tied domain names (when Confident == false)
+}

--- a/internal/gengen/types.go
+++ b/internal/gengen/types.go
@@ -27,3 +27,62 @@ type AnalyzeResult struct {
 	Confident bool     // true if a single domain matched clearly
 	Ambiguous []string // tied domain names (when Confident == false)
 }
+
+// ResolvedManifest describes the full set of entities requested by the user.
+// Produced by the analyzer (Stage 1) or LLM (Stage 2).
+type ResolvedManifest struct {
+	Domain    string
+	Catalogs  []EntitySpec
+	Documents []EntitySpec
+	Registers []EntitySpec
+	Enums     []EnumSpec
+	DSLFiles  map[string]string // relative path → content
+}
+
+// EntitySpec describes a single entity (catalog, document, register).
+type EntitySpec struct {
+	Name       string
+	Kind       string // "catalog", "document", "register"
+	Fields     []FieldSpec
+	TableParts []TablePartSpec
+	Posting    bool
+}
+
+// FieldSpec describes a single field in an entity.
+type FieldSpec struct {
+	Name      string
+	Type      string // "string", "date", "number", "bool", "reference:X", "enum:X"
+	RefEntity string // non-empty when Type is "reference:X"
+	EnumName  string // non-empty when Type is "enum:X"
+}
+
+// TablePartSpec describes a table part (ТЧ) in an entity.
+type TablePartSpec struct {
+	Name   string
+	Fields []FieldSpec
+}
+
+// EnumSpec describes an enumeration.
+type EnumSpec struct {
+	Name   string
+	Values []string
+}
+
+// DeltaManifest describes the difference between requested and existing manifests.
+type DeltaManifest struct {
+	NewCatalogs   []EntitySpec             // entities that don't exist yet
+	NewDocuments  []EntitySpec
+	NewRegisters  []EntitySpec
+	NewEnums      []EnumSpec
+	NewFields     map[string][]FieldSpec   // entity name → new fields to add
+	NewTableParts map[string][]TablePartSpec // entity name → new table parts
+	NewDSLFiles   map[string]string        // relative path → content
+	Conflicts     []Conflict               // name collisions
+}
+
+// Conflict describes a name collision between requested and existing.
+type Conflict struct {
+	Kind    string // "catalog", "document", "enum", "register"
+	Name    string
+	Message string // e.g. "Контрагент already exists, use --add-fields instead"
+}

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -630,6 +630,164 @@ func (s *Server) gengenGenerate(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) gengenMerge(w http.ResponseWriter, r *http.Request) {
+	if !s.isAdmin(r) {
+		s.renderForbidden(w, r)
+		return
+	}
+	var req struct {
+		Prompt    string   `json:"prompt"`
+		Domain    string   `json:"domain"`
+		Addons    []string `json:"addons"`
+		OutputDir string   `json:"output_dir"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResp(w, 400, map[string]any{"error": "Некорректный запрос"})
+		return
+	}
+
+	if req.OutputDir == "" {
+		jsonResp(w, 400, map[string]any{"error": "Укажите output_dir — путь к существующему проекту"})
+		return
+	}
+
+	// 1. Analyze
+	var result *gengen.AnalyzeResult
+	if req.Domain != "" {
+		result = &gengen.AnalyzeResult{Domain: req.Domain, Confident: true}
+	} else {
+		result = gengen.Analyze(req.Prompt)
+	}
+
+	if result.Domain == "unknown" {
+		jsonResp(w, 400, map[string]any{"error": "Домен не определён"})
+		return
+	}
+
+	// 2. Resolve template
+	if result.Template == "" {
+		candidates := []string{"examples/" + result.Domain, "templates/" + result.Domain}
+		for _, t := range candidates {
+			if dirExists(t) {
+				result.Template = t
+				break
+			}
+		}
+	}
+
+	if result.Template == "" {
+		jsonResp(w, 400, map[string]any{"error": "Нет шаблона для домена: " + result.Domain})
+		return
+	}
+
+	// 3. Scan existing
+	before, err := gengen.ScanProjectFromFiles(req.OutputDir)
+	if err != nil {
+		jsonResp(w, 500, map[string]any{"error": "Сканирование проекта: " + err.Error()})
+		return
+	}
+
+	// 4. Generate (copyDir skips existing files)
+	gen := &gengen.Generator{OutputDir: req.OutputDir}
+	if err := gen.Generate(result.Template, req.Addons); err != nil {
+		jsonResp(w, 500, map[string]any{"error": err.Error()})
+		return
+	}
+
+	// 5. Scan after
+	after, err := gengen.ScanProjectFromFiles(req.OutputDir)
+	if err != nil {
+		jsonResp(w, 500, map[string]any{"error": "Сканирование после генерации: " + err.Error()})
+		return
+	}
+
+	// 6. Compute diff
+	diff := map[string]any{
+		"new_catalogs":  diffKeys(before.Catalogs, after.Catalogs),
+		"new_documents": diffKeys(before.Documents, after.Documents),
+		"new_enums":     diffKeysEnum(before.Enums, after.Enums),
+		"new_dsl":       diffKeysStr(before.DSLFiles, after.DSLFiles),
+		"new_fields":    diffFields(before, after),
+	}
+
+	jsonResp(w, 200, map[string]any{
+		"domain":   result.Domain,
+		"template": result.Template,
+		"diff":     diff,
+	})
+}
+
+// diffKeys returns keys in after that are not in before (for map[string]T).
+func diffKeys[T any](before, after map[string]T) []string {
+	var result []string
+	for k := range after {
+		if _, ok := before[k]; !ok {
+			result = append(result, k)
+		}
+	}
+	return result
+}
+
+func diffKeysEnum(before, after map[string]gengen.EnumInfo) []string {
+	var result []string
+	for k := range after {
+		if _, ok := before[k]; !ok {
+			result = append(result, k)
+		}
+	}
+	return result
+}
+
+func diffKeysStr(before, after map[string]string) []string {
+	var result []string
+	for k := range after {
+		if _, ok := before[k]; !ok {
+			result = append(result, k)
+		}
+	}
+	return result
+}
+
+func diffFields(before, after *gengen.ExistingManifest) map[string][]string {
+	result := make(map[string][]string)
+
+	// Catalogs
+	for name, afterCat := range after.Catalogs {
+		beforeCat, ok := before.Catalogs[name]
+		if !ok {
+			continue
+		}
+		beforeFields := make(map[string]bool)
+		for _, f := range beforeCat.Fields {
+			beforeFields[f.Name] = true
+		}
+		for _, f := range afterCat.Fields {
+			if !beforeFields[f.Name] {
+				result[name] = append(result[name], f.Name)
+			}
+		}
+	}
+
+	// Documents
+	for name, afterDoc := range after.Documents {
+		beforeDoc, ok := before.Documents[name]
+		if !ok {
+			continue
+		}
+		beforeFields := make(map[string]bool)
+		for _, f := range beforeDoc.Fields {
+			beforeFields[f.Name] = true
+		}
+		for _, f := range afterDoc.Fields {
+			if !beforeFields[f.Name] {
+				result[name] = append(result[name], f.Name)
+			}
+		}
+	}
+
+	return result
+}
+
 func dirExists(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -14,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/dsl/lexer"
 	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/gengen"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/query"
 	"github.com/ivantit66/onebase/internal/runtime"
@@ -495,4 +499,141 @@ func coerceParams(params map[string]any) {
 // поэтому здесь строгий strconv.ParseFloat.
 func parseFloat(s string) (float64, error) {
 	return strconv.ParseFloat(strings.TrimSpace(s), 64)
+}
+
+// ─── Gengen — генерация конфигурации ────────────────────────────────────────
+
+func (s *Server) gengenPage(w http.ResponseWriter, r *http.Request) {
+	if !s.isAdmin(r) {
+		s.renderForbidden(w, r)
+		return
+	}
+	domains := make([]map[string]any, 0)
+	for name, keywords := range gengen.AvailableDomains() {
+		domains = append(domains, map[string]any{
+			"Name":     name,
+			"Keywords": strings.Join(keywords[:min(len(keywords), 3)], ", "),
+		})
+	}
+	s.render(w, r, "page-gengen", map[string]any{
+		"Domains": domains,
+	})
+}
+
+func (s *Server) gengenAnalyze(w http.ResponseWriter, r *http.Request) {
+	if !s.isAdmin(r) {
+		s.renderForbidden(w, r)
+		return
+	}
+	var req struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResp(w, 400, map[string]any{"error": "Некорректный запрос"})
+		return
+	}
+	result := gengen.Analyze(req.Prompt)
+	jsonResp(w, 200, map[string]any{
+		"domain":    result.Domain,
+		"template":  result.Template,
+		"confident": result.Confident,
+		"ambiguous": result.Ambiguous,
+	})
+}
+
+func (s *Server) gengenGenerate(w http.ResponseWriter, r *http.Request) {
+	if !s.isAdmin(r) {
+		s.renderForbidden(w, r)
+		return
+	}
+	var req struct {
+		Prompt  string   `json:"prompt"`
+		Domain  string   `json:"domain"`
+		Addons  []string `json:"addons"`
+		YAML    map[string]string `json:"yaml"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonResp(w, 400, map[string]any{"error": "Некорректный запрос"})
+		return
+	}
+
+	// 1. Analyze if domain not specified
+	var result *gengen.AnalyzeResult
+	if req.Domain != "" {
+		result = &gengen.AnalyzeResult{Domain: req.Domain, Confident: true}
+	} else {
+		result = gengen.Analyze(req.Prompt)
+	}
+
+	if result.Domain == "unknown" {
+		jsonResp(w, 400, map[string]any{"error": "Домен не определён. Укажите --domain или уточните промпт."})
+		return
+	}
+
+	// 2. Resolve template
+	if result.Template == "" {
+		candidates := []string{"examples/" + result.Domain, "templates/" + result.Domain}
+		for _, t := range candidates {
+			if dirExists(t) {
+				result.Template = t
+				break
+			}
+		}
+	}
+
+	if result.Template == "" {
+		jsonResp(w, 400, map[string]any{"error": "Нет шаблона для домена: " + result.Domain})
+		return
+	}
+
+	// 3. Generate to temp dir
+	outDir := "/tmp/gengen-" + uuid.New().String()[:8]
+	gen := &gengen.Generator{OutputDir: outDir}
+	if err := gen.Generate(result.Template, req.Addons); err != nil {
+		jsonResp(w, 500, map[string]any{"error": err.Error()})
+		return
+	}
+
+	// 4. Override YAML files if provided (user edited them)
+	for relPath, content := range req.YAML {
+		if content == "" {
+			continue
+		}
+		fullPath := filepath.Join(outDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			jsonResp(w, 500, map[string]any{"error": err.Error()})
+			return
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+			jsonResp(w, 500, map[string]any{"error": err.Error()})
+			return
+		}
+	}
+
+	// 5. Collect generated files for preview
+	files := make(map[string]string)
+	filepath.WalkDir(outDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(outDir, path)
+		data, _ := os.ReadFile(path)
+		files[rel] = string(data)
+		return nil
+	})
+
+	jsonResp(w, 200, map[string]any{
+		"domain":   result.Domain,
+		"template": result.Template,
+		"output":   outDir,
+		"files":    files,
+	})
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -114,6 +114,13 @@ func (s *Server) tr(lang, key string) string {
 func (s *Server) Mount(r chi.Router) {
 	r.Get("/ui", s.index)
 	r.Get("/ui/", s.index)
+
+	// Gengen — ДО catch-all роутов! (иначе /ui/dev/gengen матчится как {kind}/{entity})
+	r.Get("/ui/dev/gengen", s.gengenPage)
+	r.Post("/ui/dev/gengen/analyze", s.gengenAnalyze)
+	r.Post("/ui/dev/gengen/generate", s.gengenGenerate)
+	r.Post("/ui/dev/gengen/merge", s.gengenMerge)
+
 	r.Get("/ui/{kind}/{entity}", s.list)
 	r.Get("/ui/{kind}/{entity}/new", s.form)
 	r.Post("/ui/{kind}/{entity}/new", s.submit)
@@ -209,12 +216,6 @@ func (s *Server) Mount(r chi.Router) {
 	r.Get("/ui/dev/entity-search", s.devEntitySearch)
 	r.Get("/ui/dev/code-console", s.codeConsolePage)
 	r.Post("/ui/dev/code-exec", s.codeConsoleExec)
-
-	// Gengen — генерация конфигурации
-	r.Get("/ui/dev/gengen", s.gengenPage)
-	r.Post("/ui/dev/gengen/analyze", s.gengenAnalyze)
-	r.Post("/ui/dev/gengen/generate", s.gengenGenerate)
-	r.Post("/ui/dev/gengen/merge", s.gengenMerge)
 
 	// All functions (admin only)
 	r.Get("/ui/all-functions", s.allFunctions)

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -214,6 +214,7 @@ func (s *Server) Mount(r chi.Router) {
 	r.Get("/ui/dev/gengen", s.gengenPage)
 	r.Post("/ui/dev/gengen/analyze", s.gengenAnalyze)
 	r.Post("/ui/dev/gengen/generate", s.gengenGenerate)
+	r.Post("/ui/dev/gengen/merge", s.gengenMerge)
 
 	// All functions (admin only)
 	r.Get("/ui/all-functions", s.allFunctions)

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -210,6 +210,11 @@ func (s *Server) Mount(r chi.Router) {
 	r.Get("/ui/dev/code-console", s.codeConsolePage)
 	r.Post("/ui/dev/code-exec", s.codeConsoleExec)
 
+	// Gengen — генерация конфигурации
+	r.Get("/ui/dev/gengen", s.gengenPage)
+	r.Post("/ui/dev/gengen/analyze", s.gengenAnalyze)
+	r.Post("/ui/dev/gengen/generate", s.gengenGenerate)
+
 	// All functions (admin only)
 	r.Get("/ui/all-functions", s.allFunctions)
 

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -303,7 +303,7 @@ var tmpl = template.Must(template.New("root").Funcs(template.FuncMap{
 	"echartsJSON": echartsJSON,
 	"splitCamel":  splitCamel,
 	"fmtCell":     fmtReportCell,
-}).Parse(tplHead + tplNav + tplIndex + tplList + tplForm + tplManagedForm + tplRegister + tplReport + tplProcessor + tplAbout + tplDeleteMarked + tplInfoReg + tplConstants + tplHistory + tplJournal + tplScheduled + tplAccountReg + tplQueryBuilder + tplAllFunctions + tplQueryConsole + tplCodeConsole + tplForbidden))
+}).Parse(tplHead + tplNav + tplIndex + tplList + tplForm + tplManagedForm + tplRegister + tplReport + tplProcessor + tplAbout + tplDeleteMarked + tplInfoReg + tplConstants + tplHistory + tplJournal + tplScheduled + tplAccountReg + tplQueryBuilder + tplAllFunctions + tplQueryConsole + tplCodeConsole + tplGengen + tplForbidden))
 
 const tplHead = `
 {{define "head"}}<!DOCTYPE html>
@@ -466,6 +466,7 @@ const tplNav = `
       <div class="sys-submenu">
         <a href="/ui/dev/query-console">{{t $.Lang "Консоль запросов"}}</a>
         <a href="/ui/dev/code-console">{{t $.Lang "Консоль кода"}}</a>
+        <a href="/ui/dev/gengen">{{t $.Lang "Gengen"}}</a>
       </div>
     </div>{{end}}
       {{if .HasAuth}}{{if not .DenyPasswdChange}}<a href="/ui/profile/passwd">{{t $.Lang "Сменить пароль"}}</a>{{end}}{{end}}

--- a/internal/ui/tpl_gengen.go
+++ b/internal/ui/tpl_gengen.go
@@ -1,0 +1,219 @@
+package ui
+
+const tplGengen = `
+{{define "page-gengen"}}
+{{template "head" .}}{{template "nav" .}}
+<main style="max-width:100%">
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px">
+  <h2 style="margin:0">Gengen — генерация конфигурации</h2>
+</div>
+
+<!-- Step 1: Prompt -->
+<div class="card" style="margin-bottom:16px">
+  <h3 style="margin-top:0">Шаг 1: Опишите конфигурацию</h3>
+  <textarea id="gg-prompt" rows="4" style="width:100%;font-size:14px;border:1px solid #e2e8f0;border-radius:6px;padding:10px;resize:vertical"
+    placeholder="Например: конфигурация для хранения текстов и переводов. Текст содержит ссылку на событие, дату события, наименование, язык оригинала. Перевод содержит ссылку на текст-основание, текст перевода, язык перевода, количество символов"></textarea>
+  <div style="display:flex;gap:8px;margin-top:10px;align-items:center">
+    <button onclick="ggAnalyze()" class="btn" style="background:#3b82f6;color:#fff;border:none;border-radius:6px;padding:8px 20px;cursor:pointer;font-size:14px">Анализировать</button>
+    <span id="gg-status" style="font-size:13px;color:#64748b"></span>
+  </div>
+</div>
+
+<!-- Step 2: Analysis result -->
+<div id="gg-analysis-card" class="card" style="margin-bottom:16px;display:none">
+  <h3 style="margin-top:0">Шаг 2: Результат анализа</h3>
+  <div style="display:flex;gap:16px;align-items:center;margin-bottom:12px">
+    <div>
+      <span style="font-size:12px;color:#64748b">Домен:</span>
+      <span id="gg-domain" style="font-weight:600;font-size:16px;margin-left:6px"></span>
+    </div>
+    <div>
+      <span style="font-size:12px;color:#64748b">Уверенность:</span>
+      <span id="gg-confidence" style="font-weight:600;font-size:16px;margin-left:6px"></span>
+    </div>
+  </div>
+  <div id="gg-ambiguous" style="display:none;background:#fef3c7;color:#92400e;padding:8px 12px;border-radius:6px;font-size:13px;margin-bottom:10px"></div>
+  <div style="display:flex;gap:8px">
+    <button onclick="ggGenerate()" class="btn" style="background:#10b981;color:#fff;border:none;border-radius:6px;padding:8px 20px;cursor:pointer;font-size:14px">Сгенерировать</button>
+    <label style="font-size:13px;color:#64748b;display:flex;align-items:center;gap:4px">
+      <input type="checkbox" id="gg-override" onchange="ggToggleOverride()"> Переопределить YAML
+    </label>
+  </div>
+</div>
+
+<!-- Step 3: YAML editor (hidden by default) -->
+<div id="gg-yaml-card" class="card" style="margin-bottom:16px;display:none">
+  <h3 style="margin-top:0">Шаг 3: Редактирование YAML</h3>
+  <p style="font-size:13px;color:#64748b;margin-bottom:12px">Отредактируйте сгенерированные файлы перед созданием проекта</p>
+  <div id="gg-yaml-tabs" style="display:flex;gap:4px;margin-bottom:10px;flex-wrap:wrap"></div>
+  <div id="gg-yaml-editor" style="position:relative">
+    <textarea id="gg-yaml-content" rows="20" style="width:100%;font-family:monospace;font-size:13px;border:1px solid #e2e8f0;border-radius:6px;padding:10px;resize:vertical" spellcheck="false"></textarea>
+  </div>
+</div>
+
+<!-- Step 4: Generated files -->
+<div id="gg-output-card" class="card" style="margin-bottom:16px;display:none">
+  <h3 style="margin-top:0">Шаг 4: Сгенерированные файлы</h3>
+  <div style="display:flex;gap:8px;margin-bottom:12px;align-items:center">
+    <span id="gg-output-path" style="font-size:13px;color:#64748b;font-family:monospace"></span>
+    <button onclick="ggCopyPath()" style="background:#e2e8f0;color:#475569;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px">Копировать путь</button>
+  </div>
+  <div id="gg-file-tabs" style="display:flex;gap:4px;margin-bottom:10px;flex-wrap:wrap"></div>
+  <pre id="gg-file-content" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;padding:12px;font-size:13px;overflow-x:auto;max-height:500px;overflow-y:auto;white-space:pre-wrap"></pre>
+</div>
+
+<!-- Available domains reference -->
+<div class="card">
+  <h3 style="margin-top:0">Доступные домены</h3>
+  <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:8px">
+    {{range .Domains}}
+    <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;padding:10px">
+      <strong>{{.Name}}</strong>
+      <div style="font-size:12px;color:#64748b;margin-top:4px">{{.Keywords}}</div>
+    </div>
+    {{end}}
+  </div>
+</div>
+</main>
+
+<script>
+let ggFiles = {};
+let ggYamlFiles = {};
+let ggActiveTab = null;
+let ggActiveYamlTab = null;
+
+function ggAnalyze() {
+  const prompt = document.getElementById('gg-prompt').value.trim();
+  if (!prompt) { alert('Введите описание конфигурации'); return; }
+
+  const status = document.getElementById('gg-status');
+  status.textContent = 'Анализ...';
+
+  fetch('/ui/dev/gengen/analyze', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({prompt})
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.error) { alert(data.error); status.textContent = ''; return; }
+
+    document.getElementById('gg-domain').textContent = data.domain;
+    document.getElementById('gg-confidence').textContent = data.confident ? '✓ Высокая' : '⚠ Средняя';
+    document.getElementById('gg-confidence').style.color = data.confident ? '#10b981' : '#f59e0b';
+
+    const amb = document.getElementById('gg-ambiguous');
+    if (data.ambiguous && data.ambiguous.length > 0) {
+      amb.textContent = 'Возможны варианты: ' + data.ambiguous.join(', ');
+      amb.style.display = 'block';
+    } else {
+      amb.style.display = 'none';
+    }
+
+    document.getElementById('gg-analysis-card').style.display = 'block';
+    document.getElementById('gg-output-card').style.display = 'none';
+    status.textContent = 'Домен: ' + data.domain;
+  })
+  .catch(err => { status.textContent = 'Ошибка: ' + err; });
+}
+
+function ggGenerate() {
+  const prompt = document.getElementById('gg-prompt').value.trim();
+  const override = document.getElementById('gg-override').checked;
+  const domain = document.getElementById('gg-domain').textContent;
+
+  const status = document.getElementById('gg-status');
+  status.textContent = 'Генерация...';
+
+  let yaml = {};
+  if (override) {
+    yaml = ggYamlFiles;
+  }
+
+  fetch('/ui/dev/gengen/generate', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({prompt, domain, yaml})
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.error) { alert(data.error); status.textContent = ''; return; }
+
+    ggFiles = data.files || {};
+    document.getElementById('gg-output-path').textContent = data.output;
+
+    // Render file tabs
+    const tabs = document.getElementById('gg-file-tabs');
+    tabs.innerHTML = '';
+    let first = true;
+    for (const [name, content] of Object.entries(ggFiles)) {
+      const btn = document.createElement('button');
+      btn.textContent = name;
+      btn.className = 'gg-tab';
+      btn.style.cssText = 'background:' + (first ? '#3b82f6;color:#fff' : '#e2e8f0;color:#475569') + ';border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px';
+      btn.onclick = () => {
+        document.querySelectorAll('.gg-tab').forEach(t => t.style.cssText = 'background:#e2e8f0;color:#475569;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px');
+        btn.style.cssText = 'background:#3b82f6;color:#fff;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px';
+        document.getElementById('gg-file-content').textContent = content;
+      };
+      tabs.appendChild(btn);
+      if (first) {
+        document.getElementById('gg-file-content').textContent = content;
+        first = false;
+      }
+    }
+
+    document.getElementById('gg-output-card').style.display = 'block';
+    status.textContent = 'Сгенерировано!';
+  })
+  .catch(err => { status.textContent = 'Ошибка: ' + err; });
+}
+
+function ggToggleOverride() {
+  const show = document.getElementById('gg-override').checked;
+  document.getElementById('gg-yaml-card').style.display = show ? 'block' : 'none';
+  if (show && Object.keys(ggFiles).length > 0) {
+    ggRenderYamlTabs();
+  }
+}
+
+function ggRenderYamlTabs() {
+  const tabs = document.getElementById('gg-yaml-tabs');
+  tabs.innerHTML = '';
+  let first = true;
+  for (const [name, content] of Object.entries(ggFiles)) {
+    ggYamlFiles[name] = content;
+    const btn = document.createElement('button');
+    btn.textContent = name;
+    btn.style.cssText = 'background:' + (first ? '#3b82f6;color:#fff' : '#e2e8f0;color:#475569') + ';border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px';
+    btn.onclick = () => {
+      // Save current tab content
+      if (ggActiveYamlTab) {
+        ggYamlFiles[ggActiveYamlTab] = document.getElementById('gg-yaml-content').value;
+      }
+      document.querySelectorAll('#gg-yaml-tabs button').forEach(t => t.style.cssText = 'background:#e2e8f0;color:#475569;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px');
+      btn.style.cssText = 'background:#3b82f6;color:#fff;border:none;border-radius:4px;padding:4px 10px;cursor:pointer;font-size:12px';
+      document.getElementById('gg-yaml-content').value = content;
+      ggActiveYamlTab = name;
+    };
+    tabs.appendChild(btn);
+    if (first) {
+      document.getElementById('gg-yaml-content').value = content;
+      ggActiveYamlTab = name;
+      first = false;
+    }
+  }
+}
+
+function ggCopyPath() {
+  const path = document.getElementById('gg-output-path').textContent;
+  navigator.clipboard.writeText(path).then(() => {
+    const btn = event.target;
+    const orig = btn.textContent;
+    btn.textContent = 'Скопировано!';
+    setTimeout(() => btn.textContent = orig, 1500);
+  });
+}
+</script>
+{{end}}
+`

--- a/internal/ui/tpl_gengen.go
+++ b/internal/ui/tpl_gengen.go
@@ -63,7 +63,7 @@ const tplGengen = `
 </div>
 
 <!-- Available domains reference -->
-<div class="card">
+<div class="card" style="margin-bottom:16px">
   <h3 style="margin-top:0">Доступные домены</h3>
   <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:8px">
     {{range .Domains}}
@@ -72,6 +72,21 @@ const tplGengen = `
       <div style="font-size:12px;color:#64748b;margin-top:4px">{{.Keywords}}</div>
     </div>
     {{end}}
+  </div>
+</div>
+
+<!-- Merge section -->
+<div class="card" style="margin-bottom:16px">
+  <h3 style="margin-top:0">Добавить в существующий проект</h3>
+  <p style="font-size:13px;color:#64748b;margin-bottom:10px">Добавляет сущности из шаблона в существующий проект, не затирая файлы</p>
+  <div style="display:flex;gap:8px;align-items:center;margin-bottom:10px">
+    <input id="gg-merge-dir" type="text" style="flex:1;font-size:14px;border:1px solid #e2e8f0;border-radius:6px;padding:8px"
+      placeholder="Путь к проекту, напр. /home/dev/projects/trade">
+    <button onclick="ggMerge()" class="btn" style="background:#8b5cf6;color:#fff;border:none;border-radius:6px;padding:8px 20px;cursor:pointer;font-size:14px">Добавить</button>
+  </div>
+  <div id="gg-merge-result" style="display:none">
+    <h4 style="margin:10px 0 6px">Результат:</h4>
+    <div id="gg-merge-diff" style="font-size:13px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;padding:10px;max-height:300px;overflow-y:auto"></div>
   </div>
 </div>
 </main>
@@ -213,6 +228,59 @@ function ggCopyPath() {
     btn.textContent = 'Скопировано!';
     setTimeout(() => btn.textContent = orig, 1500);
   });
+}
+
+function ggMerge() {
+  const prompt = document.getElementById('gg-prompt').value.trim();
+  const domain = document.getElementById('gg-domain').textContent || '';
+  const outputDir = document.getElementById('gg-merge-dir').value.trim();
+
+  if (!outputDir) { alert('Укажите путь к проекту'); return; }
+  if (!domain && !prompt) { alert('Сначала проанализируйте промпт или укажите домен'); return; }
+
+  fetch('/ui/dev/gengen/merge', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({prompt, domain, output_dir: outputDir})
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.error) { alert(data.error); return; }
+
+    const diff = data.diff || {};
+    const lines = [];
+
+    if (diff.new_catalogs && diff.new_catalogs.length > 0) {
+      lines.push('<strong>Новые справочники:</strong>');
+      diff.new_catalogs.forEach(n => lines.push('  + ' + n));
+    }
+    if (diff.new_documents && diff.new_documents.length > 0) {
+      lines.push('<strong>Новые документы:</strong>');
+      diff.new_documents.forEach(n => lines.push('  + ' + n));
+    }
+    if (diff.new_enums && diff.new_enums.length > 0) {
+      lines.push('<strong>Новые перечисления:</strong>');
+      diff.new_enums.forEach(n => lines.push('  + ' + n));
+    }
+    if (diff.new_dsl && diff.new_dsl.length > 0) {
+      lines.push('<strong>Новые DSL-файлы:</strong>');
+      diff.new_dsl.forEach(n => lines.push('  + ' + n));
+    }
+    if (diff.new_fields && Object.keys(diff.new_fields).length > 0) {
+      lines.push('<strong>Новые поля:</strong>');
+      for (const [entity, fields] of Object.entries(diff.new_fields)) {
+        fields.forEach(f => lines.push('  + ' + entity + ' → ' + f));
+      }
+    }
+
+    if (lines.length === 0) {
+      lines.push('Нет изменений — всё уже существует');
+    }
+
+    document.getElementById('gg-merge-diff').innerHTML = lines.join('<br>');
+    document.getElementById('gg-merge-result').style.display = 'block';
+  })
+  .catch(err => { alert('Ошибка: ' + err); });
 }
 </script>
 {{end}}

--- a/templates/crm/catalogs/клиенты.yaml
+++ b/templates/crm/catalogs/клиенты.yaml
@@ -1,0 +1,8 @@
+name: Клиенты
+fields:
+  - name: Наименование
+    type: string
+  - name: Телефон
+    type: string
+  - name: Email
+    type: string

--- a/templates/crm/config/app.yaml
+++ b/templates/crm/config/app.yaml
@@ -1,0 +1,10 @@
+name: crm
+description: CRM — клиенты, сделки, воронка продаж
+version: "1.0"
+database:
+  type: sqlite
+  path: crm.db
+modules:
+  - catalogs
+  - documents
+  - reports

--- a/templates/crm/documents/сделка.yaml
+++ b/templates/crm/documents/сделка.yaml
@@ -1,0 +1,12 @@
+name: Сделка
+fields:
+  - name: Клиент
+    type: reference:Клиенты
+  - name: Менеджер
+    type: string
+  - name: Статус
+    type: string
+  - name: Сумма
+    type: number
+  - name: ДатаСоздания
+    type: date

--- a/templates/finance/catalogs/категории.yaml
+++ b/templates/finance/catalogs/категории.yaml
@@ -1,0 +1,6 @@
+name: Категории
+fields:
+  - name: Наименование
+    type: string
+  - name: Тип
+    type: string

--- a/templates/finance/config/app.yaml
+++ b/templates/finance/config/app.yaml
@@ -1,0 +1,10 @@
+name: finance
+description: Финансы — доходы, расходы, бюджет
+version: "1.0"
+database:
+  type: sqlite
+  path: finance.db
+modules:
+  - catalogs
+  - documents
+  - reports

--- a/templates/finance/documents/финансовая_операция.yaml
+++ b/templates/finance/documents/финансовая_операция.yaml
@@ -1,0 +1,12 @@
+name: ФинансоваяОперация
+fields:
+  - name: Категория
+    type: reference:Категории
+  - name: Сумма
+    type: number
+  - name: Дата
+    type: date
+  - name: Описание
+    type: string
+  - name: Тип
+    type: string

--- a/templates/tasks/catalogs/проекты.yaml
+++ b/templates/tasks/catalogs/проекты.yaml
@@ -1,0 +1,10 @@
+name: Проекты
+fields:
+  - name: Наименование
+    type: string
+  - name: Описание
+    type: string
+  - name: ДатаНачала
+    type: date
+  - name: ДатаОкончания
+    type: date

--- a/templates/tasks/config/app.yaml
+++ b/templates/tasks/config/app.yaml
@@ -1,0 +1,10 @@
+name: tasks
+description: Управление задачами и проектами
+version: "1.0"
+database:
+  type: sqlite
+  path: tasks.db
+modules:
+  - catalogs
+  - documents
+  - reports

--- a/templates/tasks/documents/задача.yaml
+++ b/templates/tasks/documents/задача.yaml
@@ -1,0 +1,14 @@
+name: Задача
+fields:
+  - name: Наименование
+    type: string
+  - name: Проект
+    type: reference:Проекты
+  - name: Исполнитель
+    type: string
+  - name: Приоритет
+    type: string
+  - name: Статус
+    type: string
+  - name: Дедлайн
+    type: date

--- a/templates/texts/catalogs/события.yaml
+++ b/templates/texts/catalogs/события.yaml
@@ -1,0 +1,6 @@
+name: События
+fields:
+  - name: Наименование
+    type: string
+  - name: Описание
+    type: string

--- a/templates/texts/config/app.yaml
+++ b/templates/texts/config/app.yaml
@@ -1,0 +1,10 @@
+name: texts
+description: Тексты и переводы — учёт текстов, событий и переводов
+version: "1.0"
+database:
+  type: sqlite
+  path: texts.db
+modules:
+  - catalogs
+  - documents
+  - reports

--- a/templates/texts/documents/перевод_текста.yaml
+++ b/templates/texts/documents/перевод_текста.yaml
@@ -1,0 +1,10 @@
+name: ПереводТекста
+fields:
+  - name: Основание
+    type: reference:Текст
+  - name: ТекстПеревода
+    type: string
+  - name: ЯзыкПеревода
+    type: string
+  - name: КоличествоСимволов
+    type: number

--- a/templates/texts/documents/текст.yaml
+++ b/templates/texts/documents/текст.yaml
@@ -1,0 +1,10 @@
+name: Текст
+fields:
+  - name: Событие
+    type: reference:События
+  - name: ДатаСобытия
+    type: date
+  - name: Наименование
+    type: string
+  - name: ЯзыкОригинала
+    type: string

--- a/templates/warehouse/catalogs/номенклатура.yaml
+++ b/templates/warehouse/catalogs/номенклатура.yaml
@@ -1,0 +1,8 @@
+name: Номенклатура
+fields:
+  - name: Наименование
+    type: string
+  - name: Артикул
+    type: string
+  - name: ЕдиницаИзмерения
+    type: string

--- a/templates/warehouse/catalogs/склад.yaml
+++ b/templates/warehouse/catalogs/склад.yaml
@@ -1,0 +1,6 @@
+name: Склад
+fields:
+  - name: Наименование
+    type: string
+  - name: Адрес
+    type: string

--- a/templates/warehouse/config/app.yaml
+++ b/templates/warehouse/config/app.yaml
@@ -1,0 +1,10 @@
+name: warehouse
+description: Складской учёт — товары, ячейки, инвентаризация
+version: "1.0"
+database:
+  type: sqlite
+  path: warehouse.db
+modules:
+  - catalogs
+  - documents
+  - reports

--- a/templates/warehouse/documents/поступление_товаров.yaml
+++ b/templates/warehouse/documents/поступление_товаров.yaml
@@ -1,0 +1,19 @@
+name: ПоступлениеТоваров
+fields:
+  - name: Склад
+    type: reference:Склад
+  - name: Дата
+    type: date
+  - name: Контрагент
+    type: string
+table:
+  - name: Товары
+    fields:
+      - name: Номенклатура
+        type: reference:Номенклатура
+      - name: Количество
+        type: number
+      - name: Цена
+        type: number
+      - name: Сумма
+        type: number


### PR DESCRIPTION
## Что добавлено

### Web UI
- **Система → Инструменты разработчика → Gengen** — новая страница для генерации конфигурации

### Функционал
- **Анализ промпта**: keyword matching → определение домена (7 доменов: trade, warehouse, crm, finance, tasks, accounting, texts)
- **Генерация проекта**: копирование шаблона + возможность редактирования YAML перед созданием
- **Предпросмотр**: все сгенерированные файлы с табами
- **CLI**: `onebase generate --prompt --output --domain`

### Шаблоны
- `texts` — тексты и переводы (каталог События, документы Текст, ПереводТекста)
- `warehouse` — складской учёт
- `crm` — клиенты и сделки
- `finance` — финансы
- `tasks` — задачи и проекты

### Новые файлы
- `internal/gengen/` — пакет анализа и генерации
- `internal/cli/generate.go` — CLI команда
- `internal/ui/tpl_gengen.go` — HTML шаблон страницы
- `templates/` — файловые шаблоны доменов