### PR TITLE
fix: регистронезависимые отборы по кириллице + кнопки ссылок в отчётах

### DIFF
--- a/internal/storage/dialect.go
+++ b/internal/storage/dialect.go
@@ -148,7 +148,9 @@ func (SQLiteDialect) Now() string                   { return "datetime('now')" }
 // non-constant DEFAULT expressions to be parenthesised.
 func (SQLiteDialect) CurrentTimestampTZ() string { return "(datetime('now'))" }
 func (SQLiteDialect) LowerLike(col string) string {
-	return "LOWER(CAST(" + col + " AS TEXT))"
+	// ob_lower — Unicode-aware замена встроенной LOWER (см. init в sqlite.go);
+	// нужна для регистронезависимых отборов/поиска по кириллице.
+	return "ob_lower(CAST(" + col + " AS TEXT))"
 }
 func (SQLiteDialect) CaseInsensitiveLikeOp() string { return "LIKE" }
 func (SQLiteDialect) TypeBool() string              { return "INTEGER" } // 0/1

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -3,12 +3,35 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
-	_ "modernc.org/sqlite"
+	sqlite "modernc.org/sqlite"
 )
+
+// init регистрирует Unicode-aware функцию ob_lower для SQLite. Встроенная
+// SQLite LOWER() приводит к нижнему регистру только ASCII, поэтому отборы и
+// поиск по кириллице получались регистрозависимыми. ob_lower использует
+// strings.ToLower (полная таблица Unicode) и применяется в LowerLike SQLite-
+// диалекта. Регистрация глобальна и действует на все коннекты, открытые позже.
+func init() {
+	sqlite.MustRegisterDeterministicScalarFunction("ob_lower", 1, func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+		if len(args) != 1 || args[0] == nil {
+			return nil, nil
+		}
+		switch v := args[0].(type) {
+		case string:
+			return strings.ToLower(v), nil
+		case []byte:
+			return strings.ToLower(string(v)), nil
+		default:
+			return v, nil
+		}
+	})
+}
 
 // ConnectSQLite opens (or creates) a SQLite database file at the given path
 // and applies pragmas that match the project's operational profile:

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -252,6 +252,54 @@ func TestSQLiteMigrateMinimal(t *testing.T) {
 	}
 }
 
+// TestSQLiteCyrillicCaseInsensitive проверяет, что отбор и полнотекстовый
+// поиск по кириллице регистронезависимы на SQLite. Встроенная LOWER() в
+// SQLite приводит к нижнему регистру только ASCII — без ob_lower (см. init в
+// sqlite.go) этот тест падал бы для русского текста.
+func TestSQLiteCyrillicCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	defer db.Close()
+
+	cat := &metadata.Entity{
+		Name: "Counterparty",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Name", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{cat}); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if err := db.Upsert(ctx, cat.Name, uuid.New(), map[string]any{"Name": "Иванов"}, cat); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Поиск в нижнем регистре должен найти запись «Иванов».
+	rows, err := db.List(ctx, cat.Name, cat, ListParams{Search: "иванов"})
+	if err != nil {
+		t.Fatalf("List search: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("Search 'иванов': got %d rows, want 1 (Иванов)", len(rows))
+	}
+
+	// Отбор по полю Name в верхнем регистре должен найти ту же запись.
+	rows, err = db.List(ctx, cat.Name, cat, ListParams{
+		Filters: map[string]FilterValue{"Name": {Value: "ИВАН"}},
+	})
+	if err != nil {
+		t.Fatalf("List filter: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("Filter Name~'ИВАН': got %d rows, want 1 (Иванов)", len(rows))
+	}
+}
+
 func TestSQLiteDialectLatestPerKey(t *testing.T) {
 	d := SQLiteDialect{}
 	sql := d.LatestPerKey(

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1473,6 +1473,7 @@ const tplReport = `
 {{else}}<p class="empty">{{t $.Lang "Нет данных"}}</p>{{end}}
 </div>
 {{end}}
+{{template "form-shared-js" .}}
 </main></div></body></html>
 {{end}}
 `


### PR DESCRIPTION
## Что и зачем

Два независимых фикса.

### 1. Регистронезависимые отборы по кириллице (SQLite)
Отборы в списках и полнотекстовый поиск были регистрозависимы для русского текста на SQLite: фильтры уже оборачивали обе стороны в `LOWER()`, но встроенная `LOWER()` в SQLite (`modernc.org/sqlite`) приводит к нижнему регистру **только ASCII** — кириллицу оставляет как есть.

- Регистрируем Unicode-aware скалярную функцию `ob_lower` (на базе `strings.ToLower`) для всех SQLite-коннектов.
- `SQLiteDialect.LowerLike` теперь использует `ob_lower` вместо `LOWER`.
- Чинит сразу **отборы списков, полнотекстовый поиск, журнал регистрации и аудит** (все идут через `LowerLike`).
- PostgreSQL не затронут — там нативная `LOWER` уже Unicode-aware.
- Добавлен тест `TestSQLiteCyrillicCaseInsensitive` (до фикса падал бы).

### 2. Кнопки 🔍 и `...` у параметров отчёта
Кнопки у ссылочных параметров отчёта не работали: они вызывают JS-функции `openRefPicker()`/`openRefCurrent()`, определённые в блоке `form-shared-js`, который подключался только в `page-form`/`page-managed-form`, но не в `page-report` (`openRefPicker is not defined` в консоли).

- Добавлен `{{template "form-shared-js" .}}` в шаблон `page-report`.

## Проверка
- `go build ./...` и `go test ./...` — без ошибок.
- Q1 покрыт юнит-тестом.
- Q2 (фронтенд) рекомендуется проверить в браузере: открыть отчёт со ссылочным параметром, нажать `...` (picker) и 🔍 (карточка значения).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
