### PR TITLE
fix(backup): не включать .git в бэкап конфигурации (ошибка восстановления Access is denied)

### DIFF
--- a/internal/backup/universal.go
+++ b/internal/backup/universal.go
@@ -361,6 +361,23 @@ func numericToString(n pgtype.Numeric) string {
 	return result
 }
 
+// skipConfigPath reports whether a slash-separated relative path inside the
+// configuration directory must be excluded from backup and restore. Version
+// control metadata and the backups/ directory are not part of the
+// configuration; in particular, read-only .git object files break a file-mode
+// restore on Windows with "Access is denied" when restore tries to overwrite
+// them. The check matches whole path segments so files like ".gitignore" are
+// preserved while the ".git" directory tree is pruned.
+func skipConfigPath(rel string) bool {
+	for _, seg := range strings.Split(rel, "/") {
+		switch seg {
+		case ".git", ".svn", ".hg":
+			return true
+		}
+	}
+	return strings.HasPrefix(rel, "backups/")
+}
+
 // exportConfig writes config files into the config/ directory inside zw.
 func exportConfig(ctx context.Context, db *storage.DB, configSource, configDir string, zw *zip.Writer) error {
 	if configSource == "database" {
@@ -387,12 +404,18 @@ func exportConfig(ctx context.Context, db *storage.DB, configSource, configDir s
 
 	// File source: walk configDir.
 	return filepath.WalkDir(configDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
 			return nil
 		}
 		rel, _ := filepath.Rel(configDir, path)
 		rel = strings.ReplaceAll(rel, `\`, "/")
-		if strings.HasPrefix(rel, "backups/") {
+		if skipConfigPath(rel) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
 			return nil
 		}
 		content, err := os.ReadFile(path)
@@ -599,10 +622,21 @@ func importConfig(ctx context.Context, db *storage.DB, configDest, cfgFileDir, c
 	}
 	// File destination: copy YAML files to cfgFileDir.
 	return filepath.WalkDir(configDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
 			return nil
 		}
 		rel, _ := filepath.Rel(configDir, path)
+		// Defensive: older archives may have bundled the project's .git tree.
+		// Skip it so restore does not try to overwrite read-only git objects.
+		if skipConfigPath(filepath.ToSlash(rel)) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
 		dst := filepath.Join(cfgFileDir, rel)
 		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 			return err

--- a/internal/backup/universal_test.go
+++ b/internal/backup/universal_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -376,5 +377,82 @@ func TestAttachmentsExportRestore(t *testing.T) {
 	})
 	if !bytes.Equal(restoredContent, attContent) {
 		t.Errorf("restored content mismatch: got %q, want %q", restoredContent, attContent)
+	}
+}
+
+func TestSkipConfigPath(t *testing.T) {
+	cases := []struct {
+		rel  string
+		skip bool
+	}{
+		{"metadata/Номенклатура.yaml", false},
+		{".gitignore", false},          // file, not the .git dir
+		{"sub/.gitignore", false},      // whole-segment match only
+		{".git", true},                 // the directory itself
+		{".git/objects/00/abc", true},  // read-only object that breaks restore
+		{"deep/.git/config", true},     // nested repo
+		{".svn/entries", true},         // other VCS
+		{".hg/store", true},            // other VCS
+		{"backups/full.obz", true},     // backups are not config
+		{"backupsX/keep.yaml", false},  // prefix must be the backups/ dir
+	}
+	for _, c := range cases {
+		if got := skipConfigPath(c.rel); got != c.skip {
+			t.Errorf("skipConfigPath(%q) = %v, want %v", c.rel, got, c.skip)
+		}
+	}
+}
+
+// TestExportConfig_FileSourceExcludesGit verifies that a file-source config
+// export prunes the project's .git tree (and other VCS metadata) so that a
+// later restore never tries to overwrite read-only git objects — the
+// "Access is denied" bug on Windows.
+func TestExportConfig_FileSourceExcludesGit(t *testing.T) {
+	configDir := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(configDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("metadata/Товар.yaml", "name: Товар")
+	write(".gitignore", "*.db")
+	write(".git/objects/00/abcdef", "binary-git-object")
+	write(".git/HEAD", "ref: refs/heads/main")
+	write("backups/old.obz", "archive")
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	if err := exportConfig(context.Background(), nil, "file", configDir, zw); err != nil {
+		t.Fatalf("exportConfig: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, f := range zr.File {
+		got[f.Name] = true
+	}
+	for name := range got {
+		if strings.Contains(name, "/.git/") || strings.HasSuffix(name, "/.git") {
+			t.Errorf("archive must not contain .git entries, found %q", name)
+		}
+		if strings.Contains(name, "backups/") {
+			t.Errorf("archive must not contain backups entries, found %q", name)
+		}
+	}
+	if !got["config/metadata/Товар.yaml"] {
+		t.Errorf("expected config metadata to be exported, entries: %v", got)
+	}
+	if !got["config/.gitignore"] {
+		t.Errorf(".gitignore (a regular file) should be exported, entries: %v", got)
 	}
 }


### PR DESCRIPTION
## Проблема

При восстановлении базы из `.obz` (источник конфигурации — **файлы**) восстановление падало на Windows:

```
Ошибка восстановления: import config: open C:\Project\trade\.git\objects\00\4b93...: Access is denied
```

## Причина

`exportConfig` в файловом режиме обходил весь каталог проекта и пропускал только `backups/`. Поэтому в архив попадала вся папка `.git/`. При восстановлении `importConfig` (file-режим) пытался перезаписать **read-only git-объекты** в корне проекта → `Access is denied`.

## Решение

- Добавлен хелпер `skipConfigPath(rel)` — отсекает по **целым сегментам** пути `.git`, `.svn`, `.hg` и каталог `backups/` (обычный файл `.gitignore` сохраняется).
- Применён в `exportConfig` (`.git` больше не попадает в архив) и в `importConfig` (обход обрезается через `fs.SkipDir`).
- Импорт-сторона защищает и **уже созданные** архивы, где `.git` был зашит ранее — они теперь восстанавливаются без ошибки.

Следующий шаг восстановления (`migrateSchema → project.Load`) безопасен: загрузчик читает только известные подкаталоги, а не обходит дерево вслепую.

## Тесты

- `TestSkipConfigPath` — таблица граничных случаев.
- `TestExportConfig_FileSourceExcludesGit` — роундтрип: `.git/` и `backups/` исключены, `metadata/*.yaml` и `.gitignore` сохранены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
