### PR TITLE
fix: issues #16, #20, #21 — ссылки в VT, коллизии имён, рудименты импорта

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -52,6 +52,9 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 		// отдельно — они не часть project.Project.
 		roles, _ := auth.LoadRolesYAML(filepath.Join(bc.Dir, "roles"))
 		issues = append(issues, configcheck.CheckCrossRefs(proj, roles)...)
+		// Коллизии имён таблиц: справочник и документ с одинаковым именем
+		// делят одну физическую таблицу lower(имя) (issue #20).
+		issues = append(issues, configcheck.CheckNameCollisions(proj)...)
 		// п.45: исполняемая валидация запросов против in-memory схемы из
 		// метаданных (best-effort — при сбое настройки схемы просто пропускаем,
 		// чтобы не ломать обычную проверку компиляции).

--- a/internal/configcheck/cross_refs.go
+++ b/internal/configcheck/cross_refs.go
@@ -187,6 +187,60 @@ func CheckCrossRefs(proj *project.Project, roles []*auth.Role) []Issue {
 	return issues
 }
 
+// CheckNameCollisions ловит совпадение имён сущностей (справочников и
+// документов) без учёта регистра. Имя физической таблицы строится как
+// metadata.TableName(name) = lower(name) без префикса вида, поэтому каталог
+// «Счёт» и документ «Счёт» претендуют на одну таблицу «счёт» — миграция тихо
+// смешает их колонки. Регистры (рег_/инфо_) и табличные части (<сущность>_<тч>)
+// имеют префиксы и в этом пространстве имён не участвуют. См. issue #20.
+func CheckNameCollisions(proj *project.Project) []Issue {
+	type ent struct {
+		name string
+		kind string
+	}
+	byTable := map[string][]ent{}
+	kindLabel := func(k metadata.Kind) string {
+		switch k {
+		case metadata.KindCatalog:
+			return "справочник"
+		case metadata.KindDocument:
+			return "документ"
+		default:
+			return string(k)
+		}
+	}
+	for _, e := range proj.Entities {
+		tbl := metadata.TableName(e.Name)
+		byTable[tbl] = append(byTable[tbl], ent{name: e.Name, kind: kindLabel(e.Kind)})
+	}
+
+	var tables []string
+	for tbl, group := range byTable {
+		if len(group) > 1 {
+			tables = append(tables, tbl)
+		}
+	}
+	sort.Strings(tables)
+
+	var issues []Issue
+	for _, tbl := range tables {
+		group := byTable[tbl]
+		sort.Slice(group, func(i, j int) bool { return group[i].name < group[j].name })
+		var parts []string
+		for _, g := range group {
+			parts = append(parts, fmt.Sprintf("%s %q", g.kind, g.name))
+		}
+		issues = append(issues, Issue{
+			Object: tbl,
+			Kind:   "Имя таблицы",
+			Message: fmt.Sprintf(
+				"коллизия имён: %s используют одну таблицу %q — переименуйте один из объектов",
+				strings.Join(parts, ", "), tbl),
+		})
+	}
+	return issues
+}
+
 // fieldInEntity сообщает, есть ли у сущности поле с таким именем.
 func fieldInEntity(e *metadata.Entity, name string) bool {
 	for i := range e.Fields {

--- a/internal/configcheck/cross_refs_test.go
+++ b/internal/configcheck/cross_refs_test.go
@@ -141,3 +141,39 @@ table:
 		t.Errorf("Сумма и @row валидны — ошибки быть не должно: %+v", issues)
 	}
 }
+
+// CheckNameCollisions должен ловить справочник и документ с одинаковым именем
+// (делят одну таблицу lower(имя)) и молчать, когда имена различны (issue #20).
+func TestCheckNameCollisions(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "catalogs", "счёт.yaml"), `name: Счёт
+fields:
+  - name: Наименование
+    type: string`)
+	mkFile(t, filepath.Join(dir, "documents", "счёт.yaml"), `name: Счёт
+fields:
+  - name: Номер
+    type: string`)
+	// Документ с уникальным именем — коллизии быть не должно.
+	mkFile(t, filepath.Join(dir, "documents", "заказ.yaml"), `name: Заказ
+fields:
+  - name: Номер
+    type: string`)
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	issues := CheckNameCollisions(proj)
+	if len(issues) != 1 {
+		t.Fatalf("ожидалась ровно одна коллизия, получено %d: %+v", len(issues), issues)
+	}
+	if issues[0].Object != "счёт" || !strings.Contains(issues[0].Message, "коллизия") {
+		t.Errorf("неожиданная ошибка коллизии: %+v", issues[0])
+	}
+	if !strings.Contains(issues[0].Message, "справочник") || !strings.Contains(issues[0].Message, "документ") {
+		t.Errorf("сообщение должно называть оба вида объектов: %q", issues[0].Message)
+	}
+}

--- a/internal/converter/parser1c/metadata.go
+++ b/internal/converter/parser1c/metadata.go
@@ -240,6 +240,19 @@ func ParseDir(dir string) (*ConfigDump, error) {
 		case "ConfigDumpInfo.xml", "config.xml", "Languages":
 			// служебный файл / языки — пропускаем
 
+		case "CommonPictures", "Styles", "StyleItems", "Interfaces",
+			"WebServices", "HTTPServices", "WSReferences", "XDTOPackages",
+			"CommonCommandGroups", "CommandInterfaces":
+			// ресурсы оформления/интеграции — не прикладные данные. Раньше они
+			// попадали в default-ветку и конвертировались в справочники
+			// (issue #16: «логотип» из CommonPictures становился справочником).
+			objects, _ := os.ReadDir(subDir)
+			for _, obj := range objects {
+				if obj.IsDir() {
+					dump.SkippedDirs = append(dump.SkippedDirs, SkippedItem{Kind: kind, Name: obj.Name()})
+				}
+			}
+
 		case "CommonModules":
 			mods, err := parseCommonModules(subDir)
 			if err != nil {

--- a/internal/project/scaffold.go
+++ b/internal/project/scaffold.go
@@ -14,20 +14,12 @@ func Scaffold(dir, name string) error {
 		}
 	}
 
+	// Создаём только пустую валидную конфигурацию: каталог структуры + app.yaml.
+	// Демонстрационные объекты (Контрагент/Счёт) намеренно НЕ создаются — раньше
+	// они подмешивались как «рудименты» в новые и импортируемые конфигурации
+	// (issue #16). Пустая конфигурация — чистый старт, как пустая ИБ в 1С.
 	files := map[string]string{
 		filepath.Join(dir, "config", "app.yaml"): "name: " + name + "\nversion: \"1.0\"\n",
-		filepath.Join(dir, "catalogs", "контрагент.yaml"): "name: Контрагент\nfields:\n" +
-			"  - name: Наименование\n    type: string\n" +
-			"  - name: ИНН\n    type: string\n",
-		filepath.Join(dir, "documents", "счёт.yaml"): "name: Счёт\nfields:\n" +
-			"  - name: Номер\n    type: string\n" +
-			"  - name: Дата\n    type: date\n" +
-			"  - name: Контрагент\n    type: reference:Контрагент\n",
-		filepath.Join(dir, "src", "счёт.os"): "Процедура ПриЗаписи()\n" +
-			"  Если this.Номер = \"\" Тогда\n" +
-			"    Error(\"Номер обязателен\");\n" +
-			"  КонецЕсли;\n" +
-			"КонецПроцедуры\n",
 	}
 
 	for path, content := range files {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1135,13 +1135,13 @@ func preScanAllRefDims(tokens []tok, opts CompileOpts) []refDimInfo {
 			if isAccumRegType(upper) {
 				for _, reg := range opts.Registers {
 					if strings.EqualFold(reg.Name, regName) {
-						return buildVTRefDimInfos(append(reg.Dimensions, reg.Attributes...))
+						return buildVTRefDimInfos(append(reg.Dimensions, reg.Attributes...), opts.Entities)
 					}
 				}
 			} else if isInfoRegType(upper) {
 				for _, ir := range opts.InfoRegs {
 					if strings.EqualFold(ir.Name, regName) {
-						return buildVTRefDimInfos(ir.Dimensions)
+						return buildVTRefDimInfos(ir.Dimensions, opts.Entities)
 					}
 				}
 			}
@@ -1197,18 +1197,27 @@ func filterUsedRefDims(dims []refDimInfo, tokens []tok) []refDimInfo {
 
 // buildVTRefDimInfos creates refDimInfos for VT outer queries where the subquery
 // aliases _id columns to logical names, so JOIN ON uses fieldName instead of idCol.
-func buildVTRefDimInfos(dims []metadata.Field) []refDimInfo {
+// entities позволяет выставить refIsDoc: ссылка-измерение на документ отображается
+// через .номер, а не .наименование (у документов нет наименования).
+func buildVTRefDimInfos(dims []metadata.Field, entities []*metadata.Entity) []refDimInfo {
 	var result []refDimInfo
 	for _, d := range dims {
 		if d.RefEntity != "" {
 			fn := strings.ToLower(d.Name)
-			result = append(result, refDimInfo{
+			rd := refDimInfo{
 				fieldName: fn,
 				idCol:     fn, // VT aliased from _id
 				joinAlias: "ref_" + fn,
 				joinTable: strings.ToLower(d.RefEntity),
 				isVT:      true,
-			})
+			}
+			for _, e := range entities {
+				if strings.EqualFold(e.Name, d.RefEntity) && e.Kind == metadata.KindDocument {
+					rd.refIsDoc = true
+					break
+				}
+			}
+			result = append(result, rd)
 		}
 	}
 	return result

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -598,6 +598,41 @@ func TestCompile_VT_RefDim_AutoJoin(t *testing.T) {
 	}
 }
 
+// TestCompile_VT_RefDim_Document verifies that a dimension referencing a document
+// resolves to .номер (not .наименование) in a virtual-table (Остатки) query —
+// documents have no наименование column. Regression for buildVTRefDimInfos not
+// propagating refIsDoc.
+func TestCompile_VT_RefDim_Document(t *testing.T) {
+	src := "ВЫБРАТЬ ЗаказПоставщику, КоличествоОстаток " +
+		"ИЗ РегистрНакопления.ТоварыВПути.Остатки()"
+
+	reg := &metadata.Register{
+		Name: "ТоварыВПути",
+		Dimensions: []metadata.Field{
+			{Name: "ЗаказПоставщику", RefEntity: "ЗаказПоставщику"},
+		},
+		Resources: []metadata.Field{{Name: "Количество"}},
+	}
+
+	r, err := query.Compile(src, query.CompileOpts{
+		Registers: []*metadata.Register{reg},
+		Entities: []*metadata.Entity{
+			{Name: "ЗаказПоставщику", Kind: metadata.KindDocument},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := r.SQL
+
+	if !strings.Contains(sql, "ref_заказпоставщику.номер") {
+		t.Errorf("expected document ref to resolve to .номер, got: %s", sql)
+	}
+	if strings.Contains(sql, "ref_заказпоставщику.наименование") {
+		t.Errorf("document ref must not use .наименование, got: %s", sql)
+	}
+}
+
 // TestCompile_VT_WithUserAlias verifies that КАК after a VT subquery is consumed
 // and the user-provided alias is used in the auto-JOIN ON clause.
 func TestCompile_VT_WithUserAlias(t *testing.T) {


### PR DESCRIPTION
## Обзор

Три независимых фикса по issue из трекера. Каждый — отдельным коммитом.

### #21 — ссылки-измерения на документы в виртуальных таблицах
`buildVTRefDimInfos` не выставляла `refIsDoc`, поэтому измерение-ссылка на документ в VT-запросе (`.Остатки()`) пыталось читать `.наименование`, которого у документов нет — они нумеруются. Прокинул сущности и `refIsDoc`, как в обычном пути. Документ теперь выводится через `.номер`. Регрессионный тест `TestCompile_VT_RefDim_Document`.

> Вскрылось при исправлении конфигурации ПУТ, где измерения регистров были объявлены `type: string` вместо `reference:X` (правка в репозитории конфигурации).

### #20 — диагностика коллизии имён таблиц
Имя физической таблицы строится как `lower(имя)` без префикса вида, поэтому справочник «Счёт» и документ «Счёт» претендуют на одну таблицу `счёт` — миграция тихо смешает колонки. Добавил `CheckNameCollisions`: `onebase check` выдаёт ошибку при совпадении имён сущностей разных видов. Тест `TestCheckNameCollisions`.

Полная схема префиксов (`спр_`/`док_`) — отдельный ломающий план: допущение «таблица = `lower(имя)`» зашито в query-компиляторе и др. слоях.

### #16 — рудименты в новых и импортируемых конфигурациях
- `Scaffold` создаёт только пустую валидную конфигурацию (`config/app.yaml` + структура), без демо-объектов `Контрагент`/`Счёт`.
- Конвертер 1С явно пропускает ресурсы оформления/интеграции (`CommonPictures`, `Styles`, `WebServices` и т.п.) вместо превращения их в справочники — «логотип» из `CommonPictures` больше не станет каталогом.

## Проверки
- `onebase check` по конфигурации ПУТ — OK.
- Тесты `query`, `configcheck`, `converter/...`, `launcher`, `cli`, `project` — зелёные, сборка проходит.

Closes #16, #20, #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
