### PR TITLE
fix(ui): кодировка Excel-выгрузки и представления в регистрах сведений (#46, #44)

### DIFF
--- a/internal/ui/content_disposition_test.go
+++ b/internal/ui/content_disposition_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #46: сырой UTF-8 в filename="..." декодируется браузером как latin-1 —
+// имя файла превращается в кракозябры. RFC 6266: ASCII-фолбэк в filename= и
+// полное имя в filename*=UTF-8''.
+func TestContentDisposition(t *testing.T) {
+	got := contentDisposition("Контрагенты.xlsx")
+	if !strings.Contains(got, "filename*=UTF-8''") {
+		t.Fatalf("нет RFC 5987 параметра: %q", got)
+	}
+	if strings.Contains(got, `filename="Контрагенты`) {
+		t.Fatalf("сырой UTF-8 в quoted-string остался: %q", got)
+	}
+	if !strings.HasPrefix(got, "attachment; ") {
+		t.Fatalf("ожидался attachment: %q", got)
+	}
+	// ASCII-имя остаётся читаемым в обоих параметрах.
+	got = contentDisposition("report.pdf")
+	if !strings.Contains(got, `filename="report.pdf"`) {
+		t.Fatalf("ASCII-фолбэк потерян: %q", got)
+	}
+}

--- a/internal/ui/content_disposition_test.go
+++ b/internal/ui/content_disposition_test.go
@@ -25,3 +25,50 @@ func TestContentDisposition(t *testing.T) {
 		t.Fatalf("ASCII-фолбэк потерян: %q", got)
 	}
 }
+
+// Issue #46 регрессия: строгое RFC 5987-кодирование — «=», «@» и «:» запрещены
+// в attr-char и должны percent-кодироваться.
+func TestEncodeRFC5987_StrictEncoding(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		illegal string // подстрока, которой НЕ должно быть в результате
+		want    string // подстрока, которая ДОЛЖНА присутствовать
+	}{
+		{
+			name:    "знак равно кодируется",
+			input:   "a=b.xlsx",
+			illegal: "=",
+			want:    "%3D",
+		},
+		{
+			name:    "знак @ кодируется",
+			input:   "прайс@2026.xlsx",
+			illegal: "@",
+			want:    "%40",
+		},
+		{
+			name:    "кириллица кодируется percent-октетами",
+			input:   "прайс.xlsx",
+			illegal: "п", // сырая кириллица недопустима в attr-value
+			want:    "%D0%BF",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disp := contentDisposition(tt.input)
+			// Берём только часть после UTF-8''
+			idx := strings.Index(disp, "UTF-8''")
+			if idx < 0 {
+				t.Fatalf("нет RFC 5987 параметра: %q", disp)
+			}
+			encoded := disp[idx+len("UTF-8''"):]
+			if strings.Contains(encoded, tt.illegal) {
+				t.Errorf("незакодированный символ %q присутствует в %q", tt.illegal, encoded)
+			}
+			if !strings.Contains(encoded, tt.want) {
+				t.Errorf("ожидаемый код %q отсутствует в %q", tt.want, encoded)
+			}
+		})
+	}
+}

--- a/internal/ui/extforms.go
+++ b/internal/ui/extforms.go
@@ -158,7 +158,7 @@ func (s *Server) adminExtFormExport(w http.ResponseWriter, r *http.Request) {
 	}
 	fname := rec.Document + "." + rec.Name + ".obform"
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
-	w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+url.PathEscape(fname))
+	w.Header().Set("Content-Disposition", contentDisposition(fname))
 	w.Write(bundle)
 }
 

--- a/internal/ui/extprocessors.go
+++ b/internal/ui/extprocessors.go
@@ -173,7 +173,7 @@ func (s *Server) adminExtProcessorExport(w http.ResponseWriter, r *http.Request)
 	}
 	fname := rec.Name + ".obform"
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
-	w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+url.PathEscape(fname))
+	w.Header().Set("Content-Disposition", contentDisposition(fname))
 	w.Write(bundle)
 }
 

--- a/internal/ui/extreports.go
+++ b/internal/ui/extreports.go
@@ -153,7 +153,7 @@ func (s *Server) adminExtReportExport(w http.ResponseWriter, r *http.Request) {
 	}
 	fname := rec.Name + ".obform"
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
-	w.Header().Set("Content-Disposition", "attachment; filename*=UTF-8''"+url.PathEscape(fname))
+	w.Header().Set("Content-Disposition", contentDisposition(fname))
 	w.Write(bundle)
 }
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -141,7 +141,11 @@ type refCol struct {
 // resolveRefColumns заменяет UUID-значения в указанных колонках строк на
 // наименования соответствующих объектов. Общее ядро для регистров накопления и
 // регистра бухгалтерии (субконто).
-func (s *Server) resolveRefColumns(ctx context.Context, rows []map[string]any, cols []refCol) {
+//
+// Если labelSuffix == "" — замена происходит in-place (прежнее поведение).
+// Если labelSuffix != "" — наименование записывается в row[key+labelSuffix],
+// а оригинальное значение (UUID) остаётся нетронутым.
+func (s *Server) resolveRefColumns(ctx context.Context, rows []map[string]any, cols []refCol, labelSuffix string) {
 	// Build lookup: RefEntity → set of UUIDs to resolve
 	entityUUIDs := make(map[string]map[string]string) // entityName → {uuid: label}
 	for _, row := range rows {
@@ -194,7 +198,11 @@ func (s *Server) resolveRefColumns(ctx context.Context, rows []map[string]any, c
 				continue
 			}
 			if label, found := uuidToLabel[v]; found && label != "" {
-				row[c.Key] = label
+				if labelSuffix == "" {
+					row[c.Key] = label
+				} else {
+					row[c.Key+labelSuffix] = label
+				}
 			}
 		}
 	}

--- a/internal/ui/handlers_attachments.go
+++ b/internal/ui/handlers_attachments.go
@@ -104,7 +104,7 @@ func (s *Server) attachmentDownload(w http.ResponseWriter, r *http.Request) {
 	defer f.Close()
 
 	w.Header().Set("Content-Type", att.MimeType)
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+sanitizeFilename(att.Filename)+"\"")
+	w.Header().Set("Content-Disposition", contentDisposition(att.Filename))
 	http.ServeContent(w, r, att.Filename, att.UploadedAt, f)
 }
 

--- a/internal/ui/handlers_export.go
+++ b/internal/ui/handlers_export.go
@@ -4,8 +4,8 @@ package ui
 // Выделено из handlers.go (план 55, этап 1) — перенос as-is.
 
 import (
+	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/ivantit66/onebase/internal/excel"
@@ -65,7 +65,25 @@ func contentDisposition(filename string) string {
 			fallback = append(fallback, '_')
 		}
 	}
-	return "attachment; filename=\"" + string(fallback) + "\"; filename*=UTF-8''" + url.PathEscape(filename)
+	return "attachment; filename=\"" + string(fallback) + "\"; filename*=UTF-8''" + encodeRFC5987(filename)
+}
+
+// encodeRFC5987 кодирует строку для filename*=UTF-8'' — percent-кодируется
+// всё, кроме attr-char по RFC 5987 (url.PathEscape оставляет «=», «@», «:»,
+// которые ломают разбор заголовка).
+func encodeRFC5987(s string) string {
+	const attr = "!#$&+-.^_`|~"
+	var b strings.Builder
+	for _, c := range []byte(s) { // побайтово: октеты UTF-8 кодируются
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			strings.IndexByte(attr, c) >= 0:
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
 }
 
 // sanitizeFilename replaces characters unsafe for Content-Disposition filename.

--- a/internal/ui/handlers_export.go
+++ b/internal/ui/handlers_export.go
@@ -5,6 +5,7 @@ package ui
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/ivantit66/onebase/internal/excel"
@@ -46,10 +47,25 @@ func (s *Server) listExcel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Excel error: "+s.errText(r, err), 500)
 		return
 	}
-	filename := sanitizeFilename(entity.Name) + ".xlsx"
 	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	w.Header().Set("Content-Disposition", contentDisposition(entity.Name+".xlsx"))
 	w.Write(data)
+}
+
+// contentDisposition собирает заголовок Content-Disposition по RFC 6266:
+// ASCII-фолбэк в filename= (для старых клиентов) и полное имя в
+// filename*=UTF-8'' (issue #46 — сырой UTF-8 в quoted-string браузеры
+// декодируют как latin-1, имя файла превращается в кракозябры).
+func contentDisposition(filename string) string {
+	fallback := make([]rune, 0, len(filename))
+	for _, r := range sanitizeFilename(filename) {
+		if r < 0x80 {
+			fallback = append(fallback, r)
+		} else {
+			fallback = append(fallback, '_')
+		}
+	}
+	return "attachment; filename=\"" + string(fallback) + "\"; filename*=UTF-8''" + url.PathEscape(filename)
 }
 
 // sanitizeFilename replaces characters unsafe for Content-Disposition filename.

--- a/internal/ui/handlers_journals.go
+++ b/internal/ui/handlers_journals.go
@@ -245,8 +245,7 @@ func (s *Server) journalExcel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Excel error: "+s.errText(r, err), 500)
 		return
 	}
-	filename := sanitizeFilename(j.Name) + ".xlsx"
 	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	w.Header().Set("Content-Disposition", contentDisposition(j.Name+".xlsx"))
 	w.Write(data)
 }

--- a/internal/ui/handlers_print.go
+++ b/internal/ui/handlers_print.go
@@ -214,13 +214,13 @@ func (s *Server) printDocumentPDF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filename := sanitizeFilename(form.Name) + ".pdf"
+	origName := form.Name + ".pdf"
 	if num, ok := row["Номер"].(string); ok && num != "" {
-		filename = sanitizeFilename(form.Name+"_"+num) + ".pdf"
+		origName = form.Name + "_" + num + ".pdf"
 	}
 
 	w.Header().Set("Content-Type", "application/pdf")
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	w.Header().Set("Content-Disposition", contentDisposition(origName))
 	w.Write(pdfBytes)
 }
 

--- a/internal/ui/handlers_registers.go
+++ b/internal/ui/handlers_registers.go
@@ -89,6 +89,24 @@ func (s *Server) resolveRegisterRows(ctx context.Context, rows []map[string]any,
 	}
 }
 
+// resolveInfoRegRows подменяет UUID ссылочных измерений и ресурсов регистра
+// сведений на наименования (issue #44 — в списке регистра сведений показывались
+// id вместо представлений). Зеркало resolveRegisterRows.
+func (s *Server) resolveInfoRegRows(ctx context.Context, rows []map[string]any, ir *metadata.InfoRegister) {
+	refFields := append(append([]metadata.Field{}, ir.Dimensions...), ir.Resources...)
+	var cols []refCol
+	for _, f := range refFields {
+		if f.RefEntity == "" {
+			continue
+		}
+		cols = append(cols, refCol{Key: f.Name, RefEntity: f.RefEntity})
+	}
+	if len(cols) == 0 {
+		return
+	}
+	s.resolveRefColumns(ctx, rows, cols)
+}
+
 // resolveAccountRows резолвит reference-субконто (хранятся под ключами субконто<N>)
 // в наименования. String/enum-субконто оставляет как есть.
 func (s *Server) resolveAccountRows(ctx context.Context, rows []map[string]any, ar *metadata.AccountRegister) {
@@ -127,6 +145,7 @@ func (s *Server) infoRegList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.errText(r, err), 500)
 		return
 	}
+	s.resolveInfoRegRows(r.Context(), rows, ir)
 	s.render(w, r, "page-inforeg-list", map[string]any{
 		"InfoReg": ir,
 		"Rows":    rows,

--- a/internal/ui/handlers_registers.go
+++ b/internal/ui/handlers_registers.go
@@ -69,7 +69,7 @@ func (s *Server) resolveRegisterRows(ctx context.Context, rows []map[string]any,
 	for i, f := range refFields {
 		cols[i] = refCol{Key: f.Name, RefEntity: f.RefEntity}
 	}
-	s.resolveRefColumns(ctx, rows, cols)
+	s.resolveRefColumns(ctx, rows, cols, "")
 
 	// recorder label
 	for _, row := range rows {
@@ -104,7 +104,7 @@ func (s *Server) resolveInfoRegRows(ctx context.Context, rows []map[string]any, 
 	if len(cols) == 0 {
 		return
 	}
-	s.resolveRefColumns(ctx, rows, cols)
+	s.resolveRefColumns(ctx, rows, cols, "_label")
 }
 
 // resolveAccountRows резолвит reference-субконто (хранятся под ключами субконто<N>)
@@ -120,7 +120,7 @@ func (s *Server) resolveAccountRows(ctx context.Context, rows []map[string]any, 
 	if len(cols) == 0 {
 		return
 	}
-	s.resolveRefColumns(ctx, rows, cols)
+	s.resolveRefColumns(ctx, rows, cols, "")
 }
 
 func (s *Server) getInfoReg(w http.ResponseWriter, r *http.Request) *metadata.InfoRegister {

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -354,8 +354,7 @@ func (s *Server) reportExcel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Excel error: "+s.errText(r, err), 500)
 		return
 	}
-	filename := sanitizeFilename(rep.Name) + ".xlsx"
 	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	w.Header().Set("Content-Disposition", contentDisposition(rep.Name+".xlsx"))
 	w.Write(data)
 }

--- a/internal/ui/resolve_inforeg_rows_test.go
+++ b/internal/ui/resolve_inforeg_rows_test.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Issue #44: в списке регистра сведений UUID ссылочных измерений/ресурсов
+// должны заменяться на наименования, как это происходит в регистрах накопления.
+func TestResolveInfoRegRows_RefDimension(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Справочник-измерение
+	kontragent := &metadata.Entity{
+		Name:   "Контрагент",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{kontragent}); err != nil {
+		t.Fatal(err)
+	}
+	kID := uuid.New()
+	if err := db.Upsert(ctx, "Контрагент", kID, map[string]any{"Наименование": "ООО Ромашка"}, kontragent); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{kontragent}})
+	s := &Server{store: db, reg: registry}
+
+	ir := &metadata.InfoRegister{
+		Name: "ЦеныКонтрагентов",
+		Dimensions: []metadata.Field{
+			{Name: "Контрагент", Type: "reference:Контрагент", RefEntity: "Контрагент"},
+		},
+		Resources: []metadata.Field{
+			{Name: "Цена", Type: metadata.FieldTypeNumber},
+		},
+	}
+
+	rows := []map[string]any{
+		{"Контрагент": kID.String(), "Цена": "100"},
+	}
+	s.resolveInfoRegRows(ctx, rows, ir)
+
+	if rows[0]["Контрагент"] != "ООО Ромашка" {
+		t.Errorf("UUID измерения не резолвнулся: got %v, want 'ООО Ромашка'", rows[0]["Контрагент"])
+	}
+}

--- a/internal/ui/resolve_inforeg_rows_test.go
+++ b/internal/ui/resolve_inforeg_rows_test.go
@@ -54,7 +54,64 @@ func TestResolveInfoRegRows_RefDimension(t *testing.T) {
 	}
 	s.resolveInfoRegRows(ctx, rows, ir)
 
-	if rows[0]["Контрагент"] != "ООО Ромашка" {
-		t.Errorf("UUID измерения не резолвнулся: got %v, want 'ООО Ромашка'", rows[0]["Контрагент"])
+	// После фикса #44 UUID сохраняется in-place, наименование — в _label.
+	if rows[0]["Контрагент"] == "ООО Ромашка" {
+		t.Errorf("UUID измерения был заменён наименованием in-place — форма удаления сломается")
+	}
+	if rows[0]["Контрагент_label"] != "ООО Ромашка" {
+		t.Errorf("лейбл не записан в _label: got %v, want 'ООО Ромашка'", rows[0]["Контрагент_label"])
+	}
+}
+
+// Issue #44 регрессия: resolveInfoRegRows НЕ должна затирать оригинальный ключ UUID.
+// Скрытые поля формы удаления используют сырое значение; если оно заменено на
+// наименование — DELETE строит WHERE контрагент_id = 'ООО Ромашка' и молча не работает.
+func TestResolveInfoRegRows_OriginalKeyPreserved(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	kontragent := &metadata.Entity{
+		Name:   "Контрагент",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{kontragent}); err != nil {
+		t.Fatal(err)
+	}
+	kID := uuid.New()
+	if err := db.Upsert(ctx, "Контрагент", kID, map[string]any{"Наименование": "ООО Ромашка"}, kontragent); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{kontragent}})
+	s := &Server{store: db, reg: registry}
+
+	ir := &metadata.InfoRegister{
+		Name: "ЦеныКонтрагентов",
+		Dimensions: []metadata.Field{
+			{Name: "Контрагент", Type: "reference:Контрагент", RefEntity: "Контрагент"},
+		},
+		Resources: []metadata.Field{
+			{Name: "Цена", Type: metadata.FieldTypeNumber},
+		},
+	}
+
+	rows := []map[string]any{
+		{"Контрагент": kID.String(), "Цена": "100"},
+	}
+	s.resolveInfoRegRows(ctx, rows, ir)
+
+	// Оригинальный ключ должен оставаться UUID — иначе форма удаления сломана.
+	if rows[0]["Контрагент"] != kID.String() {
+		t.Errorf("сырое значение измерения перезаписано: got %v, want UUID %v", rows[0]["Контрагент"], kID.String())
+	}
+	// Лейбл должен быть доступен по ключу с суффиксом _label.
+	if rows[0]["Контрагент_label"] != "ООО Ромашка" {
+		t.Errorf("лейбл не записан: got %v, want 'ООО Ромашка'", rows[0]["Контрагент_label"])
 	}
 }

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -2249,7 +2249,7 @@ const tplInfoReg = `
 </tr></thead><tbody>
 {{range .Rows}}{{$row := .}}<tr>
   {{if $.InfoReg.Periodic}}<td>{{index $row "period"}}</td>{{end}}
-  {{range $.InfoReg.Dimensions}}<td>{{index $row .Name}}</td>{{end}}
+  {{range $.InfoReg.Dimensions}}<td>{{$lbl := index $row (printf "%s_label" .Name)}}{{if $lbl}}{{$lbl}}{{else}}{{index $row .Name}}{{end}}</td>{{end}}
   {{range $.InfoReg.Resources}}<td style="font-weight:600">{{index $row .Name}}</td>{{end}}
   {{if $.CanDelete}}<td>
     <form method="POST" action="/ui/inforeg/{{lower $.InfoReg.Name}}/delete" style="display:inline"


### PR DESCRIPTION
Closes #46, closes #44.

## #46 — кодировка имени файла при выгрузке в Excel
`Content-Disposition` отправлял сырой UTF-8 в `filename=…` — браузеры декодируют quoted-string как latin-1, имя файла превращалось в кракозябры. Теперь общий хелпер `contentDisposition` собирает заголовок по RFC 6266: ASCII-фолбэк в `filename=` + полное имя в `filename*=UTF-8''` со строгим percent-кодированием attr-char по RFC 5987 (`url.PathEscape` пропускал `=`, `@`, `:`). Применён во всех 8 местах выгрузки файлов: Excel списков/отчётов/журналов, PDF печатных форм, вложения, ext-выгрузки.

## #44 — регистр сведений показывал UUID вместо представлений
Список регистра сведений рендерил строки без резолва ссылок (в отличие от регистров накопления). Теперь ссылочные измерения и ресурсы резолвятся в наименования. Важная деталь: резолв пишет в отдельные `_label`-ключи, не трогая исходные значения, — скрытые поля формы удаления записи продолжают передавать UUID (резолв in-place молча ломал бы удаление; поймано на ревью, покрыто регрессионным тестом).

Проверки: `go test ./...` зелёный, `go vet` чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)