### PR TITLE
feat(configurator): ссылка на синтакс-помощник в меню и топбаре (#42)

### DIFF
--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -712,5 +712,8 @@
   "Ошибка чтения архива": "Fehler beim Lesen des Archivs",
   "Form.xml не найден в загруженных файлах": "Form.xml in den hochgeladenen Dateien nicht gefunden",
   "Импорт не удался": "Import fehlgeschlagen",
-  "Сохранение в БД": "Speichern in der Datenbank"
+  "Сохранение в БД": "Speichern in der Datenbank",
+  "Справка по встроенному языку": "Referenz der integrierten Sprache",
+  "Синтакс-помощник": "Syntax-Assistent",
+  "Справка": "Hilfe"
 }

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -739,5 +739,8 @@
   "Ошибка чтения архива": "Archive read error",
   "Form.xml не найден в загруженных файлах": "Form.xml not found in the uploaded files",
   "Импорт не удался": "Import failed",
-  "Сохранение в БД": "Saving to database"
+  "Сохранение в БД": "Saving to database",
+  "Справка по встроенному языку": "Built-in language reference",
+  "Синтакс-помощник": "Syntax assistant",
+  "Справка": "Help"
 }

--- a/internal/launcher/configurator_tmpl.go
+++ b/internal/launcher/configurator_tmpl.go
@@ -444,6 +444,7 @@ window.MonacoEnvironment = { getWorkerUrl: function () {
       <a href="#" onclick="cfgAdmin('audit');return false">{{t $.Lang "Журнал регистрации"}}</a>
       <a href="#" onclick="cfgAdmin('settings');return false">{{t $.Lang "Параметры базы"}}</a>
       <a href="#" onclick="cfgAdmin('ai');return false">{{t $.Lang "ИИ-помощник"}}</a>
+      <a href="#" onclick="toggleSyntaxRef();cfgMenuToggle();return false">{{t $.Lang "Справка по встроенному языку"}} (F1)</a>
       <a href="/bases/{{.Base.ID}}/configurator/logout" style="color:#c00;border-top:1px solid #e5e7eb;margin-top:2px">🚪 {{t $.Lang "Выйти"}}</a>
     </div>
   </div>
@@ -453,6 +454,7 @@ window.MonacoEnvironment = { getWorkerUrl: function () {
   <button id="cfg-save-topbar" onclick="cfgSaveActive()" title="{{t $.Lang "Сохранить (Ctrl+S)"}}" class="cfg-save-topbar">&#128190; {{t $.Lang "Сохранить"}}</button>
   <button onclick="launchEnterprise()" title="{{t $.Lang "Запустить предприятие"}}" class="run-enterprise-btn"><svg viewBox="0 0 24 24" fill="#333"><polygon points="6,3 20,12 6,21"/></svg></button>
   <button id="dbg-toggle" class="dbg-topbar-btn" onclick="dbgToggle()">&#128027; {{t $.Lang "Отладка: ВЫКЛ"}}</button>
+  <button onclick="toggleSyntaxRef()" title="{{t $.Lang "Синтакс-помощник"}} (F1)" class="dbg-topbar-btn">&#10067; {{t $.Lang "Справка"}}</button>
   <span id="monaco-status" style="font-size:9px;color:#94a3b8">Monaco:...</span>
 </div>
 <div class="tabs">

--- a/internal/launcher/help_link_render_test.go
+++ b/internal/launcher/help_link_render_test.go
@@ -1,0 +1,40 @@
+package launcher
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Issue #42: ссылка на синтакс-помощник должна быть в меню и топбаре конфигуратора.
+func renderCfgHead(t *testing.T) string {
+	t.Helper()
+	data := &configuratorData{Base: &Base{ID: "test-base", Name: "Тест", ConfigSource: "file"}, Lang: "ru"}
+	var buf bytes.Buffer
+	if err := cfgTmpl.ExecuteTemplate(&buf, "cfg-head", data); err != nil {
+		t.Fatalf("ExecuteTemplate cfg-head: %v", err)
+	}
+	return buf.String()
+}
+
+// Пункт меню «Справка по встроенному языку» должен вызывать toggleSyntaxRef.
+func TestConfigurator_HelpLinkInMenu(t *testing.T) {
+	html := renderCfgHead(t)
+	if !strings.Contains(html, "Справка по встроенному языку") {
+		t.Error("в cfg-head нет пункта меню «Справка по встроенному языку»")
+	}
+	if !strings.Contains(html, `onclick="toggleSyntaxRef()`) {
+		t.Error("в cfg-head пункт меню не вызывает toggleSyntaxRef()")
+	}
+}
+
+// Кнопка справки должна быть в топбаре.
+func TestConfigurator_HelpButtonInTopbar(t *testing.T) {
+	html := renderCfgHead(t)
+	if !strings.Contains(html, "Справка") {
+		t.Error("в cfg-head нет кнопки «Справка» в топбаре")
+	}
+	if !strings.Contains(html, `onclick="toggleSyntaxRef()"`) {
+		t.Error("в cfg-head кнопка топбара не вызывает toggleSyntaxRef()")
+	}
+}


### PR DESCRIPTION
Closes #42.

Справка по встроенным функциям в конфигураторе уже существовала — «Синтакс-помощник» (поиск, дерево функций/методов/конструкций/языка запросов, сигнатуры, примеры, вставка в редактор), но единственной точкой входа была малозаметная вертикальная кнопка у правого края и недокументированный F1.

Добавлены заметные точки входа:
- пункт «Справка по встроенному языку (F1)» в меню конфигуратора;
- кнопка «❓ Справка» в топбаре рядом с отладкой.

Рендер-тесты, переводы en/de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)