### PR TITLE
fix(configurator): кнопка «+ Добавить поле» в справочнике/документе (issue #65)

### DIFF
--- a/internal/launcher/add_field_button_render_test.go
+++ b/internal/launcher/add_field_button_render_test.go
@@ -1,0 +1,56 @@
+package launcher
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Issue #65: кнопка «+ Добавить поле» в конфигураторе не реагировала на клик.
+// Причина — в onclick имя сущности подставлялось как 3-й аргумент cfgAddField
+// БЕЗ кавычек (text/template выводит {{$e.Name}} сырым), из-за чего браузер
+// трактовал «Номенклатура» как необъявленную JS-переменную и падал с
+// ReferenceError ещё до вызова функции. Фиксируем, что имя обёрнуто в кавычки —
+// и для реквизитов шапки, и для полей табличной части.
+func TestConfigurator_AddFieldButtonQuotesEntity(t *testing.T) {
+	data := &configuratorData{
+		Base: &Base{ID: "test-base", Name: "Тест", ConfigSource: "file"},
+		Lang: "ru",
+		Tab:  "tree",
+		Catalogs: []cfgEntity{{
+			Name: "Номенклатура", Kind: "Справочник",
+			Fields: []cfgField{{Name: "Цена", Type: "number"}},
+			TableParts: []cfgTablePart{{
+				Name:   "Состав",
+				Fields: []cfgField{{Name: "Количество", Type: "number"}},
+			}},
+		}},
+	}
+	var buf bytes.Buffer
+	if err := cfgTmpl.ExecuteTemplate(&buf, "tab-tree", data); err != nil {
+		t.Fatalf("ExecuteTemplate tab-tree: %v", err)
+	}
+	html := buf.String()
+
+	for _, want := range []string{
+		// реквизиты шапки (строка-кнопка после таблицы полей)
+		`cfgAddField('ft-Номенклатура','new_field','Номенклатура')`,
+		// поля табличной части
+		`cfgAddField('ft-Номенклатура-tp0','new_tp.Состав.field','Номенклатура')`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("в onclick кнопки «Добавить поле» нет ожидаемого фрагмента: %q", want)
+		}
+	}
+
+	// И явно убеждаемся, что неэкранированный вариант (имя без кавычек,
+	// вызывающий ReferenceError) больше не встречается.
+	for _, bad := range []string{
+		`'new_field',Номенклатура)`,
+		`.field',Номенклатура)`,
+	} {
+		if strings.Contains(html, bad) {
+			t.Errorf("в onclick осталось неэкранированное имя сущности: %q", bad)
+		}
+	}
+}

--- a/internal/launcher/configurator_tmpl.go
+++ b/internal/launcher/configurator_tmpl.go
@@ -5662,7 +5662,7 @@ const cfgTabTree = `{{define "tab-tree"}}
 </tr>
 {{end}}
 </table>
-<button type="button" onclick="cfgAddField('ft-{{$e.Name}}','new_field',{{$e.Name}})" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить поле"}}</button>
+<button type="button" onclick="cfgAddField('ft-{{$e.Name}}','new_field','{{$e.Name}}')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить поле"}}</button>
 </details>
 {{end}}
 
@@ -5708,7 +5708,7 @@ const cfgTabTree = `{{define "tab-tree"}}
 </tr>
 {{end}}
 </table>
-<button type="button" onclick="cfgAddField('ft-{{$e.Name}}-tp{{$j}}','new_tp.{{$tp.Name}}.field',{{$e.Name}})" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить поле"}}</button>
+<button type="button" onclick="cfgAddField('ft-{{$e.Name}}-tp{{$j}}','new_tp.{{$tp.Name}}.field','{{$e.Name}}')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить поле"}}</button>
 </div>
 </details>
 {{end}}


### PR DESCRIPTION
Закрывает #65.

## Проблема
В конфигураторе кнопка «+ Добавить поле» у справочника и документа не реагировала на клик (v0.6.0, Chrome).

## Причина
В `internal/launcher/configurator_tmpl.go` кнопки (реквизиты шапки и поля табличной части) передавали имя сущности 3-м аргументом `cfgAddField(...)` **без кавычек**. Шаблон компилируется через `text/template`, который выводит `{{$e.Name}}` сырым, поэтому в браузер уходило:

```js
cfgAddField('ft-Номенклатура','new_field',Номенклатура)
```

`Номенклатура` трактуется как необъявленная JS-переменная → `ReferenceError` при клике → обработчик падает до вызова функции, строка поля не добавляется.

Баг существовал с момента добавления кнопки (`3a3b8de`), это не регрессия. Бэкенд сохранения новых полей (`new_field.N.*`, `tp.<имя>.field.N.*`) был исправен — проблема чисто фронтендовая.

## Исправление
Обернул имя сущности в кавычки в обоих вызовах — `,'{{$e.Name}}')` — как уже сделано в соседнем рабочем `cfgAddTP`.

## Проверка
- Новый `TestConfigurator_AddFieldButtonQuotesEntity` — сначала падал (фиксируя баг), после правки проходит; покрывает реквизиты шапки и поля табличной части.
- `go vet ./internal/launcher/` — чисто.
- `go build ./...` — успешно.
- Полный прогон `go test ./internal/launcher/` — `ok`, регрессий нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
