### PR TITLE
fix(ci): зелёный CI — BOM, govet/ineffassign и кросс-платформенные тесты

### DIFF
--- a/internal/gengen/merge_generator.go
+++ b/internal/gengen/merge_generator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -364,14 +365,10 @@ func buildTablePartNode(tp TablePartSpec) *yaml.Node {
 
 // sanitizeFilename converts an entity name to a safe filename.
 func sanitizeFilename(name string) string {
-	// For now, just lowercase. Cyrillic is fine in filenames on Linux.
-	result := ""
-	for _, r := range name {
-		if r >= 'A' && r <= 'Z' {
-			result += string(r + 32)
-		} else {
-			result += string(r)
-		}
-	}
-	return result
+	// Приводим к нижнему регистру через strings.ToLower — он умеет Unicode,
+	// поэтому кириллица («Контрагент» → «контрагент») тоже опускается. Прежний
+	// ASCII-only вариант (A-Z) оставлял кириллицу как есть, из-за чего на
+	// регистрозависимой ФС (Linux CI) файл «Контрагент.yaml» не совпадал с
+	// ожидаемым «контрагент.yaml».
+	return strings.ToLower(name)
 }

--- a/internal/pdfimport/pdfparse/ascii85.go
+++ b/internal/pdfimport/pdfparse/ascii85.go
@@ -1,4 +1,4 @@
-﻿// file with help function for ascii85 decoder
+// file with help function for ascii85 decoder
 // later if new decoders is going to add it reasonable to rename file and add them here
 // also create interfaces to switch between them (like in unidoc)
 

--- a/internal/pdfimport/pdfparse/lex.go
+++ b/internal/pdfimport/pdfparse/lex.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 The Go Authors.  All rights reserved.
+// Copyright 2014 The Go Authors.  All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/internal/pdfimport/pdfparse/name.go
+++ b/internal/pdfimport/pdfparse/name.go
@@ -1,4 +1,4 @@
-﻿// Derived from http://www.jdawiseman.com/papers/trivia/character-entities.html
+// Derived from http://www.jdawiseman.com/papers/trivia/character-entities.html
 
 package pdfparse
 

--- a/internal/pdfimport/pdfparse/page.go
+++ b/internal/pdfimport/pdfparse/page.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 The Go Authors.  All rights reserved.
+// Copyright 2014 The Go Authors.  All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -987,7 +987,6 @@ func (p Page) readContent(strm Value) Content {
 					if x.Kind() == String {
 						if i == v.Len()-1 {
 							showText(x.RawString())
-							op = "BT"
 							continue
 						} else {
 							showText(x.RawString())

--- a/internal/pdfimport/pdfparse/ps.go
+++ b/internal/pdfimport/pdfparse/ps.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 The Go Authors.  All rights reserved.
+// Copyright 2014 The Go Authors.  All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/internal/pdfimport/pdfparse/read.go
+++ b/internal/pdfimport/pdfparse/read.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 The Go Authors.  All rights reserved.
+// Copyright 2014 The Go Authors.  All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -70,7 +70,6 @@ import (
 	"encoding/ascii85"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -853,7 +852,7 @@ func (v Value) Reader() io.ReadCloser {
 		}
 	}
 
-	return ioutil.NopCloser(rd)
+	return io.NopCloser(rd)
 }
 
 func applyFilter(rd io.Reader, name string, param Value) io.Reader {
@@ -1051,7 +1050,7 @@ func okayV4(encrypt dict) bool {
 	if stmf != strf {
 		return false
 	}
-	cfparam, ok := cf[stmf].(dict)
+	cfparam, _ := cf[stmf].(dict)
 	if cfparam["AuthEvent"] != nil && cfparam["AuthEvent"] != name("DocOpen") {
 		return false
 	}

--- a/internal/pdfimport/pdfparse/text.go
+++ b/internal/pdfimport/pdfparse/text.go
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 The Go Authors.  All rights reserved.
+// Copyright 2014 The Go Authors.  All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/internal/sheet/sheet.go
+++ b/internal/sheet/sheet.go
@@ -323,11 +323,10 @@ func (d *Document) PageBreak() {
 // высота формата минус верхнее и нижнее поля.
 func (d *Document) usablePageHeightMM() float64 {
 	w, h := formatSizeMM(d.Page.Format)
-	_ = w
 	if orientLandscape(d.Page.Orientation) {
-		w2, h2 := h, w
-		w, h = w2, h2
+		w, h = h, w
 	}
+	_ = w
 	usable := h - d.Page.MarginsMM.Top - d.Page.MarginsMM.Bottom
 	if usable <= 0 {
 		return h

--- a/internal/storage/regfilter.go
+++ b/internal/storage/regfilter.go
@@ -60,7 +60,6 @@ func dimWhereClause(d Dialect, dims []metadata.Field, f RegFilter, startIdx int,
 	if includeTo && f.To != nil {
 		conds = append(conds, fmt.Sprintf("period <= %s", d.Placeholder(idx)))
 		args = append(args, *f.To)
-		idx++
 	}
 
 	if len(conds) == 0 {

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -640,6 +640,10 @@ func (s *Server) gengenGenerate(w http.ResponseWriter, r *http.Request) {
 // выходит за пределы base. relPath из недоверенного источника (тело запроса)
 // может содержать «..» или абсолютный путь — тогда возвращается ошибка.
 func safeJoinWithin(base, relPath string) (string, error) {
+	// Бэкслеш — разделитель только на Windows. Нормализуем его в «/», иначе на
+	// Linux строка вида «..\..\etc\passwd» воспринимается как одно имя файла и
+	// traversal в Windows-нотации не отклоняется.
+	relPath = strings.ReplaceAll(relPath, `\`, "/")
 	full := filepath.Join(base, relPath)
 	rel, err := filepath.Rel(base, full)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {


### PR DESCRIPTION
Делает CI на `main` зелёным. Краснота накопилась в ранее смерженном коде и была частично замаскирована: build-джоб падал на первом же шаге (BOM-проверка) и до `go vet`/`go test` не доходил.

## 1. BOM + lint (коммит «убрать UTF-8 BOM и почистить govet/ineffassign»)
- BOM убран из 7 файлов `internal/pdfimport/pdfparse/*.go` — ломал шаг «Check for UTF-8 BOM».
- `read.go`: `ioutil.NopCloser` → `io.NopCloser` (+ убран импорт `io/ioutil`) — govet inline.
- `read.go`: `cfparam, ok :=` → `cfparam, _ :=` — ineffassign.
- `page.go`: удалена мёртвая `op = "BT"` во внутреннем цикле `TJ` — ineffassign.
- `sheet.go`: упрощён swap `w, h` для landscape — ineffassign.
- `regfilter.go`: убран лишний `idx++` в конце блока `includeTo` — ineffassign.

## 2. Кросс-платформенные тесты (коммит «кросс-платформенные падения тестов на Linux»)
После снятия BOM-маскировки build-джоб дошёл до `go test -race ./...` и обнажил два предсуществующих падения, которые проходили только на регистронезависимой ФС Windows:
- `gengen/sanitizeFilename`: ASCII-only lowercasing (только `A-Z`) оставлял кириллицу как есть → файл `Контрагент.yaml` вместо `контрагент.yaml`; на Linux тесты `MergeGenerator` не находили файл. → `strings.ToLower` (Unicode-aware).
- `ui/safeJoinWithin`: бэкслеш на Linux не разделитель, поэтому `..\..\` не отклонялось как traversal (`TestSafeJoinWithin`). → нормализуем `\`→`/` перед проверкой; заодно hardening — Windows-нотация traversal теперь блокируется и на Linux-сервере.

## Проверка
- BOM-grep — чисто; `go vet ./...` — 0; `go build ./...` — 0; `golangci-lint` — 0 issues.
- `go test ./internal/pdfimport/... ./internal/sheet/... ./internal/storage/... ./internal/gengen/... ./internal/ui/...` — ok (локально, Windows).
- Падения gengen/ui воспроизводятся только на регистрозависимой ФС → финальная проверка на Linux выполняется этим прогоном CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
