### PR TITLE
ci: добавить i18ncheck в пайплайн (ловить непереведённые ключи до мержа)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
           fi
           echo "BOM не найден — ок."
 
+      # Полнота переводов шаблонов: тот же tools/i18ncheck, что в pre-commit
+      # hook. В CI ловит непереведённые {{t}}-ключи до мержа — pre-commit
+      # срабатывает только локально и обходится --no-verify (план 64: 19 ключей
+      # редактора макетов просочились в main). Быстрый шаг — до тяжёлых тестов.
+      - name: i18n translations check
+        run: go run ./tools/i18ncheck
+
       - name: go vet
         run: go vet ./...
 


### PR DESCRIPTION
## Зачем

`i18ncheck` (полнота переводов `{{t}}`-ключей шаблонов) до сих пор работал только в pre-commit hook — он срабатывает локально и обходится `--no-verify`. Из-за этого непереведённые ключи просачиваются в `main` мимо CI: в этой сессии всплыли **19 ключей** UI визуального редактора макетов (план 64, #73), заблокировавшие коммиты в main.

## Что

Шаг `go run ./tools/i18ncheck` добавлен в job `build`, сразу после BOM-check — до тяжёлых `-race` тестов, чтобы падать быстро. Тот же инструмент, что в pre-commit hook. При ключах без перевода ни в одной локали утилита делает `os.Exit(1)` → job падает → PR блокируется.

Этот PR — первая боевая проверка шага: на текущем (уже починенном) main `i18ncheck` возвращает 0.

## Проверка
- [x] локально `go run ./tools/i18ncheck` → OK (exit 0)
- [x] подтверждён `os.Exit(1)` при FAIL (tools/i18ncheck:112)
- [ ] новый шаг проходит в CI этого PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)