### PR TITLE
fix(report): titles при правке композиции + detail_link drill-down (#86, #87)

### DIFF
--- a/internal/launcher/report_composition_form.go
+++ b/internal/launcher/report_composition_form.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -113,22 +114,61 @@ func parseCompositionForm(f url.Values) (*report.Composition, bool) {
 }
 
 // applyReportComposition обновляет блок composition в сыром YAML отчёта по форме.
-// Существующий composition сохраняется, если в форме нет comp.present;
-// перезаписывается/очищается, если present. Остальные поля отчёта не трогаются.
+// Если в форме нет comp.present — YAML возвращается без изменений. Иначе блок
+// composition точечно перезаписывается (или удаляется, если форма пуста) прямо
+// в дереве YAML, чтобы остальные поля отчёта — мультиязычные titles, params и
+// любые будущие — сохранялись как есть. Раньше функция round-trip'ила YAML через
+// частичную структуру без поля Titles и молча теряла titles (issue #86).
 func applyReportComposition(raw []byte, f url.Values) ([]byte, error) {
-	var doc struct {
-		Name        string              `yaml:"name"`
-		Title       string              `yaml:"title,omitempty"`
-		Params      []map[string]any    `yaml:"params,omitempty"`
-		Query       string              `yaml:"query"`
-		ChartProc   string              `yaml:"chart_proc,omitempty"`
-		Composition *report.Composition `yaml:"composition,omitempty"`
+	c, present := parseCompositionForm(f)
+	if !present {
+		return raw, nil
 	}
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
 		return nil, err
 	}
-	if c, present := parseCompositionForm(f); present {
-		doc.Composition = c // c==nil очищает блок
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("applyReportComposition: ожидалось YAML-отображение в корне отчёта")
 	}
-	return yaml.Marshal(&doc)
+	var val any
+	if c != nil {
+		val = c // c==nil (пустая форма) → ключ composition удаляется
+	}
+	if err := setYAMLMapField(root.Content[0], "composition", val); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(&root)
+}
+
+// setYAMLMapField устанавливает значение ключа в mapping-узле YAML, сохраняя
+// порядок и форматирование прочих ключей. val==nil удаляет ключ. Позволяет
+// точечно править одно поле документа без round-trip через типизированную
+// структуру (которая молча теряет неперечисленные в ней поля).
+func setYAMLMapField(m *yaml.Node, key string, val any) error {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			if val == nil {
+				m.Content = append(m.Content[:i], m.Content[i+2:]...)
+				return nil
+			}
+			var vn yaml.Node
+			if err := vn.Encode(val); err != nil {
+				return err
+			}
+			m.Content[i+1] = &vn
+			return nil
+		}
+	}
+	if val == nil {
+		return nil
+	}
+	var vn yaml.Node
+	if err := vn.Encode(val); err != nil {
+		return err
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		&vn)
+	return nil
 }

--- a/internal/launcher/report_composition_form_test.go
+++ b/internal/launcher/report_composition_form_test.go
@@ -230,6 +230,38 @@ func TestParseCompositionFormDetailLinkEmpty(t *testing.T) {
 	}
 }
 
+func TestApplyReportCompositionPreservesOtherFields(t *testing.T) {
+	// Поля отчёта, не относящиеся к composition (мультиязычные titles, title,
+	// params), не должны теряться при сохранении настроек композиции через
+	// конфигуратор. Регресс: applyReportComposition round-trip'ил YAML через
+	// структуру без поля Titles → titles молча удалялись (issue #86).
+	raw := []byte("name: R\ntitle: Отчёт\ntitles:\n  en: Report\nquery: \"ВЫБРАТЬ 1\"\nparams:\n  - {name: Период, type: date}\n")
+
+	f := url.Values{}
+	f.Set("comp.present", "1")
+	f.Set("comp.grouping.0", "Менеджер")
+	f.Set("comp.measure.0.field", "Сумма")
+	f.Set("comp.measure.0.agg", "sum")
+
+	out, err := applyReportComposition(raw, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "titles:") || !strings.Contains(s, "Report") {
+		t.Fatalf("titles потеряны при сохранении composition:\n%s", s)
+	}
+	if !strings.Contains(s, "Отчёт") {
+		t.Fatalf("title потерян:\n%s", s)
+	}
+	if !strings.Contains(s, "Период") {
+		t.Fatalf("params потеряны:\n%s", s)
+	}
+	if !strings.Contains(s, "Менеджер") {
+		t.Fatalf("новая composition не записана:\n%s", s)
+	}
+}
+
 func TestApplyReportComposition(t *testing.T) {
 	raw := []byte("name: R\nquery: \"ВЫБРАТЬ 1\"\ncomposition:\n  groupings: [Старое]\n  measures:\n    - {field: X, agg: sum}\n")
 

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -126,7 +126,11 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 		})
 		return
 	}
-	s.resolveUUIDsInReport(r.Context(), rows)
+	detailLinkCol := ""
+	if rep.Composition != nil {
+		detailLinkCol = rep.Composition.DetailLink
+	}
+	s.resolveUUIDsInReport(r.Context(), rows, detailLinkCol)
 
 	if rep.Composition != nil {
 		ev := newInterpEvaluator(s.interp)
@@ -201,8 +205,10 @@ func (s *Server) runChartProc(ctx context.Context, rep *reportpkg.Report, rows [
 	return chart.ToEChartsOption()
 }
 
-// resolveUUIDsInReport replaces UUID-looking strings in report rows with entity display names.
-func (s *Server) resolveUUIDsInReport(ctx context.Context, rows []map[string]any) {
+// resolveUUIDsInReport replaces UUID-looking strings in report rows with entity
+// display names. skipCol (если непустой) исключается из подстановки — нужен для
+// колонки detail_link, где UUID должен остаться для ссылки на документ (issue #87).
+func (s *Server) resolveUUIDsInReport(ctx context.Context, rows []map[string]any, skipCol string) {
 	uuidToLabel := make(map[string]string)
 	for _, row := range rows {
 		for _, v := range row {
@@ -227,8 +233,21 @@ func (s *Server) resolveUUIDsInReport(ctx context.Context, rows []map[string]any
 			}
 		}
 	}
+	applyResolvedLabels(rows, uuidToLabel, skipCol)
+}
+
+// applyResolvedLabels подставляет наименования вместо UUID в строках отчёта,
+// пропуская колонку skipCol. Колонка detail_link хранит UUID регистратора для
+// ссылки на документ — его нельзя превращать в имя, иначе drill-down строит
+// /ui/.../<имя> вместо /<uuid> и ломается (issue #87). Имя колонки сравнивается
+// регистронезависимо: колонки запроса приходят в нижнем регистре, а detail_link
+// в composition — в исходном.
+func applyResolvedLabels(rows []map[string]any, uuidToLabel map[string]string, skipCol string) {
 	for _, row := range rows {
 		for col, v := range row {
+			if skipCol != "" && strings.EqualFold(col, skipCol) {
+				continue
+			}
 			if str, ok := v.(string); ok {
 				if label, found := uuidToLabel[str]; found && label != "" {
 					row[col] = label
@@ -364,7 +383,11 @@ func (s *Server) reportExcel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "query error: "+s.errText(r, err), 500)
 		return
 	}
-	s.resolveUUIDsInReport(r.Context(), rows)
+	detailLinkCol := ""
+	if rep.Composition != nil {
+		detailLinkCol = rep.Composition.DetailLink
+	}
+	s.resolveUUIDsInReport(r.Context(), rows, detailLinkCol)
 
 	// Если отчёт использует компоновщик — строим дерево групп/итогов для Excel.
 	if rep.Composition != nil {

--- a/internal/ui/report_uuid_resolve_test.go
+++ b/internal/ui/report_uuid_resolve_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import "testing"
+
+// detail_link колонка хранит UUID регистратора для ссылки на документ; её UUID
+// нельзя подменять наименованием, иначе drill-down строит /ui/.../<имя> вместо
+// /<uuid> и ссылка ведёт в никуда (issue #87). applyResolvedLabels должна
+// пропускать указанную колонку.
+func TestApplyResolvedLabelsSkipsDetailLinkColumn(t *testing.T) {
+	id := "550e8400-e29b-41d4-a716-446655440000"
+	rows := []map[string]any{
+		{"Контрагент": id, "Регистратор": id},
+	}
+	labels := map[string]string{id: "ООО Ромашка"}
+
+	applyResolvedLabels(rows, labels, "Регистратор")
+
+	if got := rows[0]["Контрагент"]; got != "ООО Ромашка" {
+		t.Fatalf("обычная колонка должна резолвиться в имя: %v", got)
+	}
+	if got := rows[0]["Регистратор"]; got != id {
+		t.Fatalf("detail_link колонка должна сохранить UUID: %v", got)
+	}
+}
+
+// Без skipCol поведение прежнее — резолвятся все колонки.
+func TestApplyResolvedLabelsNoSkip(t *testing.T) {
+	id := "550e8400-e29b-41d4-a716-446655440000"
+	rows := []map[string]any{{"Контрагент": id}}
+	labels := map[string]string{id: "ООО Ромашка"}
+
+	applyResolvedLabels(rows, labels, "")
+
+	if got := rows[0]["Контрагент"]; got != "ООО Ромашка" {
+		t.Fatalf("без skip колонка должна резолвиться: %v", got)
+	}
+}
+
+// Сравнение имени пропускаемой колонки регистронезависимо: колонки запроса
+// приходят в нижнем регистре, а detail_link в composition — в исходном.
+func TestApplyResolvedLabelsSkipCaseInsensitive(t *testing.T) {
+	id := "550e8400-e29b-41d4-a716-446655440000"
+	rows := []map[string]any{{"регистратор": id}}
+	labels := map[string]string{id: "Накладная №1"}
+
+	applyResolvedLabels(rows, labels, "Регистратор")
+
+	if got := rows[0]["регистратор"]; got != id {
+		t.Fatalf("skip должен быть регистронезависимым, UUID сохранён: %v", got)
+	}
+}


### PR DESCRIPTION
Чинит два блокера, найденных code-review PR #81 (движок СКД).

## #86 — потеря `titles` при сохранении композиции
`applyReportComposition` round-trip'ил YAML отчёта через структуру без поля `Titles` → мультиязычные `titles:` (и любые неперечисленные поля) молча терялись при первом сохранении настроек композиции в конфигураторе.

**Фикс:** точечная правка узла `composition` через `yaml.Node` — порядок и форматирование прочих полей сохраняются, ничего не теряется (в т.ч. будущие поля отчёта).

## #87 — `detail_link` ломал drill-down
`resolveUUIDsInReport` подменял UUID→именем во **всех** колонках, включая `detail_link`, где UUID нужен для ссылки на документ. Итог: ссылка строилась как `/ui/<вид>/<сущность>/<имя>` вместо `/<uuid>` и вела в никуда.

**Фикс:** параметр `skipCol` исключает колонку `detail_link` из подстановки (регистронезависимо, т.к. колонки запроса в нижнем регистре). Применено в обоих путях — HTML и Excel.

## Тесты (TDD, писались до фикса)
- `TestApplyReportCompositionPreservesOtherFields` — titles/title/params сохраняются;
- `TestApplyResolvedLabelsSkipsDetailLinkColumn`, `...NoSkip`, `...SkipCaseInsensitive`.

`go build ./...`, `go test ./internal/launcher/ ./internal/ui/ ./internal/report/...`, `i18ncheck` — зелёные.

Fixes #86
Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)