### PR TITLE
fix(report): корректность СКД — ключ группировки, сортировка nil, Excel-кнопка (#88, #90, #91)

### DIFF
--- a/internal/report/compose/compose.go
+++ b/internal/report/compose/compose.go
@@ -241,11 +241,20 @@ func sortDetails(rows []DetailRow, spec report.Composition) {
 }
 
 // compareVals: -1/0/1. Числа сравниваются как decimal, иначе как строки.
+// Если одно значение числовое, а другое нет (nil-подытог пустой группы,
+// нечисловой текст) — числовое считается «меньше», то есть непарсимое уходит
+// в конец при сортировке по возрастанию, а не сравнивается лексикографически
+// с числом (issue #90).
 func compareVals(a, b any) int {
 	da, oka := toDecimal(a)
 	db, okb := toDecimal(b)
-	if oka && okb {
+	switch {
+	case oka && okb:
 		return da.Cmp(db)
+	case oka:
+		return -1
+	case okb:
+		return 1
 	}
 	sa, sb := toStr(a), toStr(b)
 	switch {
@@ -269,11 +278,26 @@ func toStr(v any) string {
 }
 
 // normalizeGroupKey приводит значение группировки к надёжному ключу map.
-// decimal.Decimal внутри держит *big.Int — как ключ map он сравнивался бы по
-// указателю, а не по значению, поэтому числа группируем по каноничной строке.
+// Числа любого типа (int/int64/float64/decimal) канонизируются в одну строку —
+// иначе равные по значению ключи разных типов попали бы в разные группы, а
+// decimal.Decimal как ключ map сравнивался бы по указателю big.Int. []byte
+// (его может вернуть драйвер БД) неэшируем как ключ map — приводим к строке,
+// иначе buildGroups паникует. compareVals при сортировке всё равно распарсит
+// числовую строку обратно в decimal, так что числовой порядок сохраняется.
 func normalizeGroupKey(v any) any {
-	if d, ok := v.(decimal.Decimal); ok {
-		return d.String()
+	switch x := v.(type) {
+	case nil:
+		return nil
+	case []byte:
+		return string(x)
+	case decimal.Decimal:
+		return x.String()
+	case int:
+		return decimal.NewFromInt(int64(x)).String()
+	case int64:
+		return decimal.NewFromInt(x).String()
+	case float64:
+		return decimal.NewFromFloat(x).String()
 	}
 	return v
 }

--- a/internal/report/compose/compose_test.go
+++ b/internal/report/compose/compose_test.go
@@ -70,6 +70,47 @@ func TestGroupByDecimalKey(t *testing.T) {
 	decEq(t, res.Groups[0].Subtotals["Сумма"], "30")
 }
 
+func TestGroupByByteSliceKeyNoPanic(t *testing.T) {
+	// Драйвер БД может вернуть значение колонки как []byte; []byte неэшируем как
+	// ключ map → раньше группировка по такой колонке паниковала (issue #88).
+	rows := []Row{
+		{"Код": []byte("A"), "Сумма": "10"},
+		{"Код": []byte("A"), "Сумма": "20"},
+		{"Код": []byte("B"), "Сумма": "5"},
+	}
+	spec := report.Composition{
+		Groupings: []string{"Код"},
+		Measures:  []report.Measure{{Field: "Сумма", Agg: "sum"}},
+	}
+	res, err := Compose(rows, spec, noEval{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Groups) != 2 {
+		t.Fatalf("ожидали 2 группы по []byte-ключам, получили %d", len(res.Groups))
+	}
+	decEq(t, res.Groups[0].Subtotals["Сумма"], "30")
+}
+
+func TestGroupByMixedNumericKey(t *testing.T) {
+	// Одно числовое значение, пришедшее как int64 и как decimal, должно попасть
+	// в одну группу (issue #88): ключ канонизируется по значению, не по типу.
+	rows := []Row{
+		{"Год": int64(2026), "Сумма": "10"},
+		{"Год": decimal.NewFromInt(2026), "Сумма": "20"},
+		{"Год": int64(2025), "Сумма": "5"},
+	}
+	spec := report.Composition{
+		Groupings: []string{"Год"},
+		Measures:  []report.Measure{{Field: "Сумма", Agg: "sum"}},
+	}
+	res, _ := Compose(rows, spec, noEval{})
+	if len(res.Groups) != 2 {
+		t.Fatalf("int64 и decimal одного значения должны слиться, получили %d групп", len(res.Groups))
+	}
+	decEq(t, res.Groups[0].Subtotals["Сумма"], "30")
+}
+
 func TestNestedAndDetails(t *testing.T) {
 	rows := []Row{
 		{"М": "И", "К": "Р", "Сумма": "600"},
@@ -132,6 +173,27 @@ func TestSort(t *testing.T) {
 	got := []any{res.Groups[0].Key, res.Groups[1].Key, res.Groups[2].Key}
 	if got[0] != "Б" || got[1] != "В" || got[2] != "А" {
 		t.Fatalf("order by subtotal desc: %v", got)
+	}
+}
+
+func TestSortGroupsNilSubtotalLast(t *testing.T) {
+	// Группа без числовых строк (min пустого набора = nil) при сортировке по
+	// этому показателю не должна лексикографически прыгать впереди числовых
+	// подытогов (issue #90): nil уходит в конец при возрастании.
+	rows := []Row{
+		{"М": "А", "Сумма": "100"},
+		{"М": "Пусто", "Сумма": "нечисло"}, // min → nil
+		{"М": "Б", "Сумма": "300"},
+	}
+	spec := report.Composition{
+		Groupings: []string{"М"},
+		Measures:  []report.Measure{{Field: "Сумма", Agg: "min"}},
+		Sort:      []report.SortKey{{Field: "Сумма", Dir: "asc"}},
+	}
+	res, _ := Compose(rows, spec, noEval{})
+	got := []any{res.Groups[0].Key, res.Groups[1].Key, res.Groups[2].Key}
+	if got[0] != "А" || got[1] != "Б" || got[2] != "Пусто" {
+		t.Fatalf("nil-подытог должен быть последним при asc: %v", got)
 	}
 }
 

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -2312,6 +2312,9 @@ const tplReport = `
 {{end}}
 {{if .ComposedHTML}}
 {{if .Capped}}<div class="card" style="background:#fffbeb;border-color:#fde68a;margin-bottom:8px;padding:8px 12px">{{t $.Lang "Показаны первые строки — данных больше потолка."}}</div>{{end}}
+<div style="display:flex;justify-content:flex-end;margin-bottom:8px">
+  <a class="btn btn-sm" href="/ui/report/{{lower .Report.Name}}/excel{{reportParamQuery .Report.Params .ParamValues}}" style="background:#16a34a;color:#fff" title="{{t $.Lang "Скачать Excel"}}">{{t $.Lang "Excel ↓"}}</a>
+</div>
 <details class="card report-block" data-block="data" open>
 <summary>{{t $.Lang "Данные"}}</summary>
 <div class="rc-toolbar" style="margin-bottom:8px;display:flex;gap:8px"><button type="button" id="rc-expand" class="btn btn-sm">{{t $.Lang "Развернуть всё"}}</button><button type="button" id="rc-collapse" class="btn btn-sm">{{t $.Lang "Свернуть всё"}}</button></div>


### PR DESCRIPTION
Закрывает 3 из 6 issues, найденных code-review движка СКД (#81).

## #88 — паника/двоение групп по ключу
`normalizeGroupKey` обрабатывал только `decimal.Decimal`. Группировка по BLOB-колонке (`[]byte` неэшируем как ключ map) **паниковала**; одно значение, пришедшее как `int64` и `decimal`, попадало в разные группы. Теперь любое число (int/int64/float64/decimal) канонизируется в одну строку, а `[]byte` приводится к строке. `compareVals` при сортировке распарсит числовую строку обратно — числовой порядок сохранён.

## #90 — сортировка при nil-подытоге
Группа без числовых строк (`min`/`avg` пустого набора = nil) при сортировке по этому показателю сравнивалась лексикографически (`"" vs "150"`) и прыгала вперёд. Теперь nil/нечисловое уходит в конец при возрастании.

## #91 — кнопка Excel для СКД
Композиционные отчёты не показывали кнопку «Excel ↓» (была только у плоских), хотя экспорт composition в `reportExcel` уже поддерживался — добавлена кнопка на форму. Второй пункт #91 (`chart_proc` при composition) — **не баг**: график СКД задаётся декларативным `composition.Chart`, а `chart_proc` остаётся путём для плоских отчётов.

## Тесты (TDD, до фикса видел RED — паника/неверный порядок)
`TestGroupByByteSliceKeyNoPanic`, `TestGroupByMixedNumericKey`, `TestSortGroupsNilSubtotalLast`.
`go build ./...`, тесты `report/...` и `ui`, i18ncheck — зелёные.

Fixes #88
Fixes #90
Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)