### PR TITLE
refactor(report): единый обход дерева СКД для HTML и Excel (#93, пункт 1)

### DIFF
--- a/internal/ui/report_compose_excel.go
+++ b/internal/ui/report_compose_excel.go
@@ -22,85 +22,57 @@ func numForExcel(v any) any {
 	return numFor(v)
 }
 
-// composedRows строит заголовки и строки данных для excel.ExportList
-// из скомпонованного результата. Порядок строк совпадает с renderComposedTable:
+// composedRows строит заголовки и строки данных для excel.ExportList из
+// скомпонованного результата. Порядок строк задаёт walkComposed — общий с
+// HTML-рендером (renderComposedTable), поэтому выгрузка и экран не расходятся:
 //
 //	группа → [дети/детали] → подытог … → ВСЕГО
 //
 // Первая колонка — имена/ключи групп с текстовым отступом (2 пробела × уровень).
 // Значения показателей передаются как float64, чтобы Excel видел числа, а не текст.
 func composedRows(res *compose.Result, spec *report.Composition) (headers []string, rows [][]any) {
-	// Формируем заголовок: группировки через " / ", затем показатели.
 	headers = make([]string, 0, 1+len(spec.Measures))
 	headers = append(headers, strings.Join(spec.Groupings, " / "))
 	for _, m := range spec.Measures {
 		headers = append(headers, measureTitle(m))
 	}
-
-	// Обходим дерево групп.
-	for _, g := range res.Groups {
-		rows = appendGroup(rows, g, spec, 0)
-	}
-
-	// Строка общего итога «ВСЕГО».
-	if spec.Totals.Grand {
-		row := make([]any, 1+len(spec.Measures))
-		row[0] = "ВСЕГО"
-		for i, m := range spec.Measures {
-			row[i+1] = numForExcel(res.Grand[m.Field])
-		}
-		rows = append(rows, row)
-	}
-	return headers, rows
+	sink := &excelComposeSink{spec: spec, colCount: 1 + len(spec.Measures)}
+	walkComposed(res, spec, sink)
+	return headers, sink.rows
 }
 
-// appendGroup рекурсивно добавляет строки группы: строку группы, дочерние группы
-// (или детали), и при Totals.Subtotals — строку подытога.
-func appendGroup(rows [][]any, g *compose.Group, spec *report.Composition, level int) [][]any {
-	indent := strings.Repeat("  ", level)
-	colCount := 1 + len(spec.Measures)
+// excelComposeSink собирает строки [][]any для excel.ExportList.
+type excelComposeSink struct {
+	spec     *report.Composition
+	colCount int
+	rows     [][]any
+}
 
-	// Строка группы: ключ с отступом + значения показателей.
-	grpRow := make([]any, colCount)
-	grpRow[0] = indent + fmtVal(g.Key)
-	for i, m := range spec.Measures {
-		grpRow[i+1] = numForExcel(g.Subtotals[m.Field])
+// row добавляет строку: подпись в первой колонке + значения показателей
+// (numForExcel: nil → пустая ячейка, иначе float64).
+func (e *excelComposeSink) row(label string, vals map[string]any) {
+	r := make([]any, e.colCount)
+	r[0] = label
+	for i, m := range e.spec.Measures {
+		r[i+1] = numForExcel(vals[m.Field])
 	}
-	rows = append(rows, grpRow)
+	e.rows = append(e.rows, r)
+}
 
-	// Дочерние группы (рекурсия).
-	for _, ch := range g.Children {
-		rows = appendGroup(rows, ch, spec, level+1)
-	}
+func (e *excelComposeSink) group(g *compose.Group, level int, _ string) {
+	e.row(strings.Repeat("  ", level)+fmtVal(g.Key), g.Subtotals)
+}
 
-	// Детальные строки (если Detail=true). По дизайну compose, g.Details заполняется
-	// только у листовых групп (level == последний уровень группировки); у внутренних
-	// групп g.Details всегда пуст, поэтому явная проверка Children не нужна.
-	if spec.Detail {
-		childIndent := strings.Repeat("  ", level+1)
-		for _, d := range g.Details {
-			detRow := make([]any, colCount)
-			// Первая ячейка детали намеренно содержит только отступ — зеркалит
-			// HTML-рендер (writeDetail). Осмысленный идентификатор строки (ссылка на
-			// документ) появится в задаче B3 (detail_link).
-			detRow[0] = childIndent
-			for i, m := range spec.Measures {
-				detRow[i+1] = numForExcel(d.Values[m.Field])
-			}
-			rows = append(rows, detRow)
-		}
-	}
+func (e *excelComposeSink) detail(d compose.DetailRow, level int, _ string) {
+	// Первая ячейка детали — только отступ (зеркалит HTML-рендер). Осмысленный
+	// идентификатор строки (ссылка на документ) — задача B3 (detail_link).
+	e.row(strings.Repeat("  ", level), d.Values)
+}
 
-	// Строка подытога.
-	if spec.Totals.Subtotals {
-		subIndent := strings.Repeat("  ", level+1)
-		subRow := make([]any, colCount)
-		subRow[0] = fmt.Sprintf("%s··· Итого: %s ···", subIndent, fmtVal(g.Key))
-		for i, m := range spec.Measures {
-			subRow[i+1] = numForExcel(g.Subtotals[m.Field])
-		}
-		rows = append(rows, subRow)
-	}
+func (e *excelComposeSink) subtotal(g *compose.Group, level int, _ string) {
+	e.row(fmt.Sprintf("%s··· Итого: %s ···", strings.Repeat("  ", level), fmtVal(g.Key)), g.Subtotals)
+}
 
-	return rows
+func (e *excelComposeSink) grand(grand map[string]any) {
+	e.row("ВСЕГО", grand)
 }

--- a/internal/ui/report_compose_render.go
+++ b/internal/ui/report_compose_render.go
@@ -12,7 +12,8 @@ import (
 )
 
 // renderComposedTable строит единую <table> с раскрываемыми группами,
-// подитогами, общим итогом и условным оформлением деталей.
+// подитогами, общим итогом и условным оформлением деталей. Порядок строк задаёт
+// walkComposed (общий с Excel-выгрузкой); htmlComposeSink рисует каждую строку.
 func renderComposedTable(res *compose.Result, spec *report.Composition) template.HTML {
 	var b strings.Builder
 	b.WriteString(`<table class="report-composed">`)
@@ -21,70 +22,71 @@ func renderComposedTable(res *compose.Result, spec *report.Composition) template
 		b.WriteString(`<th class="num" style="` + html.EscapeString(measureAlign(m)) + `">` + html.EscapeString(measureTitle(m)) + `</th>`)
 	}
 	b.WriteString(`</tr></thead><tbody>`)
-	for _, g := range res.Groups {
-		writeGroup(&b, g, spec, 0, "")
-	}
-	if spec.Totals.Grand {
-		b.WriteString(`<tr class="grand"><td>ВСЕГО</td>`)
-		for _, m := range spec.Measures {
-			b.WriteString(`<td class="num" style="` + html.EscapeString(measureAlign(m)) + `">` + html.EscapeString(fmtMeasure(res.Grand[m.Field], m)) + `</td>`)
-		}
-		b.WriteString(`</tr>`)
-	}
+	walkComposed(res, spec, &htmlComposeSink{b: &b, spec: spec})
 	b.WriteString(`</tbody></table>`)
 	return template.HTML(b.String())
 }
 
-func writeGroup(b *strings.Builder, g *compose.Group, spec *report.Composition, level int, path string) {
-	gp := path + "/" + pathSeg(fmtVal(g.Key))
-	pad := fmt.Sprintf("padding-left:%dpx", 8+level*18)
-	rowStyle := cssOf(g.Styles[""])
-	fmt.Fprintf(b, `<tr class="grp" data-group="%s" data-level="%d" style="%s"><td style="%s">▼ %s</td>`,
-		html.EscapeString(gp), level, html.EscapeString(rowStyle), pad, html.EscapeString(fmtVal(g.Key)))
-	for _, m := range spec.Measures {
-		cell := joinStyles(measureAlign(m), cssOf(g.Styles[m.Field]))
-		b.WriteString(`<td class="num" style="` + html.EscapeString(cell) + `">` + html.EscapeString(fmtMeasure(g.Subtotals[m.Field], m)) + `</td>`)
-	}
-	b.WriteString(`</tr>`)
-	for _, ch := range g.Children {
-		writeGroup(b, ch, spec, level+1, gp)
-	}
-	for _, d := range g.Details {
-		writeDetail(b, d, spec, level+1, gp)
-	}
-	if spec.Totals.Subtotals {
-		fmt.Fprintf(b, `<tr class="subtotal" data-parent="%s" style="%s"><td style="padding-left:%dpx">··· Итого: %s ···</td>`,
-			html.EscapeString(gp), html.EscapeString(rowStyle), 8+(level+1)*18, html.EscapeString(fmtVal(g.Key)))
-		for _, m := range spec.Measures {
-			cell := joinStyles(measureAlign(m), cssOf(g.Styles[m.Field]))
-			b.WriteString(`<td class="num" style="` + html.EscapeString(cell) + `">` + html.EscapeString(fmtMeasure(g.Subtotals[m.Field], m)) + `</td>`)
-		}
-		b.WriteString(`</tr>`)
+// htmlComposeSink рисует строки скомпонованного отчёта в HTML-таблицу.
+type htmlComposeSink struct {
+	b    *strings.Builder
+	spec *report.Composition
+}
+
+// measureCells выводит ячейки показателей строки: выравнивание + условное
+// оформление по styles[поле]. Общий код для строк группы, подытога и детали
+// (раньше один и тот же цикл был скопирован трижды).
+func (h *htmlComposeSink) measureCells(vals map[string]any, styles map[string]report.CellStyle) {
+	for _, m := range h.spec.Measures {
+		cell := joinStyles(measureAlign(m), cssOf(styles[m.Field]))
+		h.b.WriteString(`<td class="num" style="` + html.EscapeString(cell) + `">` + html.EscapeString(fmtMeasure(vals[m.Field], m)) + `</td>`)
 	}
 }
 
-func writeDetail(b *strings.Builder, d compose.DetailRow, spec *report.Composition, level int, path string) {
+func (h *htmlComposeSink) group(g *compose.Group, level int, path string) {
+	pad := fmt.Sprintf("padding-left:%dpx", 8+level*18)
+	rowStyle := cssOf(g.Styles[""])
+	fmt.Fprintf(h.b, `<tr class="grp" data-group="%s" data-level="%d" style="%s"><td style="%s">▼ %s</td>`,
+		html.EscapeString(path), level, html.EscapeString(rowStyle), pad, html.EscapeString(fmtVal(g.Key)))
+	h.measureCells(g.Subtotals, g.Styles)
+	h.b.WriteString(`</tr>`)
+}
+
+func (h *htmlComposeSink) detail(d compose.DetailRow, level int, path string) {
 	rowStyle := cssOf(d.Styles[""])
-	fmt.Fprintf(b, `<tr class="det" data-parent="%s" style="%s">`, html.EscapeString(path), html.EscapeString(rowStyle))
+	fmt.Fprintf(h.b, `<tr class="det" data-parent="%s" style="%s">`, html.EscapeString(path), html.EscapeString(rowStyle))
 	// Первая ячейка: ссылка-расшифровка на исходный документ (если настроено).
-	// Ссылка строится только когда заданы и DetailLink, и DetailEntity, и значение поля непустое.
-	// Без DetailEntity переход бессмыслен — выводим пустую ячейку.
+	// Ссылка строится только когда заданы DetailLink, DetailEntity и значение поля
+	// непустое. Без DetailEntity переход бессмыслен — выводим пустую ячейку.
 	linked := false
-	if spec.DetailLink != "" && spec.DetailEntity != "" {
-		if v := fmtVal(d.Values[spec.DetailLink]); v != "" {
-			href := "/ui/document/" + url.PathEscape(spec.DetailEntity) + "/" + url.PathEscape(v)
-			fmt.Fprintf(b, `<td style="padding-left:%dpx"><a href="%s">→</a></td>`, 8+level*18, html.EscapeString(href))
+	if h.spec.DetailLink != "" && h.spec.DetailEntity != "" {
+		if v := fmtVal(d.Values[h.spec.DetailLink]); v != "" {
+			href := "/ui/document/" + url.PathEscape(h.spec.DetailEntity) + "/" + url.PathEscape(v)
+			fmt.Fprintf(h.b, `<td style="padding-left:%dpx"><a href="%s">→</a></td>`, 8+level*18, html.EscapeString(href))
 			linked = true
 		}
 	}
 	if !linked {
-		fmt.Fprintf(b, `<td style="padding-left:%dpx"></td>`, 8+level*18)
+		fmt.Fprintf(h.b, `<td style="padding-left:%dpx"></td>`, 8+level*18)
 	}
-	for _, m := range spec.Measures {
-		cell := joinStyles(measureAlign(m), cssOf(d.Styles[m.Field]))
-		b.WriteString(`<td class="num" style="` + html.EscapeString(cell) + `">` + html.EscapeString(fmtMeasure(d.Values[m.Field], m)) + `</td>`)
-	}
-	b.WriteString(`</tr>`)
+	h.measureCells(d.Values, d.Styles)
+	h.b.WriteString(`</tr>`)
+}
+
+func (h *htmlComposeSink) subtotal(g *compose.Group, level int, path string) {
+	rowStyle := cssOf(g.Styles[""])
+	fmt.Fprintf(h.b, `<tr class="subtotal" data-parent="%s" style="%s"><td style="padding-left:%dpx">··· Итого: %s ···</td>`,
+		html.EscapeString(path), html.EscapeString(rowStyle), 8+level*18, html.EscapeString(fmtVal(g.Key)))
+	h.measureCells(g.Subtotals, g.Styles)
+	h.b.WriteString(`</tr>`)
+}
+
+func (h *htmlComposeSink) grand(grand map[string]any) {
+	// У общего итога нет условного оформления — measureCells с nil-стилями даёт
+	// те же ячейки (только выравнивание), что и прежний отдельный код.
+	h.b.WriteString(`<tr class="grand"><td>ВСЕГО</td>`)
+	h.measureCells(grand, nil)
+	h.b.WriteString(`</tr>`)
 }
 
 func cssOf(s report.CellStyle) string {

--- a/internal/ui/report_compose_walk.go
+++ b/internal/ui/report_compose_walk.go
@@ -1,0 +1,54 @@
+package ui
+
+// report_compose_walk.go — единый обход дерева скомпонованного отчёта (СКД).
+// HTML-таблица (report_compose_render.go) и Excel-выгрузка (report_compose_excel.go)
+// прежде обходили это дерево независимо, дублируя порядок строк и структуру; копии
+// уже начали расходиться. Теперь обе строятся поверх walkComposed — порядок задан
+// в одном месте, потребитель лишь решает, как нарисовать каждую строку.
+
+import (
+	"github.com/ivantit66/onebase/internal/report"
+	"github.com/ivantit66/onebase/internal/report/compose"
+)
+
+// composeSink принимает события обхода в порядке рендера:
+//
+//	группа → [дочерние группы] → [детали] → [подытог] … → [общий итог]
+//
+// level — глубина строки: группа на level, её детали и подытог на level+1.
+// path — экранированный путь группы (для HTML data-group/data-parent; Excel
+// его игнорирует).
+type composeSink interface {
+	group(g *compose.Group, level int, path string)
+	detail(d compose.DetailRow, level int, path string)
+	subtotal(g *compose.Group, level int, path string)
+	grand(grand map[string]any)
+}
+
+// walkComposed обходит дерево групп результата компоновки и вызывает методы sink
+// в порядке рендера. Детали выводятся только при spec.Detail, подытоги — при
+// spec.Totals.Subtotals, общий итог — при spec.Totals.Grand.
+func walkComposed(res *compose.Result, spec *report.Composition, s composeSink) {
+	var walk func(g *compose.Group, level int, parentPath string)
+	walk = func(g *compose.Group, level int, parentPath string) {
+		path := parentPath + "/" + pathSeg(fmtVal(g.Key))
+		s.group(g, level, path)
+		for _, ch := range g.Children {
+			walk(ch, level+1, path)
+		}
+		if spec.Detail {
+			for _, d := range g.Details {
+				s.detail(d, level+1, path)
+			}
+		}
+		if spec.Totals.Subtotals {
+			s.subtotal(g, level+1, path)
+		}
+	}
+	for _, g := range res.Groups {
+		walk(g, 0, "")
+	}
+	if spec.Totals.Grand {
+		s.grand(res.Grand)
+	}
+}


### PR DESCRIPTION
Первый и самый ценный пункт техдолга #93: устранение дублированного обхода дерева скомпонованного отчёта.

## Проблема
`renderComposedTable`/`writeGroup` (HTML) и `composedRows`/`appendGroup` (Excel) **независимо** обходили дерево `compose.Result` в одном порядке. Копии уже начали расходиться (Excel-деталь не выводит то, что HTML рисует ссылкой). Плюс measure-cell-цикл в HTML был скопирован трижды (группа/подытог/деталь).

## Решение
- Новый `report_compose_walk.go`: `walkComposed` задаёт порядок строк (группа → дочерние → детали → подытог → общий итог) в одном месте, потребитель реализует `composeSink` и рисует строку по-своему.
- `htmlComposeSink` (HTML-таблица) и `excelComposeSink` (`[][]any` для Excel) — два потребителя одного обхода.
- HTML measure-cell-цикл схлопнут из 3 копий в `measureCells`.

Чистое сокращение: −111/+139 строк (новый файл обхода + минус дублирование в двух рендерах).

## Поведение не меняется
Рефакторинг под защитой существующих характеризационных тестов — вывод HTML и Excel идентичен. Зелёные без изменений: `TestRenderComposedTable`, `TestRenderGroupConditional`, `TestComposedRows*`, `TestWriteDetailLink*`, `TestComposedPathEscaping`, `TestBuildComposedChart`. `go build ./...`, `go test ./internal/ui/ ./internal/report/...`, i18ncheck — зелёные.

## Остаётся в #93 (отдельно)
Общий форматтер чисел, переиспользование `widget.EChartsOption`, свёртка grand-total. Issue оставлен открытым.

🤖 Generated with [Claude Code](https://claude.com/claude-code)