### PR TITLE
fix(configurator): создание общего модуля (#95) и прокрутка вкладок Бэкапы/Файлы/Импорт (#94)

### DIFF
--- a/internal/launcher/configurator.go
+++ b/internal/launcher/configurator.go
@@ -2207,9 +2207,8 @@ func (h *handler) configuratorNewObject(w http.ResponseWriter, r *http.Request) 
 
 	filename := nameToFilename(name) + ".yaml"
 	if kind == "module" {
+		// subdir/content приходят из newObjectContent; здесь только расширение.
 		filename = nameToFilename(name) + ".module.os"
-		content = "// " + name + "\n// Общий модуль\n\nПроцедура Главная()\nКонецПроцедуры\n"
-		subdir = "src"
 	}
 	if kind == "page" {
 		// Имя файла страницы — в исходном регистре (как демо pages/Панель.yaml),
@@ -2284,6 +2283,10 @@ func newObjectContent(kind, name string) (subdir, content string) {
 		return "processors", "name: " + name + "\ntitle: " + name + "\nparams: []\n"
 	case "page":
 		return "pages", "name: " + name + "\ntitle: " + name + "\n"
+	case "module":
+		// Общий модуль — файл src/<имя>.module.os со стартовой экспортной
+		// процедурой (расширение файла проставляется в configuratorNewObject).
+		return "src", "// " + name + "\n// Общий модуль\n\nПроцедура Главная() Экспорт\nКонецПроцедуры\n"
 	}
 	return "", ""
 }

--- a/internal/launcher/configurator_newobject_test.go
+++ b/internal/launcher/configurator_newobject_test.go
@@ -1,0 +1,20 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+)
+
+// newObjectContent("module") должен отдавать файл src/<имя>.module.os со
+// стартовой экспортной процедурой. Раньше ветки "module" не было — функция
+// возвращала пустой subdir, и создание общего модуля из дерева конфигуратора
+// падало с «Неизвестный тип объекта: module» (issue #95).
+func TestNewModuleContent(t *testing.T) {
+	subdir, content := newObjectContent("module", "ОбщийМодуль")
+	if subdir != "src" {
+		t.Errorf("subdir = %q, ожидался src", subdir)
+	}
+	if !strings.Contains(content, "Процедура") || !strings.Contains(content, "Экспорт") {
+		t.Errorf("в скелете модуля нет экспортной процедуры: %q", content)
+	}
+}

--- a/internal/launcher/configurator_tmpl.go
+++ b/internal/launcher/configurator_tmpl.go
@@ -260,7 +260,7 @@ pre.os-code{
 .cfg-new-form .btn-cancel{padding:5px 8px;background:#e8ecf2;border:1px solid #ccd0d8;border-radius:3px;font-size:12px;cursor:pointer}
 
 /* ── Converter / Files ───────────────────────────────── */
-.pad{padding:16px}
+.pad{padding:16px;flex:1;overflow-y:auto;min-height:0}
 .convert-form,.file-card{background:#fff;border:1px solid #d8dde8;border-radius:6px;padding:18px;margin-bottom:14px}
 .convert-form h3,.file-card h3{font-size:13px;font-weight:700;color:#1a3a6a;margin-bottom:12px}
 .fg{margin-bottom:12px}


### PR DESCRIPTION
## Что чинит

### #95 — «Ошибка при создании нового общего модуля»
При клике на «+» возле «Общие модули» выскакивала ошибка `Неизвестный тип объекта: module`.

**Причина:** `newObjectContent` не обрабатывал тип `module` и возвращал пустой `subdir` → `configuratorNewObject` выходил с ошибкой ещё до спец-обработки модуля (она оказалась недостижимой). Добавил ветку `module` (создаёт `src/<имя>.module.os` со стартовой экспортной процедурой) и убрал мёртвый переопределяющий блок. Покрыто тестом `TestNewModuleContent`.

### #94 — «Нет возможности прокрутить содержимое окна»
На вкладке «Бэкапы» (а также «Файлы»/«Импорт конфигурации») при окне меньше содержимого низ обрезался без прокрутки.

**Причина:** контент этих вкладок лежит в `.pad` внутри `#dbg-wrapper` (`overflow:hidden`), но у `.pad` не было своего скролла. Добавил `flex:1;overflow-y:auto;min-height:0` по образцу рабочего `.cfg-right` (вкладка «Дерево»).

## Проверка
- `go build ./...` — OK
- `go test ./internal/launcher/` — OK
- Новый тест `TestNewModuleContent` (падал до фикса, проходит после)

Fixes #95
Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)