### PR TITLE
fix(security): санитайзер raw-HTML страниц (bluemonday) и проверка типа картинок по содержимому

### DIFF
--- a/internal/dsl/interpreter/page_builtins.go
+++ b/internal/dsl/interpreter/page_builtins.go
@@ -2,9 +2,10 @@ package interpreter
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/microcosm-cc/bluemonday"
 )
 
 // Объект-построитель «Страница» (план 66). Передаётся в обработчик страницы
@@ -292,27 +293,24 @@ func (r *DSLPageRow) CallMethod(name string, args []any) any {
 
 // ─── вспомогательные ──────────────────────────────────────────────────────────
 
-// sanitizePageHTML — консервативная очистка произвольного HTML из
-// ДобавитьСыройHTML: вырезает блоки <script>/<style>, обработчики on*= и
-// javascript:-URI. Не полноценный санитайзер DOM; задаёт нижнюю планку
-// безопасности для escape-hatch'а, который по умолчанию не используется.
-// RE2 (пакет regexp) не поддерживает обратные ссылки, поэтому script/style
-// закрываем отдельными выражениями, плюс выметаем любые «осиротевшие» теги.
-var (
-	reScriptBlock = regexp.MustCompile(`(?is)<\s*script\b[^>]*>.*?<\s*/\s*script\s*>`)
-	reStyleBlock  = regexp.MustCompile(`(?is)<\s*style\b[^>]*>.*?<\s*/\s*style\s*>`)
-	reStrayTag    = regexp.MustCompile(`(?is)<\s*/?\s*(script|style)\b[^>]*>`)
-	reEventAttr   = regexp.MustCompile(`(?is)\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)`)
-	reJSURI       = regexp.MustCompile(`(?is)(href|src)\s*=\s*("\s*javascript:[^"]*"|'\s*javascript:[^']*'|javascript:[^\s>]+)`)
-)
+// pageHTMLPolicy — bluemonday-санитайзер для блока ДобавитьСыройHTML (план 66).
+// Allowlist на базе UGCPolicy (форматирование, списки, таблицы, ссылки и
+// картинки только безопасных схем, заголовки) надёжно вырезает
+// script/iframe/object, on*-обработчики и javascript:/data:-URI. Это замена
+// прежнему блоклисту на регулярках, который обходился разделителем «/» перед
+// обработчиком (<img src=x/onerror=…>), табом в схеме (java&#9;script:) и
+// data:-iframe. class/style разрешаем, чтобы автор страницы сохранял вёрстку —
+// исполняемых векторов style в современных браузерах не несёт.
+var pageHTMLPolicy = func() *bluemonday.Policy {
+	p := bluemonday.UGCPolicy()
+	p.AllowAttrs("class", "style").Globally()
+	return p
+}()
 
+// sanitizePageHTML очищает произвольный HTML из ДобавитьСыройHTML по allowlist.
+// Результат безопасно отдавать через template.HTML (pageRaw).
 func sanitizePageHTML(s string) string {
-	s = reScriptBlock.ReplaceAllString(s, "")
-	s = reStyleBlock.ReplaceAllString(s, "")
-	s = reStrayTag.ReplaceAllString(s, "")
-	s = reEventAttr.ReplaceAllString(s, "")
-	s = reJSURI.ReplaceAllString(s, `$1="#"`)
-	return s
+	return pageHTMLPolicy.Sanitize(s)
 }
 
 func argStr(args []any, i int) string {

--- a/internal/dsl/interpreter/page_sanitize_test.go
+++ b/internal/dsl/interpreter/page_sanitize_test.go
@@ -1,0 +1,48 @@
+package interpreter
+
+import (
+	"strings"
+	"testing"
+)
+
+// sanitizePageHTML должен убирать активный контент из произвольного HTML блока
+// ДобавитьСыройHTML (план 66). Прежний блоклист на регулярках обходился через
+// разделитель "/" перед обработчиком, data:-URI и xlink:href — проверяем именно
+// эти векторы плюс базовые.
+func TestSanitizePageHTML_StripsActiveContent(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		mustNotHave []string
+	}{
+		{"script", `<p>ок</p><script>alert(1)</script>`, []string{"<script", "alert(1)"}},
+		{"onerror-space", `<img src=x onerror=alert(1)>`, []string{"onerror"}},
+		{"onerror-slash", `<img/onerror=alert(1)>`, []string{"onerror"}},
+		{"svg-onload", `<svg/onload=alert(1)></svg>`, []string{"onload"}},
+		{"js-uri", `<a href="javascript:alert(1)">x</a>`, []string{"javascript:"}},
+		{"js-uri-tab", "<a href=\"java\tscript:alert(1)\">x</a>", []string{"script:alert"}},
+		{"data-iframe", `<iframe src="data:text/html,<script>alert(1)</script>"></iframe>`, []string{"<iframe", "data:text/html"}},
+		{"xlink", `<svg><a xlink:href="javascript:alert(1)"><text>x</text></a></svg>`, []string{"javascript:"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := sanitizePageHTML(c.in)
+			low := strings.ToLower(out)
+			for _, bad := range c.mustNotHave {
+				if strings.Contains(low, strings.ToLower(bad)) {
+					t.Errorf("санитайзер пропустил %q\n  вход:  %s\n  выход: %s", bad, c.in, out)
+				}
+			}
+		})
+	}
+}
+
+// Безопасное форматирование должно сохраняться — иначе ДобавитьСыройHTML теряет смысл.
+func TestSanitizePageHTML_KeepsSafeMarkup(t *testing.T) {
+	out := sanitizePageHTML(`<h3>Итоги</h3><p>Выручка <b>100</b></p><table><tr><td>A</td></tr></table>`)
+	for _, want := range []string{"<h3", "Итоги", "<b>", "<table", "<td"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("санитайзер вырезал безопасное %q: %s", want, out)
+		}
+	}
+}

--- a/internal/ui/handlers_image.go
+++ b/internal/ui/handlers_image.go
@@ -5,6 +5,7 @@ package ui
 // лежит на диске или в БД (см. storage blob backend, режим ui.file_storage).
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -38,23 +39,28 @@ func (s *Server) imageUpload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.tr(lang, "Ошибка разбора формы")+": "+s.errText(r, err), 400)
 		return
 	}
-	file, header, err := r.FormFile("file")
+	file, _, err := r.FormFile("file")
 	if err != nil {
 		http.Error(w, s.tr(lang, "Нет файла в форме"), 400)
 		return
 	}
 	defer file.Close()
 
-	mimeType := header.Header.Get("Content-Type")
-	if mimeType == "" {
-		mimeType = "application/octet-stream"
-	}
-	if !strings.HasPrefix(mimeType, "image/") {
+	// Тип определяем по СОДЕРЖИМОМУ файла, а не по Content-Type формы (он
+	// подделывается): читаем первые 512 байт для http.DetectContentType и
+	// «возвращаем» их в поток через MultiReader. Так image/svg+xml со скриптом и
+	// прочий не-растровый контент отсекаются ещё на загрузке.
+	head := make([]byte, 512)
+	n, _ := io.ReadFull(file, head)
+	head = head[:n]
+	mimeType, ok := allowedImageMime(head)
+	if !ok {
 		http.Error(w, s.tr(lang, "Можно загрузить только изображение"), 400)
 		return
 	}
+	body := io.MultiReader(bytes.NewReader(head), file)
 
-	b, err := s.store.PutBlob(r.Context(), mimeType, file, maxSize)
+	b, err := s.store.PutBlob(r.Context(), mimeType, body, maxSize)
 	if err != nil {
 		http.Error(w, s.errText(r, err), 500)
 		return
@@ -86,5 +92,22 @@ func (s *Server) imageServe(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", strconv.FormatInt(b.Size, 10))
 	}
 	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	// Бинарник отдаётся inline и в режиме sandbox: даже если в хранилище есть
+	// SVG со скриптом (загруженный до ужесточения проверки типа), при прямом
+	// открытии /image/{id} он будет инертен. На отрисовку через <img> не влияет.
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
 	io.Copy(w, rc)
+}
+
+// allowedImageMime определяет тип картинки по её первым байтам (server-side, без
+// доверия заголовку формы) и сообщает, разрешена ли она к загрузке. Только
+// настоящие растровые изображения: http.DetectContentType классифицирует SVG
+// как text/xml, поэтому image/svg+xml со скриптом сюда не проходит.
+func allowedImageMime(head []byte) (string, bool) {
+	mime := http.DetectContentType(head)
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = mime[:i]
+	}
+	return mime, strings.HasPrefix(mime, "image/")
 }

--- a/internal/ui/handlers_image_test.go
+++ b/internal/ui/handlers_image_test.go
@@ -1,0 +1,36 @@
+package ui
+
+import "testing"
+
+// allowedImageMime определяет тип по СОДЕРЖИМОМУ (а не по заголовку формы,
+// который подделывается) и пропускает только настоящие растровые изображения.
+// SVG и HTML обязаны отсекаться — иначе image/svg+xml со скриптом даёт stored
+// XSS при прямом открытии /image/{id} (nosniff тут не спасает: тип честный).
+func TestAllowedImageMime(t *testing.T) {
+	png := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0}
+	gif := []byte("GIF89a\x00\x00\x00\x00")
+	jpeg := []byte{0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0}
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`)
+	html := []byte("<!doctype html><script>alert(1)</script>")
+
+	cases := []struct {
+		name  string
+		head  []byte
+		allow bool
+	}{
+		{"png", png, true},
+		{"gif", gif, true},
+		{"jpeg", jpeg, true},
+		{"svg", svg, false},
+		{"html", html, false},
+		{"empty", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mime, ok := allowedImageMime(c.head)
+			if ok != c.allow {
+				t.Fatalf("allowedImageMime(%s) = (%q,%v), ожидалось allow=%v", c.name, mime, ok, c.allow)
+			}
+		})
+	}
+}


### PR DESCRIPTION
По итогам ревью работы за два дня — две hardening-правки вокруг новых escape-hatch'ей (план 66 «страницы» и загрузка изображений).

## 1. Санитайзер raw-HTML страниц → bluemonday
`sanitizePageHTML` (блок `ДобавитьСыройHTML`) был блоклистом на регулярках и обходился:
- `<img/onerror=alert(1)>` — `/`-разделитель перед обработчиком (regex требовал пробел);
- `java<tab>script:` — таб внутри схемы;
- `<iframe src="data:text/html,…">` — `data:`-URI не блокировался.

Заменён на allowlist **bluemonday** (`UGCPolicy` + `class`/`style`): надёжно вырезает script/iframe/object, `on*`-обработчики, `javascript:`/`data:`-URI. Безопасная разметка (заголовки, таблицы, форматирование) сохраняется.

## 2. Тип картинки — по содержимому, SVG обезврежен
`imageUpload` доверял `Content-Type` формы (подделывается) и пропускал `image/svg+xml`. SVG со скриптом → stored XSS при прямом открытии `/image/{id}` (глобальный `nosniff` тут не помогает — тип честный, а в CSP нет `script-src`).

- Тип теперь определяется через `http.DetectContentType` по первым 512 байтам (SVG классифицируется как `text/xml` → отсекается; подделанные заголовки тоже).
- Отдача блоба: `Content-Disposition: inline` + строгий per-response CSP `default-src 'none'; sandbox` — обезвреживает и **уже сохранённые** SVG, не ломая показ через `<img>`.

⚠️ Поведенческое изменение: загрузка `.svg` в поля-картинки теперь отклоняется (растровые форматы — без изменений).

## Проверка
- Новые тесты: `TestSanitizePageHTML_*` (векторы обхода + безопасная разметка), `TestAllowedImageMime` (PNG/GIF/JPEG проходят, SVG/HTML/пусто — нет).
- `go build ./...`, `go vet ./...`, полный `go test ./...` — зелёные.

Контекст: проверил — UI-сервер уже под `websec.SecurityHeaders` (`api/server.go:44`), `nosniff` на `/image` и `/ui/page` присутствует; отдельная правка не нужна.

🤖 Generated with [Claude Code](https://claude.com/claude-code)