### PR TITLE
fix(configurator): Перем через запятую, кликабельные ошибки, подсветка, шаблоны (#102–#105)

### DIFF
--- a/internal/configcheck/check.go
+++ b/internal/configcheck/check.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/ivantit66/onebase/internal/auth"
@@ -320,12 +322,26 @@ func CheckQueriesExecutable(proj *project.Project, validate func(sqlText string)
 
 // ParseDSL runs the lexer and parser on a snippet, then validates function
 // calls against known builtins + procedures defined in the same module.
+// parseErrLocRe вытаскивает "<…>:<line>:<col>: <сообщение>" из ошибки
+// лексера/парсера. Координаты кладём в поля Issue (а не только в текст), чтобы
+// в конфигураторе по ошибке можно было кликнуть и перейти к месту (issue #103).
+var parseErrLocRe = regexp.MustCompile(`:(\d+):(\d+): (.*)$`)
+
+func parseErrIssue(label, msg string) Issue {
+	if m := parseErrLocRe.FindStringSubmatch(msg); m != nil {
+		line, _ := strconv.Atoi(m[1])
+		col, _ := strconv.Atoi(m[2])
+		return Issue{File: label, Line: line, Column: col, Message: m[3]}
+	}
+	return Issue{File: label, Message: msg}
+}
+
 func ParseDSL(source, label string) []Issue {
 	l := lexer.New(source, label)
 	p := parser.New(l)
 	prog, err := p.ParseProgram()
 	if err != nil {
-		return []Issue{{File: label, Message: err.Error()}}
+		return []Issue{parseErrIssue(label, err.Error())}
 	}
 	return CheckDSLCalls(prog, label)
 }

--- a/internal/configcheck/check_test.go
+++ b/internal/configcheck/check_test.go
@@ -7,6 +7,29 @@ import (
 	"testing"
 )
 
+func TestParseDSL_SyntaxErrorHasPosition(t *testing.T) {
+	// Синтаксическая ошибка должна нести координаты (Line/Column), чтобы в
+	// конфигураторе можно было кликнуть по ней и перейти к месту (issue #103).
+	src := `Процедура Тест()
+  х = ;
+КонецПроцедуры`
+	issues := ParseDSL(src, "Тест")
+	if len(issues) != 1 {
+		t.Fatalf("ожидалась 1 проблема, получено %d: %+v", len(issues), issues)
+	}
+	is := issues[0]
+	if is.Line != 2 {
+		t.Errorf("ожидалась строка 2, получено %d (%+v)", is.Line, is)
+	}
+	if is.Column == 0 {
+		t.Errorf("ожидалась ненулевая колонка (%+v)", is)
+	}
+	// Координаты вычищены из текста — UI покажет их отдельно, без дубля.
+	if strings.Contains(is.Message, "Тест:") {
+		t.Errorf("координаты не вычищены из сообщения: %q", is.Message)
+	}
+}
+
 func TestParseDSL_Clean(t *testing.T) {
 	src := `Процедура Тест()
   Сообщить("привет");

--- a/internal/dsl/ast/ast.go
+++ b/internal/dsl/ast/ast.go
@@ -46,7 +46,7 @@ type AssignStmt struct {
 	Value  Expr
 }
 
-type VarDecl struct{ Name token.Token }
+type VarDecl struct{ Names []token.Token }
 
 type ForEachStmt struct {
 	Var        token.Token

--- a/internal/dsl/interpreter/debug_hooks.go
+++ b/internal/dsl/interpreter/debug_hooks.go
@@ -40,7 +40,9 @@ func getLocation(stmt ast.Stmt) *sourceLocation {
 	case *ast.TryStmt:
 		file, line, col = s.Tok.File, s.Tok.Line, s.Tok.Col
 	case *ast.VarDecl:
-		file, line, col = s.Name.File, s.Name.Line, s.Name.Col
+		if len(s.Names) > 0 {
+			file, line, col = s.Names[0].File, s.Names[0].Line, s.Names[0].Col
+		}
 	case *ast.BreakStmt:
 		file, line, col = s.Tok.File, s.Tok.Line, s.Tok.Col
 	case *ast.ContinueStmt:

--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -342,7 +342,9 @@ func (i *Interpreter) execStmt(s ast.Stmt, e *env) {
 	case *ast.ExprStmt:
 		i.evalExpr(v.X, e)
 	case *ast.VarDecl:
-		e.set(v.Name.Literal, nil)
+		for _, n := range v.Names {
+			e.set(n.Literal, nil)
+		}
 	case *ast.NumericForStmt:
 		start := toFloatOr0(i.evalExpr(v.Start, e))
 		end := toFloatOr0(i.evalExpr(v.End, e))

--- a/internal/dsl/interpreter/interpreter_test.go
+++ b/internal/dsl/interpreter/interpreter_test.go
@@ -27,6 +27,25 @@ func runProc(t *testing.T, src string, obj *runtime.Object) error {
 	return interp.Run(prog.Procedures[0], obj)
 }
 
+func TestInterpreter_VarDeclCommaList(t *testing.T) {
+	// Несколько переменных в одном Перем через запятую должны объявляться все.
+	src := `Процедура Выполнить()
+  Перем а, б, в;
+  а = 10;
+  б = 20;
+  в = а + б;
+  this.Результат = в;
+КонецПроцедуры`
+
+	obj := runtime.NewObject("Test", metadata.KindDocument)
+	if err := runProc(t, src, obj); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !numEq(obj.Get("Результат"), 30) {
+		t.Fatalf("expected 30, got %v", obj.Get("Результат"))
+	}
+}
+
 func TestInterpreter_ErrorOnEmptyNumber(t *testing.T) {
 	src := `Procedure OnWrite()
   If this.Number = "" Then

--- a/internal/dsl/langref/completeness_test.go
+++ b/internal/dsl/langref/completeness_test.go
@@ -108,3 +108,24 @@ func TestCoverage_Report(t *testing.T) {
 	t.Logf("охват langref: функций=%d, методов=%d по %d объектам, конструкций=%d, слов запросов=%d",
 		fn, method, len(objs), kw, q)
 }
+
+// TestKeywords_HaveSnippets — составные конструкции вставляются автодополнением
+// готовым шаблоном с позицией курсора $0 внутри тела (issue #105), а не строкой
+// Display с многоточием.
+func TestKeywords_HaveSnippets(t *testing.T) {
+	want := []string{"процедура", "функция", "если", "для каждого", "для", "пока", "попытка"}
+	for _, name := range want {
+		d, ok := ByName(name)
+		if !ok {
+			t.Errorf("нет дескриптора %q", name)
+			continue
+		}
+		if d.Snippet == "" {
+			t.Errorf("%q: пустой Snippet", name)
+			continue
+		}
+		if !strings.Contains(d.Snippet, "$0") {
+			t.Errorf("%q: в Snippet нет позиции курсора $0: %q", name, d.Snippet)
+		}
+	}
+}

--- a/internal/dsl/langref/keywords.go
+++ b/internal/dsl/langref/keywords.go
@@ -7,6 +7,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "процедура",
 		Display: "Процедура … КонецПроцедуры",
 		Aliases: []string{"Procedure", "EndProcedure"},
+		Snippet: "Процедура ${1:Имя}()\n\t$0\nКонецПроцедуры",
 		Kind:    KindKeyword,
 		Group:   "Объявления",
 		Signature: "Процедура <Имя>([Знач] <параметр>, ...) [Экспорт]\n" +
@@ -21,6 +22,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "функция",
 		Display: "Функция … КонецФункции",
 		Aliases: []string{"Function", "EndFunction"},
+		Snippet: "Функция ${1:Имя}()\n\t$0\nКонецФункции",
 		Kind:    KindKeyword,
 		Group:   "Объявления",
 		Signature: "Функция <Имя>([Знач] <параметр>, ...) [Экспорт]\n" +
@@ -46,6 +48,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "если",
 		Display: "Если … Тогда … КонецЕсли",
 		Aliases: []string{"If", "Then", "ElseIf", "Else", "EndIf"},
+		Snippet: "Если ${1:условие} Тогда\n\t$0\nКонецЕсли",
 		Kind:    KindKeyword,
 		Group:   "Ветвление",
 		Signature: "Если <условие> Тогда\n" +
@@ -65,6 +68,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "для каждого",
 		Display: "Для Каждого … Из … Цикл … КонецЦикла",
 		Aliases: []string{"For", "Each", "In", "Do", "EndDo"},
+		Snippet: "Для Каждого ${1:Элемент} Из ${2:Коллекция} Цикл\n\t$0\nКонецЦикла",
 		Kind:    KindKeyword,
 		Group:   "Циклы",
 		Signature: "Для Каждого <Элемент> Из <Коллекция> Цикл\n" +
@@ -77,6 +81,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "для",
 		Display: "Для … По … Цикл … КонецЦикла",
 		Aliases: []string{"For", "To", "Do", "EndDo"},
+		Snippet: "Для ${1:сч} = ${2:1} По ${3:10} Цикл\n\t$0\nКонецЦикла",
 		Kind:    KindKeyword,
 		Group:   "Циклы",
 		Signature: "Для <Счётчик> = <Начало> По <Конец> Цикл\n" +
@@ -90,6 +95,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "пока",
 		Display: "Пока … Цикл … КонецЦикла",
 		Aliases: []string{"While"},
+		Snippet: "Пока ${1:условие} Цикл\n\t$0\nКонецЦикла",
 		Kind:    KindKeyword,
 		Group:   "Циклы",
 		Signature: "Пока <условие> Цикл\n" +
@@ -104,6 +110,7 @@ var keywordDescriptors = []Descriptor{
 		Name:    "попытка",
 		Display: "Попытка … Исключение … КонецПопытки",
 		Aliases: []string{"Try", "Except", "EndTry"},
+		Snippet: "Попытка\n\t$1\nИсключение\n\t$0\nКонецПопытки",
 		Kind:    KindKeyword,
 		Group:   "Обработка ошибок",
 		Signature: "Попытка\n" +

--- a/internal/dsl/langref/langref.go
+++ b/internal/dsl/langref/langref.go
@@ -40,6 +40,7 @@ type Descriptor struct {
 	Returns   string   `json:"returns,omitempty"` // тип возврата ("" если нет)
 	Doc       string   `json:"doc"`               // 1–3 предложения
 	Example   string   `json:"example,omitempty"`
+	Snippet   string   `json:"snippet,omitempty"` // шаблон вставки для автодополнения (Monaco snippet: ${1:…} табстопы, $0 — курсор)
 	Group     string   `json:"group,omitempty"` // для дерева функций: "Строки", "Даты"…
 }
 

--- a/internal/dsl/parser/parser.go
+++ b/internal/dsl/parser/parser.go
@@ -331,8 +331,18 @@ func (p *Parser) parseVarDecl() (*ast.VarDecl, error) {
 	if err != nil {
 		return nil, err
 	}
+	names := []token.Token{nameTok}
+	// Несколько переменных в одном объявлении через запятую: Перем а, б, в; (как в 1С).
+	for p.cur.Type == token.COMMA {
+		p.advance() // consume ,
+		nameTok, err := p.expect(token.IDENT)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, nameTok)
+	}
 	p.consumeSemi()
-	return &ast.VarDecl{Name: nameTok}, nil
+	return &ast.VarDecl{Names: names}, nil
 }
 
 func isCompoundAssign(t token.Type) bool {

--- a/internal/dsl/parser/parser_test.go
+++ b/internal/dsl/parser/parser_test.go
@@ -38,6 +38,35 @@ func TestParser_BOMOnlyModule(t *testing.T) {
 	}
 }
 
+func TestParser_VarDeclCommaList(t *testing.T) {
+	// Перем а, б, в; — объявление нескольких переменных через запятую (как в 1С).
+	src := `Процедура Тест()
+  Перем а, б, в;
+КонецПроцедуры`
+
+	prog := parse(t, src)
+	if len(prog.Procedures) != 1 {
+		t.Fatalf("want 1 procedure, got %d", len(prog.Procedures))
+	}
+	body := prog.Procedures[0].Body
+	if len(body) != 1 {
+		t.Fatalf("want 1 stmt in body, got %d", len(body))
+	}
+	vd, ok := body[0].(*ast.VarDecl)
+	if !ok {
+		t.Fatalf("want *ast.VarDecl, got %T", body[0])
+	}
+	want := []string{"а", "б", "в"}
+	if len(vd.Names) != len(want) {
+		t.Fatalf("want %d names, got %d", len(want), len(vd.Names))
+	}
+	for i, n := range want {
+		if vd.Names[i].Literal != n {
+			t.Fatalf("name[%d]: want %q, got %q", i, n, vd.Names[i].Literal)
+		}
+	}
+}
+
 func TestParser_OnWriteProcedure(t *testing.T) {
 	src := `Procedure OnWrite()
   If this.Number = "" Then

--- a/internal/launcher/configurator_tmpl.go
+++ b/internal/launcher/configurator_tmpl.go
@@ -1089,6 +1089,18 @@ function endEdit(name) {
   }
 }
 // ── Syntax check ──────────────────────────────────────────────────
+// jumpToError ставит курсор Monaco-редактора в координаты ошибки синтаксического
+// контроля и прокручивает к ней (issue #103). key — тот же, что и у runCheck.
+function jumpToError(key, line, col) {
+  var ed = (typeof monacoEditors !== 'undefined') ? monacoEditors[key] : null;
+  if (ed) {
+    ed.revealLineInCenter(line);
+    ed.setPosition({lineNumber: line, column: col || 1});
+    ed.focus();
+  }
+  return false;
+}
+
 // runCheck reads code from a textarea (id "ta-<key>") and posts it to the
 // configurator check endpoint, then renders the result in the sibling
 // .check-result element with id "check-<key>". The kind argument selects the
@@ -1128,8 +1140,12 @@ function runCheck(kind, key, name) {
       } else {
         result.className = 'check-result check-err';
         var lines = (d.issues || []).map(function(i){
-          var pos = (i.line ? ' (стр. ' + i.line + ')' : '');
-          return '• ' + i.message + pos;
+          var txt = escapeHtml('• ' + i.message);
+          if (i.line) {
+            var pos = ' (стр. ' + i.line + (i.column ? ', поз. ' + i.column : '') + ')';
+            return '<a href="#" onclick="return jumpToError(\'' + key + '\',' + i.line + ',' + (i.column || 1) + ')" style="color:inherit;text-decoration:underline;cursor:pointer">' + txt + escapeHtml(pos) + '</a>';
+          }
+          return txt;
         });
         result.innerHTML = '<b>Найдено ошибок: ' + d.total + '</b><br>' + lines.join('<br>');
       }
@@ -2804,6 +2820,10 @@ var KW=['Процедура','КонецПроцедуры','Функция','К
   'And','Or','Not','Var'];
 var FN=['Error','Ошибка','Сообщить','Формат','ФорматСтроки','СтрЗаменить'];
 var SP=['this','Движения','Параметры'];
+// DSL регистронезависим — подсветку ключевых слов сравниваем по нижнему регистру (issue #104).
+var KWl=KW.map(function(s){return s.toLowerCase();});
+var FNl=FN.map(function(s){return s.toLowerCase();});
+var SPl=SP.map(function(s){return s.toLowerCase();});
 
 function hl(code){
   var r='',i=0,n=code.length;
@@ -2822,10 +2842,10 @@ function hl(code){
     }
     if(/[а-яёА-ЯЁa-zA-Z_]/.test(code[i])){
       var j=i;while(j<n && /[а-яёА-ЯЁa-zA-Z0-9_]/.test(code[j]))j++;
-      var w=code.slice(i,j);
-      if(KW.indexOf(w)>=0)r+='<span class="hl-kw">'+esc(w)+'</span>';
-      else if(FN.indexOf(w)>=0)r+='<span class="hl-fn">'+esc(w)+'</span>';
-      else if(SP.indexOf(w)>=0)r+='<span class="hl-sp">'+esc(w)+'</span>';
+      var w=code.slice(i,j),wl=w.toLowerCase();
+      if(KWl.indexOf(wl)>=0)r+='<span class="hl-kw">'+esc(w)+'</span>';
+      else if(FNl.indexOf(wl)>=0)r+='<span class="hl-fn">'+esc(w)+'</span>';
+      else if(SPl.indexOf(wl)>=0)r+='<span class="hl-sp">'+esc(w)+'</span>';
       else r+=esc(w);
       i=j;continue;
     }
@@ -2865,6 +2885,8 @@ require(['vs/editor/editor.main'], function() {
       'ЛЕВОЕ','ПРАВОЕ','ВНУТРЕННЕЕ','ПОЛНОЕ','СОЕДИНЕНИЕ',
       'КАК','ВОЗР','УБЫВ','СУММА','КОЛИЧЕСТВО','МИНИМУМ','МАКСИМУМ','СРЕДНЕЕ'].concat(extraBuiltins||[]);
     return {
+      // DSL регистронезависим — подсветка ключевых слов тоже (issue #104).
+      ignoreCase: true,
       keywords: [
         'Процедура','КонецПроцедуры','Функция','КонецФункции',
         'Если','Тогда','ИначеЕсли','Иначе','КонецЕсли',
@@ -2910,6 +2932,7 @@ require(['vs/editor/editor.main'], function() {
   }
   // Сниппет вставки: Имя(${1:П1}, ${2:П2})
   function _lrSnippet(d){
+    if (d.snippet) return d.snippet; // готовый шаблон конструкции (Процедура…, Если… и т.п.) — issue #105
     if (!d.params || !d.params.length) return d.display;
     var parts = d.params.map(function(p,i){ return '${'+(i+1)+':'+p.name+'}'; });
     return d.display + '(' + parts.join(', ') + ')';
@@ -2935,7 +2958,7 @@ require(['vs/editor/editor.main'], function() {
           detail: d.signature || '',
           documentation: { value: (d.doc||'') + (d.example ? _lrFence(d.example) : '') },
           insertText: _lrSnippet(d),
-          insertTextRules: (d.params && d.params.length) ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet : undefined,
+          insertTextRules: (d.snippet || (d.params && d.params.length)) ? monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet : undefined,
           range: range
         });
       });


### PR DESCRIPTION
## Что сделано

Пачка фиксов конфигуратора/DSL по issue от @artamir:

- **#102** — `Перем а, б, в;` теперь объявляет все перечисленные переменные через запятую (как в 1С), а не падает с `unexpected "," in expression`. `VarDecl` хранит срез имён (`Names`), `parseVarDecl` разбирает список.
- **#103** — ошибки синтаксического контроля стали кликабельными: координаты (Line/Column) извлекаются из текста ошибки парсера и кладутся в поля `Issue`; клик по ошибке ставит курсор Monaco в нужное место. Текст сообщения экранируется через `escapeHtml`.
- **#104** — подсветка ключевых слов регистронезависима (кастомный `hl()` сравнивает по нижнему регистру, у Monaco включён `ignoreCase`), как и сам DSL.
- **#105** — автодополнение конструкций (Процедура, Функция, Если, Для, Пока, Попытка) вставляет готовый шаблон с курсором в теле, а не строку Display с многоточием. В `Descriptor` добавлено поле `Snippet`.

Closes #102
Closes #103
Closes #104
Closes #105

## Проверка

- `go build ./...`, `go vet ./...`, `go test ./...` — зелёные.
- #102 и backend #103 — по TDD (RED→GREEN); #105 — тест langref на наличие snippet'ов с позицией курсора.
- Фронтенд-части (#103 клик, #104 подсветка, #105 вставка) — это JS внутри Go-шаблона, автотестами не покрываются. Проверены ревью и успешной сборкой/парсингом шаблона. Ручная проверка в конфигураторе:
  - [ ] `Перем а,б;` в редакторе модуля → «Синтаксис ОК»
  - [ ] клик по ошибке синтаксического контроля → курсор прыгает в место ошибки
  - [ ] ключевые слова в нижнем регистре (`процедура`, `если`) подсвечиваются
  - [ ] автодополнение «Процедура» вставляет шаблон, курсор оказывается в теле

🤖 Generated with [Claude Code](https://claude.com/claude-code)
