### PR TITLE
docs(examples): авторство и лицензия в примерах конфигураций

### DIFF
--- a/examples/accounting/config/app.yaml
+++ b/examples/accounting/config/app.yaml
@@ -1,5 +1,8 @@
 name: Бухгалтерия
 version: "1.0.0"
+author: Иван Титов
+copyright: © 2026 Иван Титов
+license: MIT
 
 # Путь к логотипу относительно папки конфигурации (PNG, SVG, JPG)
 # logo: config/logo.png

--- a/examples/crm/config/app.yaml
+++ b/examples/crm/config/app.yaml
@@ -1,2 +1,5 @@
 name: CRM — Управление отношениями с клиентами
 version: "1.0"
+author: Иван Титов
+copyright: © 2026 Иван Титов
+license: MIT

--- a/examples/finance/config/app.yaml
+++ b/examples/finance/config/app.yaml
@@ -1,2 +1,5 @@
 name: Finance — Домашние финансы
 version: "1.0"
+author: Иван Титов
+copyright: © 2026 Иван Титов
+license: MIT

--- a/examples/minimal/config/app.yaml
+++ b/examples/minimal/config/app.yaml
@@ -1,5 +1,8 @@
 name: minimal
 version: "1.0"
+author: Иван Титов
+copyright: © 2026 Иван Титов
+license: MIT
 
 # Путь к логотипу относительно папки конфигурации (PNG, SVG, JPG)
 # logo: config/logo.png

--- a/examples/trade/config/app.yaml
+++ b/examples/trade/config/app.yaml
@@ -1,5 +1,8 @@
 name: trade
 version: "1.0"
+author: Иван Титов
+copyright: © 2026 Иван Титов
+license: MIT
 
 # Путь к логотипу относительно папки конфигурации (PNG, SVG, JPG)
 # logo: config/logo.png


### PR DESCRIPTION
## Что сделано

Поля авторства и лицензии добавлены в остальные примеры конфигураций (продолжение плана 69, после `tasks`):

- `minimal`, `trade`, `accounting`, `crm`, `finance` — `author: Иван Титов`, `copyright: © 2026 Иван Титов`, `license: MIT`

Поля едут вместе с конфигурацией и показываются пользователю на экране «О программе» рядом с правообладателем платформы.

## Проверки

- [x] `onebase check` — все 5 примеров OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
