### PR TITLE
fix(configurator): сохранение реквизитов/ТЧ и точности чисел в редакторах

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -474,6 +474,7 @@
   "Добавить измерение": "Add dimension",
   "Ресурсы": "Resources",
   "Добавить ресурс": "Add resource",
+  "Добавить реквизит": "Add attribute",
   "Регистр бухгалтерии": "Accounting register",
   "Заголовок": "Title",
   "Отображаемое имя": "Display name",

--- a/internal/launcher/configurator.go
+++ b/internal/launcher/configurator.go
@@ -93,17 +93,21 @@ type saveEntity struct {
 }
 
 type saveRegister struct {
-	Name       string      `yaml:"name"`
-	Dimensions []saveField `yaml:"dimensions,omitempty"`
-	Resources  []saveField `yaml:"resources,omitempty"`
-	Attributes []saveField `yaml:"attributes,omitempty"`
+	Name       string            `yaml:"name"`
+	Title      string            `yaml:"title,omitempty"`
+	Titles     map[string]string `yaml:"titles,omitempty"`
+	Dimensions []saveField       `yaml:"dimensions,omitempty"`
+	Resources  []saveField       `yaml:"resources,omitempty"`
+	Attributes []saveField       `yaml:"attributes,omitempty"`
 }
 
 type saveInfoReg struct {
-	Name       string      `yaml:"name"`
-	Periodic   bool        `yaml:"periodic,omitempty"`
-	Dimensions []saveField `yaml:"dimensions,omitempty"`
-	Resources  []saveField `yaml:"resources,omitempty"`
+	Name       string            `yaml:"name"`
+	Title      string            `yaml:"title,omitempty"`
+	Titles     map[string]string `yaml:"titles,omitempty"`
+	Periodic   bool              `yaml:"periodic,omitempty"`
+	Dimensions []saveField       `yaml:"dimensions,omitempty"`
+	Resources  []saveField       `yaml:"resources,omitempty"`
 }
 
 type saveAccountReg struct {
@@ -148,6 +152,8 @@ type cfgConstant struct {
 	RefEntity string
 	Default   string
 	Label     string
+	Length    int // разрядность number(L,P): всего знаков (Длина)
+	Scale     int // знаков после запятой (Точность)
 }
 
 type cfgTablePart struct {
@@ -771,6 +777,8 @@ func (h *handler) loadCfgData(ctx context.Context, b *Base, tab string, lang ...
 			RefEntity: c.RefEntity,
 			Default:   c.Default,
 			Label:     c.Label,
+			Length:    c.Length,
+			Scale:     c.Scale,
 		})
 	}
 
@@ -1470,10 +1478,27 @@ func findEntityFilePath(dir, entityName string) (string, error) {
 
 func applyFieldEdits(ent *saveEntity, fields []saveField, tpFields map[string][]saveField, posting *bool, hierarchical *bool, basedOn *[]string) {
 	ent.Fields = fields
+	existingTP := make(map[string]bool, len(ent.TableParts))
 	for i, tp := range ent.TableParts {
+		existingTP[tp.Name] = true
 		if f, ok := tpFields[tp.Name]; ok {
 			ent.TableParts[i].Fields = f
 		}
+	}
+	// Новые табличные части — ключи tpFields, которых ещё нет среди
+	// существующих ТЧ. Раньше они молча терялись (цикл шёл только по
+	// ent.TableParts), из-за чего «Добавить табличную часть» в конфигураторе не
+	// сохранялось. Имена сортируем для детерминированного YAML (порядок обхода
+	// ключей карты в Go не определён).
+	var newTP []string
+	for name := range tpFields {
+		if !existingTP[name] {
+			newTP = append(newTP, name)
+		}
+	}
+	sort.Strings(newTP)
+	for _, name := range newTP {
+		ent.TableParts = append(ent.TableParts, saveTP{Name: name, Fields: tpFields[name]})
 	}
 	if posting != nil {
 		ent.Posting = *posting
@@ -1724,6 +1749,80 @@ func numberTypeWithSpec(typ, lengthVal, scaleVal string) string {
 	return fmt.Sprintf("number(%d,%d)", l, s)
 }
 
+// formRowIndices возвращает отсортированные числовые индексы строк, присланных
+// под базовым ключом base: ключи вида <base>.<idx>.name. Индексы на фронте
+// выдаёт глобальный счётчик (_cfgNewFieldIdx), поэтому непрерывности нет —
+// собираем фактически присланные. Точка после индекса исключает ложные
+// совпадения имён-префиксов (например «new_tp.Цен.field» против «...Цены...»).
+func formRowIndices(r *http.Request, base string) []int {
+	prefix := base + "."
+	var idxs []int
+	for k := range r.Form {
+		if !strings.HasPrefix(k, prefix) || !strings.HasSuffix(k, ".name") {
+			continue
+		}
+		mid := strings.TrimSuffix(strings.TrimPrefix(k, prefix), ".name")
+		if n, err := strconv.Atoi(mid); err == nil {
+			idxs = append(idxs, n)
+		}
+	}
+	sort.Ints(idxs)
+	return idxs
+}
+
+// parseRegSection читает секцию полей регистра/плана счетов из формы. Существующие
+// строки приходят как <prefix>.<i>.{name,type,length,scale,ref} (обрыв на первом
+// пустом), добавленные кнопкой «+ Добавить» — как new_<prefix>.<idx>.* (пропуск
+// пустых, индексы из глобального счётчика). Тип числа кодируется number(L,P) через
+// numberTypeWithSpec; reference/enum → typ:ref — как в редакторе реквизитов
+// сущности. Раньше точность и добавленные строки терялись.
+func parseRegSection(r *http.Request, prefix string) []saveField {
+	var fields []saveField
+	add := func(keyBase string) {
+		name := strings.TrimSpace(r.FormValue(keyBase + ".name"))
+		if name == "" {
+			return
+		}
+		typ := r.FormValue(keyBase + ".type")
+		ref := r.FormValue(keyBase + ".ref")
+		if (typ == "reference" || typ == "enum") && ref != "" {
+			typ = typ + ":" + ref
+		}
+		typ = numberTypeWithSpec(typ, r.FormValue(keyBase+".length"), r.FormValue(keyBase+".scale"))
+		fields = append(fields, saveField{Name: name, Type: typ})
+	}
+	for i := 0; i < 500; i++ {
+		if strings.TrimSpace(r.FormValue(fmt.Sprintf("%s.%d.name", prefix, i))) == "" {
+			break
+		}
+		add(fmt.Sprintf("%s.%d", prefix, i))
+	}
+	for _, i := range formRowIndices(r, "new_"+prefix) {
+		add(fmt.Sprintf("new_%s.%d", prefix, i))
+	}
+	return fields
+}
+
+// buildTPSaveField собирает saveField строки ТЧ из значений формы с базовым
+// ключом keyBase: тип, разрядность числа number(L,P), ссылку/перечисление.
+// Возвращает непустую строку ошибки, если для reference/enum не выбран объект.
+func buildTPSaveField(r *http.Request, lang, keyBase, tpName, name string) (saveField, string) {
+	typ := r.FormValue(keyBase + ".type")
+	ref := r.FormValue(keyBase + ".ref")
+	if typ == "reference" || typ == "enum" {
+		if ref == "" {
+			kind := "объект для ссылки"
+			if typ == "enum" {
+				kind = "перечисление"
+			}
+			return saveField{}, fmt.Sprintf(tr(lang, "Поле «%s.%s»: выберите %s"), tpName, name, kind)
+		}
+		typ = typ + ":" + ref
+	}
+	typ = numberTypeWithSpec(typ, r.FormValue(keyBase+".length"), r.FormValue(keyBase+".scale"))
+	return saveField{Name: name, Type: typ}, ""
+}
+
 func (h *handler) configuratorSaveFields(w http.ResponseWriter, r *http.Request) {
 	b, err := h.store.Get(chi.URLParam(r, "id"))
 	if err != nil {
@@ -1869,44 +1968,48 @@ func (h *handler) configuratorSaveFields(w http.ResponseWriter, r *http.Request)
 		}
 		tpFields[tpName] = f
 	}
-	// new table parts added via "+ Добавить табличную часть"
-	for _, tpIdx := range r.Form["new_tp_name"] {
-		tpName := strings.TrimSpace(tpIdx)
-		if tpName == "" {
+	// Новые табличные части («+ Добавить табличную часть») приходят маркером
+	// new_tp_name=<Имя>. Поля, добавленные кнопкой «+ Добавить поле» — и в
+	// новые, и в СУЩЕСТВУЮЩИЕ ТЧ — приходят под именным префиксом
+	// new_tp.<Имя>.field.<idx>.* (idx — глобальный счётчик фронта, непрерывности
+	// нет). Раньше бэкенд читал new_tp.<число>.idx, а имя клал отдельным ключом —
+	// поэтому и новые ТЧ, и реквизиты, дописанные в существующую ТЧ, терялись.
+	var newTPOrder []string
+	seenNewTP := make(map[string]bool)
+	for _, raw := range r.Form["new_tp_name"] {
+		name := strings.TrimSpace(raw)
+		if name == "" || seenNewTP[name] {
 			continue
 		}
-		tpFields[tpName] = nil
+		seenNewTP[name] = true
+		newTPOrder = append(newTPOrder, name)
+		if _, ok := tpFields[name]; !ok {
+			tpFields[name] = nil // пустая новая ТЧ всё равно должна создаться
+		}
 	}
-	for ntp := 1; ntp <= 100; ntp++ {
-		tpKey := strings.TrimSpace(r.FormValue(fmt.Sprintf("new_tp.%d.idx", ntp)))
-		if tpKey == "" {
+	// Дочитываем добавленные строки и дописываем к нужной ТЧ — существующей (из
+	// tp_names) или только что созданной (из new_tp_name).
+	appendDone := make(map[string]bool)
+	for _, tpName := range append(append([]string{}, tpNames...), newTPOrder...) {
+		if appendDone[tpName] {
 			continue
 		}
-		var f []saveField
-		for i := 1; i <= 500; i++ {
-			name := strings.TrimSpace(r.FormValue(fmt.Sprintf("new_tp.%d.field.%d.name", ntp, i)))
+		appendDone[tpName] = true
+		for _, i := range formRowIndices(r, "new_tp."+tpName+".field") {
+			keyBase := fmt.Sprintf("new_tp.%s.field.%d", tpName, i)
+			name := strings.TrimSpace(r.FormValue(keyBase + ".name"))
 			if name == "" {
 				continue
 			}
-			typ := r.FormValue(fmt.Sprintf("new_tp.%d.field.%d.type", ntp, i))
-			ref := r.FormValue(fmt.Sprintf("new_tp.%d.field.%d.ref", ntp, i))
-			if typ == "reference" || typ == "enum" {
-				if ref == "" {
-					data := h.loadCfgData(r.Context(), b, "tree")
-					kind := "объект для ссылки"
-					if typ == "enum" {
-						kind = "перечисление"
-					}
-					data.Error = fmt.Sprintf(tr(lang, "Поле «%s.%s»: выберите %s"), tpKey, name, kind)
-					renderCfg(w, r, data)
-					return
-				}
-				typ = typ + ":" + ref
+			sf, errMsg := buildTPSaveField(r, lang, keyBase, tpName, name)
+			if errMsg != "" {
+				data := h.loadCfgData(r.Context(), b, "tree")
+				data.Error = errMsg
+				renderCfg(w, r, data)
+				return
 			}
-			typ = numberTypeWithSpec(typ, r.FormValue(fmt.Sprintf("new_tp.%d.field.%d.length", ntp, i)), r.FormValue(fmt.Sprintf("new_tp.%d.field.%d.scale", ntp, i)))
-			f = append(f, saveField{Name: name, Type: typ})
+			tpFields[tpName] = append(tpFields[tpName], sf)
 		}
-		tpFields[tpKey] = f
 	}
 
 	var saveErr error
@@ -2141,26 +2244,9 @@ func (h *handler) configuratorSaveRegisterFields(w http.ResponseWriter, r *http.
 	}
 	regName := r.FormValue("register")
 
-	parseSection := func(prefix string) []saveField {
-		var fields []saveField
-		for i := 0; i < 500; i++ {
-			name := r.FormValue(fmt.Sprintf("%s.%d.name", prefix, i))
-			if name == "" {
-				break
-			}
-			typ := r.FormValue(fmt.Sprintf("%s.%d.type", prefix, i))
-			ref := r.FormValue(fmt.Sprintf("%s.%d.ref", prefix, i))
-			if typ == "reference" && ref != "" {
-				typ = "reference:" + ref
-			}
-			fields = append(fields, saveField{Name: name, Type: typ})
-		}
-		return fields
-	}
-
-	dims := parseSection("dim")
-	res := parseSection("res")
-	attrs := parseSection("attr")
+	dims := parseRegSection(r, "dim")
+	res := parseRegSection(r, "res")
+	attrs := parseRegSection(r, "attr")
 
 	var saveErr error
 	if b.ConfigSource == "database" {
@@ -2405,12 +2491,15 @@ func (h *handler) configuratorSaveConstant(w http.ResponseWriter, r *http.Reques
 	if typ == "reference" && ref != "" {
 		typ = "reference:" + ref
 	}
+	// Разрядность числовой константы number(L,P) — как у реквизитов сущности.
+	typ = numberTypeWithSpec(typ, r.FormValue("length"), r.FormValue("scale"))
 
 	type rawConst struct {
-		Name    string `yaml:"name"`
-		Type    string `yaml:"type"`
-		Default string `yaml:"default,omitempty"`
-		Label   string `yaml:"label,omitempty"`
+		Name    string            `yaml:"name"`
+		Type    string            `yaml:"type"`
+		Default string            `yaml:"default,omitempty"`
+		Label   string            `yaml:"label,omitempty"`
+		Labels  map[string]string `yaml:"labels,omitempty"`
 	}
 	type rawConstsFile struct {
 		Constants []rawConst `yaml:"constants"`
@@ -3330,6 +3419,14 @@ func saveInfoRegToFile(dir string, reg saveInfoReg) error {
 	if err != nil {
 		return err
 	}
+	// Title/Titles не редактируются в этой форме — переносим из существующего
+	// файла, иначе Marshal свежего reg затёр бы синоним регистра.
+	if raw, rerr := os.ReadFile(p); rerr == nil {
+		var existing saveInfoReg
+		if yaml.Unmarshal(raw, &existing) == nil {
+			reg.Title, reg.Titles = existing.Title, existing.Titles
+		}
+	}
 	out, err := yaml.Marshal(&reg)
 	if err != nil {
 		return err
@@ -3355,11 +3452,11 @@ func (h *handler) saveInfoRegToDB(ctx context.Context, b *Base, reg saveInfoReg)
 		if err := rows.Scan(&p, &content); err != nil {
 			continue
 		}
-		var tmp struct {
-			Name string `yaml:"name"`
-		}
-		if yaml.Unmarshal(content, &tmp) == nil && tmp.Name == reg.Name {
+		var existing saveInfoReg
+		if yaml.Unmarshal(content, &existing) == nil && existing.Name == reg.Name {
 			targetPath = p
+			// сохраняем синоним регистра (в форме не редактируется)
+			reg.Title, reg.Titles = existing.Title, existing.Titles
 			break
 		}
 	}
@@ -3390,27 +3487,11 @@ func (h *handler) configuratorSaveInfoRegFields(w http.ResponseWriter, r *http.R
 		http.Error(w, err.Error(), 400)
 		return
 	}
-	parseSection := func(prefix string) []saveField {
-		var fields []saveField
-		for i := 0; i < 500; i++ {
-			name := r.FormValue(fmt.Sprintf("%s.%d.name", prefix, i))
-			if name == "" {
-				break
-			}
-			typ := r.FormValue(fmt.Sprintf("%s.%d.type", prefix, i))
-			ref := r.FormValue(fmt.Sprintf("%s.%d.ref", prefix, i))
-			if typ == "reference" && ref != "" {
-				typ = "reference:" + ref
-			}
-			fields = append(fields, saveField{Name: name, Type: typ})
-		}
-		return fields
-	}
 	reg := saveInfoReg{
 		Name:       r.FormValue("inforeg"),
 		Periodic:   r.FormValue("periodic") == "true",
-		Dimensions: parseSection("dim"),
-		Resources:  parseSection("res"),
+		Dimensions: parseRegSection(r, "dim"),
+		Resources:  parseRegSection(r, "res"),
 	}
 	var saveErr error
 	if b.ConfigSource == "database" {
@@ -3515,23 +3596,11 @@ func (h *handler) configuratorSaveAccountRegister(w http.ResponseWriter, r *http
 		http.Error(w, err.Error(), 400)
 		return
 	}
-	parseSection := func(prefix string) []saveField {
-		var fields []saveField
-		for i := 0; i < 500; i++ {
-			name := r.FormValue(fmt.Sprintf("%s.%d.name", prefix, i))
-			if name == "" {
-				break
-			}
-			typ := r.FormValue(fmt.Sprintf("%s.%d.type", prefix, i))
-			fields = append(fields, saveField{Name: name, Type: typ})
-		}
-		return fields
-	}
 	reg := saveAccountReg{
 		Name:      r.FormValue("accountreg"),
 		Title:     strings.TrimSpace(r.FormValue("title")),
 		Accounts:  strings.TrimSpace(r.FormValue("accounts")),
-		Resources: parseSection("res"),
+		Resources: parseRegSection(r, "res"),
 	}
 	var saveErr error
 	if b.ConfigSource == "database" {

--- a/internal/launcher/configurator_precision_render_test.go
+++ b/internal/launcher/configurator_precision_render_test.go
@@ -1,0 +1,91 @@
+package launcher
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func renderCfgTree(t *testing.T, data *configuratorData) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := cfgTmpl.ExecuteTemplate(&buf, "tab-tree", data); err != nil {
+		t.Fatalf("ExecuteTemplate tab-tree: %v", err)
+	}
+	return buf.String()
+}
+
+// Регистр накопления: у числовых полей должны быть инпуты Длина/Точность, а у
+// каждой секции — кнопка «+ Добавить» (раньше их не было вовсе, нельзя было
+// добавить поле через UI).
+func TestRegisterDetail_PrecisionAndAddButtons(t *testing.T) {
+	data := &configuratorData{
+		Base: &Base{ID: "b", Name: "X", ConfigSource: "file"}, Lang: "ru", Tab: "tree",
+		Registers: []cfgRegister{{
+			Name:       "Остатки",
+			Dimensions: []cfgField{{Name: "Товар", Type: "string"}},
+			Resources:  []cfgField{{Name: "Сумма", Type: "number", Length: 15, Scale: 2}},
+		}},
+	}
+	html := renderCfgTree(t, data)
+	for _, want := range []string{
+		`name="res.0.length"`,
+		`name="res.0.scale"`,
+		`cfgAddField('rg-dim-Остатки','new_dim','')`,
+		`cfgAddField('rg-res-Остатки','new_res','')`,
+		`cfgAddField('rg-attr-Остатки','new_attr','')`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("register-detail: нет фрагмента %q", want)
+		}
+	}
+}
+
+// Регистр сведений: у числовых измерений/ресурсов — инпуты Длина/Точность.
+func TestInfoRegDetail_Precision(t *testing.T) {
+	data := &configuratorData{
+		Base: &Base{ID: "b", Name: "X", ConfigSource: "file"}, Lang: "ru", Tab: "tree",
+		InfoRegisters: []cfgInfoRegister{{
+			Name:       "Курсы",
+			Dimensions: []cfgField{{Name: "Валюта", Type: "string"}},
+			Resources:  []cfgField{{Name: "Курс", Type: "number", Length: 10, Scale: 4}},
+		}},
+	}
+	html := renderCfgTree(t, data)
+	for _, want := range []string{`name="res.0.length"`, `name="res.0.scale"`} {
+		if !strings.Contains(html, want) {
+			t.Errorf("inforeg-detail: нет фрагмента %q", want)
+		}
+	}
+}
+
+// План счетов: у числового ресурса — инпуты Длина/Точность.
+func TestAccountRegDetail_Precision(t *testing.T) {
+	data := &configuratorData{
+		Base: &Base{ID: "b", Name: "X", ConfigSource: "file"}, Lang: "ru", Tab: "tree",
+		AccountRegisters: []cfgAccountRegister{{
+			Name:      "Бухучёт",
+			Resources: []cfgField{{Name: "Сумма", Type: "number", Length: 18, Scale: 2}},
+		}},
+	}
+	html := renderCfgTree(t, data)
+	for _, want := range []string{`name="res.0.length"`, `name="res.0.scale"`} {
+		if !strings.Contains(html, want) {
+			t.Errorf("accountreg-detail: нет фрагмента %q", want)
+		}
+	}
+}
+
+// Константа: у типа «число» — инпуты Длина/Точность (имена length/scale).
+func TestConstantDetail_Precision(t *testing.T) {
+	data := &configuratorData{
+		Base: &Base{ID: "b", Name: "X", ConfigSource: "file"}, Lang: "ru", Tab: "tree",
+		Constants: []cfgConstant{{Name: "СтавкаНДС", Type: "number", Length: 5, Scale: 2, Label: "НДС"}},
+	}
+	html := renderCfgTree(t, data)
+	for _, want := range []string{`name="length"`, `name="scale"`} {
+		if !strings.Contains(html, want) {
+			t.Errorf("constant-detail: нет фрагмента %q", want)
+		}
+	}
+}

--- a/internal/launcher/configurator_reg_save_test.go
+++ b/internal/launcher/configurator_reg_save_test.go
@@ -1,0 +1,167 @@
+package launcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// postCfg POST-ит форму в произвольный обработчик конфигуратора с заголовком
+// X-Onebase-Ajax (renderCfg отвечает JSON, без полного рендера страницы).
+func postCfg(t *testing.T, id, path string, form url.Values, fn http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Onebase-Ajax", "1")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	fn(rec, req)
+	return rec
+}
+
+func writeCfgFile(t *testing.T, dir, sub, name, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, sub, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func assertFileContains(t *testing.T, path string, fragments ...string) {
+	t.Helper()
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("чтение %s: %v", path, err)
+	}
+	got := string(out)
+	for _, must := range fragments {
+		if !strings.Contains(got, must) {
+			t.Errorf("в %s нет фрагмента %q\nполучилось:\n%s", filepath.Base(path), must, got)
+		}
+	}
+}
+
+// Регистр накопления: точность ресурса (number(L,P)) и добавленное измерение
+// должны сохраняться; title регистра — не теряться при round-trip.
+func TestConfiguratorSaveRegisterFields_PrecisionNewDimTitle(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "registers", "остатки.yaml", `name: Остатки
+title: Остатки товаров
+dimensions:
+  - name: Товар
+    type: string
+resources:
+  - name: Сумма
+    type: number
+`)
+	form := url.Values{}
+	form.Set("register", "Остатки")
+	form.Set("dim.0.name", "Товар")
+	form.Set("dim.0.type", "string")
+	form.Set("res.0.name", "Сумма")
+	form.Set("res.0.type", "number")
+	form.Set("res.0.length", "15")
+	form.Set("res.0.scale", "2")
+	form.Set("new_dim.1.name", "Склад")
+	form.Set("new_dim.1.type", "string")
+
+	rec := postCfg(t, "test", "/bases/test/configurator/register-fields", form, h.configuratorSaveRegisterFields)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+	assertFileContains(t, p, "type: number(15,2)", "name: Склад", "title: Остатки товаров")
+}
+
+// Регистр сведений: точность ресурса и добавленное измерение сохраняются.
+func TestConfiguratorSaveInfoRegFields_PrecisionNewDim(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "inforegs", "курсы.yaml", `name: Курсы
+title: Курсы валют
+dimensions:
+  - name: Валюта
+    type: string
+resources:
+  - name: Курс
+    type: number
+`)
+	form := url.Values{}
+	form.Set("inforeg", "Курсы")
+	form.Set("dim.0.name", "Валюта")
+	form.Set("dim.0.type", "string")
+	form.Set("res.0.name", "Курс")
+	form.Set("res.0.type", "number")
+	form.Set("res.0.length", "10")
+	form.Set("res.0.scale", "4")
+	form.Set("new_dim.1.name", "Регион")
+	form.Set("new_dim.1.type", "string")
+
+	rec := postCfg(t, "test", "/bases/test/configurator/inforeg-fields", form, h.configuratorSaveInfoRegFields)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+	assertFileContains(t, p, "type: number(10,4)", "name: Регион", "title: Курсы валют")
+}
+
+// План счетов: точность числового ресурса сохраняется.
+func TestConfiguratorSaveAccountRegister_ResourcePrecision(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "accountregs", "бухучёт.yaml", `name: Бухучёт
+resources:
+  - name: Сумма
+    type: number
+`)
+	form := url.Values{}
+	form.Set("accountreg", "Бухучёт")
+	form.Set("res.0.name", "Сумма")
+	form.Set("res.0.type", "number")
+	form.Set("res.0.length", "18")
+	form.Set("res.0.scale", "2")
+
+	rec := postCfg(t, "test", "/bases/test/configurator/account-register", form, h.configuratorSaveAccountRegister)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+	assertFileContains(t, p, "type: number(18,2)")
+}
+
+// Константа: точность числа сохраняется, а многоязычные labels не стираются
+// при сохранении через редактор (раньше локальный rawConst не имел поля Labels).
+func TestConfiguratorSaveConstant_PrecisionKeepsLabels(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "constants", "константы.yaml", `constants:
+  - name: СтавкаНДС
+    type: number
+    label: Ставка НДС
+    labels:
+      en: VAT rate
+`)
+	form := url.Values{}
+	form.Set("const_name", "СтавкаНДС")
+	form.Set("type", "number")
+	form.Set("length", "5")
+	form.Set("scale", "2")
+	form.Set("label", "Ставка НДС")
+
+	rec := postCfg(t, "test", "/bases/test/configurator/constant", form, h.configuratorSaveConstant)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+	assertFileContains(t, p, "type: number(5,2)", "labels:", "en: VAT rate")
+}

--- a/internal/launcher/configurator_tmpl.go
+++ b/internal/launcher/configurator_tmpl.go
@@ -939,18 +939,19 @@ function cfgAddTP(btn, entityName) {
   if (!tpName) return;
   var wrapper = document.createElement('details');
   wrapper.open = true;
-  var prefix = 'new_tp.'+_cfgNewTpIdx;
   var tblId = 'ft-'+entityName+'-ntp'+_cfgNewTpIdx;
+  // Поля новой ТЧ шлём под ИМЕННЫМ префиксом new_tp.<Имя>.field — тем же, что и
+  // «+ Добавить поле» у существующих ТЧ, чтобы их читал единый серверный цикл.
+  var fldPrefix = 'new_tp.'+tpName+'.field';
   wrapper.innerHTML = '<summary class="section-hd" style="cursor:pointer">📋 '+tpName+' (0)</summary>'
     +'<input type="hidden" name="new_tp_name" value="'+tpName+'">'
-    +'<input type="hidden" name="'+prefix+'.idx" value="'+_cfgNewTpIdx+'">'
     +'<div class="tp-block"><table class="fields-tbl" id="'+tblId+'">'
     +'<tr><th>{{t $.Lang "Поле"}}</th><th>{{t $.Lang "Тип"}}</th><th style="min-width:150px">{{t $.Lang "Объект"}}</th></tr>'
     +'</table>'
-    +'<button type="button" onclick="cfgAddField(\''+tblId+'\',\'new_tp.'+_cfgNewTpIdx+'.field\',\''+entityName+'\')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить поле"}}</button>'
+    +'<button type="button" onclick="cfgAddField(\''+tblId+'\',\''+fldPrefix+'\',\''+entityName+'\')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить поле"}}</button>'
     +'</div>';
   btn.parentNode.insertBefore(wrapper, btn);
-  cfgAddField(tblId, 'new_tp.'+_cfgNewTpIdx+'.field', entityName);
+  cfgAddField(tblId, fldPrefix, entityName);
 }
 // ── Predefined items row ──────────────────────────────────────────
 var _cfgPreRowIdx = 10000;
@@ -980,9 +981,14 @@ function cfgAddARField(tblId) {
   if (!tbl) return;
   tbl.style.display = '';
   var idx = tbl.querySelectorAll('tr').length - 1;
+  var numId = 'arn-new-'+idx;
   var tr = document.createElement('tr');
   tr.innerHTML = '<td><input type="text" name="res.'+idx+'.name" placeholder="ИмяРесурса" style="width:100%;font-size:12px;padding:2px 4px;border:1px solid #dde;border-radius:3px"></td>'
-    +'<td><select name="res.'+idx+'.type"><option value="number">{{t $.Lang "число"}}</option><option value="string">{{t $.Lang "строка"}}</option><option value="bool">{{t $.Lang "булево"}}</option></select></td>';
+    +'<td><select name="res.'+idx+'.type" onchange="cfgToggleNum(this,\''+numId+'\')"><option value="number">{{t $.Lang "число"}}</option><option value="string">{{t $.Lang "строка"}}</option><option value="bool">{{t $.Lang "булево"}}</option></select>'
+    +' <span id="'+numId+'" title="{{t $.Lang "Длина, Точность"}}">'
+    +'<input type="number" min="1" name="res.'+idx+'.length" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">'
+    +' , <input type="number" min="0" name="res.'+idx+'.scale" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">'
+    +'</span></td>';
   tbl.appendChild(tr);
   tr.querySelector('input').focus();
 }
@@ -5091,13 +5097,17 @@ const cfgTabTree = `{{define "tab-tree"}}
     <tr>
       <td>{{$f.Name}}</td>
       <td>
-        <select name="dim.{{$i}}.type" onchange="cfgToggleRef(this,'irdr-{{$ir.Name}}-{{$i}}')">
+        <select name="dim.{{$i}}.type" onchange="cfgToggleRef(this,'irdr-{{$ir.Name}}-{{$i}}');cfgToggleNum(this,'irdn-{{$ir.Name}}-{{$i}}')">
           <option value="string"    {{if eq $f.Type "string"}}selected{{end}}>{{t $.Lang "строка"}}</option>
           <option value="number"    {{if eq $f.Type "number"}}selected{{end}}>{{t $.Lang "число"}}</option>
           <option value="date"      {{if eq $f.Type "date"}}selected{{end}}>{{t $.Lang "дата"}}</option>
           <option value="bool"      {{if eq $f.Type "bool"}}selected{{end}}>{{t $.Lang "булево"}}</option>
           <option value="reference" {{if eq $f.Type "reference"}}selected{{end}}>{{t $.Lang "ссылка →"}}</option>
         </select>
+        <span id="irdn-{{$ir.Name}}-{{$i}}"{{if ne $f.Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+          <input type="number" min="1" name="dim.{{$i}}.length" value="{{if $f.Length}}{{$f.Length}}{{end}}" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+          , <input type="number" min="0" name="dim.{{$i}}.scale" value="{{if $f.Length}}{{$f.Scale}}{{end}}" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+        </span>
       </td>
       <td>
         <select name="dim.{{$i}}.ref" id="irdr-{{$ir.Name}}-{{$i}}"{{if ne $f.Type "reference"}} style="display:none"{{end}}>
@@ -5120,13 +5130,17 @@ const cfgTabTree = `{{define "tab-tree"}}
     <tr>
       <td>{{$f.Name}}</td>
       <td>
-        <select name="res.{{$i}}.type" onchange="cfgToggleRef(this,'irrr-{{$ir.Name}}-{{$i}}')">
+        <select name="res.{{$i}}.type" onchange="cfgToggleRef(this,'irrr-{{$ir.Name}}-{{$i}}');cfgToggleNum(this,'irrn-{{$ir.Name}}-{{$i}}')">
           <option value="string"    {{if eq $f.Type "string"}}selected{{end}}>{{t $.Lang "строка"}}</option>
           <option value="number"    {{if eq $f.Type "number"}}selected{{end}}>{{t $.Lang "число"}}</option>
           <option value="date"      {{if eq $f.Type "date"}}selected{{end}}>{{t $.Lang "дата"}}</option>
           <option value="bool"      {{if eq $f.Type "bool"}}selected{{end}}>{{t $.Lang "булево"}}</option>
           <option value="reference" {{if eq $f.Type "reference"}}selected{{end}}>{{t $.Lang "ссылка →"}}</option>
         </select>
+        <span id="irrn-{{$ir.Name}}-{{$i}}"{{if ne $f.Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+          <input type="number" min="1" name="res.{{$i}}.length" value="{{if $f.Length}}{{$f.Length}}{{end}}" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+          , <input type="number" min="0" name="res.{{$i}}.scale" value="{{if $f.Length}}{{$f.Scale}}{{end}}" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+        </span>
       </td>
       <td>
         <select name="res.{{$i}}.ref" id="irrr-{{$ir.Name}}-{{$i}}"{{if ne $f.Type "reference"}} style="display:none"{{end}}>
@@ -5174,11 +5188,15 @@ const cfgTabTree = `{{define "tab-tree"}}
     <tr>
       <td>{{$f.Name}}</td>
       <td>
-        <select name="res.{{$i}}.type">
+        <select name="res.{{$i}}.type" onchange="cfgToggleNum(this,'arn-{{$ar.Name}}-{{$i}}')">
           <option value="number" {{if eq $f.Type "number"}}selected{{end}}>{{t $.Lang "число"}}</option>
           <option value="string" {{if eq $f.Type "string"}}selected{{end}}>{{t $.Lang "строка"}}</option>
           <option value="bool"   {{if eq $f.Type "bool"}}selected{{end}}>{{t $.Lang "булево"}}</option>
         </select>
+        <span id="arn-{{$ar.Name}}-{{$i}}"{{if ne $f.Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+          <input type="number" min="1" name="res.{{$i}}.length" value="{{if $f.Length}}{{$f.Length}}{{end}}" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+          , <input type="number" min="0" name="res.{{$i}}.scale" value="{{if $f.Length}}{{$f.Scale}}{{end}}" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+        </span>
       </td>
     </tr>
     {{end}}
@@ -5230,13 +5248,17 @@ const cfgTabTree = `{{define "tab-tree"}}
       </div>
       <div class="fg" style="margin-top:8px">
         <label>{{t $.Lang "Тип"}}</label>
-        <select name="type" onchange="cfgToggleRef(this,'cnref-{{.Name}}')">
+        <select name="type" onchange="cfgToggleRef(this,'cnref-{{.Name}}');cfgToggleNum(this,'cnnum-{{.Name}}')">
           <option value="string" {{if eq .Type "string"}}selected{{end}}>{{t $.Lang "Строка"}}</option>
           <option value="number" {{if eq .Type "number"}}selected{{end}}>{{t $.Lang "Число"}}</option>
           <option value="date" {{if eq .Type "date"}}selected{{end}}>{{t $.Lang "Дата"}}</option>
           <option value="boolean" {{if eq .Type "boolean"}}selected{{end}}>{{t $.Lang "Булево"}}</option>
           <option value="reference" {{if eq .Type "reference"}}selected{{end}}>{{t $.Lang "Ссылка"}}</option>
         </select>
+        <span id="cnnum-{{.Name}}"{{if ne .Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+          <input type="number" min="1" name="length" value="{{if .Length}}{{.Length}}{{end}}" placeholder="дл" style="width:54px;padding:3px 5px;border:1px solid #cbd5e1;border-radius:4px;font-size:12px">
+          , <input type="number" min="0" name="scale" value="{{if .Length}}{{.Scale}}{{end}}" placeholder="точн" style="width:54px;padding:3px 5px;border:1px solid #cbd5e1;border-radius:4px;font-size:12px">
+        </span>
       </div>
       <div id="cnref-{{.Name}}" class="fg" style="margin-top:8px;{{if ne .Type "reference"}}display:none{{end}}">
         <label>{{t $.Lang "Объект"}}</label>
@@ -6481,22 +6503,25 @@ const cfgRegDetail = `{{define "register-detail"}}
 <form method="POST" action="/bases/{{$baseID}}/configurator/register-fields">
 <input type="hidden" name="register" value="{{$rg.Name}}">
 
-{{if $rg.Dimensions}}
 <div class="section-hd">{{t $.Lang "Измерения"}}</div>
-<table class="fields-tbl">
+<table class="fields-tbl" id="rg-dim-{{$rg.Name}}">
 <tr><th>{{t $.Lang "Поле"}}</th><th>{{t $.Lang "Тип"}}</th><th style="min-width:150px">{{t $.Lang "Объект"}}</th></tr>
 {{range $i, $f := $rg.Dimensions}}
 <input type="hidden" name="dim.{{$i}}.name" value="{{$f.Name}}">
 <tr>
   <td>{{$f.Name}}</td>
   <td>
-    <select name="dim.{{$i}}.type" onchange="cfgToggleRef(this,'cfr-{{$rg.Name}}-d{{$i}}')">
+    <select name="dim.{{$i}}.type" onchange="cfgToggleRef(this,'cfr-{{$rg.Name}}-d{{$i}}');cfgToggleNum(this,'cfn-{{$rg.Name}}-d{{$i}}')">
       <option value="string"    {{if eq $f.Type "string"}}selected{{end}}>{{t $.Lang "строка"}}</option>
       <option value="number"    {{if eq $f.Type "number"}}selected{{end}}>{{t $.Lang "число"}}</option>
       <option value="date"      {{if eq $f.Type "date"}}selected{{end}}>{{t $.Lang "дата"}}</option>
       <option value="bool"      {{if eq $f.Type "bool"}}selected{{end}}>{{t $.Lang "булево"}}</option>
       <option value="reference" {{if eq $f.Type "reference"}}selected{{end}}>{{t $.Lang "ссылка →"}}</option>
     </select>
+    <span id="cfn-{{$rg.Name}}-d{{$i}}"{{if ne $f.Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+      <input type="number" min="1" name="dim.{{$i}}.length" value="{{if $f.Length}}{{$f.Length}}{{end}}" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+      , <input type="number" min="0" name="dim.{{$i}}.scale" value="{{if $f.Length}}{{$f.Scale}}{{end}}" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+    </span>
   </td>
   <td>
     <select name="dim.{{$i}}.ref" id="cfr-{{$rg.Name}}-d{{$i}}"{{if ne $f.Type "reference"}} style="display:none"{{end}}>
@@ -6507,24 +6532,27 @@ const cfgRegDetail = `{{define "register-detail"}}
 </tr>
 {{end}}
 </table>
-{{end}}
+<button type="button" onclick="cfgAddField('rg-dim-{{$rg.Name}}','new_dim','')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить измерение"}}</button>
 
-{{if $rg.Resources}}
 <div class="section-hd">{{t $.Lang "Ресурсы"}}</div>
-<table class="fields-tbl">
+<table class="fields-tbl" id="rg-res-{{$rg.Name}}">
 <tr><th>{{t $.Lang "Поле"}}</th><th>{{t $.Lang "Тип"}}</th><th style="min-width:150px">{{t $.Lang "Объект"}}</th></tr>
 {{range $i, $f := $rg.Resources}}
 <input type="hidden" name="res.{{$i}}.name" value="{{$f.Name}}">
 <tr>
   <td>{{$f.Name}}</td>
   <td>
-    <select name="res.{{$i}}.type" onchange="cfgToggleRef(this,'cfr-{{$rg.Name}}-r{{$i}}')">
+    <select name="res.{{$i}}.type" onchange="cfgToggleRef(this,'cfr-{{$rg.Name}}-r{{$i}}');cfgToggleNum(this,'cfn-{{$rg.Name}}-r{{$i}}')">
       <option value="string"    {{if eq $f.Type "string"}}selected{{end}}>{{t $.Lang "строка"}}</option>
       <option value="number"    {{if eq $f.Type "number"}}selected{{end}}>{{t $.Lang "число"}}</option>
       <option value="date"      {{if eq $f.Type "date"}}selected{{end}}>{{t $.Lang "дата"}}</option>
       <option value="bool"      {{if eq $f.Type "bool"}}selected{{end}}>{{t $.Lang "булево"}}</option>
       <option value="reference" {{if eq $f.Type "reference"}}selected{{end}}>{{t $.Lang "ссылка →"}}</option>
     </select>
+    <span id="cfn-{{$rg.Name}}-r{{$i}}"{{if ne $f.Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+      <input type="number" min="1" name="res.{{$i}}.length" value="{{if $f.Length}}{{$f.Length}}{{end}}" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+      , <input type="number" min="0" name="res.{{$i}}.scale" value="{{if $f.Length}}{{$f.Scale}}{{end}}" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+    </span>
   </td>
   <td>
     <select name="res.{{$i}}.ref" id="cfr-{{$rg.Name}}-r{{$i}}"{{if ne $f.Type "reference"}} style="display:none"{{end}}>
@@ -6535,24 +6563,27 @@ const cfgRegDetail = `{{define "register-detail"}}
 </tr>
 {{end}}
 </table>
-{{end}}
+<button type="button" onclick="cfgAddField('rg-res-{{$rg.Name}}','new_res','')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить ресурс"}}</button>
 
-{{if $rg.Attributes}}
 <div class="section-hd">{{t $.Lang "Реквизиты"}}</div>
-<table class="fields-tbl">
+<table class="fields-tbl" id="rg-attr-{{$rg.Name}}">
 <tr><th>{{t $.Lang "Поле"}}</th><th>{{t $.Lang "Тип"}}</th><th style="min-width:150px">{{t $.Lang "Объект"}}</th></tr>
 {{range $i, $f := $rg.Attributes}}
 <input type="hidden" name="attr.{{$i}}.name" value="{{$f.Name}}">
 <tr>
   <td>{{$f.Name}}</td>
   <td>
-    <select name="attr.{{$i}}.type" onchange="cfgToggleRef(this,'cfr-{{$rg.Name}}-a{{$i}}')">
+    <select name="attr.{{$i}}.type" onchange="cfgToggleRef(this,'cfr-{{$rg.Name}}-a{{$i}}');cfgToggleNum(this,'cfn-{{$rg.Name}}-a{{$i}}')">
       <option value="string"    {{if eq $f.Type "string"}}selected{{end}}>{{t $.Lang "строка"}}</option>
       <option value="number"    {{if eq $f.Type "number"}}selected{{end}}>{{t $.Lang "число"}}</option>
       <option value="date"      {{if eq $f.Type "date"}}selected{{end}}>{{t $.Lang "дата"}}</option>
       <option value="bool"      {{if eq $f.Type "bool"}}selected{{end}}>{{t $.Lang "булево"}}</option>
       <option value="reference" {{if eq $f.Type "reference"}}selected{{end}}>{{t $.Lang "ссылка →"}}</option>
     </select>
+    <span id="cfn-{{$rg.Name}}-a{{$i}}"{{if ne $f.Type "number"}} style="display:none"{{end}} title="{{t $.Lang "Длина, Точность"}}">
+      <input type="number" min="1" name="attr.{{$i}}.length" value="{{if $f.Length}}{{$f.Length}}{{end}}" placeholder="дл" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+      , <input type="number" min="0" name="attr.{{$i}}.scale" value="{{if $f.Length}}{{$f.Scale}}{{end}}" placeholder="точн" style="width:46px;padding:2px 3px;border:1px solid #ccd0d8;border-radius:3px;font-size:11px">
+    </span>
   </td>
   <td>
     <select name="attr.{{$i}}.ref" id="cfr-{{$rg.Name}}-a{{$i}}"{{if ne $f.Type "reference"}} style="display:none"{{end}}>
@@ -6563,7 +6594,7 @@ const cfgRegDetail = `{{define "register-detail"}}
 </tr>
 {{end}}
 </table>
-{{end}}
+<button type="button" onclick="cfgAddField('rg-attr-{{$rg.Name}}','new_attr','')" style="font-size:11px;color:#1a4a80;background:none;border:1px dashed #c0c8d8;padding:2px 8px;border-radius:3px;cursor:pointer;margin:4px 0">+ {{t $.Lang "Добавить реквизит"}}</button>
 
 <div class="module-save-row" style="margin-bottom:14px">
   <button class="btn-save" type="submit">{{t $.Lang "Сохранить типы полей"}}</button>

--- a/internal/launcher/configurator_tp_save_test.go
+++ b/internal/launcher/configurator_tp_save_test.go
@@ -1,0 +1,108 @@
+package launcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// saveFieldsForm POST-ит форму редактора реквизитов в configuratorSaveFields
+// с заголовком X-Onebase-Ajax (renderCfg вернёт JSON, без полного рендера).
+func saveFieldsForm(t *testing.T, h *handler, id string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/bases/"+id+"/configurator/fields",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Onebase-Ajax", "1")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.configuratorSaveFields(rec, req)
+	return rec
+}
+
+// Регрессия (issue: правки ТЧ не сохраняются). Покрывает разом:
+//   - Баг A: поле, добавленное в СУЩЕСТВУЮЩУЮ ТЧ (префикс new_tp.<имя>.field.*),
+//     теряется, потому что ни один серверный цикл его не читал;
+//   - Баг B: новая ТЧ (new_tp_name + new_tp.<имя>.field.*) не сохранялась
+//     (applyFieldEdits не добавлял новые ТЧ; имя/idx расходились);
+//   - точность децимала и тип «дата» у добавляемых полей ТЧ.
+func TestConfiguratorSaveFields_TablePartEdits(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "catalogs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yamlPath := filepath.Join(cfgDir, "catalogs", "номенклатура.yaml")
+	initial := `name: Номенклатура
+fields:
+  - name: Наименование
+    type: string
+tableparts:
+  - name: Цены
+    fields:
+      - name: Сумма
+        type: number
+`
+	if err := os.WriteFile(yamlPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set("entity", "Номенклатура")
+	form.Set("entity_kind", "Справочник")
+	// шапка
+	form.Set("field.0.name", "Наименование")
+	form.Set("field.0.type", "string")
+	// существующая ТЧ «Цены»: исходное поле + добавленный реквизит-децимал
+	form.Set("tp_names", "Цены")
+	form.Set("tp.Цены.field.0.name", "Сумма")
+	form.Set("tp.Цены.field.0.type", "number")
+	form.Set("new_tp.Цены.field.1.name", "Скидка")
+	form.Set("new_tp.Цены.field.1.type", "number")
+	form.Set("new_tp.Цены.field.1.length", "15")
+	form.Set("new_tp.Цены.field.1.scale", "2")
+	// новая ТЧ «Состав» с числом и датой
+	form.Set("new_tp_name", "Состав")
+	form.Set("new_tp.Состав.field.2.name", "Количество")
+	form.Set("new_tp.Состав.field.2.type", "number")
+	form.Set("new_tp.Состав.field.3.name", "ДатаОтгрузки")
+	form.Set("new_tp.Состав.field.3.type", "date")
+
+	rec := saveFieldsForm(t, h, "test", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код ответа %d: %s", rec.Code, rec.Body.String())
+	}
+
+	out, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("чтение YAML: %v", err)
+	}
+	got := string(out)
+
+	for _, must := range []string{
+		// исходное поле ТЧ не потеряно
+		"name: Сумма",
+		// Баг A: реквизит, добавленный в существующую ТЧ, сохранён с точностью
+		"name: Скидка",
+		"type: number(15,2)",
+		// Баг B: новая ТЧ сохранена
+		"name: Состав",
+		"name: Количество",
+		// тип «дата» в новой ТЧ сохранён
+		"name: ДатаОтгрузки",
+		"type: date",
+	} {
+		if !strings.Contains(got, must) {
+			t.Errorf("в YAML после сохранения нет ожидаемого фрагмента %q\nполучилось:\n%s", must, got)
+		}
+	}
+}


### PR DESCRIPTION
## Что исправлено

### Табличные части (исходный баг-репорт)
- **Поле, добавленное в существующую ТЧ, не сохранялось** — кнопка «+ Добавить поле» слала ключи `new_tp.<Имя>.field.*`, которые не читал ни один серверный цикл. Добавлен единый цикл по именам (`formRowIndices` + `buildTPSaveField`), дочитывающий и дописывающий реквизит к нужной ТЧ.
- **Новая ТЧ не сохранялась** — `applyFieldEdits` не добавлял новые ТЧ (только обновлял существующие), а `cfgAddTP` расщеплял имя/idx. Теперь ТЧ добавляется, фронтенд шлёт поля под тем же именным префиксом.
- **Децимал → целое, дата → строка** — оказались следствием потери всего добавленного поля (DDL/миграция ТЧ были корректны). После фикса точность `number(L,P)` и тип `date` сохраняются.
- Кнопка «Сохранить типы полей» проверена — нужна и не дублируется.

### Похожие проблемы в других редакторах
- **Точность чисел (Длина/Точность)** теперь задаётся в UI и не стирается при сохранении: регистр накопления, регистр сведений, план счетов, константы (общий `parseRegSection` + инпуты в шаблонах).
- **Регистр накопления**: добавлены кнопки «+ Добавить измерение/ресурс/реквизит» (раньше нельзя было добавить поле через UI).
- **Регистр сведений**: новые измерения/ресурсы больше не теряются.
- **Round-trip**: многоязычные `labels:` констант и `Title/Titles` регистров/инфорегистров больше не стираются при сохранении.

## Тесты
9 новых тестов (TDD): HTTP-сохранение ТЧ и регистров/констант, render-тесты наличия инпутов Длина/Точность и кнопок «Добавить». Полный прогон зелёный (48 пакетов), `go vet` чист, `onebase check` на примере `trade` проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
