### PR TITLE
fix(dsl): раздел объявления переменных модуля (Перем) перед процедурами (issue #115)

### DIFF
--- a/internal/dsl/ast/ast.go
+++ b/internal/dsl/ast/ast.go
@@ -13,6 +13,10 @@ type Expr interface {
 }
 
 type Program struct {
+	// ModuleVars — раздел объявления переменных модуля (Перем … [Экспорт];),
+	// идущий в начале модуля до процедур и функций (как в 1С). Модули объекта
+	// из выгрузок 1С часто начинаются с него (issue #115).
+	ModuleVars []*VarDecl
 	Procedures []*ProcedureDecl
 }
 
@@ -46,7 +50,12 @@ type AssignStmt struct {
 	Value  Expr
 }
 
-type VarDecl struct{ Names []token.Token }
+// VarDecl — объявление переменных: Перем а, б, в [Экспорт];. Exported отражает
+// модификатор «Экспорт» (значим для переменных модуля, см. ast.Program.ModuleVars).
+type VarDecl struct {
+	Names    []token.Token
+	Exported bool
+}
 
 type ForEachStmt struct {
 	Var        token.Token

--- a/internal/dsl/parser/parser.go
+++ b/internal/dsl/parser/parser.go
@@ -49,6 +49,16 @@ func (p *Parser) expectSemicolon() {
 
 func (p *Parser) ParseProgram() (*ast.Program, error) {
 	prog := &ast.Program{}
+	// Раздел объявления переменных модуля (как в 1С): ноль или более «Перем …»
+	// до процедур и функций. Модули объекта из выгрузок 1С начинаются с него,
+	// иначе парсер падал на «expected Procedure or Function, got "Перем"» (issue #115).
+	for p.cur.Type == token.VAR {
+		vd, err := p.parseVarDecl()
+		if err != nil {
+			return nil, err
+		}
+		prog.ModuleVars = append(prog.ModuleVars, vd)
+	}
 	for p.cur.Type != token.EOF {
 		if p.cur.Type != token.PROCEDURE && p.cur.Type != token.FUNCTION {
 			return nil, fmt.Errorf("%s:%d:%d: expected Procedure or Function, got %q",
@@ -341,8 +351,17 @@ func (p *Parser) parseVarDecl() (*ast.VarDecl, error) {
 		}
 		names = append(names, nameTok)
 	}
+	// Опциональный модификатор «Экспорт» (переменные модуля 1С: Перем X Экспорт;).
+	// Лексер токенизирует его как IDENT — распознаём по литералу, как parseProcedure.
+	exported := false
+	if p.cur.Type == token.IDENT {
+		if low := strings.ToLower(p.cur.Literal); low == "экспорт" || low == "export" {
+			exported = true
+			p.advance()
+		}
+	}
 	p.consumeSemi()
-	return &ast.VarDecl{Names: names}, nil
+	return &ast.VarDecl{Names: names, Exported: exported}, nil
 }
 
 func isCompoundAssign(t token.Type) bool {

--- a/internal/dsl/parser/parser_test.go
+++ b/internal/dsl/parser/parser_test.go
@@ -67,6 +67,48 @@ func TestParser_VarDeclCommaList(t *testing.T) {
 	}
 }
 
+func TestParser_ModuleVarSection(t *testing.T) {
+	// issue #115: модуль объекта обработки из выгрузки 1С начинается с раздела
+	// объявления переменных модуля (Перем … [Экспорт];) до процедур. Парсер не
+	// должен падать с «expected Procedure or Function, got "Перем"».
+	src := `Перем НастройкиСервиса Экспорт;
+Перем КэшТокена, ВремяОбновления;
+
+Процедура ПолучитьТокен() Экспорт
+КонецПроцедуры`
+
+	prog := parse(t, src)
+	if len(prog.ModuleVars) != 2 {
+		t.Fatalf("want 2 module var decls, got %d", len(prog.ModuleVars))
+	}
+	if !prog.ModuleVars[0].Exported {
+		t.Fatalf("first module var must be Exported (Перем … Экспорт)")
+	}
+	if got := prog.ModuleVars[0].Names[0].Literal; got != "НастройкиСервиса" {
+		t.Fatalf("module var name: want НастройкиСервиса, got %q", got)
+	}
+	if n := len(prog.ModuleVars[1].Names); n != 2 {
+		t.Fatalf("second decl: want 2 names, got %d", n)
+	}
+	if prog.ModuleVars[1].Exported {
+		t.Fatalf("second module var must not be Exported")
+	}
+	if len(prog.Procedures) != 1 {
+		t.Fatalf("want 1 procedure, got %d", len(prog.Procedures))
+	}
+}
+
+func TestParser_ModuleVarsOnly(t *testing.T) {
+	// Модуль из одних объявлений переменных, без процедур — тоже валиден.
+	prog := parse(t, "Перем А;\nПерем Б;\n")
+	if len(prog.ModuleVars) != 2 {
+		t.Fatalf("want 2 module var decls, got %d", len(prog.ModuleVars))
+	}
+	if len(prog.Procedures) != 0 {
+		t.Fatalf("want 0 procedures, got %d", len(prog.Procedures))
+	}
+}
+
 func TestParser_OnWriteProcedure(t *testing.T) {
 	src := `Procedure OnWrite()
   If this.Number = "" Then


### PR DESCRIPTION
Closes #115.

## Проблема
При загрузке выгрузки 1С в файлы парсер падал на модуле объекта обработки:
`efactura_api.proc.os:1:1: expected Procedure or Function, got "Перем"`

## Причина
`ParseProgram` (`internal/dsl/parser/parser.go`) разбирал только раздел процедур/функций. Токен `Перем` поддерживался лишь внутри тела процедур (`parseVarDecl`), а раздел объявления переменных модуля в начале файла (структура модуля 1С: переменные → процедуры → тело) — нет. Первый же `Перем` на верхнем уровне валил разбор. Баг существовал с момента появления парсера, в одном ряду с уже сделанными фиксами толерантности к выгрузкам 1С (BOM, директивы `#Область`).

## Исправление
- `ParseProgram` разбирает ноль или более `Перем …` в начале модуля → `Program.ModuleVars` (строго до процедур, как в 1С);
- `parseVarDecl` принимает опциональный модификатор `Экспорт` (`Перем X Экспорт;`), по образцу обработки `Экспорт` в `parseProcedure`;
- рантайм не затронут: обращение к необъявленной переменной и так резолвится в `Неопределено`; разделяемое состояние модуля между процедурами в OneBase архитектурно отсутствует и вне объёма этого фикса (YAGNI).

## Проверка
- Новые тесты `TestParser_ModuleVarSection`, `TestParser_ModuleVarsOnly` — сначала падали с тем же сообщением, после правки проходят; существующие тесты парсера (включая `VarDeclCommaList`, `ExportModifier`) не сломаны.
- `go build ./...`, `go vet ./internal/dsl/...` — чисто.
- `go test ./...` — полная регрессия без падений.
- End-to-end: `onebase check` на проекте с `Перем … Экспорт;` в начале модуля обработки → «OK: ошибок не найдено».

🤖 Generated with [Claude Code](https://claude.com/claude-code)