### PR TITLE
fix(dsl): ключевые слова как имена свойств после точки (#117)

### DIFF
--- a/internal/dsl/parser/parser.go
+++ b/internal/dsl/parser/parser.go
@@ -681,10 +681,14 @@ func (p *Parser) parsePostfix(expr ast.Expr) ast.Expr {
 			expr = &ast.CallExpr{Callee: expr, Args: args}
 		case token.DOT:
 			p.advance()
-			field, err := p.expect(token.IDENT)
-			if err != nil {
+			// Имя свойства/метода после точки может совпадать с ключевым словом
+			// (например, XDTO-объект с полем «To»/«По»): в позиции члена они —
+			// обычные идентификаторы, а не синтаксис языка (issue #117).
+			if p.cur.Type != token.IDENT && !token.IsKeyword(p.cur.Type) {
 				return expr
 			}
+			field := p.cur
+			p.advance()
 			expr = &ast.MemberExpr{Object: expr, Field: field}
 		case token.LBRACKET:
 			p.advance()

--- a/internal/dsl/parser/parser_test.go
+++ b/internal/dsl/parser/parser_test.go
@@ -162,6 +162,66 @@ EndProcedure`
 	}
 }
 
+func TestParser_KeywordAsMemberName(t *testing.T) {
+	// issue #117: имя свойства/метода после точки может совпадать с
+	// зарезервированным словом (XDTO-объект с полями «To»/«По»). В позиции члена
+	// это обычные идентификаторы, и синтаксис-контроль не должен на них падать.
+	src := `Процедура Тест()
+  Запрос.To = КонецПериода;
+  Рез = Запрос.По;
+  Объект.Если("x");
+КонецПроцедуры`
+
+	prog := parse(t, src)
+	body := prog.Procedures[0].Body
+	if len(body) != 3 {
+		t.Fatalf("want 3 stmts, got %d", len(body))
+	}
+
+	// Запрос.To = … — присваивание в свойство-ключевое-слово (англ.)
+	assign, ok := body[0].(*ast.AssignStmt)
+	if !ok {
+		t.Fatalf("stmt 0: want *ast.AssignStmt, got %T", body[0])
+	}
+	tgt, ok := assign.Target.(*ast.MemberExpr)
+	if !ok {
+		t.Fatalf("stmt 0 target: want *ast.MemberExpr, got %T", assign.Target)
+	}
+	if tgt.Field.Literal != "To" {
+		t.Fatalf("stmt 0 field: want %q, got %q", "To", tgt.Field.Literal)
+	}
+
+	// Рез = Запрос.По — чтение свойства с русским ключевым словом
+	read, ok := body[1].(*ast.AssignStmt)
+	if !ok {
+		t.Fatalf("stmt 1: want *ast.AssignStmt, got %T", body[1])
+	}
+	m, ok := read.Value.(*ast.MemberExpr)
+	if !ok {
+		t.Fatalf("stmt 1 value: want *ast.MemberExpr, got %T", read.Value)
+	}
+	if m.Field.Literal != "По" {
+		t.Fatalf("stmt 1 field: want %q, got %q", "По", m.Field.Literal)
+	}
+
+	// Объект.Если("x") — вызов метода с именем-ключевым-словом
+	es, ok := body[2].(*ast.ExprStmt)
+	if !ok {
+		t.Fatalf("stmt 2: want *ast.ExprStmt, got %T", body[2])
+	}
+	call, ok := es.X.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("stmt 2: want *ast.CallExpr, got %T", es.X)
+	}
+	callee, ok := call.Callee.(*ast.MemberExpr)
+	if !ok {
+		t.Fatalf("stmt 2 callee: want *ast.MemberExpr, got %T", call.Callee)
+	}
+	if callee.Field.Literal != "Если" {
+		t.Fatalf("stmt 2 field: want %q, got %q", "Если", callee.Field.Literal)
+	}
+}
+
 func TestParser_AssignStmt(t *testing.T) {
 	src := `Procedure SetNum()
   Var x;

--- a/internal/dsl/token/token.go
+++ b/internal/dsl/token/token.go
@@ -153,6 +153,21 @@ func LookupIdent(ident string) Type {
 	return IDENT
 }
 
+// keywordTypes — множество типов-ключевых слов, построенное из карты keywords.
+// Самоподдерживается: любое слово, добавленное в keywords, попадает сюда.
+var keywordTypes = func() map[Type]bool {
+	m := make(map[Type]bool, len(keywords))
+	for _, t := range keywords {
+		m[t] = true
+	}
+	return m
+}()
+
+// IsKeyword сообщает, является ли тип зарезервированным ключевым словом. Нужно
+// для «контекстных» позиций (имя свойства/метода после точки), где ключевое
+// слово допустимо как обычный идентификатор.
+func IsKeyword(t Type) bool { return keywordTypes[t] }
+
 func (t Type) String() string {
 	switch t {
 	case ILLEGAL:


### PR DESCRIPTION
## Проблема

При импорте конфигурации синтаксис-контроль ложно падал на обращении к члену объекта, имя которого совпадает с зарезервированным словом языка:

```
efactura_api.proc.os:1332:14: unexpected "To" in expression
```

на строке `LogsRequest.To = КонецПериода;` (`To` — поле XDTO-объекта).

## Причина

В `parsePostfix` после `.` парсер требовал `token.IDENT`. Лексер превращает `to`/`по` в ключевое слово `TO` (верхняя граница цикла `Для … По …`), поэтому `expect(IDENT)` падал, постфиксный цикл «проглатывал» ошибку и выходил, а повисший `To` ниже давал `unexpected "To" in expression`. Баг затрагивал **любое** зарезервированное слово в позиции свойства/метода (`.To`, `.По`, `.Если`, …).

## Решение

- `token.IsKeyword(t)` — самоподдерживающееся множество типов-ключевых слов из карты `keywords`.
- В `parsePostfix` после `.` принимаем `IDENT` **или** любое ключевое слово как имя члена; оригинальный `Literal` (`To`/`По`) сохраняется. Правка точечная — затронут только разбор члена после точки; объявления имён (процедур, параметров, переменных) по-прежнему запрещают ключевые слова.

## Проверка

- Новый регрессионный тест `TestParser_KeywordAsMemberName` (запись `.To`, чтение `.По`, вызов метода `.Если(...)`): сначала падал с тем же `unexpected "To" in expression`, теперь зелёный.
- `go test ./internal/dsl/...` — без регрессий; `go build ./...` — OK.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)