### PR TITLE
fix(configurator): заготовка формы объекта по виду объекта (#133)

### DIFF
--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ivantit66/onebase/internal/configdb"
 	"github.com/ivantit66/onebase/internal/dsl/loader"
 	"github.com/ivantit66/onebase/internal/onec_forms"
+	"github.com/ivantit66/onebase/internal/project"
 )
 
 // ── Управляемые формы в конфигураторе (план 37, этап 4) ──────────────────────
@@ -266,12 +267,20 @@ func (h *handler) configuratorFormsEdit(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	if form == nil {
-		// «Новая форма» — заранее заполненный шаблон YAML.
+		// «Новая форма» — заранее заполненный шаблон YAML. Реквизиты группы
+		// строим из реальных реквизитов объекта (поля справочника/документа или
+		// параметры обработки/отчёта), а не из хардкода «Наименование» — у
+		// обработок такого реквизита нет (issue #133).
+		var attrs []formScaffoldAttr
+		if proj, perr := h.loadProjectFor(r.Context(), b); perr == nil {
+			attrs = objectScaffoldAttrs(proj, entity)
+			proj.Close()
+		}
 		form = &cfgManagedForm{
 			Entity: entity,
 			Name:   name,
 			Kind:   "object",
-			YAML:   newFormYAMLTemplate(entity, name),
+			YAML:   newFormYAMLTemplate(entity, name, attrs),
 		}
 	}
 
@@ -287,15 +296,65 @@ func (h *handler) configuratorFormsEdit(w http.ResponseWriter, r *http.Request) 
 	renderFormsEditor(w, data)
 }
 
-// newFormYAMLTemplate — начальный YAML при создании новой формы.
-func newFormYAMLTemplate(entity, name string) string {
+// formScaffoldAttr — реквизит объекта (поле справочника/документа либо параметр
+// обработки/отчёта), из которого строится заготовка новой формы.
+type formScaffoldAttr struct {
+	Name  string
+	Title string // синоним/подпись; пустой → подставляется Name
+}
+
+// objectScaffoldAttrs возвращает реквизиты объекта <entity> для заготовки новой
+// формы: поля справочника/документа либо параметры обработки/отчёта. Возвращает
+// nil, если объект не найден или у него нет реквизитов — тогда форма создаётся с
+// пустой группой, а не с полем «Наименование», которого у обработок нет (issue
+// #133).
+func objectScaffoldAttrs(proj *project.Project, entity string) []formScaffoldAttr {
+	if proj == nil || entity == "" {
+		return nil
+	}
+	for _, e := range proj.Entities {
+		if strings.EqualFold(e.Name, entity) {
+			attrs := make([]formScaffoldAttr, 0, len(e.Fields))
+			for _, f := range e.Fields {
+				attrs = append(attrs, formScaffoldAttr{Name: f.Name, Title: f.Title})
+			}
+			return attrs
+		}
+	}
+	for _, p := range proj.Processors {
+		if strings.EqualFold(p.Name, entity) {
+			attrs := make([]formScaffoldAttr, 0, len(p.Params))
+			for _, pr := range p.Params {
+				attrs = append(attrs, formScaffoldAttr{Name: pr.Name, Title: pr.Label})
+			}
+			return attrs
+		}
+	}
+	for _, rep := range proj.Reports {
+		if strings.EqualFold(rep.Name, entity) {
+			attrs := make([]formScaffoldAttr, 0, len(rep.Params))
+			for _, pr := range rep.Params {
+				attrs = append(attrs, formScaffoldAttr{Name: pr.Name, Title: pr.Label})
+			}
+			return attrs
+		}
+	}
+	return nil
+}
+
+// newFormYAMLTemplate — начальный YAML при создании новой формы. Группа
+// «Реквизиты» заполняется реальными реквизитами объекта (attrs); если их нет
+// (например, обработка без параметров) — группа остаётся пустой, без хардкодного
+// поля «Наименование» (issue #133).
+func newFormYAMLTemplate(entity, name string, attrs []formScaffoldAttr) string {
 	if name == "" {
 		name = "ФормаОбъекта"
 	}
 	if entity == "" {
 		entity = "Сущность"
 	}
-	return fmt.Sprintf(`schema: onebase.form/v1
+	var b strings.Builder
+	fmt.Fprintf(&b, `schema: onebase.form/v1
 form:
   name: %s
   kind: object
@@ -308,14 +367,34 @@ elements:
     name: Реквизиты
     title:
       ru: "Реквизиты"
-    children:
-      - kind: ПолеВвода
-        name: ПолеНаименование
-        title:
-          ru: "Наименование"
-        data_path: Объект.Наименование
-        required: true
 `, name, entity)
+	if len(attrs) == 0 {
+		// Реквизитов нет — пустая группа; пользователь добавит элементы сам.
+		b.WriteString("    children: []\n")
+		return b.String()
+	}
+	b.WriteString("    children:\n")
+	for _, a := range attrs {
+		title := a.Title
+		if title == "" {
+			title = a.Name
+		}
+		fmt.Fprintf(&b, `      - kind: ПолеВвода
+        name: Поле%s
+        title:
+          ru: %s
+        data_path: Объект.%s
+`, a.Name, yamlDQString(title), a.Name)
+	}
+	return b.String()
+}
+
+// yamlDQString оборачивает строку в безопасный YAML double-quoted скаляр
+// (экранирует обратный слэш и кавычку).
+func yamlDQString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
 }
 
 // configuratorFormsSave — POST: пишет YAML и (опционально) .form.os.

--- a/internal/launcher/forms_handlers_test.go
+++ b/internal/launcher/forms_handlers_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ivantit66/onebase/internal/dsl/loader"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/processor"
+	"github.com/ivantit66/onebase/internal/project"
 )
 
 // listManagedFormsFromFS должен возвращать nil/nil для проектов без forms/.
@@ -241,5 +244,88 @@ func TestFormFiles(t *testing.T) {
 	}
 	if op != wantOP {
 		t.Errorf("op = %q, want %q", op, wantOP)
+	}
+}
+
+// Issue #133: заготовка «Форма объекта» строится из реальных реквизитов объекта.
+// У обработки нет реквизита «Наименование» — шаблон не должен его подставлять.
+func TestNewFormYAMLTemplate_ScaffoldByKind(t *testing.T) {
+	proj := &project.Project{
+		Entities: []*metadata.Entity{
+			{Name: "Контрагент", Kind: metadata.KindCatalog, Fields: []metadata.Field{
+				{Name: "Наименование", Type: metadata.FieldTypeString},
+				{Name: "ИНН", Title: "ИНН контрагента", Type: metadata.FieldTypeString},
+			}},
+		},
+		Processors: []*processor.Processor{
+			{Name: "ЗагрузкаЦен", Params: []processor.Param{{Name: "Файл", Label: "Файл с ценами"}}},
+			{Name: "ПустаяОбработка"}, // без параметров — главный кейс issue #133
+		},
+	}
+
+	t.Run("обработка без параметров — пустая группа, без Наименования", func(t *testing.T) {
+		attrs := objectScaffoldAttrs(proj, "ПустаяОбработка")
+		if len(attrs) != 0 {
+			t.Fatalf("ожидалось 0 реквизитов, получили %d", len(attrs))
+		}
+		y := newFormYAMLTemplate("ПустаяОбработка", "ФормаОбъекта", attrs)
+		if strings.Contains(y, "Наименование") {
+			t.Errorf("шаблон обработки не должен содержать «Наименование»:\n%s", y)
+		}
+		if !strings.Contains(y, "children: []") {
+			t.Errorf("ожидалась пустая группа children: [] :\n%s", y)
+		}
+		// Сгенерированная форма обязана валидно загружаться.
+		mustLoadForm(t, y, "ПустаяОбработка")
+	})
+
+	t.Run("обработка с параметрами — поля из параметров", func(t *testing.T) {
+		attrs := objectScaffoldAttrs(proj, "ЗагрузкаЦен")
+		y := newFormYAMLTemplate("ЗагрузкаЦен", "ФормаОбъекта", attrs)
+		if strings.Contains(y, "Наименование") {
+			t.Errorf("шаблон обработки не должен содержать «Наименование»:\n%s", y)
+		}
+		if !strings.Contains(y, "data_path: Объект.Файл") {
+			t.Errorf("ожидалось поле по параметру «Файл»:\n%s", y)
+		}
+		if !strings.Contains(y, `ru: "Файл с ценами"`) {
+			t.Errorf("ожидалась подпись из Label параметра:\n%s", y)
+		}
+		mustLoadForm(t, y, "ЗагрузкаЦен")
+	})
+
+	t.Run("справочник — поля из метаданных, включая Наименование", func(t *testing.T) {
+		attrs := objectScaffoldAttrs(proj, "Контрагент")
+		y := newFormYAMLTemplate("Контрагент", "ФормаОбъекта", attrs)
+		if !strings.Contains(y, "data_path: Объект.Наименование") {
+			t.Errorf("шаблон справочника должен содержать поле «Наименование»:\n%s", y)
+		}
+		if !strings.Contains(y, "data_path: Объект.ИНН") || !strings.Contains(y, `ru: "ИНН контрагента"`) {
+			t.Errorf("шаблон справочника должен содержать поле «ИНН» с синонимом:\n%s", y)
+		}
+		mustLoadForm(t, y, "Контрагент")
+	})
+
+	t.Run("неизвестный объект — фолбэк на пустую группу", func(t *testing.T) {
+		if attrs := objectScaffoldAttrs(proj, "НетТакого"); attrs != nil {
+			t.Errorf("ожидался nil для неизвестного объекта, получили %v", attrs)
+		}
+		y := newFormYAMLTemplate("НетТакого", "ФормаОбъекта", nil)
+		if strings.Contains(y, "Наименование") {
+			t.Errorf("фолбэк-шаблон не должен содержать «Наименование»:\n%s", y)
+		}
+	})
+}
+
+// mustLoadForm проверяет, что YAML-заготовка валидно парсится загрузчиком
+// управляемых форм (тем же, что и live-валидация в конфигураторе).
+func mustLoadForm(t *testing.T, yaml, entity string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "x.form.yaml")
+	if err := os.WriteFile(p, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loader.NewManagedFormLoader().LoadFormFile(p, entity); err != nil {
+		t.Errorf("сгенерированная форма не загружается: %v\n%s", err, yaml)
 	}
 }


### PR DESCRIPTION
Шаблон новой «Формы объекта» строился с хардкодным полем Объект.Наименование для любого объекта. У обработок реквизита «Наименование» нет — конструктор открывался с неподходящим шаблоном справочника (а у документов поле было неуместно).

Теперь заготовка строится из реальных реквизитов объекта:
- справочник/документ — поля из метаданных (у справочника это и Наименование);
- обработка/отчёт — параметры (data_path: Объект.<Параметр>, подпись из Label);
- обработка без реквизитов — пустая группа children: [], без «Наименование»;
- объект не найден — пустой фолбэк.

objectScaffoldAttrs резолвит объект среди Entities/Processors/Reports; configuratorFormsEdit подгружает проект через loadProjectFor. Каждая сгенерированная форма в тесте дополнительно прогоняется через реальный ManagedFormLoader.