### PR TITLE
fix(dsl): понятная ошибка для оператора вне процедуры/функции (#128)

### DIFF
--- a/internal/dsl/parser/parser.go
+++ b/internal/dsl/parser/parser.go
@@ -61,7 +61,12 @@ func (p *Parser) ParseProgram() (*ast.Program, error) {
 	}
 	for p.cur.Type != token.EOF {
 		if p.cur.Type != token.PROCEDURE && p.cur.Type != token.FUNCTION {
-			return nil, fmt.Errorf("%s:%d:%d: expected Procedure or Function, got %q",
+			// На верхнем уровне модуля допустимы только объявления переменных
+			// (Перем …) и Процедуры/Функции — тела модуля (операторов вне
+			// процедур) в onebase нет, как и в модуле объекта 1С. Вместо
+			// невнятного «expected Procedure or Function, got "ф"» сообщаем
+			// причину и подсказываем, что делать (issue #128).
+			return nil, fmt.Errorf("%s:%d:%d: оператор «%s» вне процедуры или функции — поместите код в Процедуру или Функцию (тело модуля не поддерживается)",
 				p.cur.File, p.cur.Line, p.cur.Col, p.cur.Literal)
 		}
 		proc, err := p.parseProcedure()

--- a/internal/dsl/parser/parser_test.go
+++ b/internal/dsl/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ivantit66/onebase/internal/dsl/ast"
@@ -271,5 +272,30 @@ func TestParser_ExportModifier(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// issue #128: оператор вне процедуры/функции (попытка «тела модуля») должен
+// давать понятную ошибку с подсказкой, а не сырое и невнятное
+// «expected Procedure or Function, got "ф"».
+func TestParser_StatementOutsideProcedure_Issue128(t *testing.T) {
+	src := "Процедура Выполнить()\n  Сообщить(\"Привет!\")\nКонецПроцедуры\nф=6;\n"
+	_, err := parser.New(lexer.New(src, "test.os")).ParseProgram()
+	if err == nil {
+		t.Fatal("ожидалась ошибка на операторе вне процедуры, получили nil")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "expected Procedure or Function") {
+		t.Errorf("сообщение осталось невнятным англоязычным: %q", msg)
+	}
+	for _, want := range []string{"вне процедуры или функции", "«ф»", "Процедуру или Функцию"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("в сообщении нет %q: %q", want, msg)
+		}
+	}
+	// Координаты должны сохраниться как префикс file:line:col: — иначе сломается
+	// кликабельный переход к ошибке в конфигураторе (configcheck.parseErrLocRe).
+	if !strings.Contains(msg, "test.os:4:1:") {
+		t.Errorf("потеряны координаты file:line:col в сообщении: %q", msg)
 	}
 }


### PR DESCRIPTION
Код вне процедур/функций (попытка «тела модуля») давал сырое и невнятное «expected Procedure or Function, got "ф"». Тела модуля в onebase нет — как и в модуле объекта 1С, операторы должны лежать внутри Процедуры/Функции.

Поведение не меняется (код по-прежнему отвергается), но сообщение теперь объясняет причину и подсказывает, что делать:
«оператор «ф» вне процедуры или функции — поместите код в Процедуру или Функцию (тело модуля не поддерживается)». Префикс file:line:col сохранён, поэтому кликабельный переход к ошибке в конфигураторе (configcheck) и координаты «(стр. 4, поз. 1)» продолжают работать.