### PR TITLE
fix(configurator): позиционировать дерево на созданном объекте (#127)

### DIFF
--- a/internal/launcher/configurator.go
+++ b/internal/launcher/configurator.go
@@ -2579,7 +2579,34 @@ func (h *handler) configuratorNewObject(w http.ResponseWriter, r *http.Request) 
 	data := h.loadCfgData(r.Context(), b, "tree")
 	data.FieldsSavedEntity = name
 	data.FieldsSaved = true
+	// issue #127: спозиционировать дерево на только что созданном объекте —
+	// передаём точный data-id его узла, дальше клиент раскроет группу,
+	// проскроллит и выделит его.
+	data.SelectedTreeID = treeNodeID(kind, name)
 	renderCfg(w, r, data)
+}
+
+// treeNodeID возвращает data-id узла дерева конфигуратора для (вид, имя). Набор
+// префиксов обязан совпадать с разметкой дерева (configurator_tmpl.go) и
+// перечнем видов в newObjectContent. Пустая строка — для видов без узла в дереве.
+func treeNodeID(kind, name string) string {
+	prefix := map[string]string{
+		"catalog":    "e-",
+		"document":   "e-",
+		"register":   "r-",
+		"inforeg":    "ir-",
+		"accountreg": "ar-",
+		"enum":       "en-",
+		"subsystem":  "sub-",
+		"widget":     "wdg-",
+		"processor":  "proc-",
+		"page":       "page-",
+		"module":     "mod-",
+	}[kind]
+	if prefix == "" {
+		return ""
+	}
+	return prefix + name
 }
 
 func newObjectContent(kind, name string) (subdir, content string) {

--- a/internal/launcher/configurator_newobject_test.go
+++ b/internal/launcher/configurator_newobject_test.go
@@ -18,3 +18,44 @@ func TestNewModuleContent(t *testing.T) {
 		t.Errorf("в скелете модуля нет экспортной процедуры: %q", content)
 	}
 }
+
+// treeNodeID должен возвращать data-id узла дерева, совпадающий с разметкой
+// configurator_tmpl.go, для каждого вида объекта (issue #127).
+func TestTreeNodeID(t *testing.T) {
+	cases := map[string]string{
+		"catalog":    "e-Контрагент",
+		"document":   "e-Контрагент",
+		"register":   "r-Контрагент",
+		"inforeg":    "ir-Контрагент",
+		"accountreg": "ar-Контрагент",
+		"enum":       "en-Контрагент",
+		"subsystem":  "sub-Контрагент",
+		"widget":     "wdg-Контрагент",
+		"processor":  "proc-Контрагент",
+		"page":       "page-Контрагент",
+		"module":     "mod-Контрагент",
+	}
+	for kind, want := range cases {
+		if got := treeNodeID(kind, "Контрагент"); got != want {
+			t.Errorf("treeNodeID(%q) = %q, ожидалось %q", kind, got, want)
+		}
+	}
+	if got := treeNodeID("неизвестный", "X"); got != "" {
+		t.Errorf("неизвестный вид → ожидалась пустая строка, получено %q", got)
+	}
+}
+
+// Инвариант: любой вид, который умеет создавать newObjectContent (непустой
+// subdir), обязан иметь узел в дереве (непустой treeNodeID) — иначе после
+// создания позиционироваться будет не на что (issue #127).
+func TestTreeNodeID_CoversCreatableKinds(t *testing.T) {
+	kinds := []string{"catalog", "document", "register", "inforeg", "enum", "subsystem", "widget", "accountreg", "processor", "page", "module"}
+	for _, kind := range kinds {
+		if subdir, _ := newObjectContent(kind, "Тест"); subdir == "" {
+			t.Fatalf("newObjectContent(%q) вернул пустой subdir — обнови список видов в тесте", kind)
+		}
+		if treeNodeID(kind, "Тест") == "" {
+			t.Errorf("вид %q создаётся, но treeNodeID пуст — узел дерева не подсветится после создания", kind)
+		}
+	}
+}

--- a/internal/launcher/static/configurator.js
+++ b/internal/launcher/static/configurator.js
@@ -1064,14 +1064,38 @@ document.addEventListener('keydown', function(e) {
     if (s2 && document.activeElement === s2 && s2.value) { s2.value = ''; filterTree(''); }
   }
 });
-(function(){
+// Поиск узла дерева по точному data-id строковым сравнением — устойчиво к
+// кавычкам/спецсимволам в имени объекта (CSS-селектор на них спотыкается).
+function cfgFindItem(id){
+  if(!id) return null;
+  var all=document.querySelectorAll('[data-id]');
+  for(var i=0;i<all.length;i++){ if(all[i].getAttribute('data-id')===id) return all[i]; }
+  return null;
+}
+// Автовыбор узла дерева после загрузки/перезагрузки: точный selectedTreeId
+// (например, после создания объекта — issue #127) либо prefix-поиск по имени
+// сохранённого объекта. Раскрывает свёрнутую группу, а при явном создании/выборе
+// (directId) ещё и скроллит к узлу с краткой подсветкой. Выполняется по готовности
+// DOM: главный <script> подключается ДО разметки дерева, поэтому без этого узлов
+// в DOM ещё нет.
+function cfgAutoSelect(){
   var directId = window.__cfg.selectedTreeId;
   var saved = window.__cfg.fieldsSaved || window.__cfg.moduleSaved;
   var el=null;
-  if(directId)el=document.querySelector('[data-id="'+directId+'"]');
-  if(!el&&saved&&saved!=='')['e-','r-','ir-','ar-','en-','cn-','rep-','mod-','proc-','pf-','dpf-','mkt-','sub-','panel-app'].forEach(function(p){if(!el)el=document.querySelector('[data-id="'+p+saved+'"]');});
-  if(el)selItem(el);else{var f=document.querySelector('.cfg-item');if(f)selItem(f);}
-})();
+  if(directId)el=cfgFindItem(directId);
+  if(!el&&saved&&saved!=='')['e-','r-','ir-','ar-','en-','cn-','rep-','mod-','proc-','pf-','dpf-','mkt-','sub-','wdg-','page-','panel-app'].forEach(function(p){if(!el)el=cfgFindItem(p+saved);});
+  if(el){
+    var grp=el.closest('details.cfg-tree'); if(grp)grp.open=true;   // раскрыть свёрнутую группу
+    selItem(el);
+    if(directId){                                                   // явное создание/выбор — проскроллить и подсветить
+      try{el.scrollIntoView({block:'center'});}catch(e){el.scrollIntoView();}
+      el.style.outline='2px solid #f59e0b';
+      setTimeout(function(){el.style.outline='';},1600);
+    }
+  } else {var f=document.querySelector('.cfg-item');if(f)selItem(f);}
+}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',cfgAutoSelect);
+else cfgAutoSelect();
 
 // ── Module tabs ────────────────────────────────────────────────
 function modTab(el, panelId) {


### PR DESCRIPTION
После создания объекта дерево не прокручивалось к нему, а его группа могла быть свёрнута — новый объект оставался невидимым. Причина: автовыбор узла (IIFE по window.__cfg.selectedTreeId) выполнялся синхронно, ДО появления разметки дерева в DOM (главный <script> подключается раньше дерева), и selItem не раскрывал свёрнутую группу и не скроллил.

- configuratorNewObject теперь проставляет точный data-id узла нового объекта в SelectedTreeID (через новый treeNodeID(kind, name): карта видов→префиксов, совпадающая с разметкой дерева);
- автовыбор вынесен в cfgAutoSelect и запускается по готовности DOM; раскрывает свёрнутую группу <details>, а при явном создании/выборе скроллит к узлу (scrollIntoView, center) с краткой подсветкой;
- поиск узла — строковым сравнением data-id (устойчиво к спецсимволам в имени), в fallback-список префиксов добавлены page-/wdg-.

Тесты: TestTreeNodeID + инвариант TestTreeNodeID_CoversCreatableKinds (каждый создаваемый вид имеет узел в дереве). JS-синтаксис проверен node --check.