### PR TITLE
feat(configurator): изменяемая ширина боковых панелей дерева и отладк…

### DIFF
--- a/internal/launcher/static/configurator.css
+++ b/internal/launcher/static/configurator.css
@@ -16,10 +16,16 @@ body{font-family:'Segoe UI',Arial,sans-serif;font-size:13px;background:#f0f2f5;h
 
 /* ── Two-panel tree ─────────────────────────────────── */
 .cfg-split{display:flex;flex:1;overflow:hidden}
-.cfg-left{width:220px;flex-shrink:0;background:#fff;border-right:1px solid #d8dde8;overflow-y:auto;padding:6px 0;transition:width .2s}
+.cfg-left{width:var(--cfg-left-w,220px);flex-shrink:0;background:#fff;border-right:1px solid #d8dde8;overflow-y:auto;padding:6px 0;transition:width .2s}
 .cfg-left.collapsed{width:0;padding:0;overflow:hidden;border:none}
-.sidebar-toggle{position:absolute;left:220px;top:50%;z-index:10;width:16px;height:40px;background:#e8ecf2;border:1px solid #d8dde8;border-left:none;border-radius:0 4px 4px 0;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:10px;color:#666;transition:left .2s}
+.sidebar-toggle{position:absolute;left:var(--cfg-left-w,220px);top:50%;z-index:10;width:16px;height:40px;background:#e8ecf2;border:1px solid #d8dde8;border-left:none;border-radius:0 4px 4px 0;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:10px;color:#666;transition:left .2s}
 .sidebar-toggle.collapsed{left:0}
+/* ── Перетаскиваемые разделители панелей (issue #131) ── */
+.cfg-resizer{flex:0 0 5px;align-self:stretch;cursor:col-resize;background:transparent;position:relative;z-index:6;transition:background .15s}
+.cfg-resizer:hover,.cfg-resizer.dragging{background:#bcd0ec}
+.cfg-left.collapsed + .cfg-resizer{display:none}
+body.cfg-resizing{cursor:col-resize}
+body.cfg-resizing .cfg-left,body.cfg-resizing .dbg-panel{transition:none}
 .cfg-group{font-size:11px;font-weight:700;color:#888;text-transform:uppercase;letter-spacing:.5px;padding:10px 12px 4px;margin-top:4px}
 .cfg-tree details summary{font-size:11px;font-weight:700;color:#888;text-transform:uppercase;letter-spacing:.5px;padding:10px 12px 4px;margin-top:4px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:2px}
 .cfg-tree details summary::-webkit-details-marker{display:none}
@@ -236,7 +242,7 @@ pre.convert-out{background:#f5f7fa;border:1px solid #e2e6ed;padding:12px;border-
 .cfg-menu-dropdown a:last-child{border-bottom:none}
 .cfg-menu-dropdown a:hover{background:#f0f4ff;color:#1a4a80}
 
-.dbg-panel{width:320px;flex-shrink:0;background:#fff;border-left:1px solid #d8dde8;display:flex;flex-direction:column;overflow:hidden}
+.dbg-panel{width:var(--cfg-dbg-w,320px);flex-shrink:0;background:#fff;border-left:1px solid #d8dde8;display:flex;flex-direction:column;overflow:hidden}
 .dbg-status{padding:8px 12px;font-size:12px;font-weight:600;border-bottom:1px solid #eef0f5;display:flex;align-items:center;gap:6px}
 .dbg-status .dot{width:8px;height:8px;border-radius:50%;display:inline-block}
 .dbg-status .dot.running{background:#16a34a}

--- a/internal/launcher/static/configurator.js
+++ b/internal/launcher/static/configurator.js
@@ -1035,6 +1035,65 @@ function initTree() { applyGroupOrder(); initTreeDnd(); }
 initTree();
 document.addEventListener('DOMContentLoaded', initTree);
 
+// ── Перетаскиваемые разделители боковых панелей (issue #131) ────────────────
+// Ширина панели хранится в CSS-переменной (--cfg-left-w / --cfg-dbg-w) и
+// localStorage. .collapsed перебивает переменную по специфичности, поэтому
+// сворачивание дерева продолжает работать. side:'right' — ручка справа от панели
+// (дерево слева), 'left' — слева (панель отладки справа).
+function cfgMakeResizer(target, opts){
+  var h=document.createElement('div');
+  h.className='cfg-resizer';
+  if(opts.id)h.id=opts.id;
+  h.title='Потяните, чтобы изменить ширину';
+  if(opts.side==='left')target.parentNode.insertBefore(h,target);
+  else target.parentNode.insertBefore(h,target.nextSibling);
+  h.addEventListener('pointerdown',function(e){
+    e.preventDefault();
+    try{h.setPointerCapture(e.pointerId);}catch(_){}
+    h.classList.add('dragging');
+    document.body.classList.add('cfg-resizing');
+    var startX=e.clientX, startW=target.getBoundingClientRect().width;
+    function move(ev){
+      var dx=ev.clientX-startX;
+      var w=opts.side==='left'?startW-dx:startW+dx;
+      w=Math.max(opts.min,Math.min(opts.max,w));
+      document.documentElement.style.setProperty(opts.cssVar,w+'px');
+    }
+    function up(){
+      h.classList.remove('dragging');
+      document.body.classList.remove('cfg-resizing');
+      h.removeEventListener('pointermove',move);
+      h.removeEventListener('pointerup',up);
+      var cur=getComputedStyle(document.documentElement).getPropertyValue(opts.cssVar).trim();
+      try{localStorage.setItem(opts.storeKey,cur);}catch(_){}
+    }
+    h.addEventListener('pointermove',move);
+    h.addEventListener('pointerup',up);
+  });
+  // двойной клик по ручке — сброс к ширине по умолчанию
+  h.addEventListener('dblclick',function(){
+    document.documentElement.style.removeProperty(opts.cssVar);
+    try{localStorage.removeItem(opts.storeKey);}catch(_){}
+  });
+  return h;
+}
+function cfgRestoreVar(cssVar,storeKey){
+  try{var v=localStorage.getItem(storeKey);if(v)document.documentElement.style.setProperty(cssVar,v);}catch(_){}
+}
+function initResizers(){
+  cfgRestoreVar('--cfg-left-w','cfgLeftW');
+  cfgRestoreVar('--cfg-dbg-w','cfgDbgW');
+  var left=document.getElementById('cfg-sidebar');
+  if(left&&!left._rsz){left._rsz=cfgMakeResizer(left,{side:'right',cssVar:'--cfg-left-w',storeKey:'cfgLeftW',min:150,max:600});}
+  var dbg=document.getElementById('dbg-panel');
+  if(dbg&&!dbg._rsz){
+    var rz=cfgMakeResizer(dbg,{side:'left',cssVar:'--cfg-dbg-w',storeKey:'cfgDbgW',min:220,max:680,id:'dbg-resizer'});
+    rz.style.display=(dbg.style.display==='none')?'none':'';   // показывается вместе с панелью отладки
+    dbg._rsz=rz;
+  }
+}
+document.addEventListener('DOMContentLoaded',initResizers);
+
 // ── Поиск/фильтр по дереву метаданных (как в 1С) ───────────────────────────
 function filterTree(q) {
   q = (q || '').trim().toLowerCase();
@@ -3264,6 +3323,7 @@ function dbgToggle() {
         btn.innerHTML = '&#128027; Отладка: ВКЛ';
         btn.className = 'dbg-topbar-btn dbg-on';
         panel.style.display = 'flex';
+        var rzOn = document.getElementById('dbg-resizer'); if (rzOn) rzOn.style.display = '';   // issue #131
         dbgUpdateStatus('running', 'init');
         var diagEl = document.getElementById('dbg-diag');
         if (diagEl) diagEl.innerHTML = '<div style="color:#22c55e;font-size:10px">Enable OK: dbg=' + (d.dbg_ptr||'?') + ' sess=' + (d.sess_ptr||'?') + '</div>';
@@ -3278,6 +3338,7 @@ function dbgToggle() {
         btn.innerHTML = '&#128027; Отладка: ВЫКЛ';
         btn.className = 'dbg-topbar-btn';
         panel.style.display = 'none';
+        var rzOff = document.getElementById('dbg-resizer'); if (rzOff) rzOff.style.display = 'none';   // issue #131
         dbgStopPoll();
         dbgClearLineHighlight();
         dbgUpdateStatus('disabled', 'off');


### PR DESCRIPTION
…и (#131)

Ширина панели дерева конфигурации (.cfg-left, было 220px) и панели отладки (.dbg-panel, было 320px) была фиксированной. Теперь между панелями есть перетаскиваемый разделитель: ширина живёт в CSS-переменной (--cfg-left-w / --cfg-dbg-w) и сохраняется в localStorage; двойной клик по ручке сбрасывает к значению по умолчанию.

- ширина через CSS-переменную, поэтому .collapsed{width:0} по-прежнему перебивает её по специфичности — сворачивание дерева работает; кнопка sidebar-toggle следует за шириной (left:var(--cfg-left-w));
- cfgMakeResizer вставляет ручку-сплиттер сиблингом, drag по pointer-событиям с клампом [min,max] и снятием transition на время перетаскивания;
- ресайзер дерева прячется при свёрнутом дереве (CSS-селектор соседа), ресайзер отладки показывается/прячется вместе с панелью (dbgToggle + начальное состояние в initResizers).

UI-правка: Go-тестов нет, синтаксис JS проверен node --check, сборка зелёная.