### PR TITLE
fix(ui): скрывать админ-пункты меню от неадминистраторов (#149)

### DIFF
--- a/internal/ui/handlers_pos.go
+++ b/internal/ui/handlers_pos.go
@@ -6,6 +6,13 @@ import "net/http"
 // device-agent. Серверу хранить нечего (значения per-машина живут в localStorage
 // браузера), поэтому страница статична — только рендер формы.
 func (s *Server) agentSettings(w http.ResponseWriter, r *http.Request) {
+	// Настройки агента оборудования (адрес/токен устройства) — конфигурация
+	// уровня администратора. Без этой проверки страница была доступна любому
+	// аутентифицированному пользователю (issue #149).
+	if !s.isAdmin(r) {
+		s.renderForbidden(w, r)
+		return
+	}
 	s.render(w, r, "page-agent-settings", map[string]any{})
 }
 

--- a/internal/ui/nav_admin_visibility_test.go
+++ b/internal/ui/nav_admin_visibility_test.go
@@ -1,0 +1,89 @@
+package ui
+
+// Issue #149: пункты меню «Система», ведущие в админ-разделы, не должны
+// показываться пользователю без прав администратора. Серверные обработчики
+// этих разделов и так отдают 403 неадмину — кроме agentSettings, у которого
+// серверной проверки не было (см. TestAgentSettings_ForbiddenForNonAdmin).
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// adminNavLinks — ссылки меню «Система», доступные только администратору.
+var adminNavLinks = []string{
+	"/ui/admin/users",
+	"/ui/admin/roles",
+	"/ui/admin/sessions",
+	"/ui/admin/audit",
+	"/ui/admin/scheduled",
+	"/ui/delete-marked",
+	"/ui/admin/cleanup",
+	"/ui/settings/agent",
+}
+
+func renderNav(t *testing.T, isAdmin bool) string {
+	t.Helper()
+	var buf bytes.Buffer
+	data := map[string]any{"Cfg": Config{}, "Lang": "ru", "IsAdmin": isAdmin}
+	if err := tmpl.ExecuteTemplate(&buf, "nav", data); err != nil {
+		t.Fatalf("execute nav: %v", err)
+	}
+	return buf.String()
+}
+
+func TestNav_NonAdminOmitsAdminLinks(t *testing.T) {
+	out := renderNav(t, false)
+	for _, link := range adminNavLinks {
+		if strings.Contains(out, link) {
+			t.Errorf("меню неадмина не должно содержать %q", link)
+		}
+	}
+}
+
+func TestNav_AdminShowsAdminLinks(t *testing.T) {
+	out := renderNav(t, true)
+	for _, link := range adminNavLinks {
+		if !strings.Contains(out, link) {
+			t.Errorf("меню админа должно содержать %q", link)
+		}
+	}
+}
+
+func TestAgentSettings_ForbiddenForNonAdmin(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.Migrate(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+	authRepo := auth.NewRepo(db)
+	if err := authRepo.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Непустой список пользователей → isAdmin(запрос без пользователя)==false.
+	if _, err := authRepo.Create(ctx, "clerk", "pw", "Клерк", false); err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{store: db, reg: runtime.NewRegistry(), authRepo: authRepo, messages: NewMessageStore()}
+
+	req := httptest.NewRequest("GET", "/ui/settings/agent", nil)
+	rec := httptest.NewRecorder()
+	s.agentSettings(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("agentSettings неадмину: ожидался 403, получен %d", rec.Code)
+	}
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -728,16 +728,18 @@ const tplNav = `
     <button class="sys-btn" onclick="var d=document.getElementById('sysd');d.classList.toggle('open')">&#9881; {{t $.Lang "Система"}} &#9660;</button>
     <div class="sys-drop" id="sysd">
       <a href="/ui/about">{{t $.Lang "О программе"}}</a>
+      {{if .IsAdmin}}
       <a href="/ui/admin/users">{{t $.Lang "Пользователи"}}</a>
       <a href="/ui/admin/roles">{{t $.Lang "Роли и права"}}</a>
       <a href="/ui/admin/sessions">{{t $.Lang "Активные пользователи"}}</a>
       <a href="/ui/admin/audit">{{t $.Lang "Журнал изменений"}}</a>
-      {{if .IsAdmin}}<a href="/ui/admin/webhooks">{{t $.Lang "Журнал веб-хуков"}}</a>{{end}}
+      <a href="/ui/admin/webhooks">{{t $.Lang "Журнал веб-хуков"}}</a>
       <a href="/ui/admin/scheduled">{{t $.Lang "Регламентные задания"}}</a>
       <a href="/ui/delete-marked">{{t $.Lang "Удалить помеченные"}}</a>
       <a href="/ui/admin/cleanup">{{t $.Lang "Очистка регистров"}}</a>
+      {{end}}
       <a href="/ui/pos">{{t $.Lang "Рабочее место кассира (РМК)"}}</a>
-      <a href="/ui/settings/agent">{{t $.Lang "Настройки агента оборудования"}}</a>
+      {{if .IsAdmin}}<a href="/ui/settings/agent">{{t $.Lang "Настройки агента оборудования"}}</a>{{end}}
       {{if .IsAdmin}}<a href="/ui/admin/extforms">{{t $.Lang "Внешние печатные формы"}}</a>{{end}}
       {{if .IsAdmin}}<a href="/ui/admin/extreports">{{t $.Lang "Внешние отчёты"}}</a>{{end}}
       {{if .IsAdmin}}<a href="/ui/admin/extprocessors">{{t $.Lang "Внешние обработки"}}</a>{{end}}


### PR DESCRIPTION
Closes #149.

## Проверка
Сверено с исходниками: 8 ссылок раздела «Система» (`/ui/admin/users`, `/roles`, `/sessions`, `/audit`, `/scheduled`, `/ui/delete-marked`, `/admin/cleanup`, `/settings/agent`) рендерились без `{{if .IsAdmin}}`. Но **серверные обработчики 7 из 8 и так отдают 403 неадмину** (`adminUsers/Roles/Sessions/Audit`, `scheduledList`, `adminCleanup`, `deleteMarkedAll` — все проверяют `isAdmin`). То есть утечки данных не было — это раскрытие пунктов меню. Единственное реальное упущение: `agentSettings` (`/ui/settings/agent`) **не проверял права на сервере**.

## Что сделано
- Админ-ссылки меню обёрнуты в один блок `{{if .IsAdmin}}` (РМК остаётся видимым кассирам).
- В `agentSettings` добавлена серверная проверка `isAdmin` → 403.

## Тесты
- Рендер меню для админа/неадмина (ссылки скрыты только у неадмина).
- `agentSettings` неадмину → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)