### PR TITLE
fix(ui): серверный хук ПриЧтенииНаСервере на GET формы объекта (#148)

### DIFF
--- a/internal/metadata/form_module.go
+++ b/internal/metadata/form_module.go
@@ -10,43 +10,44 @@ import (
 type FormEventType string
 
 const (
-	FormEventOnOpen        FormEventType = "ПриОткрытии"         // OnOpen
-	FormEventBeforeWrite   FormEventType = "ПередЗаписью"        // BeforeWrite
-	FormEventOnWrite       FormEventType = "ПриЗаписи"           // OnWrite
-	FormEventAfterWrite    FormEventType = "ПослеЗаписи"         // AfterWrite
-	FormEventBeforeClose   FormEventType = "ПередЗакрытием"      // BeforeClose
-	FormEventOnClose       FormEventType = "ПриЗакрытии"         // OnClose
-	FormEventOnActivate    FormEventType = "ПриАктивации"        // OnActivate
-	FormEventItemChoice    FormEventType = "ОбработкаВыбора"     // ItemChoice
-	FormEventStartChoice   FormEventType = "НачалоВыбора"        // StartChoice
-	FormEventOnChange      FormEventType = "ПриИзменении"        // OnChange
-	FormEventOnCreate      FormEventType = "ПриСоздании"         // OnCreate
-	FormEventBeforeDelete  FormEventType = "ПередУдалением"      // BeforeDelete
-	FormEventOnDelete      FormEventType = "ПриУдалении"         // OnDelete
-	FormEventAfterDelete   FormEventType = "ПослеУдаления"       // AfterDelete
+	FormEventOnOpen         FormEventType = "ПриОткрытии"        // OnOpen (client-side, after render)
+	FormEventOnReadAtServer FormEventType = "ПриЧтенииНаСервере" // OnReadAtServer (server-side, before render → может запретить чтение)
+	FormEventBeforeWrite    FormEventType = "ПередЗаписью"       // BeforeWrite
+	FormEventOnWrite        FormEventType = "ПриЗаписи"          // OnWrite
+	FormEventAfterWrite     FormEventType = "ПослеЗаписи"        // AfterWrite
+	FormEventBeforeClose    FormEventType = "ПередЗакрытием"     // BeforeClose
+	FormEventOnClose        FormEventType = "ПриЗакрытии"        // OnClose
+	FormEventOnActivate     FormEventType = "ПриАктивации"       // OnActivate
+	FormEventItemChoice     FormEventType = "ОбработкаВыбора"    // ItemChoice
+	FormEventStartChoice    FormEventType = "НачалоВыбора"       // StartChoice
+	FormEventOnChange       FormEventType = "ПриИзменении"       // OnChange
+	FormEventOnCreate       FormEventType = "ПриСоздании"        // OnCreate
+	FormEventBeforeDelete   FormEventType = "ПередУдалением"     // BeforeDelete
+	FormEventOnDelete       FormEventType = "ПриУдалении"        // OnDelete
+	FormEventAfterDelete    FormEventType = "ПослеУдаления"      // AfterDelete
 	// События для табличных частей (замечание #15): даём YAML-конфигу
 	// возможность их объявлять. UI пока умеет дергать ExecuteElementEvent
 	// generic-маршрутом — кастомные триггеры (auto-fill цены при добавлении
 	// строки и т.п.) реализуются в конфиге пользователя.
-	FormEventOnRowAdded     FormEventType = "ПриДобавленииСтроки"   // OnRowAdded
-	FormEventOnRowChanged   FormEventType = "ПриИзмененииСтроки"    // OnRowChanged
-	FormEventOnRowDeleted   FormEventType = "ПриУдаленииСтроки"     // OnRowDeleted
-	FormEventOnRowActivated FormEventType = "ПриАктивизацииСтроки"  // OnRowActivated
+	FormEventOnRowAdded     FormEventType = "ПриДобавленииСтроки"  // OnRowAdded
+	FormEventOnRowChanged   FormEventType = "ПриИзмененииСтроки"   // OnRowChanged
+	FormEventOnRowDeleted   FormEventType = "ПриУдаленииСтроки"    // OnRowDeleted
+	FormEventOnRowActivated FormEventType = "ПриАктивизацииСтроки" // OnRowActivated
 	// События, добавленные для управляемых форм (план 37). Используются
 	// конвертером 1С и редактором; интерпретатор вызывает их по той же
 	// generic-схеме что и существующие row-события.
-	FormEventOnClick           FormEventType = "Нажатие"                // OnClick
-	FormEventBeforeRowAdd      FormEventType = "ПередДобавлениемСтроки" // BeforeAddRow
-	FormEventAfterRowAdd       FormEventType = "ПослеДобавленияСтроки"  // AfterAddRow
-	FormEventBeforeRowDelete   FormEventType = "ПередУдалениемСтроки"   // BeforeDeleteRow
-	FormEventStartListChoice   FormEventType = "НачалоВыбораИзСписка"   // StartListChoice
-	FormEventAutoComplete      FormEventType = "АвтоПодбор"             // AutoComplete
-	FormEventExecuteCommand    FormEventType = "ВыполнитьКоманду"       // Command
+	FormEventOnClick         FormEventType = "Нажатие"                // OnClick
+	FormEventBeforeRowAdd    FormEventType = "ПередДобавлениемСтроки" // BeforeAddRow
+	FormEventAfterRowAdd     FormEventType = "ПослеДобавленияСтроки"  // AfterAddRow
+	FormEventBeforeRowDelete FormEventType = "ПередУдалениемСтроки"   // BeforeDeleteRow
+	FormEventStartListChoice FormEventType = "НачалоВыбораИзСписка"   // StartListChoice
+	FormEventAutoComplete    FormEventType = "АвтоПодбор"             // AutoComplete
+	FormEventExecuteCommand  FormEventType = "ВыполнитьКоманду"       // Command
 	// Выбор — вторая фаза диалога подбора (план 46): обработчик кнопки
 	// показывает диалог через билтин ПоказатьПодбор (фаза 1, событие Нажатие),
 	// а результат пользователь возвращает событием Выбор с переменной
 	// ПодборРезультат. Generic: годится для любого диалога мультивыбора.
-	FormEventOnChoice          FormEventType = "Выбор"                  // OnChoice
+	FormEventOnChoice FormEventType = "Выбор" // OnChoice
 )
 
 // FormElementType represents types of form elements
@@ -67,10 +68,10 @@ const (
 	FormElementFormField  FormElementType = "ПолеФормы"      // FormField
 	FormElementTablePart  FormElementType = "ТабличнаяЧасть" // TablePart
 	// Управляемые формы (план 37): дополнения для покрытия XML 1С и UI-редактора.
-	FormElementColumn           FormElementType = "Колонка"          // Column (Table inner)
-	FormElementCommandBar       FormElementType = "КоманднаяПанель"  // CommandBar
-	FormElementPicture          FormElementType = "ПолеКартинки"     // PictureField
-	FormElementCommandBarButton FormElementType = "КнопкаКП"         // CommandBar Button
+	FormElementColumn           FormElementType = "Колонка"         // Column (Table inner)
+	FormElementCommandBar       FormElementType = "КоманднаяПанель" // CommandBar
+	FormElementPicture          FormElementType = "ПолеКартинки"    // PictureField
+	FormElementCommandBarButton FormElementType = "КнопкаКП"        // CommandBar Button
 )
 
 // Layout kinds of a form module. Пустая строка трактуется как "autogen"
@@ -90,8 +91,8 @@ type FormElement struct {
 	// TitleMap (поле yaml:"title"); это поле не сериализуется в YAML
 	// (тег "-"), и заполняется ToFormModule из TitleMap.Get("ru") как
 	// fallback для legacy-рендерера.
-	Title     string `yaml:"-"`
-	FieldName string `yaml:"field,omitempty"`
+	Title     string                   `yaml:"-"`
+	FieldName string                   `yaml:"field,omitempty"`
 	TablePart string                   `yaml:"table_part,omitempty"`
 	Visible   bool                     `yaml:"visible,omitempty"`
 	Enabled   bool                     `yaml:"enabled,omitempty"`
@@ -103,23 +104,23 @@ type FormElement struct {
 	// Поля, добавленные планом 37. Все опциональны; YAML-загрузчик
 	// заполняет их при чтении managed-формы, конвертер 1С использует
 	// для round-trip, рендерер — для отрисовки HTML.
-	OriginalID string            `yaml:"original_id,omitempty"` // id из Form.xml для round-trip
-	TitleMap   map[string]string `yaml:"title,omitempty"`       // локализованный заголовок (ru, en, ...) — основной источник в managed-YAML
-	DataPath        string            `yaml:"data_path,omitempty"`         // "Объект.Контрагент", "Список.Цена"
-	Picture         string            `yaml:"picture,omitempty"`           // "_resources/.../Picture.png" или "stdpic:Post"
-	ValuesPicture   string            `yaml:"values_picture,omitempty"`    // палитра выбора (для PictureField/InputField)
-	Width           int               `yaml:"width,omitempty"`             // ширина в условных единицах
-	Height          int               `yaml:"height,omitempty"`            // высота
-	HorizontalAlign string            `yaml:"halign,omitempty"`            // left|center|right|stretch
-	VerticalAlign   string            `yaml:"valign,omitempty"`            // top|center|bottom
-	ReadOnly        bool              `yaml:"readonly,omitempty"`          // только чтение
-	UseGrid         bool              `yaml:"use_grid,omitempty"`          // (устар.) SlickGrid теперь включён по умолчанию
-	NoGrid          bool              `yaml:"no_grid,omitempty"`           // отключить SlickGrid у ТЧ (вернуть простую таблицу)
-	Hint            string            `yaml:"hint,omitempty"`              // всплывающая подсказка
-	Mask            string            `yaml:"mask,omitempty"`              // маска ввода
-	Type            string            `yaml:"type,omitempty"`              // "file" для файлового поля, и т.п.
-	Choice          bool              `yaml:"choice,omitempty"`            // включена кнопка выбора у InputField
-	UnknownXML      []byte            `yaml:"unknown_xml,omitempty"`       // экзотический XML, сохраняется как есть
+	OriginalID      string            `yaml:"original_id,omitempty"`    // id из Form.xml для round-trip
+	TitleMap        map[string]string `yaml:"title,omitempty"`          // локализованный заголовок (ru, en, ...) — основной источник в managed-YAML
+	DataPath        string            `yaml:"data_path,omitempty"`      // "Объект.Контрагент", "Список.Цена"
+	Picture         string            `yaml:"picture,omitempty"`        // "_resources/.../Picture.png" или "stdpic:Post"
+	ValuesPicture   string            `yaml:"values_picture,omitempty"` // палитра выбора (для PictureField/InputField)
+	Width           int               `yaml:"width,omitempty"`          // ширина в условных единицах
+	Height          int               `yaml:"height,omitempty"`         // высота
+	HorizontalAlign string            `yaml:"halign,omitempty"`         // left|center|right|stretch
+	VerticalAlign   string            `yaml:"valign,omitempty"`         // top|center|bottom
+	ReadOnly        bool              `yaml:"readonly,omitempty"`       // только чтение
+	UseGrid         bool              `yaml:"use_grid,omitempty"`       // (устар.) SlickGrid теперь включён по умолчанию
+	NoGrid          bool              `yaml:"no_grid,omitempty"`        // отключить SlickGrid у ТЧ (вернуть простую таблицу)
+	Hint            string            `yaml:"hint,omitempty"`           // всплывающая подсказка
+	Mask            string            `yaml:"mask,omitempty"`           // маска ввода
+	Type            string            `yaml:"type,omitempty"`           // "file" для файлового поля, и т.п.
+	Choice          bool              `yaml:"choice,omitempty"`         // включена кнопка выбора у InputField
+	UnknownXML      []byte            `yaml:"unknown_xml,omitempty"`    // экзотический XML, сохраняется как есть
 }
 
 // FormModule represents a form module with event handlers
@@ -132,14 +133,14 @@ type FormModule struct {
 	Procedures map[string]*FormProcedure `yaml:"-"`
 
 	// Поля, добавленные планом 37 для управляемых форм.
-	LayoutKind             string           `yaml:"layout_kind,omitempty"`              // "managed"|"autogen" (пусто=autogen)
-	Title                  map[string]string `yaml:"title,omitempty"`                   // локализованный заголовок формы
-	OriginalID             string           `yaml:"original_id,omitempty"`              // id корневого узла из 1С
-	Attributes             []*FormAttribute `yaml:"attributes,omitempty"`               // реквизиты формы
-	Commands               []*FormCommand   `yaml:"commands,omitempty"`                 // команды формы
-	AutoCommandBar         *FormCommandBar  `yaml:"auto_command_bar,omitempty"`         // авто-командная панель
-	AutoSaveDataInSettings bool             `yaml:"auto_save_data_in_settings,omitempty"`
-	VerticalScroll         string           `yaml:"vertical_scroll,omitempty"`          // auto|never|always
+	LayoutKind             string            `yaml:"layout_kind,omitempty"`      // "managed"|"autogen" (пусто=autogen)
+	Title                  map[string]string `yaml:"title,omitempty"`            // локализованный заголовок формы
+	OriginalID             string            `yaml:"original_id,omitempty"`      // id корневого узла из 1С
+	Attributes             []*FormAttribute  `yaml:"attributes,omitempty"`       // реквизиты формы
+	Commands               []*FormCommand    `yaml:"commands,omitempty"`         // команды формы
+	AutoCommandBar         *FormCommandBar   `yaml:"auto_command_bar,omitempty"` // авто-командная панель
+	AutoSaveDataInSettings bool              `yaml:"auto_save_data_in_settings,omitempty"`
+	VerticalScroll         string            `yaml:"vertical_scroll,omitempty"` // auto|never|always
 	// OneCMeta — служебный блок, используемый только конвертером 1С,
 	// рантайм его игнорирует. Может содержать version, unknown_xml и т.п.
 	OneCMeta map[string]any `yaml:"oneC_meta,omitempty"`
@@ -176,18 +177,18 @@ type FormProcParam struct {
 // FormAttribute — реквизит формы (живёт только в форме, отдельно от полей сущности).
 // При импорте из 1С строится из Form.xml/Attributes.
 type FormAttribute struct {
-	ID            string                 `yaml:"id,omitempty"`            // ID из IR, опционально
-	OriginalID    string                 `yaml:"original_id,omitempty"`   // id из 1С
+	ID            string                 `yaml:"id,omitempty"`          // ID из IR, опционально
+	OriginalID    string                 `yaml:"original_id,omitempty"` // id из 1С
 	Name          string                 `yaml:"name"`
 	Title         map[string]string      `yaml:"title,omitempty"`
-	TypeRef       string                 `yaml:"type"`                    // "string(40)", "decimal(15,2)", "CatalogRef.Контрагенты", "ValueTable"
+	TypeRef       string                 `yaml:"type"` // "string(40)", "decimal(15,2)", "CatalogRef.Контрагенты", "ValueTable"
 	Length        int                    `yaml:"length,omitempty"`
 	Precision     int                    `yaml:"precision,omitempty"`
 	AllowedLength string                 `yaml:"allowed_length,omitempty"` // "Variable"|"Fixed"
 	Save          bool                   `yaml:"save,omitempty"`
 	FillingValue  string                 `yaml:"filling_value,omitempty"`
-	MainAttribute bool                   `yaml:"main,omitempty"`          // соответствует <MainAttribute>true</MainAttribute>
-	Columns       []*FormAttributeColumn `yaml:"columns,omitempty"`       // для ValueTable
+	MainAttribute bool                   `yaml:"main,omitempty"`    // соответствует <MainAttribute>true</MainAttribute>
+	Columns       []*FormAttributeColumn `yaml:"columns,omitempty"` // для ValueTable
 	Props         map[string]any         `yaml:"props,omitempty"`
 }
 

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -236,37 +236,11 @@ func (p *docProxy) LoadObject(uuidStr string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("неверный идентификатор ссылки: %q", uuidStr)
 	}
-	row, err := p.s.store.GetByID(p.ctx(), p.entity.Name, id, p.entity)
+	// loadRuntimeObject грузит шапку + ТЧ и обогащает ссылочные поля до
+	// *Ref{…,Manager}, чтобы DSL мог писать Док.СсылочноеПоле.ПолучитьОбъект().
+	obj, err := p.s.loadRuntimeObject(p.ctx(), p.entity, id)
 	if err != nil {
 		return nil, err
-	}
-	fields := make(map[string]any, len(row))
-	for _, f := range p.entity.Fields {
-		if v, ok := row[f.Name]; ok && v != nil {
-			fields[strings.ToLower(f.Name)] = v
-		}
-	}
-	tpRows := make(map[string][]map[string]any, len(p.entity.TableParts))
-	for _, tp := range p.entity.TableParts {
-		rows, err := p.s.store.GetTablePartRows(p.ctx(), p.entity.Name, tp.Name, id, tp)
-		if err != nil {
-			return nil, fmt.Errorf("табличная часть %s: %w", tp.Name, err)
-		}
-		tpRows[tp.Name] = rows
-	}
-	obj := &runtime.Object{
-		ID:            id,
-		Type:          p.entity.Name,
-		Kind:          p.entity.Kind,
-		Fields:        fields,
-		TablePartRows: tpRows,
-	}
-	// Обогащаем UUID-строки в ссылочных полях шапки и ТЧ до *Ref{…,Manager},
-	// чтобы DSL мог писать Док.СсылочноеПоле.ПолучитьОбъект()/.Наименование.
-	// Без этого Док.Покупатель — голая строка UUID, у которой нет методов.
-	p.s.enrichHeaderRefs(p.ctx(), p.entity, obj)
-	for _, tp := range p.entity.TableParts {
-		p.s.enrichTPRowsWithRefs(p.ctx(), tp, tpRows[tp.Name])
 	}
 	return &docWriter{
 		s:      p.s,

--- a/internal/ui/form_read_hook_test.go
+++ b/internal/ui/form_read_hook_test.go
@@ -1,0 +1,91 @@
+package ui
+
+// Issue #148: серверный обработчик формы ПриЧтенииНаСервере должен вызываться
+// платформой на GET формы объекта ДО рендера HTML. Если обработчик бросает
+// исключение (ВызватьИсключение) — платформа обязана отдать 403 и НЕ раскрывать
+// данные записи. Это даёт конфигурациям RLS на чтение (row-level security),
+// которого раньше не было: ПриОткрытии исполнялся только на клиенте, после
+// того как сервер уже отдал форму со всеми полями.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func executeFormEditGET(t *testing.T, s *Server, ent *metadata.Entity, id uuid.UUID) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/ui/catalog/"+ent.Name+"/"+id.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("kind", "catalog")
+	rctx.URLParams.Add("entity", ent.Name)
+	rctx.URLParams.Add("id", id.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	s.formEdit(rec, req)
+	return rec
+}
+
+func insertContragent(t *testing.T, s *Server, ent *metadata.Entity, name string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if err := s.store.Upsert(context.Background(), ent.Name, id,
+		map[string]any{"Наименование": name}, ent); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func TestFormEdit_OnReadAtServerDeniesRead(t *testing.T) {
+	srv, ent := setupManagedEventsServer(t, `
+Процедура ПроверитьДоступ()
+	ВызватьИсключение("Нет доступа к чужому документу");
+КонецПроцедуры
+`, map[metadata.FormEventType]string{
+		metadata.FormEventType("ПриЧтенииНаСервере"): "ПроверитьДоступ",
+	}, []*metadata.FormElement{
+		{Kind: metadata.FormElementField, Name: "Наименование", DataPath: "Объект.Наименование"},
+	})
+
+	id := insertContragent(t, srv, ent, "СЕКРЕТНЫЙ-КОНТРАГЕНТ")
+	rec := executeFormEditGET(t, srv, ent, id)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("ожидался 403 (ПриЧтенииНаСервере бросил исключение), получен %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "СЕКРЕТНЫЙ-КОНТРАГЕНТ") {
+		t.Errorf("при отказе ПриЧтенииНаСервере форма не должна раскрывать данные записи")
+	}
+}
+
+func TestFormEdit_OnReadAtServerAllowsRead(t *testing.T) {
+	srv, ent := setupManagedEventsServer(t, `
+Процедура ПроверитьДоступ()
+КонецПроцедуры
+`, map[metadata.FormEventType]string{
+		metadata.FormEventType("ПриЧтенииНаСервере"): "ПроверитьДоступ",
+	}, []*metadata.FormElement{
+		{Kind: metadata.FormElementField, Name: "Наименование", DataPath: "Объект.Наименование"},
+	})
+
+	id := insertContragent(t, srv, ent, "ОБЫЧНЫЙ-КОНТРАГЕНТ")
+	rec := executeFormEditGET(t, srv, ent, id)
+
+	if rec.Code != http.StatusOK {
+		body := rec.Body.String()
+		if len(body) > 300 {
+			body = body[:300]
+		}
+		t.Fatalf("ожидался 200, получен %d; body=%s", rec.Code, body)
+	}
+	if !strings.Contains(rec.Body.String(), "ОБЫЧНЫЙ-КОНТРАГЕНТ") {
+		t.Errorf("форма должна показывать данные, когда ПриЧтенииНаСервере разрешает чтение")
+	}
+}

--- a/internal/ui/form_server_events.go
+++ b/internal/ui/form_server_events.go
@@ -1,0 +1,111 @@
+package ui
+
+// Серверные события управляемых форм, исполняемые ДО рендера HTML (issue #148).
+//
+// Раньше единственным «событием открытия» был ПриОткрытии — но он исполняется
+// на КЛИЕНТЕ (obFire по DOMContentLoaded), уже после того как сервер отдал форму
+// со всеми полями. Это не позволяло реализовать RLS на чтение: пользователь
+// видел данные чужой записи, даже если обработчик потом бросал исключение.
+//
+// ПриЧтенииНаСервере (по аналогии с 1С «ПриЧтенииНаСервере») исполняется
+// синхронно на сервере при GET формы объекта, до формирования HTML. Если
+// обработчик бросает ВызватьИсключение — formEdit отдаёт 403 и не раскрывает
+// данные.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+// loadRuntimeObject загружает существующую запись (шапка + табличные части +
+// обогащённые ссылки) в *runtime.Object — пригодный для исполнения обработчиков
+// формы как «Объект». Та же логика, что в docProxy.LoadObject.
+func (s *Server) loadRuntimeObject(ctx context.Context, entity *metadata.Entity, id uuid.UUID) (*runtime.Object, error) {
+	row, err := s.store.GetByID(ctx, entity.Name, id, entity)
+	if err != nil {
+		return nil, err
+	}
+	fields := make(map[string]any, len(row))
+	for _, f := range entity.Fields {
+		if v, ok := row[f.Name]; ok && v != nil {
+			fields[strings.ToLower(f.Name)] = v
+		}
+	}
+	tpRows := make(map[string][]map[string]any, len(entity.TableParts))
+	for _, tp := range entity.TableParts {
+		rows, err := s.store.GetTablePartRows(ctx, entity.Name, tp.Name, id, tp)
+		if err != nil {
+			return nil, fmt.Errorf("табличная часть %s: %w", tp.Name, err)
+		}
+		tpRows[tp.Name] = rows
+	}
+	obj := &runtime.Object{
+		ID:            id,
+		Type:          entity.Name,
+		Kind:          entity.Kind,
+		Fields:        fields,
+		TablePartRows: tpRows,
+	}
+	s.enrichHeaderRefs(ctx, entity, obj)
+	for _, tp := range entity.TableParts {
+		s.enrichTPRowsWithRefs(ctx, tp, tpRows[tp.Name])
+	}
+	return obj, nil
+}
+
+// runFormReadHook исполняет серверный обработчик ПриЧтенииНаСервере формы объекта
+// (если он объявлен) с «Объект», загруженным из БД. Возвращает ошибку обработчика
+// (если он бросил исключение) — тогда вызывающий код обязан отказать в рендере.
+//
+// Если формы/обработчика/AST нет — возвращает nil (no-op). Ошибку загрузки
+// объекта тоже глотает в nil: пусть обычный путь formEdit отрисует ошибку 404.
+func (s *Server) runFormReadHook(ctx context.Context, entity *metadata.Entity, form *metadata.FormModule, id uuid.UUID) error {
+	if form == nil || s.interp == nil {
+		return nil
+	}
+	procName := resolveHandlerProc(form, "", string(metadata.FormEventOnReadAtServer))
+	if procName == "" {
+		return nil
+	}
+	program, ok := form.ProgramAST.(*ast.Program)
+	if !ok || program == nil {
+		return nil
+	}
+	var decl *ast.ProcedureDecl
+	for _, p := range program.Procedures {
+		if strings.EqualFold(p.Name.Literal, procName) {
+			decl = p
+			break
+		}
+	}
+	if decl == nil {
+		return nil
+	}
+
+	obj, err := s.loadRuntimeObject(ctx, entity, id)
+	if err != nil {
+		return nil
+	}
+
+	mc := runtime.NewMovementsCollector(entity.Name, obj.ID)
+	var msgs []string
+	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)
+	thisObj := &formObjectThis{obj: obj, entity: entity, form: form}
+	vars["Объект"] = thisObj
+	vars["ЭтотОбъект"] = thisObj
+
+	formProcs := make(map[string]*ast.ProcedureDecl, len(program.Procedures))
+	for _, p := range program.Procedures {
+		formProcs[strings.ToLower(p.Name.Literal)] = p
+	}
+	vars["__form_procs__"] = formProcs
+
+	return s.interp.Run(decl, thisObj, vars)
+}

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -569,6 +569,16 @@ func (s *Server) formEdit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.errText(r, err), 404)
 		return
 	}
+	// Issue #148: серверный обработчик ПриЧтенииНаСервере исполняется ДО рендера
+	// HTML. Если он бросает исключение — отдаём 403 и не раскрываем данные записи
+	// (row-level security на чтение). Без этого ПриОткрытии срабатывал лишь на
+	// клиенте, уже после отдачи формы со всеми полями.
+	if managed := pickManagedForm(entity, "object"); managed != nil {
+		if denied := s.runFormReadHook(r.Context(), entity, managed, id); denied != nil {
+			s.renderForbidden(w, r)
+			return
+		}
+	}
 	refOptions, _ := s.loadRefOptions(r.Context(), entity)
 	tpRefOpts, _ := s.loadTPRefOptions(r.Context(), entity)
 	langEdit := s.resolveLang(r)


### PR DESCRIPTION
Closes #148.

## Проверка
`ПриОткрытии` **исполняется на клиенте** (`obFire` по `DOMContentLoaded`, `templates_managed.go`) — уже после того как сервер отдал форму со всеми полями. Поэтому RLS на чтение реализовать было нельзя: пользователь видел данные чужой записи, даже если обработчик потом бросал исключение. (Диагноз автора «не вызывается» неточен — вызывается, но слишком поздно; суть проблемы верна.)

## Что сделано
Добавлено серверное событие формы **ПриЧтенииНаСервере** (по аналогии с 1С): исполняется в `formEdit` синхронно на сервере при GET формы объекта, **до** формирования HTML, с `Объект` из БД. Если обработчик бросает `ВызватьИсключение` — отдаём 403 и не раскрываем данные.

```yaml
# forms/<сущность>/объекта.form.yaml
events: { ПриЧтенииНаСервере: ПроверитьДоступ }
```

Загрузка runtime-объекта вынесена в `loadRuntimeObject` и переиспользована в `docProxy.LoadObject` (убрано дублирование).

## Тесты
- Обработчик с `ВызватьИсключение` → 403 без утечки данных.
- Обработчик без возражений → 200 с данными.

🤖 Generated with [Claude Code](https://claude.com/claude-code)