### PR TITLE
fix(ui): показывать вложения в управляемых формах объекта (#152)

### DIFF
--- a/internal/ui/managed_attachments_test.go
+++ b/internal/ui/managed_attachments_test.go
@@ -1,0 +1,52 @@
+package ui
+
+// Issue #152: управляемая (managed) форма объекта должна показывать UI загрузки
+// файлов-вложений — как это уже делает авто-генерируемая форма. Бэкенд вложений
+// (handlers_attachments.go, таблица _attachments, роуты POST .../attachments)
+// существует и работает; не хватало только UI в managed-форме, поэтому
+// табличная часть «Файлы» рендерилась обычным гридом без <input type=file>.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func TestManagedForm_RendersAttachmentsUpload(t *testing.T) {
+	srv, ent := setupManagedEventsServer(t, ``, nil, []*metadata.FormElement{
+		{Kind: metadata.FormElementField, Name: "Наименование", DataPath: "Объект.Наименование"},
+	})
+	id := uuid.New()
+	if err := srv.store.Upsert(context.Background(), ent.Name, id,
+		map[string]any{"Наименование": "Контрагент-1"}, ent); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/ui/catalog/"+ent.Name+"/"+id.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("kind", "catalog")
+	rctx.URLParams.Add("entity", ent.Name)
+	rctx.URLParams.Add("id", id.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	srv.formEdit(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ожидался 200, получен %d", rec.Code)
+	}
+	body := rec.Body.String()
+	// id и /attachments — ASCII, не percent-кодируются html/template.
+	if !strings.Contains(body, id.String()+"/attachments") {
+		t.Errorf("в managed-форме нет формы загрузки вложений (action .../attachments)")
+	}
+	if !strings.Contains(body, `name="file"`) {
+		t.Errorf("в managed-форме нет <input type=file name=file> для вложений")
+	}
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1638,7 +1638,18 @@ const tplForm = `
   });
 })();
 </script>
-{{if and (not .IsNew) (not .IsPopup)}}
+{{template "ob-attachments" .}}
+</div>
+{{template "form-shared-js" .}}
+</main></div></body></html>
+{{end}}
+
+{{/* ob-attachments — панель вложений к записи (issue #152). Общая для
+     page-form и page-managed-form; бэкенд один (handlers_attachments.go,
+     роуты POST /ui/<kind>/<entity>/<id>/attachments). Показывается для
+     сохранённой записи объекта (не новая, не попап, не обработка). */}}
+{{define "ob-attachments"}}
+{{if and (not .IsNew) (not .IsPopup) (not .IsProcessor)}}
 <div class="card" style="margin-top:16px">
   <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
     <h3 style="margin:0;font-size:14px;font-weight:600;color:#374151">{{t $.Lang "Вложения"}}</h3>
@@ -1684,9 +1695,6 @@ const tplForm = `
 })();
 </script>
 {{end}}
-</div>
-{{template "form-shared-js" .}}
-</main></div></body></html>
 {{end}}
 
 {{/* form-shared-js — общий <script> блок, используется page-form и

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -1562,6 +1562,9 @@ function addVtRow(vtName, fields) {
 })();</script>
 {{end}}
 
+{{/* Вложения к записи (issue #152) — тот же UI, что и в авто-форме. */}}
+{{template "ob-attachments" .}}
+
 {{template "form-shared-js" .}}
 
 {{/* Авто-вызов ПриОткрытииФормы при загрузке страницы. Без этого


### PR DESCRIPTION
Closes #152.

## Проверка
Бэкенд вложений уже есть и работает: `handlers_attachments.go`, таблица `_attachments`, роуты `POST /ui/<kind>/<entity>/<id>/attachments`. **Авто-генерируемая** форма рендерит полноценную панель загрузки. А вот **управляемая** (managed) форма не показывала никакого UI вложений — поэтому `ТабличнаяЧасть «Файлы»` выглядела как обычный грид без `<input type=file>`.

Важно: вложения — отдельный платформенный механизм (`_attachments`), **а не табличная часть**; `ТабличнаяЧасть «Файлы»` для этого не нужна.

## Что сделано
Панель вложений вынесена в общий шаблон `{{define "ob-attachments"}}` и подключена и в `page-form`, и в `page-managed-form`. Показывается для сохранённой записи объекта (не новая, не попап, не обработка).

## Тесты
- managed-форма сохранённого объекта содержит форму загрузки (`action .../attachments`, `input name=file`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)