### PR TITLE
fix(ui): реализовать рендеринг ПолеДаты в управляемых формах (#150)

### DIFF
--- a/internal/ui/managed_date_field_test.go
+++ b/internal/ui/managed_date_field_test.go
@@ -1,0 +1,67 @@
+package ui
+
+// Issue #150: формат даты в форме. Полноценный произвольный формат
+// (dd.MM.yyyy HH:mm) для редактируемого поля невозможен — нативный HTML5
+// контрол показывает дату по локали браузера и не настраивается. Но элемент
+// kind: ПолеДаты (он уже есть в схеме — FormElementDatePicker) должен
+// рендериться как нативный выбор ДАТЫ без времени (<input type="date">),
+// который в ru-локали показывается как дд.ММ.гггг и корректно сохраняется
+// (formToFields парсит "2006-01-02"). Раньше ПолеДаты не рендерился вовсе.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func renderManagedElement(t *testing.T, el *metadata.FormElement) string {
+	t.Helper()
+	ent := &metadata.Entity{
+		Name: "Письмо",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "ДатаПоступления", Type: metadata.FieldTypeDate},
+		},
+	}
+	ctx := map[string]any{
+		"Entity":      ent,
+		"Values":      map[string]string{"ДатаПоступления": "2026-06-20T10:00"},
+		"RefOptions":  map[string]any{},
+		"EnumOptions": map[string]any{},
+	}
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "managed-element", map[string]any{"El": el, "Ctx": ctx}); err != nil {
+		t.Fatalf("execute managed-element: %v", err)
+	}
+	return buf.String()
+}
+
+func TestManagedForm_PoleDatyRendersDateInput(t *testing.T) {
+	out := renderManagedElement(t, &metadata.FormElement{
+		Kind:     metadata.FormElementDatePicker,
+		Name:     "ДатаПоступления",
+		DataPath: "Объект.ДатаПоступления",
+	})
+	if !strings.Contains(out, `type="date"`) {
+		t.Errorf("ПолеДаты должно рендерить <input type=\"date\">, получили:\n%s", out)
+	}
+	if strings.Contains(out, "datetime-local") {
+		t.Errorf("ПолеДаты не должно рендерить datetime-local")
+	}
+	if !strings.Contains(out, `value="2026-06-20"`) {
+		t.Errorf("значение ПолеДаты должно быть датой без времени (2026-06-20):\n%s", out)
+	}
+}
+
+func TestManagedForm_PoleVvodaDateStaysDatetimeLocal(t *testing.T) {
+	out := renderManagedElement(t, &metadata.FormElement{
+		Kind:     metadata.FormElementField,
+		Name:     "ДатаПоступления",
+		DataPath: "Объект.ДатаПоступления",
+	})
+	if !strings.Contains(out, "datetime-local") {
+		t.Errorf("ПолеВвода по дате должно остаться datetime-local:\n%s", out)
+	}
+}

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -271,6 +271,17 @@ const tplManagedForm = `
   </div>
   {{end}}
   {{end}}
+{{else if eq (str $el.Kind) "ПолеДаты"}}
+  {{/* Нативный выбор ДАТЫ без времени (issue #150). Браузер показывает дату
+       по локали (в ru — дд.ММ.гггг). Значение круглим до YYYY-MM-DD, что
+       корректно парсится при сохранении (formToFields, layout 2006-01-02). */}}
+  {{$fn := dpField $el.DataPath}}
+  {{$hChg := hasHandler $el "ПриИзменении"}}
+  {{$dv := index $ctx.Values $fn}}
+  <div class="form-group">
+    <label>{{fieldTitleRU $el.TitleMap $fn}}{{if $el.Required}} <span style="color:#dc2626">*</span>{{end}}</label>
+    <input type="date" name="{{$fn}}" value="{{if ge (len $dv) 10}}{{slice $dv 0 10}}{{else}}{{$dv}}{{end}}"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+  </div>
 {{else if eq (str $el.Kind) "СтраницаКоманднаяПанель"}}
   {{/* пропускаем — отрисовывается через toolbar в обвязке формы */}}
 {{else if eq (str $el.Kind) "КоманднаяПанель"}}


### PR DESCRIPTION
Closes #150.

## Проверка
Вопреки отчёту, элемент `kind: ПолеДаты` (`FormElementDatePicker`) **уже был в схеме** — но managed-форма показывала заглушку «рендеринг не реализован». Произвольный формат (`dd.MM.yyyy HH:mm`) для редактируемого datetime-поля нативным HTML5-контролом задать нельзя — `<input type=datetime-local>` отображается по локали браузера и не настраивается.

## Что сделано
`ПолеДаты` теперь рендерится нативным выбором **даты без времени** (`<input type="date">`): в ru-локали показывается как дд.ММ.гггг, значение круглится до `YYYY-MM-DD` и корректно сохраняется (`formToFields` парсит `2006-01-02`). Это закрывает кейс «дата без времени в человеческом формате». Для даты-времени остаётся обычное `ПолеВвода` → `datetime-local`.

## Тесты
- `ПолеДаты` → `<input type=date>` со значением-датой.
- `ПолеВвода` по дате остаётся `datetime-local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)