### PR TITLE
feat(ui): actions.delete.visible — скрыть кнопку удаления в форме (#151)

### DIFF
--- a/internal/dsl/loader/managed_form_loader.go
+++ b/internal/dsl/loader/managed_form_loader.go
@@ -103,12 +103,13 @@ type formYAMLDoc struct {
 		AutoSaveDataInSettings bool              `yaml:"auto_save_settings"`
 		VerticalScroll         string            `yaml:"vertical_scroll"`
 	} `yaml:"form"`
-	Attributes []*metadata.FormAttribute `yaml:"attributes"`
-	Commands   []*metadata.FormCommand   `yaml:"commands"`
-	CommandBar *metadata.FormCommandBar  `yaml:"command_bar"`
-	Elements   []*metadata.FormElement   `yaml:"elements"`
-	Events     map[string]string         `yaml:"events"`
-	OneCMeta   map[string]any            `yaml:"oneC_meta"`
+	Attributes []*metadata.FormAttribute       `yaml:"attributes"`
+	Commands   []*metadata.FormCommand         `yaml:"commands"`
+	CommandBar *metadata.FormCommandBar        `yaml:"command_bar"`
+	Elements   []*metadata.FormElement         `yaml:"elements"`
+	Events     map[string]string               `yaml:"events"`
+	Actions    map[string]*metadata.FormAction `yaml:"actions"`
+	OneCMeta   map[string]any                  `yaml:"oneC_meta"`
 }
 
 func (mfl *ManagedFormLoader) parseYAML(data []byte, entityNameFallback string) (*metadata.FormModule, error) {
@@ -143,6 +144,7 @@ func (mfl *ManagedFormLoader) parseYAML(data []byte, entityNameFallback string) 
 		AutoCommandBar:         doc.CommandBar,
 		Elements:               doc.Elements,
 		Handlers:               toEventMap(doc.Events),
+		Actions:                doc.Actions,
 		Procedures:             make(map[string]*metadata.FormProcedure),
 		OneCMeta:               doc.OneCMeta,
 	}

--- a/internal/dsl/loader/managed_form_loader_test.go
+++ b/internal/dsl/loader/managed_form_loader_test.go
@@ -138,6 +138,35 @@ func TestManagedFormLoader_ParseYAML(t *testing.T) {
 	}
 }
 
+func TestManagedFormLoader_ParsesDeleteAction(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "контрагенты.form.yaml")
+	doc := `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Контрагенты
+actions:
+  delete:
+    visible: false
+`
+	if err := os.WriteFile(yamlPath, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mfl := NewManagedFormLoader()
+	form, err := mfl.LoadFormFile(yamlPath, "Контрагенты")
+	if err != nil {
+		t.Fatalf("LoadFormFile: %v", err)
+	}
+	a, ok := form.Actions["delete"]
+	if !ok || a == nil {
+		t.Fatalf("actions.delete не разобран из YAML; Actions=%v", form.Actions)
+	}
+	if a.Visible == nil || *a.Visible {
+		t.Errorf("actions.delete.visible должно быть false, got %v", a.Visible)
+	}
+}
+
 func TestManagedFormLoader_LoadEntityForms_NoDir(t *testing.T) {
 	dir := t.TempDir()
 	mfl := NewManagedFormLoader()

--- a/internal/metadata/form_module.go
+++ b/internal/metadata/form_module.go
@@ -122,6 +122,13 @@ type FormElement struct {
 	UnknownXML      []byte            `yaml:"unknown_xml,omitempty"`       // экзотический XML, сохраняется как есть
 }
 
+// FormAction — переопределение стандартного действия формы объекта (issue #151).
+type FormAction struct {
+	// Visible — показывать ли кнопку действия. nil = поведение по умолчанию
+	// (для delete — по праву CanDelete). false = скрыть кнопку.
+	Visible *bool `yaml:"visible,omitempty"`
+}
+
 // FormModule represents a form module with event handlers
 type FormModule struct {
 	EntityName string                    `yaml:"entity,omitempty"`
@@ -130,6 +137,13 @@ type FormModule struct {
 	Elements   []*FormElement            `yaml:"elements,omitempty"`
 	Handlers   map[FormEventType]string  `yaml:"events,omitempty"`
 	Procedures map[string]*FormProcedure `yaml:"-"`
+
+	// Actions — переопределение стандартных действий формы объекта (issue #151).
+	// Пока поддерживается ключ "delete": actions.delete.visible=false скрывает
+	// платформенную кнопку «Удалить», чтобы конфиг мог увести удаление в свой
+	// процессор. Платформенное удаление и так пишется в _audit и закрыто правом
+	// delete — это про управление UI-кнопкой.
+	Actions map[string]*FormAction `yaml:"actions,omitempty"`
 
 	// Поля, добавленные планом 37 для управляемых форм.
 	LayoutKind             string           `yaml:"layout_kind,omitempty"`              // "managed"|"autogen" (пусто=autogen)

--- a/internal/ui/managed_delete_action_test.go
+++ b/internal/ui/managed_delete_action_test.go
@@ -1,0 +1,68 @@
+package ui
+
+// Issue #151 (опциональная фича): actions.delete.visible=false скрывает
+// платформенную кнопку «Удалить» в managed-форме объекта. Это позволяет
+// конфигу увести удаление в собственный процессор (например, с расширенным
+// аудитом). Само платформенное удаление и так пишется в _audit и закрыто
+// правом delete — здесь речь только об управлении UI-кнопкой.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func renderObjectFormGET(t *testing.T, s *Server, ent *metadata.Entity, id uuid.UUID) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/ui/catalog/"+ent.Name+"/"+id.String(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("kind", "catalog")
+	rctx.URLParams.Add("entity", ent.Name)
+	rctx.URLParams.Add("id", id.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	s.formEdit(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ожидался 200, получен %d", rec.Code)
+	}
+	return rec.Body.String()
+}
+
+func setupDeleteActionServer(t *testing.T) (*Server, *metadata.Entity, uuid.UUID) {
+	t.Helper()
+	srv, ent := setupManagedEventsServer(t, ``, nil, []*metadata.FormElement{
+		{Kind: metadata.FormElementField, Name: "Наименование", DataPath: "Объект.Наименование"},
+	})
+	id := uuid.New()
+	if err := srv.store.Upsert(context.Background(), ent.Name, id,
+		map[string]any{"Наименование": "X"}, ent); err != nil {
+		t.Fatal(err)
+	}
+	return srv, ent, id
+}
+
+func TestManagedForm_DeleteShownByDefault(t *testing.T) {
+	srv, ent, id := setupDeleteActionServer(t)
+	body := renderObjectFormGET(t, srv, ent, id)
+	if !strings.Contains(body, id.String()+"/delete") {
+		t.Errorf("по умолчанию кнопка удаления должна присутствовать в форме")
+	}
+}
+
+func TestManagedForm_HidesDeleteWhenActionInvisible(t *testing.T) {
+	srv, ent, id := setupDeleteActionServer(t)
+	vis := false
+	ent.Forms[0].Actions = map[string]*metadata.FormAction{"delete": {Visible: &vis}}
+
+	body := renderObjectFormGET(t, srv, ent, id)
+	if strings.Contains(body, id.String()+"/delete") {
+		t.Errorf("при actions.delete.visible=false кнопка удаления должна быть скрыта")
+	}
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -46,8 +46,8 @@ var tmpl = template.Must(template.New("root").Funcs(template.FuncMap{
 		}
 		return fmt.Sprintf("%v", v)
 	},
-	"isRef":      func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "reference:") },
-	"isEnum":     func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "enum:") },
+	"isRef":  func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "reference:") },
+	"isEnum": func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "enum:") },
 	"enumLabel": func(labels map[string]map[string]string, field, value string) string {
 		if m, ok := labels[field]; ok {
 			if lbl, ok := m[value]; ok && lbl != "" {
@@ -149,6 +149,19 @@ var tmpl = template.Must(template.New("root").Funcs(template.FuncMap{
 		}
 		_, ok := form.Handlers[metadata.FormEventType(eventName)]
 		return ok
+	},
+	// deleteHidden — скрыта ли кнопка «Удалить» формы через
+	// actions.delete.visible=false (issue #151). По умолчанию (нет actions
+	// или visible) — false: кнопка показывается по праву CanDelete.
+	"deleteHidden": func(form *metadata.FormModule) bool {
+		if form == nil || form.Actions == nil {
+			return false
+		}
+		a, ok := form.Actions["delete"]
+		if !ok || a == nil || a.Visible == nil {
+			return false
+		}
+		return !*a.Visible
 	},
 	// tablePartByName ищет metadata.TablePart в Entity по имени.
 	// Возвращает указатель на копию (или nil) — нужно managed-шаблону

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -384,7 +384,7 @@ const tplManagedForm = `
       </div>
     </div>
     {{end}}
-    {{if .CanDelete}}
+    {{if and .CanDelete (not (deleteHidden .Form))}}
     <form method="POST" action="/ui/{{lower (str .Entity.Kind)}}/{{.Entity.Name}}/{{.ID}}/delete"
           onsubmit="return confirm('{{if .IsAdmin}}Удалить запись навсегда?{{else}}Пометить запись на удаление?{{end}}')" style="margin-left:auto">
       <button class="btn btn-danger btn-sm" type="submit">{{if .IsAdmin}}Удалить{{else}}Пометить на удаление{{end}}</button>


### PR DESCRIPTION
Closes #151.

## Проверка (важно)
Два из трёх тезисов отчёта по коду **не подтвердились**:
- **«Кнопка рендерится для всех»** — нет: кнопка под `{{if .CanDelete}}`; неадмин видит «Пометить на удаление» (пометка), а не жёсткое удаление. `deleteRecord` требует право `delete`.
- **«Обходит журнал аудита»** — нет: `storage.Delete` пишет событие `delete` в `_audit` при включённом аудите (`crud.go`). Кастомный `СобытияАудита` дублирует встроенный `_audit`.
- Бэкап-факт: глобальный администратор (`IsAdmin`) обходит права сущности — это by-design (суперпользователь).

## Что добавлено (валидный остаток запроса)
Декларативное скрытие платформенной кнопки удаления, чтобы увести удаление в свой процессор:

```yaml
# forms/<сущность>/объекта.form.yaml
actions:
  delete:
    visible: false
```

## Тесты
- `actions.delete.visible=false` → кнопки удаления нет в форме.
- по умолчанию → кнопка есть.
- парсинг `actions:` из YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)