### PR TITLE
feat(ui): режим открытия форм — вкладки ↔ отдельные страницы (#129/#130)

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -1,5 +1,8 @@
 {
   "Вкладки": "Tabs",
+  "Режим открытия форм": "Form opening mode",
+  "Отдельные страницы": "Separate pages",
+  "По умолчанию (глобально)": "Default (global)",
   "Открывать формы отдельными страницами": "Open forms as separate pages",
   "Открывать формы во вкладках": "Open forms in tabs",
   "Файлы конфигурации": "Configuration files",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "Вкладки": "Tabs",
+  "Открывать формы отдельными страницами": "Open forms as separate pages",
+  "Открывать формы во вкладках": "Open forms in tabs",
   "Файлы конфигурации": "Configuration files",
   "Открыть в редакторе": "Open in editor",
   "Выберите файл слева для просмотра": "Select a file on the left to preview",

--- a/internal/launcher/admin_handlers.go
+++ b/internal/launcher/admin_handlers.go
@@ -661,6 +661,13 @@ func (h *handler) cfgAdminSettings(w http.ResponseWriter, r *http.Request) {
 	if db.GetExecEnabled(r.Context()) {
 		execChecked = "checked"
 	}
+	formMode := db.GetFormOpenMode(r.Context())
+	pagesSel, tabsSel := "", ""
+	if formMode == storage.FormModeTabs {
+		tabsSel = "selected"
+	} else {
+		pagesSel = "selected"
+	}
 	html := fmt.Sprintf(`<div style="padding:16px">
 	<h3 style="margin:0 0 14px;font-size:15px">Параметры базы</h3>
 	<div style="padding:12px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:4px;max-width:520px">
@@ -676,6 +683,14 @@ func (h *handler) cfgAdminSettings(w http.ResponseWriter, r *http.Request) {
 	    Сворачиваемые группы в левом меню
 	  </label>
 	  <div style="font-size:11px;color:#666;margin-top:6px">Когда включено, группы меню (Отчёты, Регистры, Обработки…) можно сворачивать; тяжёлые группы свёрнуты по умолчанию, чтобы меню не растягивало страницу.</div>
+	  <label style="font-size:12px;display:flex;align-items:center;gap:10px;margin-top:12px">
+	    Режим открытия форм по умолчанию:
+	    <select id="form_open_mode" style="padding:3px 6px;border:1px solid #cbd5e1;border-radius:3px;font-size:12px">
+	      <option value="pages" %s>Отдельные страницы</option>
+	      <option value="tabs" %s>Вкладки</option>
+	    </select>
+	  </label>
+	  <div style="font-size:11px;color:#666;margin-top:6px">Дефолт для пользователей без личной настройки. «Вкладки» открывают формы в оболочке <code>/ui/app</code>, «Отдельные страницы» — как обычные страницы <code>/ui</code>. Каждый пользователь может переопределить это в «Параметрах».</div>
 	  <div style="font-size:13px;font-weight:600;margin:16px 0 8px">Безопасность</div>
 	  <label style="font-size:12px;display:flex;align-items:center;gap:8px">
 	    <input type="checkbox" id="st-net" %s>
@@ -697,7 +712,8 @@ function cfgSettingsSave(){
   var c=document.getElementById('st-collapsenav').checked;
   var net=document.getElementById('st-net').checked;
   var exec=document.getElementById('st-exec').checked;
-  fetch('/bases/%s/configurator/admin/settings/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({list_page_size:n,collapsible_nav:c,network_enabled:net,exec_enabled:exec})})
+  var fm=document.getElementById('form_open_mode').value;
+  fetch('/bases/%s/configurator/admin/settings/save',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({list_page_size:n,collapsible_nav:c,network_enabled:net,exec_enabled:exec,form_open_mode:fm})})
     .then(function(r){return r.json()})
     .then(function(d){
       var m=document.getElementById('st-msg');
@@ -706,7 +722,7 @@ function cfgSettingsSave(){
     })
     .catch(function(){var m=document.getElementById('st-msg');m.textContent='Ошибка сети';m.style.color='#c00';});
 }
-</script>`, storage.MaxListPageSize, pageSize, storage.MaxListPageSize, navChecked, netChecked, execChecked, b.ID)
+</script>`, storage.MaxListPageSize, pageSize, storage.MaxListPageSize, navChecked, pagesSel, tabsSel, netChecked, execChecked, b.ID)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
 }
@@ -721,10 +737,11 @@ func (h *handler) cfgAdminSettingsSave(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req struct {
-		ListPageSize   int   `json:"list_page_size"`
-		CollapsibleNav *bool `json:"collapsible_nav"`
-		NetworkEnabled *bool `json:"network_enabled"`
-		ExecEnabled    *bool `json:"exec_enabled"`
+		ListPageSize   int    `json:"list_page_size"`
+		CollapsibleNav *bool  `json:"collapsible_nav"`
+		NetworkEnabled *bool  `json:"network_enabled"`
+		ExecEnabled    *bool  `json:"exec_enabled"`
+		FormOpenMode   string `json:"form_open_mode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, 400, map[string]any{"error": err.Error()})
@@ -753,6 +770,12 @@ func (h *handler) cfgAdminSettingsSave(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ExecEnabled != nil {
 		if err := db.SaveExecEnabled(r.Context(), *req.ExecEnabled); err != nil {
+			writeJSON(w, 500, map[string]any{"error": err.Error()})
+			return
+		}
+	}
+	if req.FormOpenMode != "" {
+		if err := db.SaveFormOpenMode(r.Context(), req.FormOpenMode); err != nil {
 			writeJSON(w, 500, map[string]any{"error": err.Error()})
 			return
 		}

--- a/internal/launcher/admin_settings_form_mode_test.go
+++ b/internal/launcher/admin_settings_form_mode_test.go
@@ -1,0 +1,26 @@
+package launcher
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Проверяем, что настройка глобального режима сохраняется/читается тем же
+// механизмом, что использует страница настроек конфигуратора.
+func TestConfigurator_FormOpenModeSetting(t *testing.T) {
+	db, err := storage.ConnectSQLite(context.Background(), filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	if err := db.SaveFormOpenMode(ctx, storage.FormModeTabs); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.GetFormOpenMode(ctx); got != storage.FormModeTabs {
+		t.Errorf("ожидался tabs, получено %q", got)
+	}
+}

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -225,6 +225,71 @@ func (db *DB) SaveFormOpenMode(ctx context.Context, mode string) error {
 	return nil
 }
 
+// userFormModeKey — ключ персонального режима пользователя в _settings.
+func userFormModeKey(user string) string {
+	return "ui.form_open_mode.user." + user
+}
+
+// GetUserFormOpenMode возвращает персональный режим пользователя или "" если
+// не задан (пустой логин — всегда "", персонального режима нет).
+func (db *DB) GetUserFormOpenMode(ctx context.Context, user string) string {
+	if user == "" {
+		return ""
+	}
+	d := db.dialect
+	var v string
+	err := db.QueryRow(ctx,
+		`SELECT value FROM _settings WHERE key = `+d.Placeholder(1),
+		userFormModeKey(user)).Scan(&v)
+	if err != nil {
+		return ""
+	}
+	switch strings.TrimSpace(v) {
+	case FormModeTabs:
+		return FormModeTabs
+	case FormModePages:
+		return FormModePages
+	default:
+		return ""
+	}
+}
+
+// SaveUserFormOpenMode пишет персональный режим. Значение "" или "default"
+// удаляет персональную настройку (вернуться к глобальному дефолту).
+func (db *DB) SaveUserFormOpenMode(ctx context.Context, user, mode string) error {
+	if user == "" {
+		return nil
+	}
+	if err := db.EnsureSettingsSchema(ctx); err != nil {
+		return err
+	}
+	d := db.dialect
+	m := strings.TrimSpace(mode)
+	if m == "" || m == "default" {
+		_, err := db.Exec(ctx,
+			`DELETE FROM _settings WHERE key = `+d.Placeholder(1),
+			userFormModeKey(user))
+		return err
+	}
+	q := fmt.Sprintf(
+		`INSERT INTO _settings (key, value) VALUES (%s, %s)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+		d.Placeholder(1), d.Placeholder(2))
+	if _, err := db.Exec(ctx, q, userFormModeKey(user), normFormMode(m)); err != nil {
+		return fmt.Errorf("settings: save user form mode: %w", err)
+	}
+	return nil
+}
+
+// EffectiveFormOpenMode — итоговый режим: персональный, если задан, иначе
+// глобальный (который при отсутствии — pages).
+func (db *DB) EffectiveFormOpenMode(ctx context.Context, user string) string {
+	if p := db.GetUserFormOpenMode(ctx, user); p != "" {
+		return p
+	}
+	return db.GetFormOpenMode(ctx)
+}
+
 // Режимы хранения бинарников (картинки поля image). Аналог двух способов
 // хранения файлов в 1С: «тома на диске» и «в информационной базе».
 const (

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -172,6 +172,59 @@ func (db *DB) SaveNavCollapsible(ctx context.Context, on bool) error {
 	return nil
 }
 
+// Режимы открытия форм в Предприятии (issue #129/#130).
+const (
+	// FormModePages — формы открываются отдельными страницами (/ui). Дефолт.
+	FormModePages = "pages"
+	// FormModeTabs — формы открываются во вкладках (оболочка /ui/app).
+	FormModeTabs = "tabs"
+	// DefaultFormOpenMode — режим по умолчанию при отсутствии настройки.
+	DefaultFormOpenMode = FormModePages
+)
+
+// normFormMode приводит значение к каноническому режиму; всё неизвестное —
+// к дефолту pages.
+func normFormMode(v string) string {
+	switch strings.TrimSpace(v) {
+	case FormModeTabs:
+		return FormModeTabs
+	case FormModePages:
+		return FormModePages
+	default:
+		return DefaultFormOpenMode
+	}
+}
+
+// GetFormOpenMode читает глобальный режим открытия форм из _settings
+// (ui.form_open_mode). Отсутствие ключа/таблицы/битое значение → pages.
+func (db *DB) GetFormOpenMode(ctx context.Context) string {
+	d := db.dialect
+	var v string
+	err := db.QueryRow(ctx,
+		`SELECT value FROM _settings WHERE key = `+d.Placeholder(1),
+		"ui.form_open_mode").Scan(&v)
+	if err != nil {
+		return DefaultFormOpenMode
+	}
+	return normFormMode(v)
+}
+
+// SaveFormOpenMode сохраняет глобальный режим (нормализуется к pages/tabs).
+func (db *DB) SaveFormOpenMode(ctx context.Context, mode string) error {
+	if err := db.EnsureSettingsSchema(ctx); err != nil {
+		return err
+	}
+	d := db.dialect
+	q := fmt.Sprintf(
+		`INSERT INTO _settings (key, value) VALUES (%s, %s)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+		d.Placeholder(1), d.Placeholder(2))
+	if _, err := db.Exec(ctx, q, "ui.form_open_mode", normFormMode(mode)); err != nil {
+		return fmt.Errorf("settings: save ui.form_open_mode: %w", err)
+	}
+	return nil
+}
+
 // Режимы хранения бинарников (картинки поля image). Аналог двух способов
 // хранения файлов в 1С: «тома на диске» и «в информационной базе».
 const (

--- a/internal/storage/settings_form_mode_test.go
+++ b/internal/storage/settings_form_mode_test.go
@@ -39,3 +39,41 @@ func TestFormOpenMode_GlobalDefaultAndSave(t *testing.T) {
 		t.Errorf("битое значение должно дать %q, получено %q", FormModePages, got)
 	}
 }
+
+func TestFormOpenMode_PersonalOverridesGlobal(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	// Глобально tabs, у пользователя ничего — эффективный tabs.
+	if err := db.SaveFormOpenMode(ctx, FormModeTabs); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.EffectiveFormOpenMode(ctx, "ivan"); got != FormModeTabs {
+		t.Errorf("без персонального → глобальный tabs, получено %q", got)
+	}
+	// Персонально pages — перебивает глобальный.
+	if err := db.SaveUserFormOpenMode(ctx, "ivan", FormModePages); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.EffectiveFormOpenMode(ctx, "ivan"); got != FormModePages {
+		t.Errorf("персональный pages должен перебить, получено %q", got)
+	}
+	// Другой пользователь не затронут — у него глобальный tabs.
+	if got := db.EffectiveFormOpenMode(ctx, "petr"); got != FormModeTabs {
+		t.Errorf("у другого пользователя глобальный tabs, получено %q", got)
+	}
+	// Сброс персонального ("" или "default") → снова глобальный.
+	if err := db.SaveUserFormOpenMode(ctx, "ivan", "default"); err != nil {
+		t.Fatal(err)
+	}
+	if got := db.GetUserFormOpenMode(ctx, "ivan"); got != "" {
+		t.Errorf("после сброса персональный должен быть пуст, получено %q", got)
+	}
+	if got := db.EffectiveFormOpenMode(ctx, "ivan"); got != FormModeTabs {
+		t.Errorf("после сброса → глобальный tabs, получено %q", got)
+	}
+	// Пустой логин (аноним) → глобальный.
+	if got := db.EffectiveFormOpenMode(ctx, ""); got != FormModeTabs {
+		t.Errorf("аноним → глобальный tabs, получено %q", got)
+	}
+}

--- a/internal/storage/settings_form_mode_test.go
+++ b/internal/storage/settings_form_mode_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := ConnectSQLite(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestFormOpenMode_GlobalDefaultAndSave(t *testing.T) {
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	// Без ключа — дефолт pages.
+	if got := db.GetFormOpenMode(ctx); got != FormModePages {
+		t.Errorf("дефолт: ожидался %q, получено %q", FormModePages, got)
+	}
+	// Сохранили tabs — читается tabs.
+	if err := db.SaveFormOpenMode(ctx, FormModeTabs); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if got := db.GetFormOpenMode(ctx); got != FormModeTabs {
+		t.Errorf("после save tabs: получено %q", got)
+	}
+	// Битое значение → pages.
+	if err := db.SaveFormOpenMode(ctx, "мусор"); err != nil {
+		t.Fatalf("save мусор: %v", err)
+	}
+	if got := db.GetFormOpenMode(ctx); got != FormModePages {
+		t.Errorf("битое значение должно дать %q, получено %q", FormModePages, got)
+	}
+}

--- a/internal/ui/form_mode_test.go
+++ b/internal/ui/form_mode_test.go
@@ -122,3 +122,15 @@ func TestNav_ShowsTabsToggle(t *testing.T) {
 		t.Error("в топбаре нет формы переключателя режима (/ui/form-mode)")
 	}
 }
+
+// TestParams_HasFormModeRadio проверяет, что в «Параметрах» (меню Система → nav)
+// есть радиогруппа режима открытия форм со всеми тремя значениями: персональный
+// pages/tabs и сброс к глобальному default.
+func TestParams_HasFormModeRadio(t *testing.T) {
+	out := renderNavWithMode(t, storage.FormModeTabs)
+	for _, want := range []string{`value="pages"`, `value="tabs"`, `value="default"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("в «Параметрах» нет радио %s", want)
+		}
+	}
+}

--- a/internal/ui/form_mode_test.go
+++ b/internal/ui/form_mode_test.go
@@ -89,9 +89,11 @@ func TestSetFormMode_PersistsAndRedirects(t *testing.T) {
 	}
 }
 
-// TestSetFormMode_AnonymousFallsBackToGlobal проверяет краевой случай спеки:
-// у анонимной сессии персонального режима нет, действует глобальный дефолт.
-func TestSetFormMode_AnonymousFallsBackToGlobal(t *testing.T) {
+// TestSetFormMode_AnonymousWritesGlobal: у анонимной сессии (no-auth база,
+// login == "") персонального режима нет, поэтому переключатель меняет
+// ГЛОБАЛЬНЫЙ режим — иначе кнопка/радио были бы мёртвыми (issue #129/#130,
+// фикс блокера ревью). POST mode=tabs → глобальный tabs → редирект в /ui/app.
+func TestSetFormMode_AnonymousWritesGlobal(t *testing.T) {
 	s := newServerForFormMode(t)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/ui/form-mode", strings.NewReader("mode=tabs"))
@@ -100,9 +102,25 @@ func TestSetFormMode_AnonymousFallsBackToGlobal(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("ожидался 303, получено %d", rec.Code)
 	}
-	// Глобально pages (дефолт), персональный не сохранён → редирект на /ui.
-	if loc := rec.Header().Get("Location"); loc != "/ui" {
-		t.Errorf("Location = %q, ожидалось /ui", loc)
+	// Глобальный режим действительно переключился на tabs.
+	if got := s.store.GetFormOpenMode(req.Context()); got != storage.FormModeTabs {
+		t.Errorf("аноним не переключил глобальный режим: %q", got)
+	}
+	// Эффективный режим анонима теперь tabs → редирект в оболочку вкладок.
+	if loc := rec.Header().Get("Location"); loc != "/ui/app" {
+		t.Errorf("Location = %q, ожидалось /ui/app", loc)
+	}
+	// Возврат: POST mode=pages → глобальный снова pages → редирект на /ui
+	// (доказывает, что в no-auth базе переключатель работает в обе стороны).
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/ui/form-mode", strings.NewReader("mode=pages"))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.setFormMode(rec2, req2)
+	if got := s.store.GetFormOpenMode(req2.Context()); got != storage.FormModePages {
+		t.Errorf("аноним не вернул глобальный режим в pages: %q", got)
+	}
+	if loc := rec2.Header().Get("Location"); loc != "/ui" {
+		t.Errorf("Location(возврат) = %q, ожидалось /ui", loc)
 	}
 }
 

--- a/internal/ui/form_mode_test.go
+++ b/internal/ui/form_mode_test.go
@@ -1,13 +1,16 @@
 package ui
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/widget"
@@ -62,5 +65,60 @@ func TestIndex_NoRedirectInPagesMode(t *testing.T) {
 	s.index(rec, req)
 	if rec.Code == http.StatusSeeOther {
 		t.Fatalf("в режиме pages редиректа быть не должно, получено %d", rec.Code)
+	}
+}
+
+func TestSetFormMode_PersistsAndRedirects(t *testing.T) {
+	s := newServerForFormMode(t)
+	rec := httptest.NewRecorder()
+	// Персональный режим хранится по логину, поэтому привязываем пользователя к
+	// запросу (анонимная сессия персонального режима не имеет — см. спеку).
+	req := httptest.NewRequest(http.MethodPost, "/ui/form-mode", strings.NewReader("mode=tabs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{Login: "ivan"}))
+	s.setFormMode(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("ожидался 303, получено %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/ui/app" {
+		t.Errorf("Location = %q, ожидалось /ui/app", loc)
+	}
+	// Персональный режим действительно сохранён — последующее разрешение даёт tabs.
+	if got := s.store.EffectiveFormOpenMode(req.Context(), "ivan"); got != storage.FormModeTabs {
+		t.Errorf("после POST персональный режим не сохранён: %q", got)
+	}
+}
+
+// TestSetFormMode_AnonymousFallsBackToGlobal проверяет краевой случай спеки:
+// у анонимной сессии персонального режима нет, действует глобальный дефолт.
+func TestSetFormMode_AnonymousFallsBackToGlobal(t *testing.T) {
+	s := newServerForFormMode(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/ui/form-mode", strings.NewReader("mode=tabs"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	s.setFormMode(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("ожидался 303, получено %d", rec.Code)
+	}
+	// Глобально pages (дефолт), персональный не сохранён → редирект на /ui.
+	if loc := rec.Header().Get("Location"); loc != "/ui" {
+		t.Errorf("Location = %q, ожидалось /ui", loc)
+	}
+}
+
+func renderNavWithMode(t *testing.T, mode string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	data := map[string]any{"Cfg": Config{}, "Lang": "ru", "IsAdmin": false, "FormOpenMode": mode}
+	if err := tmpl.ExecuteTemplate(&buf, "nav", data); err != nil {
+		t.Fatalf("execute nav: %v", err)
+	}
+	return buf.String()
+}
+
+func TestNav_ShowsTabsToggle(t *testing.T) {
+	out := renderNavWithMode(t, storage.FormModePages)
+	if !strings.Contains(out, "/ui/form-mode") {
+		t.Error("в топбаре нет формы переключателя режима (/ui/form-mode)")
 	}
 }

--- a/internal/ui/form_mode_test.go
+++ b/internal/ui/form_mode_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/ivantit66/onebase/internal/widget"
+)
+
+// newServerForFormMode конструирует минимальный *Server для тестов режима
+// открытия форм (мирроринг TestAgentSettings_ForbiddenForNonAdmin: реестр +
+// SQLite, но с миграцией и виджет-кэшем, чтобы прошёл полный рендер index).
+func newServerForFormMode(t *testing.T) *Server {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.Migrate(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+	return &Server{
+		store:       db,
+		reg:         runtime.NewRegistry(),
+		messages:    NewMessageStore(),
+		widgetCache: widget.NewCache(60 * time.Second),
+	}
+}
+
+func TestIndex_RedirectsToTabsWhenTabsMode(t *testing.T) {
+	s := newServerForFormMode(t)
+	ctx := context.Background()
+	if err := s.store.SaveFormOpenMode(ctx, storage.FormModeTabs); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	// ASCII-имя подсистемы: http.Redirect percent-кодирует не-ASCII байты в
+	// Location (стандартная библиотека), поэтому для точного сравнения строки
+	// берём ASCII; кириллица сохраняется тем же образом, только в %xx-форме.
+	req := httptest.NewRequest(http.MethodGet, "/ui?subsystem=Sales", nil)
+	s.index(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("ожидался 303, получено %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/ui/app?subsystem=Sales" {
+		t.Errorf("Location = %q, ожидалось /ui/app?subsystem=Sales", loc)
+	}
+}
+
+func TestIndex_NoRedirectInPagesMode(t *testing.T) {
+	s := newServerForFormMode(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ui", nil)
+	s.index(rec, req)
+	if rec.Code == http.StatusSeeOther {
+		t.Fatalf("в режиме pages редиректа быть не должно, получено %d", rec.Code)
+	}
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -320,6 +320,11 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	if _, ok := data["IsAdmin"]; !ok {
 		data["IsAdmin"] = s.isAdmin(r)
 	}
+	if _, ok := data["FormOpenMode"]; !ok {
+		login := currentUserLogin(r)
+		data["FormOpenMode"] = s.store.EffectiveFormOpenMode(r.Context(), login)
+		data["FormOpenModePersonal"] = s.store.GetUserFormOpenMode(r.Context(), login)
+	}
 	// Default per-entity permission flags so partial render paths (e.g. validation
 	// errors) still show the right action buttons.
 	if ent, ok := data["Entity"].(*metadata.Entity); ok {

--- a/internal/ui/handlers_form_mode.go
+++ b/internal/ui/handlers_form_mode.go
@@ -6,13 +6,25 @@ import (
 	"github.com/ivantit66/onebase/internal/storage"
 )
 
-// setFormMode пишет персональный режим открытия форм текущего пользователя
-// (поле формы mode = pages | tabs | default) и уводит на вход выбранного
-// режима. issue #129/#130.
+// setFormMode пишет режим открытия форм текущего пользователя (поле формы
+// mode = pages | tabs | default) и уводит на вход выбранного режима.
+// issue #129/#130.
+//
+// В безавторизационной базе (login == "") персонального режима не существует:
+// эффективный режим анонимной сессии — это глобальный. Поэтому переключатель
+// меняет глобальный режим (SaveFormOpenMode), иначе кнопка/радио были бы
+// мёртвыми — клик ничего не делал бы (SaveUserFormOpenMode при пустом логине —
+// no-op). Для авторизованного пользователя пишется персональный режим.
 func (s *Server) setFormMode(w http.ResponseWriter, r *http.Request) {
 	mode := r.FormValue("mode")
 	login := currentUserLogin(r)
-	if err := s.store.SaveUserFormOpenMode(r.Context(), login, mode); err != nil {
+	var err error
+	if login == "" {
+		err = s.store.SaveFormOpenMode(r.Context(), mode)
+	} else {
+		err = s.store.SaveUserFormOpenMode(r.Context(), login, mode)
+	}
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/ui/handlers_form_mode.go
+++ b/internal/ui/handlers_form_mode.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"net/http"
+
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// setFormMode пишет персональный режим открытия форм текущего пользователя
+// (поле формы mode = pages | tabs | default) и уводит на вход выбранного
+// режима. issue #129/#130.
+func (s *Server) setFormMode(w http.ResponseWriter, r *http.Request) {
+	mode := r.FormValue("mode")
+	login := currentUserLogin(r)
+	if err := s.store.SaveUserFormOpenMode(r.Context(), login, mode); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	target := "/ui"
+	if s.store.EffectiveFormOpenMode(r.Context(), login) == storage.FormModeTabs {
+		target = "/ui/app"
+	}
+	http.Redirect(w, r, target, http.StatusSeeOther)
+}

--- a/internal/ui/handlers_home.go
+++ b/internal/ui/handlers_home.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/widget"
 )
 
@@ -89,6 +90,17 @@ func (s *Server) logo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) index(w http.ResponseWriter, r *http.Request) {
+	// Режим вкладок: входная страница уводит в оболочку /ui/app (issue #129/#130).
+	if s.store.EffectiveFormOpenMode(r.Context(), currentUserLogin(r)) == storage.FormModeTabs {
+		target := "/ui/app"
+		// subsystem передаётся «как есть» — той же конвенцией, что в ссылках
+		// меню (server.go/templates) и в шиме /ui/app (tabs.go).
+		if sub := r.URL.Query().Get("subsystem"); sub != "" {
+			target += "?subsystem=" + sub
+		}
+		http.Redirect(w, r, target, http.StatusSeeOther)
+		return
+	}
 	hp := s.reg.HomePage()
 	if sub := r.URL.Query().Get("subsystem"); sub != "" {
 		if ss := s.reg.GetSubsystem(sub); ss != nil && ss.HomePage != nil {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -154,7 +154,8 @@ func (s *Server) Mount(r chi.Router) {
 	mountStatic(r)
 	r.Get("/ui", s.index)
 	r.Get("/ui/", s.index)
-	r.Get("/ui/app", s.appShell) // оболочка вкладок (issue #129/#130, фаза 1)
+	r.Get("/ui/app", s.appShell)           // оболочка вкладок (issue #129/#130, фаза 1)
+	r.Post("/ui/form-mode", s.setFormMode) // переключение режима открытия форм
 
 	// Gengen — ДО catch-all роутов! (иначе /ui/dev/gengen матчится как {kind}/{entity})
 	r.Get("/ui/dev/gengen", s.gengenPage)

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -786,6 +786,15 @@ const tplNav = `
 <header class="topbar">
   <button class="nav-toggle" type="button" aria-label="{{t $.Lang "Меню"}}" aria-controls="ob-nav" aria-expanded="false" onclick="obNavToggle()">&#9776;</button>
   <a href="/ui/" class="topbar-title" style="text-decoration:none;color:inherit" title="{{t $.Lang "Главная"}}">{{if .Cfg.Logo}}<img src="/ui/logo" alt="" style="height:22px;max-width:90px;vertical-align:middle;margin-right:6px;border-radius:2px">{{end}}⚡ {{if .Cfg.AppName}}{{.Cfg.AppName}}{{else}}onebase{{end}}</a>
+  <form method="post" action="/ui/form-mode" style="display:inline;margin:0">
+    {{if eq (printf "%v" .FormOpenMode) "tabs"}}
+      <input type="hidden" name="mode" value="pages">
+      <button type="submit" class="sys-btn" title="{{t $.Lang "Открывать формы отдельными страницами"}}">&#9645; {{t $.Lang "Страницы"}}</button>
+    {{else}}
+      <input type="hidden" name="mode" value="tabs">
+      <button type="submit" class="sys-btn" title="{{t $.Lang "Открывать формы во вкладках"}}">&#10697; {{t $.Lang "Вкладки"}}</button>
+    {{end}}
+  </form>
   <div class="sys-menu">
     <button class="sys-btn" onclick="var d=document.getElementById('sysd');d.classList.toggle('open')">&#9881; {{t $.Lang "Система"}} &#9660;</button>
     <div class="sys-drop" id="sysd">

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -822,6 +822,15 @@ const tplNav = `
         <a href="/ui/dev/gengen">{{t $.Lang "Gengen"}}</a>
       </div>
     </div>{{end}}
+      <div style="border-top:1px solid #f1f5f9;padding:10px 16px">
+        <div style="font-size:12px;color:#64748b;margin-bottom:6px;font-weight:600">{{t $.Lang "Режим открытия форм"}}</div>
+        <form method="post" action="/ui/form-mode" style="margin:0;padding:0">
+          <label style="display:block;font-size:13px;padding:2px 0;cursor:pointer"><input type="radio" name="mode" value="pages" {{if eq (printf "%v" .FormOpenModePersonal) "pages"}}checked{{end}}> {{t $.Lang "Отдельные страницы"}}</label>
+          <label style="display:block;font-size:13px;padding:2px 0;cursor:pointer"><input type="radio" name="mode" value="tabs" {{if eq (printf "%v" .FormOpenModePersonal) "tabs"}}checked{{end}}> {{t $.Lang "Вкладки"}}</label>
+          <label style="display:block;font-size:13px;padding:2px 0;cursor:pointer"><input type="radio" name="mode" value="default" {{if eq (printf "%v" .FormOpenModePersonal) ""}}checked{{end}}> {{t $.Lang "По умолчанию (глобально)"}}</label>
+          <button type="submit" class="sys-btn" style="margin-top:6px">{{t $.Lang "Применить"}}</button>
+        </form>
+      </div>
       {{if .HasAuth}}{{if not .DenyPasswdChange}}<a href="/ui/profile/passwd">{{t $.Lang "Сменить пароль"}}</a>{{end}}{{end}}
       <form method="POST" action="/logout" style="margin:0;padding:0"><button type="submit" style="display:block;width:100%;padding:10px 16px;color:#dc2626;text-decoration:none;font-size:14px;text-align:left;background:none;border:none;border-top:1px solid #f1f5f9;cursor:pointer">{{t $.Lang "Выйти"}}</button></form>
     </div>


### PR DESCRIPTION
## Суть
Настройка режима открытия форм в Предприятии, как в 1С: **«Отдельные страницы»** (как сейчас) или **«Вкладки»** (оболочка `/ui/app`). Подключает уже собранную оболочку вкладок ко входу и делает её обнаружимой.

- **Глобальный дефолт** (`_settings: ui.form_open_mode`, по умолчанию `pages`) + **персональное переопределение** по пользователю (`ui.form_open_mode.user.<login>`). Эффективный режим = персональный → глобальный → `pages`.
- **Топбар:** кнопка-переключатель «⧉ Вкладки» / «▭ Страницы» (POST `/ui/form-mode`) — мгновенно и заметно.
- **Меню «⚙ Система»:** радио «Режим открытия форм» (Отдельные страницы / Вкладки / По умолчанию).
- **Конфигуратор → настройки базы:** глобальный дефолт.
- `GET /ui` редиректит на `/ui/app` при `tabs`; прямые ссылки `/ui/...` и режим `pages` — без изменений (обратная совместимость).

## Реализация
Спека+план: `docs/superpowers/specs|plans/2026-06-21-form-open-mode.*` (локально). 6 задач по TDD, по коммиту на задачу.

## Тесты
- `internal/storage`: дефолт/save/битое→pages, персональный перебивает глобальный, изоляция пользователей, сброс, аноним→глобал.
- `internal/ui`: редирект index при tabs / без редиректа при pages; POST `/ui/form-mode`; наличие кнопки и радио в `nav`.
- `internal/launcher`: round-trip глобального дефолта.
- `go build ./...`, `go test ./internal/{storage,ui,launcher}`, `i18ncheck` — зелёные.

## Ручная проверка
- [ ] Топбар «⧉ Вкладки» → `/ui` уводит в `/ui/app`; «▭ Страницы» возвращает.
- [ ] «Система» → радио «По умолчанию» — берётся глобальный режим.
- [ ] Конфигуратор → сменить дефолт → у нового пользователя без персонального применяется глобальный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)