### PR TITLE
chore: игнорировать локальные заметки ручной проверки (ПРОВЕРКА*.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ starterplan.MD
 tz.md
 improvement-roadmap.md
 
+# Локальные заметки ручной проверки фич (не в публичном репо)
+ПРОВЕРКА*.md
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Добавляет в `.gitignore` паттерн `ПРОВЕРКА*.md` — локальные заметки ручной проверки фич (`ПРОВЕРКА_ФИЧ.md`, `bp3_exchange_contract/ПРОВЕРКА.md`) не должны попадать в публичный репозиторий.

Только `.gitignore`, код не затронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)