### PR TITLE
fix(dsl): Соответствие.Поле — явная ошибка вместо тихого Неопределено

### DIFF
--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -415,6 +415,11 @@ func (i *Interpreter) assign(target ast.Expr, val any, e *env) {
 			o.Set(field, val)
 		case *Struct:
 			o.Set(field, val)
+		case *Map:
+			// Симметрично чтению: запись по точке у Соответствия не работает —
+			// раньше тихо терялась, теперь явная ошибка с подсказкой.
+			RaiseUserError("Соответствие не поддерживает запись по точке «." + t.Field.Literal +
+				"» — используйте Вставить(\"" + t.Field.Literal + "\", Значение)")
 		}
 	case *ast.IndexExpr:
 		obj := i.evalExpr(t.Object, e)
@@ -455,6 +460,12 @@ func (i *Interpreter) evalExpr(expr ast.Expr, e *env) any {
 			return o.Get(field)
 		case *Ref:
 			return o.Get(field)
+		case *Map:
+			// Соответствие не поддерживает чтение по точке (как в 1С) — частая
+			// ошибка с результатом ПрочитатьJSON. Раньше тихо возвращали
+			// Неопределено, что прятало опечатку; теперь — понятная ошибка.
+			RaiseUserError("Соответствие не поддерживает чтение по точке «." + v.Field.Literal +
+				"» — используйте Получить(\"" + v.Field.Literal + "\")")
 		}
 		return nil
 	case *ast.IndexExpr:

--- a/internal/dsl/interpreter/map_member_access_test.go
+++ b/internal/dsl/interpreter/map_member_access_test.go
@@ -1,0 +1,64 @@
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/dsl/lexer"
+	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+// runProcErr прогоняет первую процедуру и возвращает ошибку выполнения (если есть).
+func runProcErr(t *testing.T, src string) error {
+	t.Helper()
+	prog, err := parser.New(lexer.New(src, "test.os")).ParseProgram()
+	require.NoError(t, err)
+	require.NotEmpty(t, prog.Procedures)
+	obj := runtime.NewObject("Test", metadata.KindDocument)
+	var result any
+	return interpreter.New().RunWithResult(prog.Procedures[0], obj, &result)
+}
+
+// Чтение по точке у Соответствия (частая ошибка с результатом ПрочитатьJSON)
+// раньше тихо возвращало Неопределено; теперь — понятная ошибка с подсказкой
+// про Получить(). См. поведение 1С: Соответствие.Ключ — ошибка, а не nil.
+func TestMapDotRead_RaisesWithHint(t *testing.T) {
+	src := `Процедура Тест()
+		м = ПрочитатьJSON("{""ИНН"":""7701234567""}");
+		Возврат м.ИНН;
+	КонецПроцедуры`
+	err := runProcErr(t, src)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Соответствие не поддерживает чтение по точке")
+	assert.ErrorContains(t, err, `Получить("ИНН")`)
+}
+
+// Запись по точке у Соответствия раньше тихо терялась; теперь — ошибка с
+// подсказкой про Вставить().
+func TestMapDotWrite_RaisesWithHint(t *testing.T) {
+	src := `Процедура Тест()
+		м = Новый Соответствие;
+		м.ИНН = "7701234567";
+	КонецПроцедуры`
+	err := runProcErr(t, src)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Соответствие не поддерживает запись по точке")
+	assert.ErrorContains(t, err, `Вставить("ИНН"`)
+}
+
+// Позитивный контроль: штатный доступ через Получить/Вставить работает как и
+// раньше — правка не задела метод-вызовы.
+func TestMapMethodAccess_StillWorks(t *testing.T) {
+	src := `Процедура Тест()
+		м = Новый Соответствие;
+		м.Вставить("ИНН", "7701234567");
+		Возврат м.Получить("ИНН");
+	КонецПроцедуры`
+	err := runProcErr(t, src)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Развитие обсуждения из #181: убираем «тихий nil» при точечном доступе к Соответствию.

## Проблема
`Соответствие.Поле` раньше:
- **чтение** — молча возвращало `Неопределено`;
- **запись** (`Соответствие.Поле = …`) — молча терялась (в `assign` для `*Map` не было ветки).

Из-за этого опечатка не диагностировалась, а проявлялась только «по пустым данным» — ровно так в демо импорта (#181) создавались записи с пустым наименованием. В 1С `Соответствие.Ключ` — это ошибка, а не `nil`, так что текущее поведение было даже *менее* 1С-корректным.

## Что меняется
В `MemberExpr` (чтение в `evalExpr` и запись в `assign`) добавлена ветка `*Map` с понятной ошибкой и подсказкой:

```
Соответствие не поддерживает чтение по точке «.ИНН» — используйте Получить("ИНН")
Соответствие не поддерживает запись по точке «.ИНН» — используйте Вставить("ИНН", Значение)
```

Семантику JSON намеренно **не** трогаем (Соответствие остаётся Соответствием; точечный доступ только у Структуры — как в 1С).

## Совместимость
Затронут **только** «голый» `Соответствие.Поле`. Не затронуты:
- метод-вызовы `.Получить(...)` / `.Вставить(...)` / `.Количество()` (другой путь исполнения);
- доступ по индексу `Соответствие[ключ]`;
- `Структура` / ссылки / `Это`-объекты.

## Проверки
- `go test ./...` — зелёный; добавлены юнит-тесты (чтение→`Получить`, запись→`Вставить`, позитивный контроль метод-доступа).
- `onebase check` по всем `examples/` (accounting/crm/finance/minimal/tasks/trade) — OK.
- Grep по примерам: все `Новый Соответствие` используются через методы, точечного доступа к полю нет — кроме того самого демо импорта из #181, которое теперь даёт явную ошибку вместо пустых записей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
