### PR TITLE
fix: устранить замечания ревью по безопасности и проверкам

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -50,6 +50,16 @@ type Handlers struct {
 	LoginLimit *LoginLimiter // rate-limit попыток входа (план 53); optional
 }
 
+func setSessionCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "onebase_session",
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 // limitExceeded отвечает 429 + Retry-After, если ключ заблокирован лимитером.
 func (h *Handlers) limitExceeded(w http.ResponseWriter, r *http.Request, login string) bool {
 	if h.LoginLimit == nil {
@@ -149,13 +159,7 @@ func (h *Handlers) LoginSubmit(w http.ResponseWriter, r *http.Request) {
 		h.Auditor.LogAction(r.Context(), "login", "", "", "", user.ID, user.Login, ip)
 	}
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     "onebase_session",
-		Value:    token,
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	setSessionCookie(w, token)
 
 	returnURL := r.URL.Query().Get("return")
 	if returnURL == "" || !isLocalURL(returnURL) {
@@ -196,10 +200,15 @@ func (h *Handlers) LoginJSON(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if h.Auditor != nil {
+		h.Auditor.LogAction(r.Context(), "login", "", "", "", user.ID, user.Login, r.RemoteAddr)
+	}
+
+	setSessionCookie(w, token)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"token": token,
-		"user":  map[string]any{"id": user.ID, "login": user.Login, "is_admin": user.IsAdmin},
+		"ok":   true,
+		"user": map[string]any{"id": user.ID, "login": user.Login, "is_admin": user.IsAdmin},
 	})
 }
 
@@ -256,13 +265,7 @@ func (h *Handlers) Bootstrap(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/login", http.StatusFound)
 		return
 	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     "onebase_session",
-		Value:    token,
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	setSessionCookie(w, token)
 	http.Redirect(w, r, returnURL, http.StatusFound)
 }
 

--- a/internal/auth/handlers_json_test.go
+++ b/internal/auth/handlers_json_test.go
@@ -1,0 +1,56 @@
+package auth_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/auth"
+)
+
+func TestLoginJSONSetsSessionCookieAndDoesNotReturnToken(t *testing.T) {
+	repo, ctx := newTestRepo(t)
+	if _, err := repo.Create(ctx, "ivan", "secret123", "Иван", false); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h := &auth.Handlers{Repo: repo}
+
+	req := httptest.NewRequest("POST", "/auth/login", strings.NewReader(`{"login":"ivan","password":"secret123"}`))
+	req.RemoteAddr = "10.0.0.1:55555"
+	rec := httptest.NewRecorder()
+	h.LoginJSON(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("LoginJSON status = %d, body: %s", rec.Code, rec.Body.String())
+	}
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "onebase_session" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil || sessionCookie.Value == "" {
+		t.Fatalf("LoginJSON did not set onebase_session cookie")
+	}
+	if !sessionCookie.HttpOnly || sessionCookie.SameSite != http.SameSiteLaxMode || sessionCookie.Path != "/" {
+		t.Fatalf("unexpected session cookie attrs: %+v", sessionCookie)
+	}
+	if _, err := repo.LookupSession(ctx, sessionCookie.Value); err != nil {
+		t.Fatalf("cookie session token is not valid: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := body["token"]; ok {
+		t.Fatalf("LoginJSON must not expose session token in JSON body: %v", body)
+	}
+	user, _ := body["user"].(map[string]any)
+	if user["login"] != "ivan" {
+		t.Fatalf("unexpected response user: %v", body["user"])
+	}
+}

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -1,16 +1,11 @@
 package cli
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/configcheck"
-	"github.com/ivantit66/onebase/internal/project"
-	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -43,46 +38,7 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	}
 	defer bc.Cleanup()
 
-	dirIssues, dirWarnings := configcheck.CheckDir(bc.Dir)
-	issues := dirIssues
-	warnings := dirWarnings
-	// project.Load даёт кросс-ссылочные ошибки и Project для компиляции запросов.
-	if proj, lerr := project.Load(bc.Dir); lerr == nil {
-		issues = append(issues, configcheck.CheckQueries(proj)...)
-		issues = append(issues, configcheck.CheckReportComposition(proj)...)
-		// Кросс-ссылки между объектами (документы в журналах/подсистемах/ролях,
-		// виджеты главной страницы, источник печатной формы). Роли грузятся
-		// отдельно — они не часть project.Project.
-		roles, _ := auth.LoadRolesYAML(filepath.Join(bc.Dir, "roles"))
-		issues = append(issues, configcheck.CheckCrossRefs(proj, roles)...)
-		// Неблокирующие предупреждения по макетам v2 (например rowspan в repeat-
-		// области может некорректно разрываться по страницам PDF).
-		warnings = append(warnings, configcheck.CheckLayoutWarnings(proj)...)
-		// HTTP-сервисы (план 61): дубли root_url, наличие обработчиков, auth.
-		issues = append(issues, configcheck.CheckHTTPServices(proj)...)
-		// Страницы (план 66): наличие обработчика ПриФормировании.
-		issues = append(issues, configcheck.CheckPages(proj)...)
-		// Коллизии имён таблиц: справочник и документ с одинаковым именем
-		// делят одну физическую таблицу lower(имя) (issue #20).
-		issues = append(issues, configcheck.CheckNameCollisions(proj)...)
-		// п.45: исполняемая валидация запросов против in-memory схемы из
-		// метаданных (best-effort — при сбое настройки схемы просто пропускаем,
-		// чтобы не ломать обычную проверку компиляции).
-		if db, closeDB, derr := buildSchemaDB(proj); derr == nil {
-			validate := func(sql string) error { return db.ValidateQuery(context.Background(), sql) }
-			issues = append(issues, configcheck.CheckQueriesExecutable(proj, validate)...)
-			// Запросы внутри .os-модулей (Запрос.Текст = "...") — компиляция + PREPARE.
-			issues = append(issues, configcheck.CheckModuleQueries(proj, validate)...)
-			closeDB()
-		} else {
-			// Схему поднять не удалось — хотя бы проверим компиляцию модульных запросов.
-			issues = append(issues, configcheck.CheckModuleQueries(proj, nil)...)
-		}
-		proj.Close()
-	} else if !configcheck.AlreadyReported(issues, lerr.Error()) {
-		issues = append(issues, configcheck.Issue{Message: "Project.Load: " + lerr.Error()})
-	}
-	res := configcheck.NewResult(issues, warnings)
+	res := configcheck.RunFull(bc.Dir)
 
 	if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
 		enc := json.NewEncoder(os.Stdout)
@@ -97,47 +53,6 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 		os.Exit(1)
 	}
 	return nil
-}
-
-// buildSchemaDB поднимает временную SQLite-базу со схемой из метаданных проекта
-// (entity/register/inforeg/constant/accountreg) — для исполняемой валидации
-// запросов (п.45). Возвращает базу и closer (закрыть + удалить файл). Файл, а не
-// ":memory:", т.к. ConnectSQLite ориентирован на путь; один коннект в пуле
-// (SetMaxOpenConns(1)) гарантирует, что миграции и PREPARE видят одну схему.
-func buildSchemaDB(proj *project.Project) (*storage.DB, func(), error) {
-	ctx := context.Background()
-	f, err := os.CreateTemp("", "onebase_check_*.db")
-	if err != nil {
-		return nil, nil, err
-	}
-	path := f.Name()
-	f.Close()
-	db, err := storage.ConnectSQLite(ctx, path)
-	if err != nil {
-		os.Remove(path)
-		return nil, nil, err
-	}
-	closer := func() { db.Close(); os.Remove(path) }
-	steps := []func() error{
-		func() error { return db.Migrate(ctx, proj.Entities) },
-		func() error { return db.MigrateRegisters(ctx, proj.Registers) },
-		func() error { return db.MigrateInfoRegisters(ctx, proj.InfoRegisters) },
-		func() error { return db.MigrateConstants(ctx, proj.Constants) },
-		func() error { return db.MigrateAccountRegisters(ctx, proj.AccountRegisters) },
-		// План счетов (_accounts) — отдельная системная таблица, на которую
-		// JOIN-ятся бух-отчёты (оборотно-сальдовая). run/dev/deploy создают её
-		// через EnsureAccountsTable; повторяем здесь, иначе исполняемая
-		// валидация запросов падает с «no such table: _accounts».
-		func() error { return db.EnsureAccountsTable(ctx) },
-		func() error { return db.SyncAccounts(ctx, proj.ChartsOfAccounts) },
-	}
-	for _, step := range steps {
-		if err := step(); err != nil {
-			closer()
-			return nil, nil, err
-		}
-	}
-	return db, closer, nil
 }
 
 func printIssuesText(res configcheck.Result) {

--- a/internal/configcheck/full.go
+++ b/internal/configcheck/full.go
@@ -1,0 +1,77 @@
+package configcheck
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/project"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// RunFull performs the complete configuration validation used by both
+// `onebase check` and the web configurator "check all" endpoint.
+func RunFull(dir string) Result {
+	dirIssues, dirWarnings := CheckDir(dir)
+	issues := dirIssues
+	warnings := dirWarnings
+
+	if proj, err := project.Load(dir); err == nil {
+		issues = append(issues, CheckQueries(proj)...)
+		issues = append(issues, CheckReportComposition(proj)...)
+		roles, _ := auth.LoadRolesYAML(filepath.Join(dir, "roles"))
+		issues = append(issues, CheckCrossRefs(proj, roles)...)
+		warnings = append(warnings, CheckLayoutWarnings(proj)...)
+		issues = append(issues, CheckHTTPServices(proj)...)
+		issues = append(issues, CheckPages(proj)...)
+		issues = append(issues, CheckNameCollisions(proj)...)
+		if db, closeDB, derr := BuildSchemaDB(proj); derr == nil {
+			validate := func(sql string) error { return db.ValidateQuery(context.Background(), sql) }
+			issues = append(issues, CheckQueriesExecutable(proj, validate)...)
+			issues = append(issues, CheckModuleQueries(proj, validate)...)
+			closeDB()
+		} else {
+			issues = append(issues, CheckModuleQueries(proj, nil)...)
+		}
+		proj.Close()
+	} else if !AlreadyReported(issues, err.Error()) {
+		issues = append(issues, Issue{Message: "Project.Load: " + err.Error()})
+	}
+
+	return NewResult(issues, warnings)
+}
+
+// BuildSchemaDB creates a temporary SQLite database with the schema described by
+// project metadata so executable query validation can PREPARE generated SQL.
+func BuildSchemaDB(proj *project.Project) (*storage.DB, func(), error) {
+	ctx := context.Background()
+	f, err := os.CreateTemp("", "onebase_check_*.db")
+	if err != nil {
+		return nil, nil, err
+	}
+	path := f.Name()
+	f.Close()
+	db, err := storage.ConnectSQLite(ctx, path)
+	if err != nil {
+		os.Remove(path)
+		return nil, nil, err
+	}
+	closer := func() { db.Close(); os.Remove(path) }
+	steps := []func() error{
+		func() error { return db.Migrate(ctx, proj.Entities) },
+		func() error { return db.MigrateRegisters(ctx, proj.Registers) },
+		func() error { return db.MigrateInfoRegisters(ctx, proj.InfoRegisters) },
+		func() error { return db.MigrateConstants(ctx, proj.Constants) },
+		func() error { return db.MigrateAccountRegisters(ctx, proj.AccountRegisters) },
+		func() error { return db.EnsureAccountsTable(ctx) },
+		func() error { return db.SyncAccounts(ctx, proj.ChartsOfAccounts) },
+	}
+	for _, step := range steps {
+		if err := step(); err != nil {
+			closer()
+			return nil, nil, err
+		}
+	}
+	return db, closer, nil
+}

--- a/internal/configcheck/full_test.go
+++ b/internal/configcheck/full_test.go
@@ -1,0 +1,33 @@
+package configcheck
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunFullIncludesNameCollisionCheck(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "catalogs", "счёт.yaml"), `name: Счёт
+fields:
+  - name: Наименование
+    type: string
+`)
+	mkFile(t, filepath.Join(dir, "documents", "счёт.yaml"), `name: Счёт
+fields:
+  - name: Дата
+    type: date
+`)
+
+	res := RunFull(dir)
+
+	if res.OK {
+		t.Fatalf("RunFull returned OK, want name collision issue")
+	}
+	for _, is := range res.Issues {
+		if is.Kind == "Имя таблицы" && strings.Contains(is.Message, "коллизия имён") {
+			return
+		}
+	}
+	t.Fatalf("name collision issue not found: %+v", res.Issues)
+}

--- a/internal/configdb/path_test.go
+++ b/internal/configdb/path_test.go
@@ -1,0 +1,88 @@
+package configdb_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/configdb"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func newSQLiteRepo(t *testing.T) (*configdb.Repo, *storage.DB, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "config.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+	repo := configdb.New(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	return repo, db, ctx
+}
+
+func TestValidatePath(t *testing.T) {
+	valid := []string{
+		"tree_order.yaml",
+		"config/app.yaml",
+		"src/модуль.module.os",
+		"forms/заказ/форма.form.yaml",
+		"printforms/заказ/печать.layout.yaml",
+	}
+	for _, p := range valid {
+		if err := configdb.ValidatePath(p); err != nil {
+			t.Fatalf("ValidatePath(%q): %v", p, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"../evil.yaml",
+		"config/../../evil.yaml",
+		"/tmp/evil.yaml",
+		`config\evil.yaml`,
+		"config//app.yaml",
+		"config/app.yaml/",
+		"config/evil:name.yaml",
+		"config/\x00evil.yaml",
+	}
+	for _, p := range invalid {
+		if err := configdb.ValidatePath(p); err == nil {
+			t.Fatalf("ValidatePath(%q) succeeded, want error", p)
+		}
+	}
+}
+
+func TestRepoRejectsUnsafePaths(t *testing.T) {
+	repo, _, ctx := newSQLiteRepo(t)
+
+	if err := repo.SaveFile(ctx, "../evil.yaml", []byte("x")); err == nil {
+		t.Fatal("SaveFile accepted traversal path")
+	}
+	if err := repo.DeleteFile(ctx, "../evil.yaml"); err == nil {
+		t.Fatal("DeleteFile accepted traversal path")
+	}
+	if _, _, err := repo.ReadFile(ctx, "../evil.yaml"); err == nil {
+		t.Fatal("ReadFile accepted traversal path")
+	}
+}
+
+func TestExportToDirRejectsStoredTraversalPath(t *testing.T) {
+	repo, db, ctx := newSQLiteRepo(t)
+	_, err := db.Exec(ctx, `INSERT INTO _onebase_config(path, content) VALUES (?, ?)`, "../evil.yaml", []byte("x"))
+	if err != nil {
+		t.Fatalf("insert unsafe path: %v", err)
+	}
+
+	dst := t.TempDir()
+	if err := repo.ExportToDir(ctx, dst); err == nil {
+		t.Fatal("ExportToDir accepted stored traversal path")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "..", "evil.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("ExportToDir wrote outside target, stat err=%v", err)
+	}
+}

--- a/internal/configdb/repo.go
+++ b/internal/configdb/repo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -51,6 +52,9 @@ func (r *Repo) ImportFromDir(ctx context.Context, dir string) error {
 			return err
 		}
 		rel = strings.ReplaceAll(rel, `\`, `/`)
+		if err := ValidatePath(rel); err != nil {
+			return fmt.Errorf("configdb: unsafe import path %q: %w", rel, err)
+		}
 
 		content, err := os.ReadFile(path)
 		if err != nil {
@@ -68,6 +72,9 @@ func (r *Repo) ImportFromDir(ctx context.Context, dir string) error {
 
 // SaveFile upserts a single config file entry.
 func (r *Repo) SaveFile(ctx context.Context, path string, content []byte) error {
+	if err := ValidatePath(path); err != nil {
+		return fmt.Errorf("configdb: unsafe path %q: %w", path, err)
+	}
 	d := r.db.Dialect()
 	_, err := r.db.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO _onebase_config (path, content, updated_at)
@@ -81,6 +88,9 @@ func (r *Repo) SaveFile(ctx context.Context, path string, content []byte) error 
 // ReadFile возвращает содержимое одного файла конфигурации. Второе значение
 // false — записи нет (это не ошибка для опциональных файлов вроде tree_order.yaml).
 func (r *Repo) ReadFile(ctx context.Context, path string) ([]byte, bool, error) {
+	if err := ValidatePath(path); err != nil {
+		return nil, false, fmt.Errorf("configdb: unsafe path %q: %w", path, err)
+	}
 	ph := r.db.Dialect().Placeholder(1)
 	var content []byte
 	err := r.db.QueryRow(ctx, `SELECT content FROM _onebase_config WHERE path = `+ph, path).Scan(&content)
@@ -92,6 +102,9 @@ func (r *Repo) ReadFile(ctx context.Context, path string) ([]byte, bool, error) 
 }
 
 func (r *Repo) DeleteFile(ctx context.Context, path string) error {
+	if err := ValidatePath(path); err != nil {
+		return fmt.Errorf("configdb: unsafe path %q: %w", path, err)
+	}
 	_, err := r.db.Exec(ctx, `DELETE FROM _onebase_config WHERE path = `+r.db.Dialect().Placeholder(1), path)
 	return err
 }
@@ -109,7 +122,10 @@ func (r *Repo) ExportToDir(ctx context.Context, dir string) error {
 		if err := rows.Scan(&path, &content); err != nil {
 			return err
 		}
-		osPath := filepath.Join(dir, filepath.FromSlash(path))
+		osPath, err := SafeJoin(dir, path)
+		if err != nil {
+			return fmt.Errorf("configdb: unsafe export path %q: %w", path, err)
+		}
 		if err := os.MkdirAll(filepath.Dir(osPath), 0o755); err != nil {
 			return fmt.Errorf("configdb: mkdir: %w", err)
 		}
@@ -132,6 +148,11 @@ type ConfigFile struct {
 // с указанного префикса. Префикс может быть пустым — тогда возвращается
 // всё содержимое.
 func (r *Repo) ListByPrefix(ctx context.Context, prefix string) ([]ConfigFile, error) {
+	if prefix != "" {
+		if err := ValidatePath(prefix); err != nil {
+			return nil, fmt.Errorf("configdb: unsafe prefix %q: %w", prefix, err)
+		}
+	}
 	ph := r.db.Dialect().Placeholder(1)
 	rows, err := r.db.Query(ctx, `SELECT path, content FROM _onebase_config WHERE path LIKE `+ph+` ORDER BY path`, prefix+"%")
 	if err != nil {
@@ -153,6 +174,74 @@ func (r *Repo) IsEmpty(ctx context.Context) (bool, error) {
 	var count int
 	err := r.db.QueryRow(ctx, `SELECT count(*) FROM _onebase_config`).Scan(&count)
 	return count == 0, err
+}
+
+var winReservedNames = map[string]bool{
+	"con": true, "prn": true, "aux": true, "nul": true,
+	"com1": true, "com2": true, "com3": true, "com4": true, "com5": true,
+	"com6": true, "com7": true, "com8": true, "com9": true,
+	"lpt1": true, "lpt2": true, "lpt3": true, "lpt4": true, "lpt5": true,
+	"lpt6": true, "lpt7": true, "lpt8": true, "lpt9": true,
+}
+
+// ValidatePath checks a slash-separated relative path before it is persisted in
+// _onebase_config or resolved against a file-backed project directory.
+func ValidatePath(rel string) error {
+	if strings.TrimSpace(rel) == "" {
+		return fmt.Errorf("empty path")
+	}
+	if path.IsAbs(rel) || filepath.IsAbs(rel) {
+		return fmt.Errorf("absolute path")
+	}
+	if strings.ContainsRune(rel, '\\') || strings.ContainsRune(rel, 0) {
+		return fmt.Errorf("invalid path separator or NUL")
+	}
+	if rel != path.Clean(rel) {
+		return fmt.Errorf("unclean path")
+	}
+	parts := strings.Split(rel, "/")
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("invalid path segment %q", part)
+		}
+		if strings.ContainsAny(part, `:*?"<>|`) {
+			return fmt.Errorf("invalid file name %q", part)
+		}
+		for _, r := range part {
+			if r < 0x20 || r == 0x7f {
+				return fmt.Errorf("control character in file name %q", part)
+			}
+		}
+		stem := strings.ToLower(strings.TrimSuffix(part, path.Ext(part)))
+		if winReservedNames[stem] {
+			return fmt.Errorf("reserved file name %q", part)
+		}
+	}
+	return nil
+}
+
+// SafeJoin validates rel and resolves it under base, rejecting paths that would
+// escape base after filepath cleaning.
+func SafeJoin(base, rel string) (string, error) {
+	if err := ValidatePath(rel); err != nil {
+		return "", err
+	}
+	baseAbs, err := filepath.Abs(base)
+	if err != nil {
+		return "", err
+	}
+	targetAbs, err := filepath.Abs(filepath.Join(baseAbs, filepath.FromSlash(rel)))
+	if err != nil {
+		return "", err
+	}
+	back, err := filepath.Rel(baseAbs, targetAbs)
+	if err != nil {
+		return "", err
+	}
+	if back == "." || back == ".." || strings.HasPrefix(back, ".."+string(filepath.Separator)) || filepath.IsAbs(back) {
+		return "", fmt.Errorf("path escapes base")
+	}
+	return targetAbs, nil
 }
 
 // MigrateContent fixes known content issues in stored YAML files.

--- a/internal/csssafe/csssafe.go
+++ b/internal/csssafe/csssafe.go
@@ -1,0 +1,113 @@
+package csssafe
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	hexColorRe = regexp.MustCompile(`(?i)^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$`)
+	rgbColorRe = regexp.MustCompile(`^rgba?\(\s*[0-9.,%\s]+\)$`)
+	lengthRe   = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)?(?:px|pt|mm|cm|in|em|rem|%)$`)
+)
+
+var namedColors = map[string]bool{
+	"aliceblue": true, "antiquewhite": true, "aquamarine": true, "azure": true,
+	"beige": true, "bisque": true, "blanchedalmond": true,
+	"black": true, "white": true, "red": true, "green": true, "blue": true,
+	"yellow": true, "orange": true, "purple": true, "gray": true, "grey": true,
+	"silver": true, "maroon": true, "olive": true, "lime": true, "aqua": true,
+	"teal": true, "navy": true, "fuchsia": true, "magenta": true, "cyan": true,
+	"pink": true, "brown": true, "gold": true, "transparent": true,
+	"darkred": true, "darkgreen": true, "darkblue": true, "lightgray": true,
+	"lightgrey": true, "lightblue": true, "lightgreen": true, "lightyellow": true,
+	"chocolate": true, "coral": true, "cornflowerblue": true, "cornsilk": true,
+	"crimson": true, "darkcyan": true, "darkgoldenrod": true, "darkgray": true,
+	"darkgrey": true, "darkkhaki": true, "darkmagenta": true, "darkolivegreen": true,
+	"darkorange": true, "darkorchid": true, "darksalmon": true, "darkseagreen": true,
+	"darkslateblue": true, "darkslategray": true, "darkslategrey": true,
+	"darkturquoise": true, "darkviolet": true, "deeppink": true, "deepskyblue": true,
+	"dimgray": true, "dimgrey": true, "dodgerblue": true, "firebrick": true,
+	"floralwhite": true, "forestgreen": true, "gainsboro": true, "ghostwhite": true,
+	"goldenrod": true, "greenyellow": true, "honeydew": true, "hotpink": true,
+	"indianred": true, "indigo": true, "ivory": true, "khaki": true, "lavender": true,
+	"lavenderblush": true, "lawngreen": true, "lemonchiffon": true, "lightcoral": true,
+	"lightcyan": true, "lightgoldenrodyellow": true, "lightpink": true,
+	"lightsalmon": true, "lightseagreen": true, "lightskyblue": true,
+	"lightslategray": true, "lightslategrey": true, "lightsteelblue": true,
+	"limegreen": true, "linen": true, "mediumaquamarine": true, "mediumblue": true,
+	"mediumorchid": true, "mediumpurple": true, "mediumseagreen": true,
+	"mediumslateblue": true, "mediumspringgreen": true, "mediumturquoise": true,
+	"mediumvioletred": true, "midnightblue": true, "mintcream": true,
+	"mistyrose": true, "moccasin": true, "navajowhite": true, "oldlace": true,
+	"olivedrab": true, "orangered": true, "orchid": true, "palegoldenrod": true,
+	"palegreen": true, "paleturquoise": true, "palevioletred": true,
+	"papayawhip": true, "peachpuff": true, "peru": true, "plum": true,
+	"powderblue": true, "rebeccapurple": true, "rosybrown": true, "royalblue": true,
+	"saddlebrown": true, "salmon": true, "sandybrown": true, "seagreen": true,
+	"seashell": true, "sienna": true, "skyblue": true, "slateblue": true,
+	"slategray": true, "slategrey": true, "snow": true, "springgreen": true,
+	"steelblue": true, "tan": true, "thistle": true, "tomato": true,
+	"turquoise": true, "violet": true, "wheat": true, "whitesmoke": true,
+	"yellowgreen": true,
+}
+
+// Color returns v only when it is a constrained CSS color value suitable for
+// inline styles.
+func Color(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	switch {
+	case hexColorRe.MatchString(v):
+		return v
+	case rgbColorRe.MatchString(v):
+		return v
+	case namedColors[strings.ToLower(v)]:
+		return v
+	}
+	return ""
+}
+
+// Length returns v only when it is a simple CSS length used by layout previews.
+func Length(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	if strings.EqualFold(v, "auto") {
+		return "auto"
+	}
+	if v == "0" || lengthRe.MatchString(v) {
+		return v
+	}
+	return ""
+}
+
+// FontFamily strips CSS-breaking characters from a font-family value.
+func FontFamily(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	v = strings.Map(func(r rune) rune {
+		switch r {
+		case '"', '\'', '<', '>', ';', '\\':
+			return -1
+		default:
+			return r
+		}
+	}, v)
+	return strings.TrimSpace(v)
+}
+
+// TextAlign returns one of the allowed text-align values.
+func TextAlign(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "left", "right", "center", "justify":
+		return strings.ToLower(strings.TrimSpace(v))
+	default:
+		return ""
+	}
+}

--- a/internal/csssafe/csssafe_test.go
+++ b/internal/csssafe/csssafe_test.go
@@ -1,0 +1,44 @@
+package csssafe
+
+import "testing"
+
+func TestColor(t *testing.T) {
+	for _, c := range []string{"#c00", "#cc0000", "#cc0000ff", "rgb(255,0,0)", "rgba(255, 0, 0, .5)", "red", "transparent"} {
+		if got := Color(c); got != c {
+			t.Fatalf("Color(%q) = %q", c, got)
+		}
+	}
+	for _, c := range []string{"red;background:url(javascript:1)", "#c00;body{}", "url(x)", "expression(x)", "нечто"} {
+		if got := Color(c); got != "" {
+			t.Fatalf("Color(%q) = %q, want empty", c, got)
+		}
+	}
+}
+
+func TestLength(t *testing.T) {
+	for _, v := range []string{"0", "10px", "12.5pt", "100%", "auto"} {
+		if got := Length(v); got != v {
+			t.Fatalf("Length(%q) = %q", v, got)
+		}
+	}
+	for _, v := range []string{`10px;color:red`, `url(x)`, `calc(100%)`, `auto;background:red`} {
+		if got := Length(v); got != "" {
+			t.Fatalf("Length(%q) = %q, want empty", v, got)
+		}
+	}
+}
+
+func TestFontFamily(t *testing.T) {
+	if got := FontFamily(`Arial";color:red`); got != "Arialcolor:red" {
+		t.Fatalf("FontFamily stripped to %q", got)
+	}
+}
+
+func TestTextAlign(t *testing.T) {
+	if got := TextAlign(" Center "); got != "center" {
+		t.Fatalf("TextAlign = %q", got)
+	}
+	if got := TextAlign("left;position:absolute"); got != "" {
+		t.Fatalf("TextAlign injected = %q", got)
+	}
+}

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -955,5 +955,12 @@
   "Переводы": "Translations",
   "Показать/скрыть поля переводов у всех объектов": "Show/hide translation fields for all objects",
   "Рабочее место кассира (РМК)": "Cashier workstation (POS)",
-  "Настройки агента оборудования": "Equipment agent settings"
+  "Настройки агента оборудования": "Equipment agent settings",
+  "existing rows contain NULL in new primary key columns (%s)": "Existing rows contain NULL in new primary key columns (%s)",
+  "existing rows contain duplicates by new primary key (%s)": "Existing rows contain duplicates by the new primary key (%s)",
+  "Недопустимое имя модуля": "Invalid module name",
+  "Недопустимое имя обработки": "Invalid processor name",
+  "Недопустимое имя файла печатной формы": "Invalid print form file name",
+  "Ошибка сохранения логотипа": "Logo save error",
+  "Ошибка удаления логотипа": "Logo delete error"
 }

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -658,12 +658,15 @@ func (h *handler) backupFullImport(w http.ResponseWriter, r *http.Request) {
 				configErr = repo.ImportFromDir(r.Context(), configDir)
 			}
 		} else {
-			filepath.WalkDir(configDir, func(path string, d os.DirEntry, err error) error {
+			configErr = filepath.WalkDir(configDir, func(path string, d os.DirEntry, err error) error {
 				if err != nil || d.IsDir() {
 					return nil
 				}
 				rel, _ := filepath.Rel(configDir, path)
-				dst := filepath.Join(b.Path, rel)
+				dst, jerr := configdb.SafeJoin(b.Path, filepath.ToSlash(rel))
+				if jerr != nil {
+					return jerr
+				}
 				os.MkdirAll(filepath.Dir(dst), 0o755)
 				content, err := os.ReadFile(path)
 				if err != nil {

--- a/internal/launcher/check_handlers.go
+++ b/internal/launcher/check_handlers.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/ivantit66/onebase/internal/configcheck"
 	"github.com/ivantit66/onebase/internal/configdb"
-	"github.com/ivantit66/onebase/internal/project"
 )
 
 // configuratorCheck is the per-fragment endpoint. It accepts ad-hoc text from
@@ -70,20 +69,7 @@ func (h *handler) configuratorCheckAll(w http.ResponseWriter, r *http.Request) {
 		defer cleanup()
 	}
 
-	dirIssues, dirWarnings := configcheck.CheckDir(dir)
-	issues := dirIssues
-
-	// project.Load surfaces cross-reference errors and gives a Project for
-	// query compilation. If file-level checks already failed it may fail too.
-	if proj, err := project.Load(dir); err == nil {
-		defer proj.Close()
-		issues = append(issues, configcheck.CheckQueries(proj)...)
-		issues = append(issues, configcheck.CheckReportComposition(proj)...)
-	} else if !configcheck.AlreadyReported(issues, err.Error()) {
-		issues = append(issues, configcheck.Issue{Message: "Project.Load: " + err.Error()})
-	}
-
-	writeJSON(w, http.StatusOK, configcheck.NewResult(issues, dirWarnings))
+	writeJSON(w, http.StatusOK, configcheck.RunFull(dir))
 }
 
 // materializeProject ensures the configuration is available as a directory tree

--- a/internal/launcher/configurator.go
+++ b/internal/launcher/configurator.go
@@ -1530,6 +1530,12 @@ func (h *handler) configuratorSaveModule(w http.ResponseWriter, r *http.Request)
 	entityName := r.FormValue("entity")
 	moduleType := r.FormValue("module_type")
 	source := r.FormValue("source")
+	if !validObjectName(entityName) {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя объекта")
+		renderCfg(w, r, data)
+		return
+	}
 
 	var filename string
 	switch moduleType {
@@ -1548,16 +1554,10 @@ func (h *handler) configuratorSaveModule(w http.ResponseWriter, r *http.Request)
 			saveErr = err
 		} else {
 			defer db.Close()
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, "src/"+filename, []byte(source))
+			saveErr = cfgUpsert(r.Context(), db, "src/"+filename, []byte(source))
 		}
 	} else {
-		srcDir := filepath.Join(b.Path, "src")
-		os.MkdirAll(srcDir, 0o755)
-		saveErr = os.WriteFile(filepath.Join(srcDir, filename), []byte(source), 0o644)
+		saveErr = h.writeConfigFileRaw(r.Context(), b, "src/"+filename, []byte(source))
 	}
 
 	data := h.loadCfgData(r.Context(), b, "tree")
@@ -1743,12 +1743,7 @@ func (h *handler) saveEntityFieldsToDB(ctx context.Context, b *Base, entityName 
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(ctx, `
-		INSERT INTO _onebase_config (path, content, updated_at)
-		VALUES ($1, $2, CURRENT_TIMESTAMP)
-		ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-	`, targetPath, out)
-	return err
+	return cfgUpsert(ctx, db, targetPath, out)
 }
 
 func (h *handler) configuratorSaveForm(w http.ResponseWriter, r *http.Request) {
@@ -2455,12 +2450,7 @@ func (h *handler) saveRegisterFieldsToDB(ctx context.Context, b *Base, regName s
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(ctx, `
-		INSERT INTO _onebase_config (path, content, updated_at)
-		VALUES ($1, $2, CURRENT_TIMESTAMP)
-		ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-	`, targetPath, out)
-	return err
+	return cfgUpsert(ctx, db, targetPath, out)
 }
 
 func (h *handler) configuratorSaveRegisterFields(w http.ResponseWriter, r *http.Request) {
@@ -2563,16 +2553,10 @@ func (h *handler) configuratorNewObject(w http.ResponseWriter, r *http.Request) 
 			repo := configdb.New(db)
 			repo.EnsureSchema(r.Context())
 			path := subdir + "/" + filename
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, path, []byte(content))
+			saveErr = cfgUpsert(r.Context(), db, path, []byte(content))
 		}
 	} else {
-		dir := filepath.Join(b.Path, subdir)
-		os.MkdirAll(dir, 0o755)
-		saveErr = os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644)
+		saveErr = h.writeConfigFileRaw(r.Context(), b, subdir+"/"+filename, []byte(content))
 	}
 
 	if saveErr != nil {
@@ -2714,11 +2698,7 @@ func (h *handler) configuratorSaveEnum(w http.ResponseWriter, r *http.Request) {
 		} else {
 			defer db.Close()
 			path := "enums/" + nameToFilename(enumName) + ".yaml"
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, path, out)
+			saveErr = cfgUpsert(r.Context(), db, path, out)
 		}
 	} else {
 		dir := filepath.Join(b.Path, "enums")
@@ -2836,11 +2816,7 @@ func (h *handler) configuratorSaveConstant(w http.ResponseWriter, r *http.Reques
 			rows.Close()
 			if targetPath != "" {
 				if out, err := updateConstantsFile(targetContent); err == nil {
-					_, saveErr = db.Exec(r.Context(), `
-						INSERT INTO _onebase_config (path, content, updated_at)
-						VALUES ($1, $2, CURRENT_TIMESTAMP)
-						ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-					`, targetPath, out)
+					saveErr = cfgUpsert(r.Context(), db, targetPath, out)
 				}
 			}
 		}
@@ -3020,11 +2996,7 @@ func (h *handler) configuratorSaveReport(w http.ResponseWriter, r *http.Request)
 			rows.Close()
 			if targetPath != "" {
 				if out, err := updateReportFile(targetContent); err == nil {
-					_, saveErr = db.Exec(r.Context(), `
-						INSERT INTO _onebase_config (path, content, updated_at)
-						VALUES ($1, $2, CURRENT_TIMESTAMP)
-						ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-					`, targetPath, out)
+					saveErr = cfgUpsert(r.Context(), db, targetPath, out)
 				}
 			}
 		}
@@ -3053,9 +3025,7 @@ func (h *handler) configuratorSaveReport(w http.ResponseWriter, r *http.Request)
 
 	// Save chart .rep.os source if provided
 	if chartSource != "" && b.ConfigSource == "file" {
-		os.MkdirAll(filepath.Join(b.Path, "src"), 0o755)
-		repOSPath := filepath.Join(b.Path, "src", repName+".rep.os")
-		saveErr = os.WriteFile(repOSPath, []byte(chartSource), 0o644)
+		saveErr = h.writeConfigFileRaw(r.Context(), b, "src/"+repName+".rep.os", []byte(chartSource))
 	}
 	data := h.loadCfgData(r.Context(), b, "tree")
 	if saveErr != nil {
@@ -3079,6 +3049,12 @@ func (h *handler) configuratorSaveCommonModule(w http.ResponseWriter, r *http.Re
 	r.ParseForm()
 	moduleName := r.FormValue("module_name")
 	source := r.FormValue("source")
+	if !validObjectName(moduleName) {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя модуля")
+		renderCfg(w, r, data)
+		return
+	}
 
 	filename := moduleNameToFilename(moduleName)
 
@@ -3089,16 +3065,10 @@ func (h *handler) configuratorSaveCommonModule(w http.ResponseWriter, r *http.Re
 			saveErr = err
 		} else {
 			defer db.Close()
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, "src/"+filename, []byte(source))
+			saveErr = cfgUpsert(r.Context(), db, "src/"+filename, []byte(source))
 		}
 	} else {
-		srcDir := filepath.Join(b.Path, "src")
-		os.MkdirAll(srcDir, 0o755)
-		saveErr = os.WriteFile(filepath.Join(srcDir, filename), []byte(source), 0o644)
+		saveErr = h.writeConfigFileRaw(r.Context(), b, "src/"+filename, []byte(source))
 	}
 
 	data := h.loadCfgData(r.Context(), b, "tree")
@@ -3133,6 +3103,12 @@ func (h *handler) configuratorSaveProcessor(w http.ResponseWriter, r *http.Reque
 	procName := r.FormValue("processor_name")
 	title := strings.TrimSpace(r.FormValue("title"))
 	source := r.FormValue("source")
+	if !validObjectName(procName) {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя обработки")
+		renderCfg(w, r, data)
+		return
+	}
 
 	type saveParam struct {
 		Name   string            `yaml:"name"`
@@ -3289,38 +3265,22 @@ func (h *handler) configuratorSaveProcessor(w http.ResponseWriter, r *http.Reque
 			saveErr = cerr
 		} else {
 			defer db.Close()
-			var existingYAML []byte
-			db.QueryRow(r.Context(),
-				`SELECT content FROM _onebase_config WHERE path=$1`, yamlFilename).Scan(&existingYAML)
+			existingYAML, _, _ := configdb.New(db).ReadFile(r.Context(), yamlFilename)
 			yamlData := buildYAML(existingYAML)
-			if _, err := db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, yamlFilename, yamlData); err != nil {
+			if err := saveConfigFiles(r, h, b, []configFileEntry{
+				{relPath: yamlFilename, content: yamlData},
+				{relPath: srcFilename, content: []byte(source)},
+			}); err != nil {
 				saveErr = err
-			}
-			if saveErr == nil {
-				_, saveErr = db.Exec(r.Context(), `
-					INSERT INTO _onebase_config (path, content, updated_at)
-					VALUES ($1, $2, CURRENT_TIMESTAMP)
-					ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-				`, srcFilename, []byte(source))
 			}
 		}
 	} else {
-		procDir := filepath.Join(b.Path, "processors")
-		os.MkdirAll(procDir, 0o755)
-		existingYAML, _ := os.ReadFile(filepath.Join(b.Path, yamlFilename))
+		existingYAML, _ := h.readConfigFileRaw(r.Context(), b, yamlFilename)
 		yamlData := buildYAML(existingYAML)
-		if err := os.WriteFile(filepath.Join(b.Path, yamlFilename), yamlData, 0o644); err != nil {
-			saveErr = err
-		}
-		if saveErr == nil {
-			srcDir := filepath.Join(b.Path, "src")
-			os.MkdirAll(srcDir, 0o755)
-			saveErr = os.WriteFile(filepath.Join(b.Path, srcFilename), []byte(source), 0o644)
-		}
+		saveErr = saveConfigFiles(r, h, b, []configFileEntry{
+			{relPath: yamlFilename, content: yamlData},
+			{relPath: srcFilename, content: []byte(source)},
+		})
 	}
 
 	data := h.loadCfgData(r.Context(), b, "tree")
@@ -3354,10 +3314,17 @@ func (h *handler) configuratorSavePrintForm(w http.ResponseWriter, r *http.Reque
 	r.ParseForm()
 	filename := strings.TrimSpace(r.FormValue("printform_filename"))
 	source := r.FormValue("source")
+	relPath := "printforms/" + filename
 
 	if filename == "" {
 		data := h.loadCfgData(r.Context(), b, "tree")
 		data.Error = tr(lang, "Имя файла печатной формы не указано")
+		renderCfg(w, r, data)
+		return
+	}
+	if err := configdb.ValidatePath(relPath); err != nil {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя файла печатной формы") + ": " + err.Error()
 		renderCfg(w, r, data)
 		return
 	}
@@ -3369,16 +3336,10 @@ func (h *handler) configuratorSavePrintForm(w http.ResponseWriter, r *http.Reque
 			saveErr = cerr
 		} else {
 			defer db.Close()
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, "printforms/"+filename, []byte(source))
+			saveErr = cfgUpsert(r.Context(), db, relPath, []byte(source))
 		}
 	} else {
-		pfDir := filepath.Join(b.Path, "printforms")
-		os.MkdirAll(pfDir, 0o755)
-		saveErr = os.WriteFile(filepath.Join(pfDir, filename), []byte(source), 0o644)
+		saveErr = h.writeConfigFileRaw(r.Context(), b, relPath, []byte(source))
 	}
 
 	var hdr struct {
@@ -3424,6 +3385,13 @@ func (h *handler) configuratorNewPrintForm(w http.ResponseWriter, r *http.Reques
 	runes := []rune(name)
 	runes[0] = unicode.ToLower(runes[0])
 	filename := string(runes) + ".yaml"
+	relPath := "printforms/" + filename
+	if err := configdb.ValidatePath(relPath); err != nil {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя файла печатной формы") + ": " + err.Error()
+		renderCfg(w, r, data)
+		return
+	}
 
 	source := fmt.Sprintf("name: %s\ndocument: %s\ntitle: \"{{Номер}} от {{Дата | date}}\"\n\nheader: |\n  ## %s\n\ntable:\n  source: Товары\n  columns:\n    - field: \"@row\"\n      label: \"№\"\n      width: 36px\n      align: center\n", name, document, name)
 
@@ -3434,18 +3402,14 @@ func (h *handler) configuratorNewPrintForm(w http.ResponseWriter, r *http.Reques
 			saveErr = cerr
 		} else {
 			defer db.Close()
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, "printforms/"+filename, []byte(source))
+			saveErr = cfgUpsert(r.Context(), db, relPath, []byte(source))
 		}
 	} else {
-		pfDir := filepath.Join(b.Path, "printforms")
-		os.MkdirAll(pfDir, 0o755)
-		fullPath := filepath.Join(pfDir, filename)
-		if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
-			saveErr = os.WriteFile(fullPath, []byte(source), 0o644)
+		fullPath, jerr := configdb.SafeJoin(b.Path, relPath)
+		if jerr != nil {
+			saveErr = jerr
+		} else if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
+			saveErr = h.writeConfigFileRaw(r.Context(), b, relPath, []byte(source))
 		}
 	}
 
@@ -3474,8 +3438,13 @@ func (h *handler) configuratorSaveLayout(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "layout name required", 400)
 		return
 	}
+	if !validLayoutName(layoutName) {
+		http.Error(w, "bad layout name", http.StatusBadRequest)
+		return
+	}
 
 	filename := layoutName + ".layout.yaml"
+	relPath := "printforms/" + filename
 
 	var saveErr error
 	if b.ConfigSource == "database" {
@@ -3484,11 +3453,7 @@ func (h *handler) configuratorSaveLayout(w http.ResponseWriter, r *http.Request)
 			saveErr = cerr
 		} else {
 			defer db.Close()
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, "printforms/"+filename, []byte(source))
+			saveErr = cfgUpsert(r.Context(), db, relPath, []byte(source))
 		}
 	} else {
 		pfDir := filepath.Join(b.Path, "printforms")
@@ -3514,9 +3479,13 @@ func (h *handler) configuratorSaveLayout(w http.ResponseWriter, r *http.Request)
 			})
 		}
 		if layoutPath == "" {
-			layoutPath = filepath.Join(pfDir, filename)
+			layoutPath, saveErr = configdb.SafeJoin(b.Path, relPath)
 		}
-		saveErr = os.WriteFile(layoutPath, []byte(source), 0o644)
+		if saveErr != nil {
+			// keep saveErr for the common response below
+		} else {
+			saveErr = os.WriteFile(layoutPath, []byte(source), 0o644)
+		}
 	}
 
 	data := h.loadCfgData(r.Context(), b, "tree")
@@ -3760,6 +3729,7 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle uploaded logo file
+	var logoSaveErr error
 	file, header, ferr := r.FormFile("app_logo_file")
 	if ferr == nil {
 		defer file.Close()
@@ -3787,18 +3757,21 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 		// Save logo file
 		if b.ConfigSource == "database" {
 			db, cerr := OpenDB(r.Context(), b)
-			if cerr == nil {
+			if cerr != nil {
+				logoSaveErr = cerr
+			} else {
 				defer db.Close()
-				db.Exec(r.Context(), `
-					INSERT INTO _onebase_config (path, content, updated_at)
-					VALUES ($1, $2, CURRENT_TIMESTAMP)
-					ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-				`, logoPath, logoData)
+				logoSaveErr = cfgUpsert(r.Context(), db, logoPath, logoData)
 			}
 		} else {
-			os.MkdirAll(filepath.Join(b.Path, "config"), 0o755)
-			os.WriteFile(filepath.Join(b.Path, logoPath), logoData, 0o644)
+			logoSaveErr = h.writeConfigFileRaw(r.Context(), b, logoPath, logoData)
 		}
+	}
+	if logoSaveErr != nil {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Ошибка сохранения логотипа") + ": " + logoSaveErr.Error()
+		renderCfg(w, r, data)
+		return
 	}
 
 	// Remove old logo file if changed
@@ -3807,10 +3780,22 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 			db, cerr := OpenDB(r.Context(), b)
 			if cerr == nil {
 				defer db.Close()
-				db.Exec(r.Context(), `DELETE FROM _onebase_config WHERE path = $1`, existingLogo)
+				if err := configdb.New(db).DeleteFile(r.Context(), existingLogo); err != nil {
+					data := h.loadCfgData(r.Context(), b, "tree")
+					data.Error = tr(lang, "Ошибка удаления логотипа") + ": " + err.Error()
+					renderCfg(w, r, data)
+					return
+				}
 			}
 		} else {
-			os.Remove(filepath.Join(b.Path, existingLogo))
+			full, err := configdb.SafeJoin(b.Path, existingLogo)
+			if err != nil {
+				data := h.loadCfgData(r.Context(), b, "tree")
+				data.Error = tr(lang, "Ошибка удаления логотипа") + ": " + err.Error()
+				renderCfg(w, r, data)
+				return
+			}
+			os.Remove(full)
 		}
 	}
 
@@ -3835,16 +3820,10 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 			saveErr = cerr
 		} else {
 			defer db.Close()
-			_, saveErr = db.Exec(r.Context(), `
-				INSERT INTO _onebase_config (path, content, updated_at)
-				VALUES ($1, $2, CURRENT_TIMESTAMP)
-				ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-			`, "config/app.yaml", out)
+			saveErr = cfgUpsert(r.Context(), db, "config/app.yaml", out)
 		}
 	} else {
-		dir := filepath.Join(b.Path, "config")
-		os.MkdirAll(dir, 0o755)
-		saveErr = os.WriteFile(filepath.Join(dir, "app.yaml"), out, 0o644)
+		saveErr = h.writeConfigFileRaw(r.Context(), b, "config/app.yaml", out)
 	}
 
 	data := h.loadCfgData(r.Context(), b, "tree")
@@ -3948,12 +3927,7 @@ func (h *handler) saveInfoRegToDB(ctx context.Context, b *Base, reg saveInfoReg,
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(ctx, `
-		INSERT INTO _onebase_config (path, content, updated_at)
-		VALUES ($1, $2, CURRENT_TIMESTAMP)
-		ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-	`, targetPath, out)
-	return err
+	return cfgUpsert(ctx, db, targetPath, out)
 }
 
 func (h *handler) configuratorSaveInfoRegFields(w http.ResponseWriter, r *http.Request) {
@@ -4080,12 +4054,7 @@ func (h *handler) saveAccountRegToDB(ctx context.Context, b *Base, reg saveAccou
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(ctx, `
-		INSERT INTO _onebase_config (path, content, updated_at)
-		VALUES ($1, $2, CURRENT_TIMESTAMP)
-		ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-	`, targetPath, out)
-	return err
+	return cfgUpsert(ctx, db, targetPath, out)
 }
 
 func (h *handler) configuratorSaveAccountRegister(w http.ResponseWriter, r *http.Request) {
@@ -4263,12 +4232,7 @@ func (h *handler) savePredefinedToDB(ctx context.Context, b *Base, entityName st
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(ctx, `
-		INSERT INTO _onebase_config (path, content, updated_at)
-		VALUES ($1, $2, CURRENT_TIMESTAMP)
-		ON CONFLICT (path) DO UPDATE SET content=EXCLUDED.content, updated_at=CURRENT_TIMESTAMP
-	`, targetPath, out)
-	return err
+	return cfgUpsert(ctx, db, targetPath, out)
 }
 
 // ── one-time code proxy ──────────────────────────────────────────────────────

--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -462,8 +462,14 @@ func saveManagedForm(r *http.Request, b *Base, entity, name string, yamlBody, os
 		return nil
 	}
 	// FS
-	yp := filepath.Join(b.Path, yamlPath)
-	op := filepath.Join(b.Path, osPath)
+	yp, err := configdb.SafeJoin(b.Path, yamlPath)
+	if err != nil {
+		return err
+	}
+	op, err := configdb.SafeJoin(b.Path, osPath)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(yp), 0o755); err != nil {
 		return err
 	}

--- a/internal/launcher/layout_import_pdf.go
+++ b/internal/launcher/layout_import_pdf.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/configdb"
 	"github.com/ivantit66/onebase/internal/pdfimport"
 )
 
@@ -98,31 +99,26 @@ func (h *handler) configuratorImportPDFLayout(w http.ResponseWriter, r *http.Req
 			return
 		}
 		defer db.Close()
-		var exists bool
-		if rows, qerr := db.Query(r.Context(), `SELECT 1 FROM _onebase_config WHERE path=$1`, relPath); qerr == nil {
-			exists = rows.Next()
-			rows.Close()
-		}
-		if exists {
+		repo := configdb.New(db)
+		if _, ok, _ := repo.ReadFile(r.Context(), relPath); ok {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Макет уже существует"))
 			return
 		}
-		if _, werr := db.Exec(r.Context(), `
-			INSERT INTO _onebase_config (path, content, updated_at)
-			VALUES ($1, $2, CURRENT_TIMESTAMP)
-			ON CONFLICT (path) DO NOTHING
-		`, relPath, src); werr != nil {
+		if werr := repo.SaveFile(r.Context(), relPath, src); werr != nil {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+werr.Error())
 			return
 		}
 	} else {
-		dir := filepath.Join(b.Path, "printforms")
-		os.MkdirAll(dir, 0o755)
-		fullPath := filepath.Join(dir, filename)
+		fullPath, jerr := configdb.SafeJoin(b.Path, relPath)
+		if jerr != nil {
+			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+jerr.Error())
+			return
+		}
 		if _, statErr := os.Stat(fullPath); statErr == nil {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Макет уже существует"))
 			return
 		}
+		os.MkdirAll(filepath.Dir(fullPath), 0o755)
 		if werr := os.WriteFile(fullPath, src, 0o644); werr != nil {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+werr.Error())
 			return

--- a/internal/launcher/layout_new.go
+++ b/internal/launcher/layout_new.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/configdb"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/printform"
 	"github.com/ivantit66/onebase/internal/sheet"
@@ -231,37 +232,27 @@ func (h *handler) configuratorNewLayout(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		defer db.Close()
+		repo := configdb.New(db)
 		// Отказ при существующем файле.
-		var exists int
-		if rows, qerr := db.Query(r.Context(), `SELECT 1 FROM _onebase_config WHERE path=$1`, relPath); qerr == nil {
-			if rows.Next() {
-				exists = 1
-			}
-			rows.Close()
-		}
-		if exists == 1 {
+		if _, ok, _ := repo.ReadFile(r.Context(), relPath); ok {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Макет уже существует"))
 			return
 		}
-		if _, werr := db.Exec(r.Context(), `
-			INSERT INTO _onebase_config (path, content, updated_at)
-			VALUES ($1, $2, CURRENT_TIMESTAMP)
-			ON CONFLICT (path) DO NOTHING
-		`, relPath, src); werr != nil {
+		if werr := repo.SaveFile(r.Context(), relPath, src); werr != nil {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+werr.Error())
 			return
 		}
 	} else {
-		dir := filepath.Join(b.Path, "printforms")
-		if subdir != "" {
-			dir = filepath.Join(dir, subdir)
+		fullPath, jerr := configdb.SafeJoin(b.Path, relPath)
+		if jerr != nil {
+			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+jerr.Error())
+			return
 		}
-		os.MkdirAll(dir, 0o755)
-		fullPath := filepath.Join(dir, filename)
 		if _, statErr := os.Stat(fullPath); statErr == nil {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Макет уже существует"))
 			return
 		}
+		os.MkdirAll(filepath.Dir(fullPath), 0o755)
 		if werr := os.WriteFile(fullPath, src, 0o644); werr != nil {
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+werr.Error())
 			return

--- a/internal/launcher/roles_handlers.go
+++ b/internal/launcher/roles_handlers.go
@@ -564,7 +564,10 @@ func (h *handler) saveConfigFile(ctx context.Context, b *Base, relPath string, c
 		defer db.Close()
 		return configdb.New(db).SaveFile(ctx, relPath, content)
 	}
-	full := filepath.Join(b.Path, filepath.FromSlash(relPath))
+	full, err := configdb.SafeJoin(b.Path, relPath)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 		return err
 	}
@@ -580,7 +583,10 @@ func (h *handler) deleteConfigFile(ctx context.Context, b *Base, relPath string)
 		defer db.Close()
 		return configdb.New(db).DeleteFile(ctx, relPath)
 	}
-	full := filepath.Join(b.Path, filepath.FromSlash(relPath))
+	full, err := configdb.SafeJoin(b.Path, relPath)
+	if err != nil {
+		return err
+	}
 	if err := os.Remove(full); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/launcher/tree_order.go
+++ b/internal/launcher/tree_order.go
@@ -107,7 +107,11 @@ func (h *handler) readConfigFileRaw(ctx context.Context, b *Base, relPath string
 		raw, ok, _ := configdb.New(db).ReadFile(ctx, relPath)
 		return raw, ok
 	}
-	raw, err := os.ReadFile(filepath.Join(b.Path, filepath.FromSlash(relPath)))
+	full, err := configdb.SafeJoin(b.Path, relPath)
+	if err != nil {
+		return nil, false
+	}
+	raw, err := os.ReadFile(full)
 	if err != nil {
 		return nil, false
 	}
@@ -115,8 +119,8 @@ func (h *handler) readConfigFileRaw(ctx context.Context, b *Base, relPath string
 }
 
 // writeConfigFileRaw записывает один файл конфигурации в обоих режимах хранения
-// (симметрично readConfigFileRaw). relPath считается уже проверенным
-// (см. safeConfigPath). В file-режиме недостающие подкаталоги создаются.
+// (симметрично readConfigFileRaw). В file-режиме недостающие подкаталоги
+// создаются после проверки, что relPath остаётся внутри директории проекта.
 func (h *handler) writeConfigFileRaw(ctx context.Context, b *Base, relPath string, content []byte) error {
 	if b.ConfigSource == "database" {
 		db, err := OpenDB(ctx, b)
@@ -130,7 +134,10 @@ func (h *handler) writeConfigFileRaw(ctx context.Context, b *Base, relPath strin
 		}
 		return repo.SaveFile(ctx, relPath, content)
 	}
-	full := filepath.Join(b.Path, filepath.FromSlash(relPath))
+	full, err := configdb.SafeJoin(b.Path, relPath)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 		return err
 	}

--- a/internal/launcher/widget_handlers.go
+++ b/internal/launcher/widget_handlers.go
@@ -243,7 +243,10 @@ func saveConfigFiles(r *http.Request, h *handler, b *Base, files []configFileEnt
 // atomicWriteConfigFile пишет файл через temp+rename в том же каталоге, чтобы
 // читатель (--watch) никогда не видел частично записанный файл (эталон — store.save).
 func atomicWriteConfigFile(basePath, relPath string, content []byte) error {
-	full := filepath.Join(basePath, filepath.FromSlash(relPath))
+	full, err := configdb.SafeJoin(basePath, relPath)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
 		return err
 	}
@@ -279,7 +282,10 @@ func deleteConfigFiles(r *http.Request, h *handler, b *Base, relPaths []string) 
 		})
 	}
 	for _, p := range relPaths {
-		full := filepath.Join(b.Path, filepath.FromSlash(p))
+		full, err := configdb.SafeJoin(b.Path, p)
+		if err != nil {
+			return err
+		}
 		if err := os.Remove(full); err != nil && !os.IsNotExist(err) {
 			return err
 		}

--- a/internal/printform/layout.go
+++ b/internal/printform/layout.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ivantit66/onebase/internal/csssafe"
 	"github.com/ivantit66/onebase/internal/sheet"
 	"gopkg.in/yaml.v3"
 )
@@ -255,6 +256,7 @@ func FindLayoutFile(osPath string) string {
 
 // borderCSS returns the CSS border declaration for the given preset.
 func borderCSS(preset, color string) string {
+	color = csssafe.Color(color)
 	if color == "" {
 		color = "#ccc"
 	}
@@ -286,8 +288,8 @@ func (lt *LayoutTemplate) PreviewHTML() string {
 		if len(lt.Columns) > 0 {
 			sb.WriteString("<colgroup>")
 			for _, c := range lt.Columns {
-				if c.Width != "" {
-					sb.WriteString(fmt.Sprintf(`<col style="width:%s">`, html.EscapeString(c.Width)))
+				if width := csssafe.Length(c.Width); width != "" {
+					sb.WriteString(fmt.Sprintf(`<col style="width:%s">`, html.EscapeString(width)))
 				} else {
 					sb.WriteString("<col>")
 				}
@@ -295,8 +297,8 @@ func (lt *LayoutTemplate) PreviewHTML() string {
 			sb.WriteString("</colgroup>")
 		}
 		for _, row := range area.Rows {
-			if row.Height != "" {
-				sb.WriteString(fmt.Sprintf(`<tr style="height:%s">`, html.EscapeString(row.Height)))
+			if height := csssafe.Length(row.Height); height != "" {
+				sb.WriteString(fmt.Sprintf(`<tr style="height:%s">`, html.EscapeString(height)))
 			} else {
 				sb.WriteString("<tr>")
 			}
@@ -312,17 +314,17 @@ func (lt *LayoutTemplate) PreviewHTML() string {
 				if cell.FontSize > 0 {
 					style += fmt.Sprintf("font-size:%dpt;", cell.FontSize)
 				}
-				if cell.FontFamily != "" {
-					style += "font-family:" + cell.FontFamily + ";"
+				if family := csssafe.FontFamily(cell.FontFamily); family != "" {
+					style += "font-family:" + family + ";"
 				}
-				if cell.BackColor != "" {
-					style += "background-color:" + cell.BackColor + ";"
+				if color := csssafe.Color(cell.BackColor); color != "" {
+					style += "background-color:" + color + ";"
 				}
-				if cell.TextColor != "" {
-					style += "color:" + cell.TextColor + ";"
+				if color := csssafe.Color(cell.TextColor); color != "" {
+					style += "color:" + color + ";"
 				}
-				if cell.Align != "" {
-					style += "text-align:" + cell.Align + ";"
+				if align := csssafe.TextAlign(cell.Align); align != "" {
+					style += "text-align:" + align + ";"
 				}
 				if cell.VAlign != "" {
 					switch strings.ToLower(cell.VAlign) {

--- a/internal/printform/layout_test.go
+++ b/internal/printform/layout_test.go
@@ -403,3 +403,49 @@ func TestPreviewHTMLEscapesText(t *testing.T) {
 		t.Errorf("unescaped parameter in preview: %s", out)
 	}
 }
+
+func TestPreviewHTMLSanitizesInlineCSS(t *testing.T) {
+	lt := &LayoutTemplate{
+		Columns: []LayoutColumn{{Width: `80px;color:red`}},
+		Areas: []*LayoutArea{
+			{
+				Name: "A",
+				Rows: []LayoutRow{
+					{
+						Height: `30px;background:url(javascript:1)`,
+						Cells: []LayoutCell{
+							{
+								Text:        "X",
+								FontFamily:  `Arial";color:red`,
+								BackColor:   `red;background:url(javascript:1)`,
+								TextColor:   `#fff"`,
+								Align:       `left;position:absolute`,
+								BorderColor: `blue;background:url(javascript:1)`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := lt.PreviewHTML()
+	for _, bad := range []string{
+		"javascript",
+		"background:url",
+		"width:80px;color:red",
+		"height:30px;background",
+		"font-family:Arial&quot;",
+		"text-align:left;position",
+		"background-color:red;background",
+	} {
+		if strings.Contains(out, bad) {
+			t.Fatalf("PreviewHTML leaked unsafe CSS %q:\n%s", bad, out)
+		}
+	}
+	if strings.Contains(out, `color:#fff&quot;`) {
+		t.Fatalf("PreviewHTML leaked unsafe text color:\n%s", out)
+	}
+	if !strings.Contains(out, "border:1px solid #ccc") {
+		t.Fatalf("unsafe border color should fall back to #ccc:\n%s", out)
+	}
+}

--- a/internal/sheet/html.go
+++ b/internal/sheet/html.go
@@ -2,8 +2,9 @@ package sheet
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/ivantit66/onebase/internal/csssafe"
 )
 
 // HTMLOptions — параметры HTML-рендера табличного документа.
@@ -275,20 +276,11 @@ func escapeHTML(s string) string {
 	return s
 }
 
-// reHexColor принимает #rgb, #rrggbb и #rrggbbaa.
-var reHexColor = regexp.MustCompile(`(?i)^#[0-9a-f]{3}(?:[0-9a-f]{3}(?:[0-9a-f]{2})?)?$`)
-
-// reCSSIdent принимает CSS-идентификаторы (имена цветов: red, dark-blue …).
-var reCSSIdent = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*$`)
-
 // safeColor возвращает значение цвета без изменений, если оно соответствует
-// #hex или CSS-имени цвета (только [a-zA-Z][a-zA-Z0-9-]*). Иначе — "".
+// #hex, rgb()/rgba() или известному CSS-имени цвета. Иначе — "".
 // Цель: не допустить разрыва атрибута style через YAML с кавычками / тегами.
 func safeColor(s string) string {
-	if reHexColor.MatchString(s) || reCSSIdent.MatchString(s) {
-		return s
-	}
-	return ""
+	return csssafe.Color(s)
 }
 
 // pictureHTML рендерит картинку ячейки в <img>, ограниченный размерами ячейки
@@ -309,11 +301,5 @@ func pictureHTML(pic string) string {
 // safeFontFamily вырезает из font-family символы, способные разорвать
 // атрибут style: " ' < > ; (инъекция через YAML).
 func safeFontFamily(s string) string {
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case '"', '\'', '<', '>', ';':
-			return -1
-		}
-		return r
-	}, s)
+	return csssafe.FontFamily(s)
 }

--- a/internal/sheet/html_test.go
+++ b/internal/sheet/html_test.go
@@ -15,14 +15,15 @@ func TestSafeColor(t *testing.T) {
 		{"#f00", "#f00"},
 		{"#aabbccdd", "#aabbccdd"},
 		{"red", "red"},
-		{"dark-blue", "dark-blue"},
+		{"darkblue", "darkblue"},
 		{"AliceBlue", "AliceBlue"},
+		{"rgba(0,0,0,0)", "rgba(0,0,0,0)"},
 		// инъекции — должны быть отброшены
 		{`red"><script>`, ""},
 		{`#fff" style="x:y`, ""},
 		{"red; color:red", ""},
 		{"url(evil)", ""},
-		{"rgba(0,0,0,0)", ""},
+		{"dark-blue", ""},
 	}
 	for _, c := range cases {
 		got := safeColor(c.in)

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -143,13 +143,18 @@ func (db *DB) MigrateInfoRegisters(ctx context.Context, regs []*metadata.InfoReg
 // правильным PK, копируя данные. Безопасно если в существующих строках
 // нет дубликатов по новому ключу — иначе INSERT упадёт с UNIQUE constraint,
 // и пользователь должен будет разобраться с дубликатами.
-//
-// Реализация SQLite-only — PostgreSQL поддерживает ALTER TABLE для PK
-// напрямую (но в onebase это пока не используется).
 func (db *DB) fixInfoRegPK(ctx context.Context, ir *metadata.InfoRegister) error {
-	if db.dialect.Name() != "sqlite" {
-		return nil // PG: ALTER TABLE сам разрулит, но это другой код-путь
+	switch db.dialect.Name() {
+	case "sqlite":
+		return db.fixInfoRegPKSQLite(ctx, ir)
+	case "postgres":
+		return db.fixInfoRegPKPostgres(ctx, ir)
+	default:
+		return nil
 	}
+}
+
+func (db *DB) fixInfoRegPKSQLite(ctx context.Context, ir *metadata.InfoRegister) error {
 	table := metadata.InfoRegTableName(ir.Name)
 
 	// Снимаем фактический PK.
@@ -270,6 +275,125 @@ func tableColumnNames(ctx context.Context, db *DB, table string) ([]string, erro
 		out = append(out, name)
 	}
 	return out, rows.Err()
+}
+
+func (db *DB) fixInfoRegPKPostgres(ctx context.Context, ir *metadata.InfoRegister) error {
+	table := metadata.InfoRegTableName(ir.Name)
+	expected := pkCols(ir)
+	actual, _, err := db.pgPrimaryKey(ctx, table)
+	if err != nil {
+		return err
+	}
+	if stringSlicesEqual(actual, expected) {
+		return nil
+	}
+
+	return db.WithTx(ctx, func(txCtx context.Context) error {
+		actual, constraint, err := db.pgPrimaryKey(txCtx, table)
+		if err != nil {
+			return err
+		}
+		if stringSlicesEqual(actual, expected) {
+			return nil
+		}
+		if len(expected) > 0 {
+			if err := db.pgEnsurePKColumnsUsable(txCtx, table, expected); err != nil {
+				return err
+			}
+		}
+		if constraint != "" {
+			if _, err := db.Exec(txCtx, "ALTER TABLE "+pgQuoteIdent(table)+" DROP CONSTRAINT "+pgQuoteIdent(constraint)); err != nil {
+				return err
+			}
+		}
+		if len(expected) == 0 {
+			return nil
+		}
+		for _, col := range expected {
+			if _, err := db.Exec(txCtx, "ALTER TABLE "+pgQuoteIdent(table)+" ALTER COLUMN "+pgQuoteIdent(col)+" SET NOT NULL"); err != nil {
+				return err
+			}
+		}
+		_, err = db.Exec(txCtx, "ALTER TABLE "+pgQuoteIdent(table)+" ADD CONSTRAINT "+
+			pgQuoteIdent(table+"_pkey")+" PRIMARY KEY ("+pgIdentList(expected)+")")
+		return err
+	})
+}
+
+func (db *DB) pgPrimaryKey(ctx context.Context, table string) ([]string, string, error) {
+	rows, err := db.Query(ctx, `
+		SELECT c.conname, a.attname
+		FROM pg_constraint c
+		JOIN pg_class t ON t.oid = c.conrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		JOIN unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+		WHERE c.contype = 'p' AND n.nspname = 'public' AND t.relname = $1
+		ORDER BY k.ord`, table)
+	if err != nil {
+		return nil, "", err
+	}
+	defer rows.Close()
+	var cols []string
+	var constraint string
+	for rows.Next() {
+		var name, col string
+		if err := rows.Scan(&name, &col); err != nil {
+			return nil, "", err
+		}
+		if constraint == "" {
+			constraint = name
+		}
+		cols = append(cols, col)
+	}
+	return cols, constraint, rows.Err()
+}
+
+func (db *DB) pgEnsurePKColumnsUsable(ctx context.Context, table string, cols []string) error {
+	qtable := pgQuoteIdent(table)
+	nullChecks := make([]string, len(cols))
+	for i, col := range cols {
+		nullChecks[i] = pgQuoteIdent(col) + " IS NULL"
+	}
+	var hasNull bool
+	if err := db.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM "+qtable+" WHERE "+strings.Join(nullChecks, " OR ")+")").Scan(&hasNull); err != nil {
+		return err
+	}
+	if hasNull {
+		return i18nerr.Errorf("existing rows contain NULL in new primary key columns (%s)", strings.Join(cols, ", "))
+	}
+
+	pkColsSQL := pgIdentList(cols)
+	var hasDuplicates bool
+	dupSQL := "SELECT EXISTS (SELECT 1 FROM (SELECT " + pkColsSQL + " FROM " + qtable +
+		" GROUP BY " + pkColsSQL + " HAVING COUNT(*) > 1 LIMIT 1) d)"
+	if err := db.QueryRow(ctx, dupSQL).Scan(&hasDuplicates); err != nil {
+		return err
+	}
+	if hasDuplicates {
+		return i18nerr.Errorf("existing rows contain duplicates by new primary key (%s)", strings.Join(cols, ", "))
+	}
+	return nil
+}
+
+func pgIdentList(cols []string) string {
+	out := make([]string, len(cols))
+	for i, col := range cols {
+		out[i] = pgQuoteIdent(col)
+	}
+	return strings.Join(out, ", ")
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Migrate applies CREATE TABLE and ADD COLUMN IF NOT EXISTS for all entities.

--- a/internal/storage/migrate_inforeg_pg_test.go
+++ b/internal/storage/migrate_inforeg_pg_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package storage
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func connectPGForInfoRegMigration(t *testing.T) *DB {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	db, err := Connect(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	t.Cleanup(db.Close)
+	return db
+}
+
+func TestMigrateInfoRegisters_PostgresRebuildsPK(t *testing.T) {
+	ctx := context.Background()
+	db := connectPGForInfoRegMigration(t)
+
+	ir := &metadata.InfoRegister{
+		Name:     "PKMigrateTest",
+		Periodic: true,
+		Dimensions: []metadata.Field{
+			{Name: "Номенклатура", Type: "reference:Номенклатура", RefEntity: "Номенклатура"},
+			{Name: "ТипЦен", Type: "reference:ТипЦен", RefEntity: "ТипЦен"},
+		},
+		Resources: []metadata.Field{{Name: "Цена", Type: "number"}},
+	}
+	table := metadata.InfoRegTableName(ir.Name)
+	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS "+pgQuoteIdent(table))
+	_, err := db.Exec(ctx, "CREATE TABLE "+pgQuoteIdent(table)+` (
+		номенклатура_id UUID NOT NULL,
+		цена NUMERIC,
+		PRIMARY KEY (номенклатура_id)
+	)`)
+	if err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	t.Cleanup(func() { _, _ = db.Exec(context.Background(), "DROP TABLE IF EXISTS "+pgQuoteIdent(table)) })
+
+	if err := db.MigrateInfoRegisters(ctx, []*metadata.InfoRegister{ir}); err != nil {
+		t.Fatalf("MigrateInfoRegisters: %v", err)
+	}
+
+	got, _, err := db.pgPrimaryKey(ctx, table)
+	if err != nil {
+		t.Fatalf("pgPrimaryKey: %v", err)
+	}
+	want := pkCols(ir)
+	if !stringSlicesEqual(got, want) {
+		t.Fatalf("primary key = %v, want %v", got, want)
+	}
+}

--- a/internal/storage/pg.go
+++ b/internal/storage/pg.go
@@ -21,6 +21,10 @@ type DB struct {
 	dialect  Dialect
 }
 
+func pgQuoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
 func Connect(ctx context.Context, dsn string) (*DB, error) {
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -380,7 +380,11 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 			data["DenyPasswdChange"] = u.DenyPasswdChange
 		}
 	}
-	if err := tmpl.ExecuteTemplate(w, name, data); err != nil {
+	t := s.tmpl
+	if t == nil {
+		t = tmpl
+	}
+	if err := t.ExecuteTemplate(w, name, data); err != nil {
 		http.Error(w, s.errText(r, err), 500)
 	}
 }

--- a/internal/ui/report_compose_render.go
+++ b/internal/ui/report_compose_render.go
@@ -5,9 +5,9 @@ import (
 	"html"
 	"html/template"
 	"net/url"
-	"regexp"
 	"strings"
 
+	"github.com/ivantit66/onebase/internal/csssafe"
 	"github.com/ivantit66/onebase/internal/report"
 	"github.com/ivantit66/onebase/internal/report/compose"
 	"github.com/ivantit66/onebase/internal/widget"
@@ -91,52 +91,12 @@ func (h *htmlComposeSink) grand(grand map[string]any) {
 	h.b.WriteString(`</tr>`)
 }
 
-// hexColorRe — hex-цвет CSS: #RGB, #RGBA, #RRGGBB, #RRGGBBAA.
-var hexColorRe = regexp.MustCompile(`^#[0-9a-fA-F]{3,8}$`)
-
-// rgbColorRe — функциональная запись rgb()/rgba() (только цифры, точки, проценты,
-// запятые и пробелы внутри скобок — без возможности вырваться из значения).
-var rgbColorRe = regexp.MustCompile(`^rgba?\(\s*[0-9.,%\s]+\)$`)
-
-// cssNamedColors — белый список известных CSS-имён цветов (нижний регистр).
-// Произвольное имя не пропускаем: значение уходит в inline-style, поэтому даже
-// при html.EscapeString нежелательно пускать неконтролируемые строки.
-var cssNamedColors = map[string]bool{
-	"black": true, "white": true, "red": true, "green": true, "blue": true,
-	"yellow": true, "orange": true, "purple": true, "gray": true, "grey": true,
-	"silver": true, "maroon": true, "olive": true, "lime": true, "aqua": true,
-	"teal": true, "navy": true, "fuchsia": true, "magenta": true, "cyan": true,
-	"pink": true, "brown": true, "gold": true, "transparent": true,
-	"darkred": true, "darkgreen": true, "darkblue": true, "lightgray": true,
-	"lightgrey": true, "lightblue": true, "lightgreen": true, "lightyellow": true,
-}
-
-// safeColor возвращает цвет, если он проходит белый список (hex, rgb()/rgba()
-// или известное CSS-имя), иначе "". Источник CellStyle.Color/Background теперь
-// пользовательский (__settings → Conditional[].Style), поэтому значение, идущее
-// в inline-CSS, валидируем (issue #16), а не доверяем как раньше (только YAML).
-func safeColor(v string) string {
-	v = strings.TrimSpace(v)
-	if v == "" {
-		return ""
-	}
-	switch {
-	case hexColorRe.MatchString(v):
-		return v
-	case rgbColorRe.MatchString(v):
-		return v
-	case cssNamedColors[strings.ToLower(v)]:
-		return v
-	}
-	return ""
-}
-
 func cssOf(s report.CellStyle) string {
 	var p []string
-	if c := safeColor(s.Color); c != "" {
+	if c := csssafe.Color(s.Color); c != "" {
 		p = append(p, "color:"+c)
 	}
-	if c := safeColor(s.Background); c != "" {
+	if c := csssafe.Color(s.Background); c != "" {
 		p = append(p, "background:"+c)
 	}
 	if s.Bold {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"html/template"
 	"net/http"
 	"sort"
 	"strings"
@@ -75,6 +76,7 @@ type Server struct {
 	extforms         *extform.Repo          // внешний контур: печатные формы из БД
 	extreports       *extform.ReportRepo    // внешний контур: отчёты из БД
 	extprocessors    *extform.ProcessorRepo // внешний контур: обработки из БД
+	tmpl             *template.Template
 }
 
 func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpreter, authRepo *auth.Repo, cfg Config, sched *scheduler.Scheduler) *Server {
@@ -86,7 +88,7 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 	if loginLimit == nil {
 		loginLimit = auth.NewLoginLimiter(5, time.Minute)
 	}
-	s := &Server{reg: reg, store: store, interp: interp, authRepo: authRepo, cfg: cfg, sched: sched, mailer: cfg.Mailer, maxFileSizeBytes: maxBytes, globalDebug: debugger.NewGlobalDebugController(), messages: NewMessageStore(), widgetCache: widget.NewCache(60 * time.Second), lockMgr: runtime.NewLockManager(), aiChatLimit: newAIWindowLimiter(10, time.Minute), loginLimit: loginLimit, extforms: extform.New(store), extreports: extform.NewReports(store), extprocessors: extform.NewProcessors(store)}
+	s := &Server{reg: reg, store: store, interp: interp, authRepo: authRepo, cfg: cfg, sched: sched, mailer: cfg.Mailer, maxFileSizeBytes: maxBytes, globalDebug: debugger.NewGlobalDebugController(), messages: NewMessageStore(), widgetCache: widget.NewCache(60 * time.Second), lockMgr: runtime.NewLockManager(), aiChatLimit: newAIWindowLimiter(10, time.Minute), loginLimit: loginLimit, extforms: extform.New(store), extreports: extform.NewReports(store), extprocessors: extform.NewProcessors(store), tmpl: template.Must(newTemplate(cfg.Bundle))}
 	s.entitySvc = &entityservice.Service{
 		Store:  store,
 		Reg:    reg,
@@ -119,7 +121,6 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 		}
 		return nil
 	}
-	globalBundle = cfg.Bundle
 	if sched != nil {
 		sched.SetMessageSink(func(userID, text string) { s.messages.Push(userID, text) })
 	}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -16,412 +16,421 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// globalBundle is set by Server at init time so the template FuncMap can access it.
-var globalBundle *i18n.Bundle
+var tmpl = template.Must(newTemplate(nil))
 
-var tmpl = template.Must(template.New("root").Funcs(template.FuncMap{
-	"lower": strings.ToLower,
-	"str": func(v any) string {
-		if v == nil {
-			return ""
-		}
-		return fmt.Sprintf("%v", v)
-	},
-	"add": func(a, b int) int { return a + b },
-	// lucideIcon рендерит инлайн-SVG иконки навигации по имени Lucide (план 72).
-	"lucideIcon": LucideIcon,
-	"t": func(lang, key string) string {
-		if globalBundle != nil {
-			return globalBundle.T(lang, key)
-		}
-		return key
-	},
-	// refID extracts UUID from a *Ref (implements GetRefUUID), otherwise returns fmt.Sprintf.
-	// Used in TP row templates so the "selected" comparison works after enrichTPRowsWithRefs.
-	"refID": func(v any) string {
-		if v == nil {
-			return ""
-		}
-		type uuidGetter interface{ GetRefUUID() string }
-		if rp, ok := v.(uuidGetter); ok {
-			return rp.GetRefUUID()
-		}
-		return fmt.Sprintf("%v", v)
-	},
-	"isRef":  func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "reference:") },
-	"isEnum": func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "enum:") },
-	"enumLabel": func(labels map[string]map[string]string, field, value string) string {
-		if m, ok := labels[field]; ok {
-			if lbl, ok := m[value]; ok && lbl != "" {
-				return lbl
+func newTemplate(bundle *i18n.Bundle) (*template.Template, error) {
+	return template.New("root").Funcs(templateFuncs(bundle)).Parse(templateSource())
+}
+
+func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
+	return template.FuncMap{
+		"lower": strings.ToLower,
+		"str": func(v any) string {
+			if v == nil {
+				return ""
 			}
-		}
-		return value
-	},
-	"isRichText": func(t any) bool { return fmt.Sprintf("%v", t) == string(metadata.FieldTypeRichText) },
-	"isImage":    func(t any) bool { return fmt.Sprintf("%v", t) == string(metadata.FieldTypeImage) },
-	// entityHasRichText — есть ли среди реквизитов шапки сущности richtext-поле.
-	// Quill (vendor-ассеты + init) грузятся на форме только при true, чтобы не
-	// тянуть редактор на формы без richtext-полей.
-	"entityHasRichText": func(e *metadata.Entity) bool {
-		if e == nil {
-			return false
-		}
-		for _, f := range e.Fields {
-			if metadata.IsRichText(f.Type) {
-				return true
+			return fmt.Sprintf("%v", v)
+		},
+		"add": func(a, b int) int { return a + b },
+		// lucideIcon рендерит инлайн-SVG иконки навигации по имени Lucide (план 72).
+		"lucideIcon": LucideIcon,
+		"t": func(lang, key string) string {
+			if bundle != nil {
+				return bundle.T(lang, key)
 			}
-		}
-		return false
-	},
-	// richPlain — текстовая проекция richtext-значения для ячейки списка
-	// (усечённая, чтобы HTML не разъезжал таблицу).
-	"richPlain": func(v any) string {
-		if v == nil {
-			return ""
-		}
-		s := richtext.Plaintext(fmt.Sprintf("%v", v))
-		const maxRunes = 100
-		r := []rune(s)
-		if len(r) > maxRunes {
-			return string(r[:maxRunes]) + "…"
-		}
-		return s
-	},
-	// dpField извлекает имя поля из data_path вида "Объект.Контрагент"
-	// (план 37, managed-формы). Если префикса нет — возвращает строку как есть.
-	"dpField": func(s string) string {
-		if i := strings.LastIndex(s, "."); i >= 0 {
-			return s[i+1:]
-		}
-		return s
-	},
-	// dpRoot — корневой компонент data_path: "Объект.Товары.Цена" → "Объект".
-	"dpRoot": func(s string) string {
-		if i := strings.Index(s, "."); i >= 0 {
-			return s[:i]
-		}
-		return s
-	},
-	// fieldByName ищет metadata.Field в entity.Fields по имени;
-	// нужен managed-шаблону чтобы определить тип ввода (ref/enum/date/bool).
-	"fieldByName": func(entity *metadata.Entity, name string) *metadata.Field {
-		if entity == nil {
-			return nil
-		}
-		for i := range entity.Fields {
-			if entity.Fields[i].Name == name {
-				return &entity.Fields[i]
+			return key
+		},
+		// refID extracts UUID from a *Ref (implements GetRefUUID), otherwise returns fmt.Sprintf.
+		// Used in TP row templates so the "selected" comparison works after enrichTPRowsWithRefs.
+		"refID": func(v any) string {
+			if v == nil {
+				return ""
 			}
-		}
-		return nil
-	},
-	// fieldTitleRU достаёт ru-вариант из map[string]string или возвращает fallback.
-	"fieldTitleRU": func(m map[string]string, fallback string) string {
-		if v, ok := m["ru"]; ok && v != "" {
-			return v
-		}
-		for _, v := range m {
-			if v != "" {
-				return v
+			type uuidGetter interface{ GetRefUUID() string }
+			if rp, ok := v.(uuidGetter); ok {
+				return rp.GetRefUUID()
 			}
-		}
-		return fallback
-	},
-	// hasChildren — удобство для шаблона: проверка на пустой Children.
-	"hasChildren": func(el *metadata.FormElement) bool {
-		return el != nil && len(el.Children) > 0
-	},
-	// hasHandler — есть ли у элемента обработчик указанного события
-	// (план 37, этап 8). Если есть — шаблон управляемой формы навешивает
-	// onclick/onchange="obFire(...)" вызывающий /ui/{kind}/{entity}/form-event.
-	"hasHandler": func(el *metadata.FormElement, eventName string) bool {
-		if el == nil || el.Handlers == nil {
-			return false
-		}
-		_, ok := el.Handlers[metadata.FormEventType(eventName)]
-		return ok
-	},
-	// hasFormHandler — есть ли у формы (а не элемента) обработчик события.
-	// Используется в managed-шаблоне для авто-вызова ПриОткрытииФормы при
-	// загрузке страницы.
-	"hasFormHandler": func(form *metadata.FormModule, eventName string) bool {
-		if form == nil || form.Handlers == nil {
-			return false
-		}
-		_, ok := form.Handlers[metadata.FormEventType(eventName)]
-		return ok
-	},
-	// deleteHidden — скрыта ли кнопка «Удалить» формы через
-	// actions.delete.visible=false (issue #151). По умолчанию (нет actions
-	// или visible) — false: кнопка показывается по праву CanDelete.
-	"deleteHidden": func(form *metadata.FormModule) bool {
-		if form == nil || form.Actions == nil {
-			return false
-		}
-		a, ok := form.Actions["delete"]
-		if !ok || a == nil || a.Visible == nil {
-			return false
-		}
-		return !*a.Visible
-	},
-	// tablePartByName ищет metadata.TablePart в Entity по имени.
-	// Возвращает указатель на копию (или nil) — нужно managed-шаблону
-	// для рендера ТабличнойЧасти с реальными колонками.
-	"tablePartByName": func(entity *metadata.Entity, name string) *metadata.TablePart {
-		if entity == nil {
-			return nil
-		}
-		for i := range entity.TableParts {
-			if entity.TableParts[i].Name == name {
-				return &entity.TableParts[i]
+			return fmt.Sprintf("%v", v)
+		},
+		"isRef":  func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "reference:") },
+		"isEnum": func(t any) bool { return strings.HasPrefix(fmt.Sprintf("%v", t), "enum:") },
+		"enumLabel": func(labels map[string]map[string]string, field, value string) string {
+			if m, ok := labels[field]; ok {
+				if lbl, ok := m[value]; ok && lbl != "" {
+					return lbl
+				}
 			}
-		}
-		return nil
-	},
-	// tpCommandButtons возвращает дочерние элементы-кнопки табличной части —
-	// команды ТЧ (план 46). Рендерятся как тулбар над таблицей; кнопка с
-	// обработчиком Нажатие вызывает obFire(name,'Нажатие',{_tp:...}).
-	"tpCommandButtons": func(el *metadata.FormElement) []*metadata.FormElement {
-		if el == nil {
-			return nil
-		}
-		var out []*metadata.FormElement
-		for _, ch := range el.Children {
-			if ch != nil && ch.Kind == metadata.FormElementButton {
-				out = append(out, ch)
-			}
-		}
-		return out
-	},
-	// hasGridTP checks if any TablePart element in the form has use_grid flag (plan 48).
-	// Used to conditionally include SlickGrid CSS/JS.
-	"hasGridTP": func(form *metadata.FormModule) bool {
-		if form == nil {
-			return false
-		}
-		found := false
-		form.Walk(func(el *metadata.FormElement) bool {
-			// SlickGrid включён для ТЧ по умолчанию; no_grid возвращает простую таблицу.
-			if el != nil && el.Kind == metadata.FormElementTablePart && !el.NoGrid {
-				found = true
+			return value
+		},
+		"isRichText": func(t any) bool { return fmt.Sprintf("%v", t) == string(metadata.FieldTypeRichText) },
+		"isImage":    func(t any) bool { return fmt.Sprintf("%v", t) == string(metadata.FieldTypeImage) },
+		// entityHasRichText — есть ли среди реквизитов шапки сущности richtext-поле.
+		// Quill (vendor-ассеты + init) грузятся на форме только при true, чтобы не
+		// тянуть редактор на формы без richtext-полей.
+		"entityHasRichText": func(e *metadata.Entity) bool {
+			if e == nil {
 				return false
 			}
-			return true
-		})
-		return found
-	},
-	// formAttrVT returns ValueTable columns for a form attribute by name.
-	"formAttrVT": func(form *metadata.FormModule, name string) []*metadata.FormAttributeColumn {
-		if form == nil {
+			for _, f := range e.Fields {
+				if metadata.IsRichText(f.Type) {
+					return true
+				}
+			}
+			return false
+		},
+		// richPlain — текстовая проекция richtext-значения для ячейки списка
+		// (усечённая, чтобы HTML не разъезжал таблицу).
+		"richPlain": func(v any) string {
+			if v == nil {
+				return ""
+			}
+			s := richtext.Plaintext(fmt.Sprintf("%v", v))
+			const maxRunes = 100
+			r := []rune(s)
+			if len(r) > maxRunes {
+				return string(r[:maxRunes]) + "…"
+			}
+			return s
+		},
+		// dpField извлекает имя поля из data_path вида "Объект.Контрагент"
+		// (план 37, managed-формы). Если префикса нет — возвращает строку как есть.
+		"dpField": func(s string) string {
+			if i := strings.LastIndex(s, "."); i >= 0 {
+				return s[i+1:]
+			}
+			return s
+		},
+		// dpRoot — корневой компонент data_path: "Объект.Товары.Цена" → "Объект".
+		"dpRoot": func(s string) string {
+			if i := strings.Index(s, "."); i >= 0 {
+				return s[:i]
+			}
+			return s
+		},
+		// fieldByName ищет metadata.Field в entity.Fields по имени;
+		// нужен managed-шаблону чтобы определить тип ввода (ref/enum/date/bool).
+		"fieldByName": func(entity *metadata.Entity, name string) *metadata.Field {
+			if entity == nil {
+				return nil
+			}
+			for i := range entity.Fields {
+				if entity.Fields[i].Name == name {
+					return &entity.Fields[i]
+				}
+			}
 			return nil
-		}
-		for _, attr := range form.Attributes {
-			if attr.Name == name && strings.EqualFold(attr.TypeRef, "ValueTable") {
-				return attr.Columns
+		},
+		// fieldTitleRU достаёт ru-вариант из map[string]string или возвращает fallback.
+		"fieldTitleRU": func(m map[string]string, fallback string) string {
+			if v, ok := m["ru"]; ok && v != "" {
+				return v
 			}
-		}
-		return nil
-	},
+			for _, v := range m {
+				if v != "" {
+					return v
+				}
+			}
+			return fallback
+		},
+		// hasChildren — удобство для шаблона: проверка на пустой Children.
+		"hasChildren": func(el *metadata.FormElement) bool {
+			return el != nil && len(el.Children) > 0
+		},
+		// hasHandler — есть ли у элемента обработчик указанного события
+		// (план 37, этап 8). Если есть — шаблон управляемой формы навешивает
+		// onclick/onchange="obFire(...)" вызывающий /ui/{kind}/{entity}/form-event.
+		"hasHandler": func(el *metadata.FormElement, eventName string) bool {
+			if el == nil || el.Handlers == nil {
+				return false
+			}
+			_, ok := el.Handlers[metadata.FormEventType(eventName)]
+			return ok
+		},
+		// hasFormHandler — есть ли у формы (а не элемента) обработчик события.
+		// Используется в managed-шаблоне для авто-вызова ПриОткрытииФормы при
+		// загрузке страницы.
+		"hasFormHandler": func(form *metadata.FormModule, eventName string) bool {
+			if form == nil || form.Handlers == nil {
+				return false
+			}
+			_, ok := form.Handlers[metadata.FormEventType(eventName)]
+			return ok
+		},
+		// deleteHidden — скрыта ли кнопка «Удалить» формы через
+		// actions.delete.visible=false (issue #151). По умолчанию (нет actions
+		// или visible) — false: кнопка показывается по праву CanDelete.
+		"deleteHidden": func(form *metadata.FormModule) bool {
+			if form == nil || form.Actions == nil {
+				return false
+			}
+			a, ok := form.Actions["delete"]
+			if !ok || a == nil || a.Visible == nil {
+				return false
+			}
+			return !*a.Visible
+		},
+		// tablePartByName ищет metadata.TablePart в Entity по имени.
+		// Возвращает указатель на копию (или nil) — нужно managed-шаблону
+		// для рендера ТабличнойЧасти с реальными колонками.
+		"tablePartByName": func(entity *metadata.Entity, name string) *metadata.TablePart {
+			if entity == nil {
+				return nil
+			}
+			for i := range entity.TableParts {
+				if entity.TableParts[i].Name == name {
+					return &entity.TableParts[i]
+				}
+			}
+			return nil
+		},
+		// tpCommandButtons возвращает дочерние элементы-кнопки табличной части —
+		// команды ТЧ (план 46). Рендерятся как тулбар над таблицей; кнопка с
+		// обработчиком Нажатие вызывает obFire(name,'Нажатие',{_tp:...}).
+		"tpCommandButtons": func(el *metadata.FormElement) []*metadata.FormElement {
+			if el == nil {
+				return nil
+			}
+			var out []*metadata.FormElement
+			for _, ch := range el.Children {
+				if ch != nil && ch.Kind == metadata.FormElementButton {
+					out = append(out, ch)
+				}
+			}
+			return out
+		},
+		// hasGridTP checks if any TablePart element in the form has use_grid flag (plan 48).
+		// Used to conditionally include SlickGrid CSS/JS.
+		"hasGridTP": func(form *metadata.FormModule) bool {
+			if form == nil {
+				return false
+			}
+			found := false
+			form.Walk(func(el *metadata.FormElement) bool {
+				// SlickGrid включён для ТЧ по умолчанию; no_grid возвращает простую таблицу.
+				if el != nil && el.Kind == metadata.FormElementTablePart && !el.NoGrid {
+					found = true
+					return false
+				}
+				return true
+			})
+			return found
+		},
+		// formAttrVT returns ValueTable columns for a form attribute by name.
+		"formAttrVT": func(form *metadata.FormModule, name string) []*metadata.FormAttributeColumn {
+			if form == nil {
+				return nil
+			}
+			for _, attr := range form.Attributes {
+				if attr.Name == name && strings.EqualFold(attr.TypeRef, "ValueTable") {
+					return attr.Columns
+				}
+			}
+			return nil
+		},
 
-	// dict собирает map[string]any из чередующихся ключей и значений —
-	// стандартный приём передать несколько аргументов в подшаблон
-	// (Go template принимает только один параметр).
-	"dict": func(values ...any) (map[string]any, error) {
-		if len(values)%2 != 0 {
-			return nil, fmt.Errorf("dict требует чётное число аргументов")
-		}
-		m := make(map[string]any, len(values)/2)
-		for i := 0; i < len(values); i += 2 {
-			k, ok := values[i].(string)
-			if !ok {
-				return nil, fmt.Errorf("dict: ключ #%d не string", i)
+		// dict собирает map[string]any из чередующихся ключей и значений —
+		// стандартный приём передать несколько аргументов в подшаблон
+		// (Go template принимает только один параметр).
+		"dict": func(values ...any) (map[string]any, error) {
+			if len(values)%2 != 0 {
+				return nil, fmt.Errorf("dict требует чётное число аргументов")
 			}
-			m[k] = values[i+1]
-		}
-		return m, nil
-	},
-	// navLabel вставляет zero-width space на границах слов PascalCase-имени
-	// (перед заглавной после строчной), чтобы длинные имена объектов
-	// переносились по словам в боковой панели, а не обрезались.
-	"navLabel": func(s string) string {
-		const zwsp = '​' // zero-width space — невидимая точка переноса
-		var b strings.Builder
-		var prev rune
-		for i, r := range s {
-			if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(prev) {
-				b.WriteRune(zwsp)
+			m := make(map[string]any, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				k, ok := values[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict: ключ #%d не string", i)
+				}
+				m[k] = values[i+1]
 			}
-			b.WriteRune(r)
-			prev = r
-		}
-		return b.String()
-	},
-	"fmtDate": func(v any) string {
-		fmtT := func(t time.Time) string {
-			lt := t.In(time.Local)
-			h, m, sec := lt.Clock()
-			if h != 0 || m != 0 || sec != 0 {
-				return lt.Format("02.01.2006 15:04:05")
+			return m, nil
+		},
+		// navLabel вставляет zero-width space на границах слов PascalCase-имени
+		// (перед заглавной после строчной), чтобы длинные имена объектов
+		// переносились по словам в боковой панели, а не обрезались.
+		"navLabel": func(s string) string {
+			const zwsp = '​' // zero-width space — невидимая точка переноса
+			var b strings.Builder
+			var prev rune
+			for i, r := range s {
+				if i > 0 && unicode.IsUpper(r) && !unicode.IsUpper(prev) {
+					b.WriteRune(zwsp)
+				}
+				b.WriteRune(r)
+				prev = r
 			}
-			return lt.Format("02.01.2006")
-		}
-		if t, ok := v.(time.Time); ok {
-			return fmtT(t)
-		}
-		if s, ok := v.(string); ok && len(s) >= 10 {
-			// Strip Go monotonic clock suffix " m=+..."
-			if i := strings.Index(s, " m=+"); i >= 0 {
-				s = s[:i]
+			return b.String()
+		},
+		"fmtDate": func(v any) string {
+			fmtT := func(t time.Time) string {
+				lt := t.In(time.Local)
+				h, m, sec := lt.Clock()
+				if h != 0 || m != 0 || sec != 0 {
+					return lt.Format("02.01.2006 15:04:05")
+				}
+				return lt.Format("02.01.2006")
 			}
-			for _, layout := range []string{
-				time.RFC3339, time.RFC3339Nano,
-				"2006-01-02 15:04:05 -0700 MST",
-				"2006-01-02 15:04:05.999999999 -0700 MST",
-				"2006-01-02T15:04:05", "2006-01-02 15:04:05",
-				"2006-01-02T15:04", "2006-01-02",
-			} {
-				if t, err := time.Parse(layout, s); err == nil {
-					return fmtT(t)
+			if t, ok := v.(time.Time); ok {
+				return fmtT(t)
+			}
+			if s, ok := v.(string); ok && len(s) >= 10 {
+				// Strip Go monotonic clock suffix " m=+..."
+				if i := strings.Index(s, " m=+"); i >= 0 {
+					s = s[:i]
+				}
+				for _, layout := range []string{
+					time.RFC3339, time.RFC3339Nano,
+					"2006-01-02 15:04:05 -0700 MST",
+					"2006-01-02 15:04:05.999999999 -0700 MST",
+					"2006-01-02T15:04:05", "2006-01-02 15:04:05",
+					"2006-01-02T15:04", "2006-01-02",
+				} {
+					if t, err := time.Parse(layout, s); err == nil {
+						return fmtT(t)
+					}
+				}
+				if len(s) >= 10 {
+					if t, err := time.ParseInLocation("2006-01-02", s[:10], time.Local); err == nil {
+						return fmtT(t)
+					}
 				}
 			}
-			if len(s) >= 10 {
-				if t, err := time.ParseInLocation("2006-01-02", s[:10], time.Local); err == nil {
-					return fmtT(t)
+			return fmt.Sprintf("%v", v)
+		},
+		"filterVal": func(params storage.ListParams, fieldName string) storage.FilterValue {
+			return filterValue(params, fieldName)
+		},
+		"sortDir": func(params storage.ListParams, fieldName string) string {
+			if params.Sort == fieldName {
+				if strings.ToLower(params.Dir) == "desc" {
+					return "desc"
 				}
+				return "asc"
 			}
-		}
-		return fmt.Sprintf("%v", v)
-	},
-	"filterVal": func(params storage.ListParams, fieldName string) storage.FilterValue {
-		return filterValue(params, fieldName)
-	},
-	"sortDir": func(params storage.ListParams, fieldName string) string {
-		if params.Sort == fieldName {
+			return ""
+		},
+		"sortIcon": func(params storage.ListParams, fieldName string) string {
+			if params.Sort != fieldName {
+				return "⇅"
+			}
 			if strings.ToLower(params.Dir) == "desc" {
+				return "↓"
+			}
+			return "↑"
+		},
+		"nextDir": func(params storage.ListParams, fieldName string) string {
+			if params.Sort == fieldName && strings.ToLower(params.Dir) != "desc" {
 				return "desc"
 			}
 			return "asc"
-		}
-		return ""
-	},
-	"sortIcon": func(params storage.ListParams, fieldName string) string {
-		if params.Sort != fieldName {
-			return "⇅"
-		}
-		if strings.ToLower(params.Dir) == "desc" {
-			return "↓"
-		}
-		return "↑"
-	},
-	"nextDir": func(params storage.ListParams, fieldName string) string {
-		if params.Sort == fieldName && strings.ToLower(params.Dir) != "desc" {
-			return "desc"
-		}
-		return "asc"
-	},
-	"hasFilter": func(params storage.ListParams) bool {
-		return len(params.Filters) > 0
-	},
-	"filterQuery": func(params storage.ListParams) string {
-		var parts []string
-		for k, v := range params.Filters {
-			if v.From != "" {
-				parts = append(parts, "f."+k+".from="+v.From)
-			}
-			if v.To != "" {
-				parts = append(parts, "f."+k+".to="+v.To)
-			}
-			if v.Value != "" {
-				parts = append(parts, "f."+k+"="+v.Value)
-			}
-		}
-		if len(parts) == 0 {
-			return ""
-		}
-		return "&" + strings.Join(parts, "&")
-	},
-	"reportParamQuery": func(params any, values map[string]any) string {
-		type param interface{ GetName() string }
-		// Use reflection-free approach: just iterate over values map
-		parts := []string{}
-		if values != nil {
-			for k, v := range values {
-				if v != nil && fmt.Sprintf("%v", v) != "" {
-					parts = append(parts, k+"="+url.QueryEscape(fmt.Sprintf("%v", v)))
+		},
+		"hasFilter": func(params storage.ListParams) bool {
+			return len(params.Filters) > 0
+		},
+		"filterQuery": func(params storage.ListParams) string {
+			var parts []string
+			for k, v := range params.Filters {
+				if v.From != "" {
+					parts = append(parts, "f."+k+".from="+v.From)
+				}
+				if v.To != "" {
+					parts = append(parts, "f."+k+".to="+v.To)
+				}
+				if v.Value != "" {
+					parts = append(parts, "f."+k+"="+v.Value)
 				}
 			}
-		}
-		if len(parts) == 0 {
-			return ""
-		}
-		return "?" + strings.Join(parts, "&")
-	},
-	// variantQuery дописывает выбранный вариант компоновки (__variant) к уже
-	// собранной query-строке параметров отчёта — чтобы выгрузка в Excel
-	// соответствовала выбранному на форме варианту.
-	"variantQuery": func(existing string, variant any) string {
-		vs, _ := variant.(string)
-		if vs == "" {
-			return existing
-		}
-		sep := "?"
-		if existing != "" {
-			sep = "&"
-		}
-		return existing + sep + "__variant=" + url.QueryEscape(vs)
-	},
-	"mul": func(a, b int) int { return a * b },
-	"int": func(v any) int {
-		switch t := v.(type) {
-		case int:
-			return t
-		case int64:
-			return int(t)
-		case float64:
-			return int(t)
-		case decimal.Decimal:
-			return int(t.IntPart())
-		}
-		return 0
-	},
-	"seq": func(n int) []int {
-		s := make([]int, n)
-		for i := range s {
-			s[i] = i
-		}
-		return s
-	},
-	"rowIdx": func(row map[string]any) int {
-		if v, ok := row["строка"]; ok {
+			if len(parts) == 0 {
+				return ""
+			}
+			return "&" + strings.Join(parts, "&")
+		},
+		"reportParamQuery": func(params any, values map[string]any) string {
+			type param interface{ GetName() string }
+			// Use reflection-free approach: just iterate over values map
+			parts := []string{}
+			if values != nil {
+				for k, v := range values {
+					if v != nil && fmt.Sprintf("%v", v) != "" {
+						parts = append(parts, k+"="+url.QueryEscape(fmt.Sprintf("%v", v)))
+					}
+				}
+			}
+			if len(parts) == 0 {
+				return ""
+			}
+			return "?" + strings.Join(parts, "&")
+		},
+		// variantQuery дописывает выбранный вариант компоновки (__variant) к уже
+		// собранной query-строке параметров отчёта — чтобы выгрузка в Excel
+		// соответствовала выбранному на форме варианту.
+		"variantQuery": func(existing string, variant any) string {
+			vs, _ := variant.(string)
+			if vs == "" {
+				return existing
+			}
+			sep := "?"
+			if existing != "" {
+				sep = "&"
+			}
+			return existing + sep + "__variant=" + url.QueryEscape(vs)
+		},
+		"mul": func(a, b int) int { return a * b },
+		"int": func(v any) int {
 			switch t := v.(type) {
 			case int:
 				return t
-			case int32:
-				return int(t)
 			case int64:
 				return int(t)
+			case float64:
+				return int(t)
+			case decimal.Decimal:
+				return int(t.IntPart())
 			}
-		}
-		return 0
-	},
-	"jsJSON": func(v any) template.JS {
-		b, err := json.Marshal(v)
-		if err != nil {
-			return template.JS("null")
-		}
-		return template.JS(b)
-	},
-	"wcell":       widgetCell,
-	"echartsJSON": echartsJSON,
-	"splitCamel":  splitCamel,
-	"fmtCell":     fmtReportCell,
-	// pageRaw помечает уже санитизированный HTML страницы (план 66) как
-	// безопасный. Источник — только ДобавитьСыройHTML, прошедший sanitizePageHTML.
-	"pageRaw": func(s string) template.HTML { return template.HTML(s) },
-	// pageChart конвертирует чарт-блок страницы в widget.ChartData для echartsJSON.
-	"pageChart": pageChartData,
-}).Parse(tplHead + tplNav + tplIndex + tplList + tplForm + tplManagedForm + tplRegister + tplReport + tplProcessor + tplAgentSettings + tplPOS + tplAbout + tplDeleteMarked + tplInfoReg + tplConstants + tplHistory + tplJournal + tplScheduled + tplAccountReg + tplQueryBuilder + tplAllFunctions + tplQueryConsole + tplCodeConsole + tplGengen + tplForbidden + tplPageCustom + tplAppShell))
+			return 0
+		},
+		"seq": func(n int) []int {
+			s := make([]int, n)
+			for i := range s {
+				s[i] = i
+			}
+			return s
+		},
+		"rowIdx": func(row map[string]any) int {
+			if v, ok := row["строка"]; ok {
+				switch t := v.(type) {
+				case int:
+					return t
+				case int32:
+					return int(t)
+				case int64:
+					return int(t)
+				}
+			}
+			return 0
+		},
+		"jsJSON": func(v any) template.JS {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return template.JS("null")
+			}
+			return template.JS(b)
+		},
+		"wcell":       widgetCell,
+		"echartsJSON": echartsJSON,
+		"splitCamel":  splitCamel,
+		"fmtCell":     fmtReportCell,
+		// pageRaw помечает уже санитизированный HTML страницы (план 66) как
+		// безопасный. Источник — только ДобавитьСыройHTML, прошедший sanitizePageHTML.
+		"pageRaw": func(s string) template.HTML { return template.HTML(s) },
+		// pageChart конвертирует чарт-блок страницы в widget.ChartData для echartsJSON.
+		"pageChart": pageChartData,
+	}
+}
+
+func templateSource() string {
+	return tplHead + tplNav + tplIndex + tplList + tplForm + tplManagedForm + tplRegister + tplReport + tplProcessor + tplAgentSettings + tplPOS + tplAbout + tplDeleteMarked + tplInfoReg + tplConstants + tplHistory + tplJournal + tplScheduled + tplAccountReg + tplQueryBuilder + tplAllFunctions + tplQueryConsole + tplCodeConsole + tplGengen + tplForbidden + tplPageCustom + tplAppShell
+}
 
 const tplHead = `
 {{define "head"}}<!DOCTYPE html>

--- a/internal/ui/templates_i18n_test.go
+++ b/internal/ui/templates_i18n_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/ivantit66/onebase/internal/i18n"
+)
+
+func mustBundle(t *testing.T, translation string) *i18n.Bundle {
+	t.Helper()
+	b, err := i18n.Load(fstest.MapFS{
+		"en.json": {Data: []byte(`{"Сохранить":` + translation + `}`)},
+	}, "")
+	if err != nil {
+		t.Fatalf("i18n.Load: %v", err)
+	}
+	return b
+}
+
+func TestTemplateFuncsUseCapturedBundle(t *testing.T) {
+	first := templateFuncs(mustBundle(t, `"Save"`))["t"].(func(string, string) string)
+	second := templateFuncs(mustBundle(t, `"Store"`))["t"].(func(string, string) string)
+
+	if got := first("en", "Сохранить"); got != "Save" {
+		t.Fatalf("first bundle translation = %q", got)
+	}
+	if got := second("en", "Сохранить"); got != "Store" {
+		t.Fatalf("second bundle translation = %q", got)
+	}
+	if got := first("en", "Сохранить"); got != "Save" {
+		t.Fatalf("first bundle was affected by second template: %q", got)
+	}
+}


### PR DESCRIPTION
## Что сделано
- добавлена строгая валидация путей configdb и безопасные записи/экспорт конфигурации
- общий full-check для CLI и web-конфигуратора
- исправление PRIMARY KEY регистров сведений в PostgreSQL
- UI-шаблоны больше не используют глобальный i18n bundle
- JSON-логин переведён на HttpOnly cookie без возврата session token в body
- общий CSS sanitizer для отчётов, печатных макетов и sheet HTML

## Проверки
- go test ./...
- go vet ./...
- go test -tags integration ./internal/storage
- go test -race ./internal/ui ./internal/auth ./internal/configdb