### PR TITLE
Fix rollup and managed form delete guardrails

### DIFF
--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -588,13 +588,34 @@ func deleteManagedForm(r *http.Request, b *Base, entity, name string) error {
 			Message:     "delete managed form " + entity + "." + name,
 		})
 	}
-	yp, op := formFiles(b, entity, name)
-	_ = os.Remove(yp)
-	_ = os.Remove(op)
+	entityLower := strings.ToLower(entity)
+	nameLower := strings.ToLower(name)
+	yp, err := configdb.SafeJoin(b.Path, fmt.Sprintf("forms/%s/%s.form.yaml", entityLower, nameLower))
+	if err != nil {
+		return err
+	}
+	op, err := configdb.SafeJoin(b.Path, fmt.Sprintf("forms/%s/%s.form.os", entityLower, nameLower))
+	if err != nil {
+		return err
+	}
+	removeFile := func(path string) error {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	if err := removeFile(yp); err != nil {
+		return err
+	}
+	if err := removeFile(op); err != nil {
+		return err
+	}
 	// _resources/ соседним каталогом — удаляем рекурсивно если есть
-	resDir := filepath.Join(filepath.Dir(yp), strings.ToLower(name))
-	_ = os.RemoveAll(resDir)
-	return nil
+	resDir, err := configdb.SafeJoin(b.Path, fmt.Sprintf("forms/%s/%s", entityLower, nameLower))
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(resDir)
 }
 
 // configuratorFormsValidate — POST YAML, возвращает JSON со списком warnings.

--- a/internal/launcher/forms_handlers_test.go
+++ b/internal/launcher/forms_handlers_test.go
@@ -126,6 +126,77 @@ func TestDeleteManagedFormDBKeepsSimilarName(t *testing.T) {
 	}
 }
 
+func TestDeleteManagedFormFSKeepsSimilarName(t *testing.T) {
+	dir := t.TempDir()
+	formDir := filepath.Join(dir, "forms", "заказ")
+	if err := os.MkdirAll(filepath.Join(formDir, "main", "_resources"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for path, body := range map[string]string{
+		filepath.Join(formDir, "main.form.yaml"):              "form:\n  name: main\n",
+		filepath.Join(formDir, "main.form.os"):                "Процедура X()\nКонецПроцедуры\n",
+		filepath.Join(formDir, "main", "_resources", "a.bin"): "res",
+		filepath.Join(formDir, "main2.form.yaml"):             "form:\n  name: main2\n",
+	} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	base := &Base{Path: dir, ConfigSource: "file"}
+	req := httptest.NewRequest("POST", "/forms/delete", nil)
+	if err := deleteManagedForm(req, base, "Заказ", "main"); err != nil {
+		t.Fatalf("deleteManagedForm: %v", err)
+	}
+
+	for _, p := range []string{
+		filepath.Join(formDir, "main.form.yaml"),
+		filepath.Join(formDir, "main.form.os"),
+		filepath.Join(formDir, "main", "_resources", "a.bin"),
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("%s should be deleted, stat err=%v", p, err)
+		}
+	}
+	if content, err := os.ReadFile(filepath.Join(formDir, "main2.form.yaml")); err != nil || !strings.Contains(string(content), "main2") {
+		t.Fatalf("similar form main2 should stay: err=%v content=%q", err, content)
+	}
+}
+
+func TestDeleteManagedFormFSRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	for path, body := range map[string]string{
+		filepath.Join(dir, "victim.form.yaml"): "keep yaml",
+		filepath.Join(dir, "victim.form.os"):   "keep os",
+	} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "victim"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "victim", "keep.txt"), []byte("keep dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := &Base{Path: dir, ConfigSource: "file"}
+	req := httptest.NewRequest("POST", "/forms/delete", nil)
+	if err := deleteManagedForm(req, base, "..", "victim"); err == nil {
+		t.Fatalf("deleteManagedForm accepted path traversal")
+	}
+
+	for _, p := range []string{
+		filepath.Join(dir, "victim.form.yaml"),
+		filepath.Join(dir, "victim.form.os"),
+		filepath.Join(dir, "victim", "keep.txt"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("%s should remain after rejected traversal: %v", p, err)
+		}
+	}
+}
+
 // extractFormKindFromYAML — точечный тест маленького helper'а.
 func TestExtractFormKindFromYAML(t *testing.T) {
 	cases := []struct {

--- a/internal/launcher/rollup_handlers.go
+++ b/internal/launcher/rollup_handlers.go
@@ -31,14 +31,15 @@ func (h *handler) cfgAdminRollup(w http.ResponseWriter, r *http.Request) {
 	// Чек-лист регистров накопления (по умолчанию все включены).
 	regRows := ""
 	for _, reg := range proj.Registers {
-		checked, suffix := "checked", ""
+		attrs, suffix := "checked", ""
 		if reg.IsTurnover() {
-			checked, suffix = "", ` <span style="color:#b45309;font-size:11px">(оборотный — не сворачивается)</span>`
+			attrs = "disabled"
+			suffix = ` <span style="color:#b45309;font-size:11px">(оборотный — не сворачивается)</span>`
 		}
 		regRows += fmt.Sprintf(
 			`<label style="display:flex;align-items:center;gap:8px;font-size:13px;padding:3px 0">
 			   <input type="checkbox" class="rb-reg" value="%s" %s> %s%s</label>`,
-			escHTML(reg.Name), checked, escHTML(reg.DisplayName(lang)), suffix)
+			escHTML(reg.Name), attrs, escHTML(reg.DisplayName(lang)), suffix)
 	}
 	if regRows == "" {
 		regRows = `<div style="color:#999;font-size:12px">В конфигурации нет регистров накопления.</div>`
@@ -98,7 +99,7 @@ func (h *handler) cfgAdminRollup(w http.ResponseWriter, r *http.Request) {
 	  </label>
 
 	  <div style="font-size:13px;font-weight:600;margin:6px 0 4px">Регистры накопления</div>
-	  <div style="font-size:11px;color:#888;margin-bottom:6px">Снимите оборотные регистры — их нельзя сворачивать в остаток.</div>
+	  <div style="font-size:11px;color:#888;margin-bottom:6px">Оборотные регистры недоступны для выбора — их нельзя сворачивать в остаток.</div>
 	  <div style="max-height:200px;overflow:auto;border:1px solid #e2e8f0;border-radius:4px;padding:6px 10px;background:#fff">` + regRows + `</div>
 ` + accBlock + infoBlock + `
 	  <label style="font-size:13px;display:flex;align-items:center;gap:8px;margin-top:12px">

--- a/internal/storage/rollup.go
+++ b/internal/storage/rollup.go
@@ -87,20 +87,50 @@ func dayStart(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }
 
-// selectRollupRegs отбирает из всех регистров только включённые в свёртку
-// (по имени, регистронезависимо).
-func selectRollupRegs(all []*metadata.Register, names []string) []*metadata.Register {
+func rollupNameKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func selectedRollupNameSet(kind string, names []string) (map[string]bool, error) {
 	want := make(map[string]bool, len(names))
 	for _, n := range names {
-		want[strings.ToLower(n)] = true
+		key := rollupNameKey(n)
+		if key == "" {
+			return nil, fmt.Errorf("%s: пустое имя", kind)
+		}
+		want[key] = true
+	}
+	return want, nil
+}
+
+// selectRollupRegs отбирает из всех регистров только включённые в свёртку
+// (по имени, регистронезависимо). Оборотные регистры отклоняются явно: их
+// нельзя сворачивать в остаток.
+func selectRollupRegs(all []*metadata.Register, names []string) ([]*metadata.Register, error) {
+	want, err := selectedRollupNameSet("регистр накопления", names)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]*metadata.Register, len(all))
+	for _, reg := range all {
+		byName[rollupNameKey(reg.Name)] = reg
+	}
+	for _, n := range names {
+		reg, ok := byName[rollupNameKey(n)]
+		if !ok {
+			return nil, fmt.Errorf("регистр накопления %q не найден", strings.TrimSpace(n))
+		}
+		if reg.IsTurnover() {
+			return nil, fmt.Errorf("регистр накопления %q оборотный: его нельзя сворачивать", reg.Name)
+		}
 	}
 	var out []*metadata.Register
 	for _, reg := range all {
-		if want[strings.ToLower(reg.Name)] {
+		if want[rollupNameKey(reg.Name)] {
 			out = append(out, reg)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // RollupPreview считает, что сделает свёртка, ничего не записывая (для UI-мастера
@@ -108,7 +138,19 @@ func selectRollupRegs(all []*metadata.Register, names []string) []*metadata.Regi
 func (db *DB) RollupPreview(ctx context.Context, regs []*metadata.Register, ents []*metadata.Entity, accountRegs []*metadata.AccountRegister, infoRegs []*metadata.InfoRegister, opts RollupOptions) (RollupReport, error) {
 	cutoff := dayStart(opts.Date)
 	rep := RollupReport{Cutoff: cutoff, Preview: true}
-	for _, reg := range selectRollupRegs(regs, opts.Registers) {
+	included, err := selectRollupRegs(regs, opts.Registers)
+	if err != nil {
+		return rep, err
+	}
+	includedAcc, err := selectRollupAccountRegs(accountRegs, opts.AccountRegisters)
+	if err != nil {
+		return rep, err
+	}
+	includedInfo, err := selectRollupInfoRegs(infoRegs, opts.InfoRegisters)
+	if err != nil {
+		return rep, err
+	}
+	for _, reg := range included {
 		folded, err := db.countMovementsBefore(ctx, reg.Name, cutoff)
 		if err != nil {
 			return rep, err
@@ -121,14 +163,14 @@ func (db *DB) RollupPreview(ctx context.Context, regs []*metadata.Register, ents
 			Name: reg.Name, FoldedMovements: folded, OpeningRows: len(open),
 		})
 	}
-	for _, ar := range selectRollupAccountRegs(accountRegs, opts.AccountRegisters) {
+	for _, ar := range includedAcc {
 		r, _, err := db.accountRegReport(ctx, ar, cutoff)
 		if err != nil {
 			return rep, err
 		}
 		rep.AccountRegisters = append(rep.AccountRegisters, r)
 	}
-	for _, ir := range selectRollupInfoRegs(infoRegs, opts.InfoRegisters) {
+	for _, ir := range includedInfo {
 		r, err := db.infoRegTrimReport(ctx, ir, cutoff)
 		if err != nil {
 			return rep, err
@@ -227,16 +269,25 @@ func (db *DB) countDanglingRefs(ctx context.Context, ents []*metadata.Entity, cu
 // Rollup выполняет свёртку базы в одной транзакции с пост-чеком «остатки до ==
 // остатки после»: при расхождении — откат и ошибка.
 func (db *DB) Rollup(ctx context.Context, regs []*metadata.Register, ents []*metadata.Entity, accountRegs []*metadata.AccountRegister, infoRegs []*metadata.InfoRegister, opts RollupOptions) (RollupReport, error) {
+	cutoff := dayStart(opts.Date)
+	included, err := selectRollupRegs(regs, opts.Registers)
+	if err != nil {
+		return RollupReport{Cutoff: cutoff}, err
+	}
+	includedAcc, err := selectRollupAccountRegs(accountRegs, opts.AccountRegisters)
+	if err != nil {
+		return RollupReport{Cutoff: cutoff}, err
+	}
+	includedInfo, err := selectRollupInfoRegs(infoRegs, opts.InfoRegisters)
+	if err != nil {
+		return RollupReport{Cutoff: cutoff}, err
+	}
 	if err := db.EnsureRollupTable(ctx); err != nil {
 		return RollupReport{}, err
 	}
-	cutoff := dayStart(opts.Date)
-	included := selectRollupRegs(regs, opts.Registers)
-	includedAcc := selectRollupAccountRegs(accountRegs, opts.AccountRegisters)
-	includedInfo := selectRollupInfoRegs(infoRegs, opts.InfoRegisters)
 	rep := RollupReport{Cutoff: cutoff}
 
-	err := db.WithTx(ctx, func(ctx context.Context) error {
+	err = db.WithTx(ctx, func(ctx context.Context) error {
 		if opts.DeleteDocuments {
 			// Жёсткий гейт по повисшим ссылкам: отказываем, если на удаляемые
 			// документы ссылаются СОХРАНЯЕМЫЕ записи (иначе ссылки повиснут).
@@ -587,18 +638,27 @@ func (db *DB) logRollup(ctx context.Context, cutoff time.Time, regs []*metadata.
 
 // selectRollupAccountRegs отбирает регистры бухгалтерии по именам (как
 // selectRollupRegs для накопления).
-func selectRollupAccountRegs(all []*metadata.AccountRegister, names []string) []*metadata.AccountRegister {
-	want := make(map[string]bool, len(names))
+func selectRollupAccountRegs(all []*metadata.AccountRegister, names []string) ([]*metadata.AccountRegister, error) {
+	want, err := selectedRollupNameSet("регистр бухгалтерии", names)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]*metadata.AccountRegister, len(all))
+	for _, ar := range all {
+		byName[rollupNameKey(ar.Name)] = ar
+	}
 	for _, n := range names {
-		want[strings.ToLower(n)] = true
+		if _, ok := byName[rollupNameKey(n)]; !ok {
+			return nil, fmt.Errorf("регистр бухгалтерии %q не найден", strings.TrimSpace(n))
+		}
 	}
 	var out []*metadata.AccountRegister
 	for _, ar := range all {
-		if want[strings.ToLower(ar.Name)] {
+		if want[rollupNameKey(ar.Name)] {
 			out = append(out, ar)
 		}
 	}
-	return out
+	return out, nil
 }
 
 const rollupAuxAccountKey = "rollup.aux_account"
@@ -826,18 +886,27 @@ func accountBalancesEqual(before, after []map[string]any, ar *metadata.AccountRe
 // включается только явным перечислением регистров.
 
 // selectRollupInfoRegs отбирает регистры сведений по именам (как selectRollupRegs).
-func selectRollupInfoRegs(all []*metadata.InfoRegister, names []string) []*metadata.InfoRegister {
-	want := make(map[string]bool, len(names))
+func selectRollupInfoRegs(all []*metadata.InfoRegister, names []string) ([]*metadata.InfoRegister, error) {
+	want, err := selectedRollupNameSet("регистр сведений", names)
+	if err != nil {
+		return nil, err
+	}
+	byName := make(map[string]*metadata.InfoRegister, len(all))
+	for _, ir := range all {
+		byName[rollupNameKey(ir.Name)] = ir
+	}
 	for _, n := range names {
-		want[strings.ToLower(n)] = true
+		if _, ok := byName[rollupNameKey(n)]; !ok {
+			return nil, fmt.Errorf("регистр сведений %q не найден", strings.TrimSpace(n))
+		}
 	}
 	var out []*metadata.InfoRegister
 	for _, ir := range all {
-		if want[strings.ToLower(ir.Name)] {
+		if want[rollupNameKey(ir.Name)] {
 			out = append(out, ir)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // infoTrimCounts считает по периодическому регистру: сколько строк до cutoff

--- a/internal/storage/rollup_test.go
+++ b/internal/storage/rollup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -156,6 +157,41 @@ func TestRollup_FoldsAccumulationRegister(t *testing.T) {
 	}
 }
 
+func TestRollup_RejectsTurnoverRegister(t *testing.T) {
+	ctx, db := rollupTestDB(t)
+	reg := &metadata.Register{
+		Name:       "ОборотыПродаж",
+		Kind:       metadata.RegisterKindTurnover,
+		Dimensions: []metadata.Field{{Name: "Товар", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatalf("MigrateRegisters: %v", err)
+	}
+	d := mustDate(t, "2025-01-10")
+	if err := db.WriteMovements(ctx, reg.Name, "Продажа", uuid.New(),
+		[]map[string]any{{"Товар": "Молоко", "Количество": 10, "ВидДвижения": "Приход"}}, reg, &d); err != nil {
+		t.Fatalf("WriteMovements: %v", err)
+	}
+
+	opts := RollupOptions{Date: mustDate(t, "2025-03-01"), Registers: []string{"ОборотыПродаж"}}
+	if _, err := db.RollupPreview(ctx, []*metadata.Register{reg}, nil, nil, nil, opts); err == nil || !strings.Contains(err.Error(), "оборот") {
+		t.Fatalf("RollupPreview err = %v, want turnover rejection", err)
+	}
+	if _, err := db.Rollup(ctx, []*metadata.Register{reg}, nil, nil, nil, opts); err == nil || !strings.Contains(err.Error(), "оборот") {
+		t.Fatalf("Rollup err = %v, want turnover rejection", err)
+	}
+
+	var total int
+	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.RegisterTableName(reg.Name)).Scan(&total)
+	if total != 1 {
+		t.Fatalf("turnover movements changed: rows=%d, want 1", total)
+	}
+	if _, ok := db.GetPostingLockDate(ctx); ok {
+		t.Fatalf("posting lock should not be set after rejected rollup")
+	}
+}
+
 func rollupDocEntity() *metadata.Entity {
 	return &metadata.Entity{
 		Name:    "РасходТовара",
@@ -254,6 +290,34 @@ func TestRollup_DeleteDocuments(t *testing.T) {
 	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(doc.Name)).Scan(&left)
 	if left != 1 {
 		t.Errorf("осталось документов=%d, ждали 1", left)
+	}
+}
+
+func TestRollup_RejectsUnknownRegisterBeforeDocumentPolicy(t *testing.T) {
+	ctx, db := rollupTestDB(t)
+	doc := rollupDocEntity()
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	if _, err := db.WriteCatalogRecord(ctx, doc, "", map[string]any{"Дата": mustDate(t, "2025-01-15"), "Сумма": 100}); err != nil {
+		t.Fatalf("WriteCatalogRecord: %v", err)
+	}
+
+	opts := RollupOptions{Date: mustDate(t, "2025-03-01"), Registers: []string{"НетТакогоРегистра"}, DeleteDocuments: true}
+	if _, err := db.RollupPreview(ctx, nil, []*metadata.Entity{doc}, nil, nil, opts); err == nil || !strings.Contains(err.Error(), "не найден") {
+		t.Fatalf("RollupPreview err = %v, want unknown register rejection", err)
+	}
+	if _, err := db.Rollup(ctx, nil, []*metadata.Entity{doc}, nil, nil, opts); err == nil || !strings.Contains(err.Error(), "не найден") {
+		t.Fatalf("Rollup err = %v, want unknown register rejection", err)
+	}
+
+	var left int
+	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(doc.Name)).Scan(&left)
+	if left != 1 {
+		t.Fatalf("document policy ran after invalid selection: documents left=%d, want 1", left)
+	}
+	if _, ok := db.GetPostingLockDate(ctx); ok {
+		t.Fatalf("posting lock should not be set after invalid selection")
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject unknown rollup register names and turnover accumulation registers before preview/run work starts
- disable turnover registers in the rollup UI
- resolve file-backed managed form delete paths through SafeJoin
- add regression tests for rollup validation and managed form delete traversal

## Tests
- go test ./internal/storage -run 'TestRollup'
- go test ./internal/launcher -run 'TestDeleteManagedForm'
- go test ./...
- go vet ./...
- git diff --check