### PR TITLE
fix(dsl): isolate function scopes for collections

### DIFF
--- a/internal/dsl/interpreter/collections_test.go
+++ b/internal/dsl/interpreter/collections_test.go
@@ -1,8 +1,10 @@
 package interpreter_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
 	"github.com/ivantit66/onebase/internal/dsl/lexer"
 	"github.com/ivantit66/onebase/internal/dsl/parser"
@@ -42,6 +44,34 @@ func evalFunc(t *testing.T, src string) any {
 	obj := runtime.NewObject("Test", metadata.KindDocument)
 	var result any
 	_ = interp.RunWithResult(prog.Procedures[0], obj, &result)
+	return result
+}
+
+func evalProgramFunc(t *testing.T, src string) any {
+	t.Helper()
+	l := lexer.New(src, "test.os")
+	p := parser.New(l)
+	prog, err := p.ParseProgram()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(prog.Procedures) == 0 {
+		t.Fatal("no procedures")
+	}
+	procs := make(map[string]*ast.ProcedureDecl, len(prog.Procedures))
+	for _, proc := range prog.Procedures {
+		procs[proc.Name.Literal] = proc
+		procs[strings.ToLower(proc.Name.Literal)] = proc
+	}
+	interp := interpreter.New()
+	interp.LookupSiblingProc = func(_ string, name string) *ast.ProcedureDecl {
+		return procs[strings.ToLower(name)]
+	}
+	obj := runtime.NewObject("Test", metadata.KindDocument)
+	var result any
+	if err := interp.RunWithResult(prog.Procedures[0], obj, &result); err != nil {
+		t.Fatalf("run: %v", err)
+	}
 	return result
 }
 
@@ -95,6 +125,55 @@ func TestArray_ForEach(t *testing.T) {
 	}
 }
 
+func TestArray_RepeatedForEachDoesNotConsume(t *testing.T) {
+	src := `Функция Тест()
+  а = Новый Массив;
+  а.Добавить(10);
+  а.Добавить(20);
+  сумма1 = 0;
+  Для Каждого Эл Из а Цикл
+    сумма1 = сумма1 + Эл;
+  КонецЦикла;
+  сумма2 = 0;
+  Для Каждого Эл Из а Цикл
+    сумма2 = сумма2 + Эл;
+  КонецЦикла;
+  Возврат Строка(а.Количество()) + ":" + Строка(сумма1) + ":" + Строка(сумма2);
+КонецФункции`
+
+	result := evalFunc(t, src)
+	if result != "2:30:30" {
+		t.Fatalf("expected 2:30:30, got %v", result)
+	}
+}
+
+func TestArray_RepeatedLookupInHelperDoesNotConsume(t *testing.T) {
+	src := `Функция Тест()
+  Факт = Новый Массив;
+  Факт.Добавить("20.1|10.1");
+  Факт.Добавить("28.1|20.1");
+  N1 = ФактПоКлючу(Факт, "20.1|10.1");
+  N2 = ФактПоКлючу(Факт, "28.1|20.1");
+  Возврат Строка(Факт.Количество()) + ":" + Строка(N1) + ":" + Строка(N2);
+КонецФункции
+
+Функция ФактПоКлючу(Факт, Ключ)
+  N = Факт.Количество();
+  Для k = 0 По N - 1 Цикл
+    Ф = Факт.Получить(k);
+    Если Ф = Ключ Тогда
+      Возврат N;
+    КонецЕсли;
+  КонецЦикла;
+  Возврат N;
+КонецФункции`
+
+	result := evalProgramFunc(t, src)
+	if result != "2:2:2" {
+		t.Fatalf("expected 2:2:2, got %v", result)
+	}
+}
+
 func TestArray_IndexAssign(t *testing.T) {
 	src := `Функция Тест()
   а = Новый Массив;
@@ -139,6 +218,48 @@ func TestMap_ForEach_KeyValue(t *testing.T) {
 	result := evalFunc(t, src)
 	if !numEq(result, 3) {
 		t.Fatalf("expected 3, got %v", result)
+	}
+}
+
+func TestMap_RepeatedForEachDoesNotConsume(t *testing.T) {
+	src := `Функция Тест()
+  м = Новый Соответствие;
+  м.Вставить("a", 1);
+  м.Вставить("b", 2);
+  сумма1 = 0;
+  Для Каждого КЗ Из м Цикл
+    сумма1 = сумма1 + КЗ.Значение;
+  КонецЦикла;
+  сумма2 = 0;
+  Для Каждого КЗ Из м Цикл
+    сумма2 = сумма2 + КЗ.Значение;
+  КонецЦикла;
+  Возврат Строка(м.Количество()) + ":" + Строка(сумма1) + ":" + Строка(сумма2);
+КонецФункции`
+
+	result := evalFunc(t, src)
+	if result != "2:3:3" {
+		t.Fatalf("expected 2:3:3, got %v", result)
+	}
+}
+
+func TestMap_RepeatedGetInHelperDoesNotConsume(t *testing.T) {
+	src := `Функция Тест()
+  Данные = Новый Соответствие;
+  Данные.Вставить("a", 10);
+  Данные.Вставить("b", 20);
+  R1 = ЗначениеПоКлючу(Данные, "a");
+  R2 = ЗначениеПоКлючу(Данные, "b");
+  Возврат Строка(Данные.Количество()) + ":" + Строка(R1) + ":" + Строка(R2);
+КонецФункции
+
+Функция ЗначениеПоКлючу(Данные, Ключ)
+  Возврат Данные.Получить(Ключ);
+КонецФункции`
+
+	result := evalProgramFunc(t, src)
+	if result != "2:10:20" {
+		t.Fatalf("expected 2:10:20, got %v", result)
 	}
 }
 

--- a/internal/dsl/interpreter/env.go
+++ b/internal/dsl/interpreter/env.go
@@ -104,13 +104,6 @@ func (e *env) get(name string) (any, bool) {
 
 func (e *env) set(name string, v any) {
 	name = strings.ToLower(name)
-	// Если переменная уже объявлена в родительском scope — обновляем там.
-	if _, ok := e.vars[name]; !ok && e.parent != nil {
-		if e.parent.has(name) {
-			e.parent.set(name, v)
-			return
-		}
-	}
 	e.vars[name] = v
 }
 
@@ -140,15 +133,4 @@ func publishTemp(e *env, vals map[string]any) func() {
 			}
 		}
 	}
-}
-
-func (e *env) has(name string) bool {
-	name = strings.ToLower(name)
-	if _, ok := e.vars[name]; ok {
-		return true
-	}
-	if e.parent != nil {
-		return e.parent.has(name)
-	}
-	return false
 }

--- a/internal/dsl/interpreter/scope_test.go
+++ b/internal/dsl/interpreter/scope_test.go
@@ -181,6 +181,69 @@ func TestDefaultParam_StringDefault(t *testing.T) {
 	}
 }
 
+func TestFunctionParamDoesNotOverwriteCallerVariable(t *testing.T) {
+	code := `Функция Тест()
+  Значение = "caller";
+  Результат = Помощник("arg");
+  Возврат Значение + ":" + Результат;
+КонецФункции
+
+Функция Помощник(Значение)
+  Значение = "local";
+  Возврат Значение;
+КонецФункции`
+	l := lexer.New(code, "<test>")
+	p := parser.New(l)
+	prog, _ := p.ParseProgram()
+	main, helper := prog.Procedures[0], prog.Procedures[1]
+	i := New()
+	i.LookupSiblingProc = func(_, name string) *ast.ProcedureDecl {
+		if name == "Помощник" || name == "помощник" {
+			return helper
+		}
+		return nil
+	}
+	var result any
+	if err := i.RunWithResult(main, &MapThis{M: map[string]any{}}, &result); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if result != "caller:local" {
+		t.Errorf("expected caller:local, got %v", result)
+	}
+}
+
+func TestFunctionLocalDoesNotOverwriteCallerCollection(t *testing.T) {
+	code := `Функция Тест()
+  Данные = Новый Массив;
+  Данные.Добавить(1);
+  Помощник();
+  Возврат Данные.Количество();
+КонецФункции
+
+Процедура Помощник()
+  Данные = Новый Массив;
+  Данные.Добавить(2);
+КонецПроцедуры`
+	l := lexer.New(code, "<test>")
+	p := parser.New(l)
+	prog, _ := p.ParseProgram()
+	main, helper := prog.Procedures[0], prog.Procedures[1]
+	i := New()
+	i.LookupSiblingProc = func(_, name string) *ast.ProcedureDecl {
+		if name == "Помощник" || name == "помощник" {
+			return helper
+		}
+		return nil
+	}
+	var result any
+	if err := i.RunWithResult(main, &MapThis{M: map[string]any{}}, &result); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !numEq(result, 1) {
+		t.Errorf("expected caller collection count 1, got %v", result)
+	}
+}
+
 // ИначеЕсли тоже должен корректно писать во внешний scope.
 func TestIfElseScope_ElseIfAssignmentPropagates(t *testing.T) {
 	code := `Функция Тест()


### PR DESCRIPTION
## Что сделано
- исправлена изоляция scope при вызове DSL-функций: параметры и локальные переменные больше не перезаписывают одноимённые переменные вызывающего кадра
- добавлены регрессии на повторный обход `Массив`/`Соответствие` и повторный lookup через helper-функции
- добавлены тесты, что параметры и локальные коллекции helper-а не затирают данные вызывающего кода

Fixes #212

## Проверка
- `go test ./internal/dsl/interpreter -count=1`
- `go test ./...`
- `go run ./cmd/onebase --no-gui check --project examples/trade`
- `go run ./cmd/onebase --no-gui check --project examples/finance`
- `go run ./cmd/onebase --no-gui check --project examples/tasks`
- `go run ./cmd/onebase --no-gui check --project examples/crm`
- `go build -o /tmp/onebase-check ./cmd/onebase`
- `git diff --check`