### PR TITLE
fix(ui): honest-check формата ПолеДаты (#219) + дедуп «Главная» в подсистемах (#215)

### DIFF
--- a/internal/configcheck/form_format_check.go
+++ b/internal/configcheck/form_format_check.go
@@ -1,0 +1,90 @@
+package configcheck
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/project"
+)
+
+// CheckFormFieldFormat возвращает НЕблокирующие предупреждения о реквизитах форм,
+// которые задают format/display_format, не применяемый рантаймом. Главный случай —
+// kind: ПолеДаты (issue #219): нативный <input type="date"> всегда показывает дату
+// по локали браузера (в ru — дд.ММ.гггг) и хранит значение в ISO; произвольный
+// формат строкой задать нельзя. Раньше такой ключ молча проглатывался (yaml.v3
+// игнорирует неизвестные поля, а unvalidated-key печатается лишь под --lint),
+// создавая «ложную уверенность»: check проходил, а формат не работал. Теперь поля
+// распознаются загрузчиком, а эта проверка ЯВНО и по умолчанию сообщает, что они
+// ничего не делают.
+func CheckFormFieldFormat(proj *project.Project) []Issue {
+	var warns []Issue
+	for _, ent := range proj.Entities {
+		for _, form := range ent.Forms {
+			label := formFileLabel(ent, form)
+			walkFormElements(form.Elements, func(el *metadata.FormElement) {
+				if el.Format == "" && el.DisplayFormat == "" {
+					return
+				}
+				attr := "format"
+				if el.Format == "" {
+					attr = "display_format"
+				}
+				var msg, fix string
+				if el.Kind == metadata.FormElementDatePicker {
+					msg = fmt.Sprintf("ПолеДаты %q задаёт %s, но он не применяется: нативный выбор даты "+
+						"показывает её по локали браузера (в ru — дд.ММ.гггг), а значение всегда хранится "+
+						"в ISO (issue #219)", formElementName(el), attr)
+					fix = "Уберите format/display_format у ПолеДаты — для ru-локали дата и так показывается " +
+						"как дд.ММ.гггг; произвольный формат нативный контрол не поддерживает."
+				} else {
+					msg = fmt.Sprintf("реквизит %q (%s) задаёт %s, но рантайм его не применяет",
+						formElementName(el), el.Kind, attr)
+					fix = "Уберите format/display_format: платформа сейчас не форматирует поля формы по этому атрибуту."
+				}
+				warns = append(warns, Issue{
+					File:         label,
+					Object:       ent.Name,
+					Kind:         "Управляемая форма",
+					Code:         "form.format-ignored",
+					Message:      msg,
+					SuggestedFix: fix,
+				})
+			})
+		}
+	}
+	return warns
+}
+
+// formFileLabel строит относительный путь формы для локатора предупреждения по
+// соглашению forms/<сущность-в-нижнем-регистре>/<форма>.form.yaml.
+func formFileLabel(ent *metadata.Entity, form *metadata.FormModule) string {
+	name := form.Name
+	if name == "" {
+		name = "объекта"
+	}
+	return "forms/" + strings.ToLower(ent.Name) + "/" + name + ".form.yaml"
+}
+
+// formElementName возвращает осмысленное имя реквизита для сообщения: имя, иначе
+// data_path, иначе вид элемента.
+func formElementName(el *metadata.FormElement) string {
+	if el.Name != "" {
+		return el.Name
+	}
+	if el.DataPath != "" {
+		return el.DataPath
+	}
+	return string(el.Kind)
+}
+
+// walkFormElements обходит дерево элементов формы (включая вложенные children).
+func walkFormElements(elements []*metadata.FormElement, fn func(*metadata.FormElement)) {
+	for _, el := range elements {
+		if el == nil {
+			continue
+		}
+		fn(el)
+		walkFormElements(el.Children, fn)
+	}
+}

--- a/internal/configcheck/form_format_check_test.go
+++ b/internal/configcheck/form_format_check_test.go
@@ -1,0 +1,95 @@
+package configcheck
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/project"
+)
+
+// projWithElement собирает минимальный проект с одной формой сущности
+// «ВходящееПисьмо» и единственным элементом el.
+func projWithElement(el *metadata.FormElement) *project.Project {
+	return &project.Project{
+		Entities: []*metadata.Entity{
+			{
+				Name: "ВходящееПисьмо",
+				Forms: []*metadata.FormModule{
+					{Name: "объекта", Elements: []*metadata.FormElement{el}},
+				},
+			},
+		},
+	}
+}
+
+func TestCheckFormFieldFormat_PoleDatyFormatWarns(t *testing.T) {
+	warns := CheckFormFieldFormat(projWithElement(&metadata.FormElement{
+		Kind:     metadata.FormElementDatePicker,
+		Name:     "Дата",
+		DataPath: "Объект.Дата",
+		Format:   "dd.MM.yyyy",
+	}))
+	if len(warns) != 1 {
+		t.Fatalf("ожидалось 1 предупреждение, получили %d: %+v", len(warns), warns)
+	}
+	w := warns[0]
+	if w.Code != "form.format-ignored" {
+		t.Errorf("Code = %q, ожидался form.format-ignored", w.Code)
+	}
+	if w.File != "forms/входящееписьмо/объекта.form.yaml" {
+		t.Errorf("File = %q, ожидался путь формы в нижнем регистре", w.File)
+	}
+	if !strings.Contains(w.Message, "ПолеДаты") || !strings.Contains(w.Message, "ISO") {
+		t.Errorf("сообщение должно объяснять суть (ПолеДаты/ISO): %q", w.Message)
+	}
+}
+
+func TestCheckFormFieldFormat_DisplayFormatAlsoWarns(t *testing.T) {
+	if warns := CheckFormFieldFormat(projWithElement(&metadata.FormElement{
+		Kind:          metadata.FormElementDatePicker,
+		Name:          "Дата",
+		DisplayFormat: "dd.MM.yyyy",
+	})); len(warns) != 1 {
+		t.Fatalf("display_format тоже должен предупреждать, получили %d", len(warns))
+	}
+}
+
+func TestCheckFormFieldFormat_NoFormatNoWarn(t *testing.T) {
+	if warns := CheckFormFieldFormat(projWithElement(&metadata.FormElement{
+		Kind:     metadata.FormElementDatePicker,
+		Name:     "Дата",
+		DataPath: "Объект.Дата",
+	})); len(warns) != 0 {
+		t.Fatalf("без format предупреждений быть не должно, получили %d: %+v", len(warns), warns)
+	}
+}
+
+// На неполедатном реквизите format тоже не применяется — предупреждаем, но другим
+// текстом (без специфики нативного контрола даты).
+func TestCheckFormFieldFormat_NonDateFieldGenericWarn(t *testing.T) {
+	warns := CheckFormFieldFormat(projWithElement(&metadata.FormElement{
+		Kind:   metadata.FormElementField,
+		Name:   "Сумма",
+		Format: "#,##0.00",
+	}))
+	if len(warns) != 1 {
+		t.Fatalf("ожидалось 1 предупреждение для не-ПолеДаты, получили %d", len(warns))
+	}
+	if strings.Contains(warns[0].Message, "ISO") {
+		t.Errorf("для не-ПолеДаты сообщение не должно говорить про ISO: %q", warns[0].Message)
+	}
+}
+
+func TestCheckFormFieldFormat_NestedChildrenWalked(t *testing.T) {
+	group := &metadata.FormElement{
+		Kind: metadata.FormElementGroupBox,
+		Name: "Группа",
+		Children: []*metadata.FormElement{
+			{Kind: metadata.FormElementDatePicker, Name: "Дата", Format: "dd.MM.yyyy"},
+		},
+	}
+	if warns := CheckFormFieldFormat(projWithElement(group)); len(warns) != 1 {
+		t.Fatalf("вложенный ПолеДаты должен обходиться, получили %d", len(warns))
+	}
+}

--- a/internal/configcheck/full.go
+++ b/internal/configcheck/full.go
@@ -40,6 +40,7 @@ func RunFullWithOptions(dir string, opts Options) Result {
 		roles, _ := auth.LoadRolesYAML(filepath.Join(dir, "roles"))
 		issues = append(issues, CheckCrossRefs(proj, roles)...)
 		warnings = append(warnings, CheckLayoutWarnings(proj)...)
+		warnings = append(warnings, CheckFormFieldFormat(proj)...)
 		issues = append(issues, CheckHTTPServices(proj)...)
 		issues = append(issues, CheckPages(proj)...)
 		issues = append(issues, CheckNameCollisions(proj)...)

--- a/internal/configcheck/lint.go
+++ b/internal/configcheck/lint.go
@@ -360,8 +360,8 @@ func formModuleYAMLSchema() *yamlLintSchema {
 	for _, k := range []string{
 		"id", "name", "kind", "field", "table_part", "visible", "enabled", "required",
 		"original_id", "data_path", "picture", "values_picture", "width", "height",
-		"halign", "valign", "readonly", "use_grid", "no_grid", "hint", "mask",
-		"type", "choice", "unknown_xml", "view",
+		"halign", "valign", "readonly", "use_grid", "no_grid", "auto_sum", "hint", "mask",
+		"format", "display_format", "type", "choice", "unknown_xml", "view",
 	} {
 		element.keys[k] = nil
 	}

--- a/internal/metadata/form_module.go
+++ b/internal/metadata/form_module.go
@@ -121,6 +121,12 @@ type FormElement struct {
 	AutoSum         bool              `yaml:"auto_sum,omitempty"`       // ТЧ: авто Сумма = Количество × Цена по именам колонок — opt-in (#215.1)
 	Hint            string            `yaml:"hint,omitempty"`           // всплывающая подсказка
 	Mask            string            `yaml:"mask,omitempty"`           // маска ввода
+	// Format/DisplayFormat распознаются, но для kind: ПолеДаты НЕ применяются в
+	// рантайме: нативный <input type=date> показывает дату по локали браузера, а
+	// значение всегда ISO (issue #219). Поля заведены, чтобы onebase check мог
+	// явно предупредить об этом, а не молча проглатывать неизвестный ключ.
+	Format        string `yaml:"format,omitempty"`
+	DisplayFormat string `yaml:"display_format,omitempty"`
 	Type            string            `yaml:"type,omitempty"`           // "file" для файлового поля, и т.п.
 	Choice          bool              `yaml:"choice,omitempty"`         // включена кнопка выбора у InputField
 	// Choices — декларативный список значений для выбора (аналог 1С СписокВыбора).

--- a/internal/ui/subsys_nav_dedup_test.go
+++ b/internal/ui/subsys_nav_dedup_test.go
@@ -1,0 +1,66 @@
+package ui
+
+// #215 п.2: в панели подсистем хардкодом печатается ведущая ссылка «Главная», а
+// затем перебираются подсистемы. Если в базе есть подсистема с представлением
+// «Главная», она дублировала ведущую ссылку (видно справа от неё). Дедуп в шаблоне
+// nav пропускает подсистему, чьё DisplayName совпадает с меткой домашней ссылки.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func renderNavSubs(t *testing.T, subs []*metadata.Subsystem) string {
+	t.Helper()
+	data := map[string]any{
+		"Cfg":              Config{},
+		"Lang":             "ru",
+		"IsAdmin":          false,
+		"Subsystems":       subs,
+		"CurrentSubsystem": "",
+	}
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "nav", data); err != nil {
+		t.Fatalf("execute nav: %v", err)
+	}
+	return buf.String()
+}
+
+func TestSubsysBar_DedupHomeSubsystem(t *testing.T) {
+	out := renderNavSubs(t, []*metadata.Subsystem{
+		{Name: "Главная", Title: "Главная"},
+		{Name: "Продажи", Title: "Продажи"},
+	})
+	// Единственная ссылка-подсистема в панели — «Продажи»; «Главная» как
+	// подсистема не печатается (ведущая ссылка её уже представляет).
+	if n := strings.Count(out, "?subsystem="); n != 1 {
+		t.Errorf("ожидалась 1 ссылка-подсистема (Продажи), нашли %d:\n%s", n, out)
+	}
+	if !strings.Contains(out, "Продажи") {
+		t.Errorf("обычная подсистема «Продажи» должна остаться в панели:\n%s", out)
+	}
+}
+
+func TestSubsysBar_KeepsNonHomeSubsystems(t *testing.T) {
+	out := renderNavSubs(t, []*metadata.Subsystem{
+		{Name: "Продажи", Title: "Продажи"},
+		{Name: "Закупки", Title: "Закупки"},
+	})
+	if n := strings.Count(out, "?subsystem="); n != 2 {
+		t.Errorf("обе обычные подсистемы должны остаться (2 ссылки), нашли %d:\n%s", n, out)
+	}
+}
+
+// Дедуп опирается на представление: подсистема с Name=Главная, но другим
+// заголовком (Title) — не дубль и должна остаться.
+func TestSubsysBar_DedupByDisplayNameNotRawName(t *testing.T) {
+	out := renderNavSubs(t, []*metadata.Subsystem{
+		{Name: "Главная", Title: "Основное"},
+	})
+	if n := strings.Count(out, "?subsystem="); n != 1 {
+		t.Errorf("подсистема с заголовком «Основное» не дубль — должна остаться, нашли %d ссылок", n)
+	}
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -993,8 +993,11 @@ const tplNav = `
 {{end}}
 {{if .Subsystems}}
 <nav class="subsys-bar">
-  <a href="/ui/" class="{{if not .CurrentSubsystem}}active{{end}}">{{t $.Lang "Главная"}}</a>
-  {{range .Subsystems}}<a href="/ui/?subsystem={{.Name}}" class="{{if eq .Name $.CurrentSubsystem}}active{{end}}">{{lucideIcon .Icon}}{{.DisplayName $.Lang}}</a>{{end}}
+  {{$home := t $.Lang "Главная"}}
+  <a href="/ui/" class="{{if not .CurrentSubsystem}}active{{end}}">{{$home}}</a>
+  {{/* #215.2: не дублируем ведущую «Главная», если в базе есть одноимённая
+       подсистема (её представление совпадает с меткой домашней ссылки). */}}
+  {{range .Subsystems}}{{if ne (.DisplayName $.Lang) $home}}<a href="/ui/?subsystem={{.Name}}" class="{{if eq .Name $.CurrentSubsystem}}active{{end}}">{{lucideIcon .Icon}}{{.DisplayName $.Lang}}</a>{{end}}{{end}}
 </nav>
 {{end}}
 <div class="app-body">


### PR DESCRIPTION
Две правки по оставшимся тест-репортам.

## #219 — `format`/`display_format` у `ПолеДаты` молча принимались, но не работали
`kind: ПолеДаты` рендерится нативным `<input type="date">`, который всегда
показывает дату по локали браузера (в ru — дд.ММ.гггг) и хранит значение в ISO.
Произвольный `format` к нему неприменим. При этом ключ молча проглатывался
(yaml.v3 игнорирует неизвестные поля, а `unvalidated-key` печатается лишь под
`--lint`), поэтому `onebase check` показывал «OK», а формат не работал —
«ложная уверенность» автора конфигурации.

Выбран вариант **honest-check** (минимальный риск, нативный календарь сохраняется):
- `FormElement` теперь распознаёт `format`/`display_format` (раньше терялись).
- Новая проверка `CheckFormFieldFormat` **по умолчанию** (не только `--lint`)
  предупреждает, что для `ПолеДаты` формат не применяется (контрол нативный,
  показ по локали, значение ISO); для прочих реквизитов — что рантайм его пока
  не использует. Предупреждение не валит `OK`.
- В lint-схему формы добавлены `format`/`display_format` и `auto_sum`
  (последний завезён в #217, но в схему не попал → давал ложный `unvalidated-key`).

Сообщение проверки:
```
forms/<...>.form.yaml: [Управляемая форма] [form.format-ignored] ПолеДаты "Дата"
задаёт format, но он не применяется: нативный выбор даты показывает её по локали
браузера (в ru — дд.ММ.гггг), а значение всегда хранится в ISO (issue #219)
  подсказка: Уберите format/display_format у ПолеДаты — для ru-локали дата и так
  показывается как дд.ММ.гггг; произвольный формат нативный контрол не поддерживает.
```

## #215 (п.2) — дубль «Главная» в панели подсистем
Панель подсистем печатала ведущую ссылку «Главная» хардкодом, затем перебирала
`.Subsystems`. Подсистема с представлением «Главная» дублировала ведущую ссылку
(видно справа). Дедуп в шаблоне `nav`: подсистема, чьё `DisplayName` совпадает с
меткой домашней ссылки, в перечень не попадает. Дедуп по представлению, а не по
«сырому» Name (подсистема с Name=Главная, но другим заголовком — не дубль).

> #215 (п.1, авто-Сумма ТЧ) уже закрыт в #217 — этот PR добивает п.2 и закрывает issue.

## Проверка
- `go test ./...` — зелёные. Тесты: `CheckFormFieldFormat` (ПолеДаты/обычное
  поле/вложенность/без формата), дедуп subsys-bar (дубль/не-дубль/по заголовку).
- `onebase check` trade/crm/finance — OK без ложных предупреждений; на временно
  добавленном `ПолеДаты + format` в crm предупреждение появляется как ожидается.

Closes #219
Closes #215