### PR TITLE
Fix build-380 report format regression and DSL no-op diagnostics

### DIFF
--- a/internal/configcheck/report_output_format.go
+++ b/internal/configcheck/report_output_format.go
@@ -8,12 +8,14 @@ import (
 )
 
 // validReportOutputFormats — допустимые значения output_format отчёта.
-var validReportOutputFormats = map[string]bool{"": true, "html": true, "pdf": true, "excel": true}
+var validReportOutputFormats = map[string]bool{
+	"": true, "html": true, "pdf": true, "excel": true, "excel_html": true,
+}
 
 // CheckReportOutputFormat проверяет, что output_format отчёта (issue #218) — одно
-// из html|pdf|excel (или пусто). Поле распознаётся загрузчиком, поэтому неизвестное
-// значение — почти наверняка опечатка; ловим её на check как ошибку, а не молча
-// игнорируем (иначе автор получает «ложную уверенность», как было с #219).
+// из html|pdf|excel|excel_html (или пусто). Поле распознаётся загрузчиком, поэтому
+// неизвестное значение — почти наверняка опечатка; ловим её на check как ошибку,
+// а не молча игнорируем (иначе автор получает «ложную уверенность», как было с #219).
 func CheckReportOutputFormat(proj *project.Project) []Issue {
 	var issues []Issue
 	for _, rep := range proj.Reports {
@@ -26,8 +28,8 @@ func CheckReportOutputFormat(proj *project.Project) []Issue {
 			Object:       rep.Name,
 			Kind:         "Отчёт",
 			Code:         "report.bad-output-format",
-			Message:      fmt.Sprintf("неизвестный output_format %q: допустимо html, pdf или excel", rep.OutputFormat),
-			SuggestedFix: "Используйте output_format: html|pdf|excel либо уберите ключ.",
+			Message:      fmt.Sprintf("неизвестный output_format %q: допустимо html, pdf, excel или excel_html", rep.OutputFormat),
+			SuggestedFix: "Используйте output_format: html|pdf|excel|excel_html либо уберите ключ.",
 		})
 	}
 	return issues

--- a/internal/configcheck/report_output_format_test.go
+++ b/internal/configcheck/report_output_format_test.go
@@ -12,7 +12,7 @@ func projWithReport(rep *report.Report) *project.Project {
 }
 
 func TestCheckReportOutputFormat_AcceptsKnown(t *testing.T) {
-	for _, of := range []string{"", "html", "pdf", "excel", "PDF", "Excel"} {
+	for _, of := range []string{"", "html", "pdf", "excel", "excel_html", "PDF", "Excel", "EXCEL_HTML"} {
 		rep := &report.Report{Name: "R", OutputFormat: of}
 		if iss := CheckReportOutputFormat(projWithReport(rep)); len(iss) != 0 {
 			t.Errorf("output_format=%q должен приниматься, получили %d ошибок", of, len(iss))

--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -712,6 +712,9 @@ func (i *Interpreter) evalCall(c *ast.CallExpr, e *env) any {
 				}
 			}
 		}
+		if recv == nil {
+			RaiseUserError("Метод " + callee.Field.Literal + " вызван у Неопределено")
+		}
 		return nil
 	}
 	return nil

--- a/internal/dsl/interpreter/interpreter_test.go
+++ b/internal/dsl/interpreter/interpreter_test.go
@@ -109,6 +109,20 @@ EndProcedure`
 	}
 }
 
+func TestInterpreter_CallMethodOnUndefinedRaises(t *testing.T) {
+	src := `Процедура Выполнить()
+  Обл = Макет.Область("Заголовок");
+КонецПроцедуры`
+	obj := runtime.NewObject("X", metadata.KindDocument)
+	err := runProc(t, src, obj)
+	if err == nil {
+		t.Fatal("expected error for method call on undefined receiver")
+	}
+	if !strings.Contains(err.Error(), "Метод Область вызван у Неопределено") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // Регрессия для замечания #13: несколько процедур в одном файле
 // (.proc.os и т.п.) должны вызывать друг друга. Реализовано через
 // Interpreter.LookupSiblingProc — резолвер по файлу.

--- a/internal/dsl/interpreter/valuetable.go
+++ b/internal/dsl/interpreter/valuetable.go
@@ -20,7 +20,19 @@ type ValueTable struct {
 func NewValueTable(_ []any) *ValueTable { return &ValueTable{} }
 
 func (t *ValueTable) TypeName() string { return "ТаблицаЗначений" }
-func (t *ValueTable) String() string   { return fmt.Sprintf("ТаблицаЗначений[%d]", len(t.rows)) }
+func (t *ValueTable) String() string {
+	return fmt.Sprintf("ТаблицаЗначений[%d]", len(t.rows))
+}
+
+func (t *ValueTable) Get(name string) any {
+	switch strings.ToLower(name) {
+	case "колонки", "columns":
+		return &vtColumns{vt: t}
+	}
+	return nil
+}
+
+func (t *ValueTable) Set(_ string, _ any) {}
 
 // IterateRows реализует контракт цикла «Для Каждого» (см. ForEachStmt):
 // каждая строка оборачивается в *MapThis.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -24,8 +24,8 @@ type Report struct {
 	Composition *Composition      `yaml:"composition"` // nil = плоская таблица (старое поведение)
 	Variants    []ReportVariant   `yaml:"variants"`    // доп. именованные компоновки по тому же запросу
 	// OutputFormat — предпочтительный формат выгрузки отчёта (issue #218): пусто|html
-	// (интерактивный просмотр + кнопки Excel/PDF), pdf или excel (соответствующая
-	// кнопка становится основной). Реальная выгрузка идёт через /ui/report/<name>/pdf
+	// (интерактивный просмотр + кнопки Excel/PDF), pdf, excel или совместимый
+	// legacy-синоним excel_html. Реальная выгрузка идёт через /ui/report/<name>/pdf
 	// и /excel независимо от этого поля; формат лишь подсказывает приоритет в UI.
 	OutputFormat string `yaml:"output_format,omitempty"`
 


### PR DESCRIPTION
## Summary
- restore `output_format: excel_html` as an accepted report format for `onebase check`
- make DSL method calls on `Неопределено` fail loudly instead of silently returning nil
- add `ТаблицаЗначений.Колонки` property access so stricter diagnostics do not break value table DSL

## Issues
- Fixes #225
- Addresses the likely false-positive mechanism behind #226; if DocFlow still reproduces missing persistence, we need a minimal project/example proving that `Справочники.ШаблоныИмпортаДокументов.Создать().Записать()` reaches a real catalog and committed DB but still leaves no row.

## Verification
- `go test ./...`
