### PR TITLE
feat(report): add named user presets

### DIFF
--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -2,10 +2,12 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/llm"
 )
 
@@ -35,6 +37,18 @@ type AuditSettings struct {
 	Login   bool // регистрировать вход / выход пользователей
 }
 
+// ReportPreset — именованный пользовательский вариант настроек отчёта.
+// SettingsJSON хранит report.UserReportSettings в каноничном JSON, но слой
+// storage не импортирует internal/report, чтобы не связывать пакеты циклом.
+type ReportPreset struct {
+	ID           string
+	Report       string
+	User         string
+	Name         string
+	SettingsJSON string
+	IsDefault    bool
+}
+
 // DefaultAuditSettings — журнал включён, пишутся изменения данных и проведение;
 // вход/выход по умолчанию не пишется (шумно для однопользовательских баз).
 func DefaultAuditSettings() AuditSettings {
@@ -59,6 +73,35 @@ func (db *DB) EnsureSettingsSchema(ctx context.Context) error {
 		`CREATE TABLE IF NOT EXISTS _settings (key TEXT PRIMARY KEY, value TEXT NOT NULL DEFAULT '')`,
 	); err != nil {
 		return fmt.Errorf("settings: create _settings: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) EnsureReportPresetSchema(ctx context.Context) error {
+	d := db.dialect
+	q := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS _report_presets (
+		id TEXT PRIMARY KEY,
+		report_name TEXT NOT NULL,
+		user_login TEXT NOT NULL DEFAULT '',
+		name TEXT NOT NULL,
+		settings_json TEXT NOT NULL DEFAULT '',
+		is_default %s NOT NULL DEFAULT %s,
+		created_at %s NOT NULL DEFAULT %s,
+		updated_at %s NOT NULL DEFAULT %s,
+		UNIQUE(report_name, user_login, name)
+	)`, d.TypeBool(), boolFalseLit(d), d.TypeTimestamp(), d.CurrentTimestampTZ(), d.TypeTimestamp(), d.CurrentTimestampTZ())
+	if _, err := db.Exec(ctx, q); err != nil {
+		return fmt.Errorf("settings: create _report_presets: %w", err)
+	}
+	if _, err := db.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_report_presets_owner ON _report_presets (report_name, user_login, name)`); err != nil {
+		return fmt.Errorf("settings: create _report_presets owner index: %w", err)
+	}
+	defaultLit := "TRUE"
+	if d.Name() == "sqlite" {
+		defaultLit = "1"
+	}
+	if _, err := db.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS idx_report_presets_default ON _report_presets (report_name, user_login) WHERE is_default = `+defaultLit); err != nil {
+		return fmt.Errorf("settings: create _report_presets default index: %w", err)
 	}
 	return nil
 }
@@ -453,4 +496,172 @@ func (db *DB) DeleteReportUserSettings(ctx context.Context, report, user string)
 		return fmt.Errorf("settings: delete report settings: %w", err)
 	}
 	return nil
+}
+
+// ListReportPresets возвращает пользовательские варианты отчёта в стабильном
+// порядке: дефолтный выше остальных, дальше по имени.
+func (db *DB) ListReportPresets(ctx context.Context, report, user string) ([]ReportPreset, error) {
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		return nil, err
+	}
+	d := db.dialect
+	rows, err := db.Query(ctx,
+		fmt.Sprintf(`SELECT id, report_name, user_login, name, settings_json, is_default
+			FROM _report_presets
+			WHERE report_name = %s AND user_login = %s
+			ORDER BY is_default DESC, name ASC`, d.Placeholder(1), d.Placeholder(2)),
+		report, user)
+	if err != nil {
+		return nil, fmt.Errorf("settings: list report presets: %w", err)
+	}
+	defer rows.Close()
+	var out []ReportPreset
+	for rows.Next() {
+		p, err := scanReportPreset(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("settings: list report presets rows: %w", err)
+	}
+	return out, nil
+}
+
+func (db *DB) GetReportPreset(ctx context.Context, report, user, id string) (*ReportPreset, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, nil
+	}
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		return nil, err
+	}
+	d := db.dialect
+	row := db.QueryRow(ctx,
+		fmt.Sprintf(`SELECT id, report_name, user_login, name, settings_json, is_default
+			FROM _report_presets
+			WHERE id = %s AND report_name = %s AND user_login = %s`,
+			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3)),
+		id, report, user)
+	p, err := scanReportPresetRow(row)
+	if err != nil {
+		return nil, nil
+	}
+	return &p, nil
+}
+
+func (db *DB) GetDefaultReportPreset(ctx context.Context, report, user string) (*ReportPreset, error) {
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		return nil, err
+	}
+	d := db.dialect
+	row := db.QueryRow(ctx,
+		fmt.Sprintf(`SELECT id, report_name, user_login, name, settings_json, is_default
+			FROM _report_presets
+			WHERE report_name = %s AND user_login = %s AND is_default = %s`,
+			d.Placeholder(1), d.Placeholder(2), reportPresetBoolLit(d, true)),
+		report, user)
+	p, err := scanReportPresetRow(row)
+	if err != nil {
+		return nil, nil
+	}
+	return &p, nil
+}
+
+// SaveReportPreset создаёт или обновляет именованный вариант. Если p.IsDefault,
+// предыдущий дефолтный вариант этого пользователя/отчёта сбрасывается в той же
+// транзакции; частичный уникальный индекс дополнительно защищает инвариант.
+func (db *DB) SaveReportPreset(ctx context.Context, p ReportPreset) (string, error) {
+	p.Report = strings.TrimSpace(p.Report)
+	p.User = strings.TrimSpace(p.User)
+	p.Name = strings.TrimSpace(p.Name)
+	if p.Report == "" {
+		return "", errors.New("report preset: empty report")
+	}
+	if p.Name == "" {
+		return "", errors.New("report preset: empty name")
+	}
+	if p.ID == "" {
+		p.ID = uuid.NewString()
+	}
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		return "", err
+	}
+	d := db.dialect
+	err := db.WithTx(ctx, func(txCtx context.Context) error {
+		if p.IsDefault {
+			if _, err := db.Exec(txCtx,
+				fmt.Sprintf(`UPDATE _report_presets SET is_default = %s, updated_at = %s WHERE report_name = %s AND user_login = %s`,
+					reportPresetBoolLit(d, false), d.Now(), d.Placeholder(1), d.Placeholder(2)),
+				p.Report, p.User); err != nil {
+				return fmt.Errorf("settings: clear report preset default: %w", err)
+			}
+		}
+		q := fmt.Sprintf(`INSERT INTO _report_presets
+			(id, report_name, user_login, name, settings_json, is_default, created_at, updated_at)
+			VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+			ON CONFLICT (id) DO UPDATE SET
+				name = EXCLUDED.name,
+				settings_json = EXCLUDED.settings_json,
+				is_default = EXCLUDED.is_default,
+				updated_at = EXCLUDED.updated_at`,
+			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4),
+			d.Placeholder(5), d.Placeholder(6), d.Now(), d.Now())
+		if _, err := db.Exec(txCtx, q, p.ID, p.Report, p.User, p.Name, p.SettingsJSON, p.IsDefault); err != nil {
+			return fmt.Errorf("settings: save report preset: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return p.ID, nil
+}
+
+func (db *DB) DeleteReportPreset(ctx context.Context, report, user, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return nil
+	}
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		return err
+	}
+	d := db.dialect
+	if _, err := db.Exec(ctx,
+		fmt.Sprintf(`DELETE FROM _report_presets WHERE id = %s AND report_name = %s AND user_login = %s`,
+			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3)),
+		id, report, user); err != nil {
+		return fmt.Errorf("settings: delete report preset: %w", err)
+	}
+	return nil
+}
+
+type presetScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanReportPreset(rows Rows) (ReportPreset, error) {
+	return scanReportPresetRow(rows)
+}
+
+func scanReportPresetRow(row presetScanner) (ReportPreset, error) {
+	var p ReportPreset
+	var isDefault any
+	if err := row.Scan(&p.ID, &p.Report, &p.User, &p.Name, &p.SettingsJSON, &isDefault); err != nil {
+		return ReportPreset{}, err
+	}
+	p.IsDefault = normalizeBool(isDefault)
+	return p, nil
+}
+
+func reportPresetBoolLit(d Dialect, v bool) string {
+	if d.Name() == "sqlite" {
+		if v {
+			return "1"
+		}
+		return "0"
+	}
+	if v {
+		return "TRUE"
+	}
+	return "FALSE"
 }

--- a/internal/storage/settings_report_test.go
+++ b/internal/storage/settings_report_test.go
@@ -95,3 +95,90 @@ func TestReportSettingsKeyNoCollision(t *testing.T) {
 		t.Fatalf("(a,b.c) затёрта: %q", v)
 	}
 }
+
+func TestReportPresets(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "presets.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+
+	id1, err := db.SaveReportPreset(ctx, ReportPreset{
+		Report:       "Продажи",
+		User:         "alice",
+		Name:         "По товарам",
+		SettingsJSON: `{"variant":"A"}`,
+		IsDefault:    true,
+	})
+	if err != nil {
+		t.Fatalf("SaveReportPreset #1: %v", err)
+	}
+	id2, err := db.SaveReportPreset(ctx, ReportPreset{
+		Report:       "Продажи",
+		User:         "alice",
+		Name:         "По складам",
+		SettingsJSON: `{"variant":"B"}`,
+		IsDefault:    true,
+	})
+	if err != nil {
+		t.Fatalf("SaveReportPreset #2: %v", err)
+	}
+	if id1 == id2 {
+		t.Fatalf("разные пресеты получили один id: %q", id1)
+	}
+
+	def, err := db.GetDefaultReportPreset(ctx, "Продажи", "alice")
+	if err != nil {
+		t.Fatalf("GetDefaultReportPreset: %v", err)
+	}
+	if def == nil || def.ID != id2 || !def.IsDefault {
+		t.Fatalf("дефолт должен быть вторым пресетом: %+v", def)
+	}
+
+	list, err := db.ListReportPresets(ctx, "Продажи", "alice")
+	if err != nil {
+		t.Fatalf("ListReportPresets: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("ожидали 2 пресета, got %+v", list)
+	}
+	if list[0].ID != id2 || !list[0].IsDefault {
+		t.Fatalf("дефолтный пресет должен быть первым: %+v", list)
+	}
+	if list[1].ID != id1 || list[1].IsDefault {
+		t.Fatalf("первый пресет должен перестать быть default: %+v", list)
+	}
+
+	got, err := db.GetReportPreset(ctx, "Продажи", "alice", id1)
+	if err != nil {
+		t.Fatalf("GetReportPreset: %v", err)
+	}
+	if got == nil || got.Name != "По товарам" || got.SettingsJSON != `{"variant":"A"}` {
+		t.Fatalf("не тот пресет: %+v", got)
+	}
+	if other, _ := db.GetReportPreset(ctx, "Продажи", "bob", id1); other != nil {
+		t.Fatalf("bob не должен видеть preset alice: %+v", other)
+	}
+
+	if _, err := db.SaveReportPreset(ctx, ReportPreset{
+		ID:           id1,
+		Report:       "Продажи",
+		User:         "alice",
+		Name:         "По товарам v2",
+		SettingsJSON: `{"variant":"A2"}`,
+	}); err != nil {
+		t.Fatalf("update preset: %v", err)
+	}
+	updated, _ := db.GetReportPreset(ctx, "Продажи", "alice", id1)
+	if updated == nil || updated.Name != "По товарам v2" || updated.SettingsJSON != `{"variant":"A2"}` {
+		t.Fatalf("update не применился: %+v", updated)
+	}
+
+	if err := db.DeleteReportPreset(ctx, "Продажи", "alice", id1); err != nil {
+		t.Fatalf("DeleteReportPreset: %v", err)
+	}
+	if deleted, _ := db.GetReportPreset(ctx, "Продажи", "alice", id1); deleted != nil {
+		t.Fatalf("пресет должен быть удалён: %+v", deleted)
+	}
+}

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -29,17 +29,29 @@ func (s *Server) reportForm(w http.ResponseWriter, r *http.Request) {
 	if !s.requirePerm(w, r, "report", rep.Name, "run") {
 		return
 	}
-	// Если у отчёта нет ни параметров, ни вариантов компоновки — строим сразу.
-	// Варианты требуют формы с выбором, поэтому при них форму показываем всегда.
-	if len(rep.Params) == 0 && len(rep.Variants) == 0 {
+	user := currentUserLogin(r)
+	presets := loadReportPresets(r.Context(), s.store, rep.Name, user)
+	activePresetID := r.FormValue("__preset")
+	if activePresetID == "" {
+		if p, err := s.store.GetDefaultReportPreset(r.Context(), rep.Name, user); err == nil && p != nil {
+			activePresetID = p.ID
+		}
+	}
+	activePreset := activeReportPreset(presets, activePresetID)
+	// Если у отчёта нет ни параметров, ни вариантов компоновки, ни пользовательских
+	// пресетов — строим сразу. Варианты/пресеты требуют формы с выбором.
+	if len(rep.Params) == 0 && len(rep.Variants) == 0 && len(presets) == 0 {
 		s.runReport(w, r, rep, map[string]any{})
 		return
 	}
 	s.render(w, r, "page-report", map[string]any{
-		"Report":        rep,
-		"ParamValues":   map[string]any{},
-		"ReportParams":  s.buildReportParams(r.Context(), s.resolveLang(r), rep.Params),
-		"ActiveVariant": r.FormValue("__variant"),
+		"Report":         rep,
+		"ParamValues":    map[string]any{},
+		"ReportParams":   s.buildReportParams(r.Context(), s.resolveLang(r), rep.Params),
+		"ActiveVariant":  r.FormValue("__variant"),
+		"ReportPresets":  presets,
+		"ActivePresetID": activePresetID,
+		"ActivePreset":   activePreset,
 	})
 }
 
@@ -83,16 +95,16 @@ func (s *Server) getReport(w http.ResponseWriter, r *http.Request) *reportpkg.Re
 func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpkg.Report, paramValues map[string]any) {
 	// Выбранный вариант компоновки (параметр __variant); пусто → основной.
 	variant := r.FormValue("__variant")
-	// Рантайм-настройки пользователя (панель «Настройки»). Эффективная
-	// компоновка: override (settings.Composition) → вариант → основной.
-	settings := readReportSettings(r)
-	if settings == nil {
-		// Нет явных правок в запросе — подставляем сохранённые настройки
-		// пользователя, чтобы отчёт открылся в привычном виде (план 70, D1).
-		settings = loadUserSettings(r.Context(), s.store, rep.Name, currentUserLogin(r))
+	user := currentUserLogin(r)
+	presets := loadReportPresets(r.Context(), s.store, rep.Name, user)
+	rs := s.reportSettingsForRequest(r, rep)
+	settings := rs.Settings
+	activePreset := activeReportPreset(presets, rs.ActivePresetID)
+	if settings != nil {
+		variant = settings.Variant
 	}
-	settings = reportSettingsWithRequestVariant(r, settings)
 	comp := effectiveComposition(rep, settings)
+	settingsJSON := reportSettingsPanelJSON(rep, settings)
 	// Build query params: convert date strings to time.Time for proper PG type inference.
 	// Keep paramValues unchanged so the form repopulates with the original strings.
 	queryValues := make(map[string]any, len(paramValues))
@@ -123,22 +135,32 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 	reportParams := s.buildReportParams(r.Context(), s.resolveLang(r), rep.Params)
 	if err != nil {
 		s.render(w, r, "page-report", map[string]any{
-			"Report":        rep,
-			"QueryError":    err.Error(),
-			"ParamValues":   paramValues,
-			"ReportParams":  reportParams,
-			"ActiveVariant": variant,
+			"Report":             rep,
+			"QueryError":         err.Error(),
+			"ParamValues":        paramValues,
+			"ReportParams":       reportParams,
+			"ActiveVariant":      variant,
+			"UserSettings":       settings,
+			"ReportSettingsJSON": settingsJSON,
+			"ReportPresets":      presets,
+			"ActivePresetID":     rs.ActivePresetID,
+			"ActivePreset":       activePreset,
 		})
 		return
 	}
 	rows, cols, err := s.store.RunQuery(r.Context(), compiled.SQL, compiled.Args)
 	if err != nil {
 		s.render(w, r, "page-report", map[string]any{
-			"Report":        rep,
-			"QueryError":    err.Error(),
-			"ParamValues":   paramValues,
-			"ReportParams":  reportParams,
-			"ActiveVariant": variant,
+			"Report":             rep,
+			"QueryError":         err.Error(),
+			"ParamValues":        paramValues,
+			"ReportParams":       reportParams,
+			"ActiveVariant":      variant,
+			"UserSettings":       settings,
+			"ReportSettingsJSON": settingsJSON,
+			"ReportPresets":      presets,
+			"ActivePresetID":     rs.ActivePresetID,
+			"ActivePreset":       activePreset,
 		})
 		return
 	}
@@ -163,20 +185,29 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 				s.render(w, r, "page-report", map[string]any{
 					"Report": rep, "QueryError": cerr.Error(),
 					"ParamValues": paramValues, "ReportParams": reportParams,
-					"ActiveVariant": variant,
+					"ActiveVariant":      variant,
+					"UserSettings":       settings,
+					"ReportSettingsJSON": settingsJSON,
+					"ReportPresets":      presets,
+					"ActivePresetID":     rs.ActivePresetID,
+					"ActivePreset":       activePreset,
 				})
 				return
 			}
 			s.render(w, r, "page-report", map[string]any{
-				"Report":          rep,
-				"ComposedHTML":    renderCrossTable(cr, comp),
-				"Capped":          cr.Capped,
-				"ComposeWarnings": cr.Warnings,
-				"ParamValues":     paramValues,
-				"ReportParams":    reportParams,
-				"ActiveVariant":   variant,
-				"UserSettings":    settings,
-				"ReportCols":      cols,
+				"Report":             rep,
+				"ComposedHTML":       renderCrossTable(cr, comp),
+				"Capped":             cr.Capped,
+				"ComposeWarnings":    cr.Warnings,
+				"ParamValues":        paramValues,
+				"ReportParams":       reportParams,
+				"ActiveVariant":      variant,
+				"UserSettings":       settings,
+				"ReportSettingsJSON": settingsJSON,
+				"ReportPresets":      presets,
+				"ActivePresetID":     rs.ActivePresetID,
+				"ActivePreset":       activePreset,
+				"ReportCols":         cols,
 			})
 			return
 		}
@@ -185,7 +216,12 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 			s.render(w, r, "page-report", map[string]any{
 				"Report": rep, "QueryError": cerr.Error(),
 				"ParamValues": paramValues, "ReportParams": reportParams,
-				"ActiveVariant": variant,
+				"ActiveVariant":      variant,
+				"UserSettings":       settings,
+				"ReportSettingsJSON": settingsJSON,
+				"ReportPresets":      presets,
+				"ActivePresetID":     rs.ActivePresetID,
+				"ActivePreset":       activePreset,
 			})
 			return
 		}
@@ -194,16 +230,20 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 			chartOption = buildComposedChart(res, comp.Chart, rows, *comp, ev)
 		}
 		s.render(w, r, "page-report", map[string]any{
-			"Report":          rep,
-			"ComposedHTML":    renderComposedTable(res, comp),
-			"Capped":          res.Capped,
-			"ComposeWarnings": res.Warnings,
-			"ChartOption":     chartOption,
-			"ParamValues":     paramValues,
-			"ReportParams":    reportParams,
-			"ActiveVariant":   variant,
-			"UserSettings":    settings,
-			"ReportCols":      cols,
+			"Report":             rep,
+			"ComposedHTML":       renderComposedTable(res, comp),
+			"Capped":             res.Capped,
+			"ComposeWarnings":    res.Warnings,
+			"ChartOption":        chartOption,
+			"ParamValues":        paramValues,
+			"ReportParams":       reportParams,
+			"ActiveVariant":      variant,
+			"UserSettings":       settings,
+			"ReportSettingsJSON": settingsJSON,
+			"ReportPresets":      presets,
+			"ActivePresetID":     rs.ActivePresetID,
+			"ActivePreset":       activePreset,
+			"ReportCols":         cols,
 		})
 		return
 	}
@@ -214,15 +254,19 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 	}
 
 	s.render(w, r, "page-report", map[string]any{
-		"Report":        rep,
-		"Cols":          cols,
-		"Rows":          rows,
-		"ParamValues":   paramValues,
-		"ChartOption":   chartOption,
-		"ReportParams":  reportParams,
-		"ActiveVariant": variant,
-		"UserSettings":  settings,
-		"ReportCols":    cols,
+		"Report":             rep,
+		"Cols":               cols,
+		"Rows":               rows,
+		"ParamValues":        paramValues,
+		"ChartOption":        chartOption,
+		"ReportParams":       reportParams,
+		"ActiveVariant":      variant,
+		"UserSettings":       settings,
+		"ReportSettingsJSON": settingsJSON,
+		"ReportPresets":      presets,
+		"ActivePresetID":     rs.ActivePresetID,
+		"ActivePreset":       activePreset,
+		"ReportCols":         cols,
 	})
 }
 
@@ -420,13 +464,7 @@ func (s *Server) writeReportExportError(w http.ResponseWriter, r *http.Request, 
 // (issue #218) — чтобы обе выгрузки шли из одних и тех же данных и не расходились
 // с экраном (runReport использует те же crossSheetRows/composedRows).
 func (s *Server) reportExportRows(r *http.Request, rep *reportpkg.Report) (headers []string, rows [][]any, err error) {
-	// readReportSettings читает __settings через FormValue (для GET — из query).
-	settings := readReportSettings(r)
-	if settings == nil {
-		// Без явного __settings — выгружаем в сохранённом пользователем виде.
-		settings = loadUserSettings(r.Context(), s.store, rep.Name, currentUserLogin(r))
-	}
-	settings = reportSettingsWithRequestVariant(r, settings)
+	settings := s.reportSettingsForRequest(r, rep).Settings
 	comp := effectiveComposition(rep, settings)
 	paramValues := make(map[string]any, len(rep.Params))
 	for _, p := range rep.Params {

--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -23,8 +23,17 @@ import (
 // разумную презентационную настройку (выбор/порядок колонок, отборы, сортировка).
 const maxUserSettingsBytes = 64 * 1024
 
+const standardReportPresetID = "__standard"
+
 // errSettingsTooLarge — отказ сохранить слишком большой блок __settings (issue #23).
 var errSettingsTooLarge = errors.New("настройки отчёта слишком велики")
+
+var errReportPresetNameRequired = errors.New("укажите название варианта отчёта")
+
+type reportSettingsRequest struct {
+	Settings       *reportpkg.UserReportSettings
+	ActivePresetID string
+}
 
 // readReportSettings разбирает пользовательские настройки из поля __settings
 // запроса (FormValue читает и POST-форму, и GET-query). Пустое или повреждённое
@@ -74,6 +83,61 @@ func requestFormValue(r *http.Request, name string) (string, bool) {
 	return vs[0], true
 }
 
+func (s *Server) reportSettingsForRequest(r *http.Request, rep *reportpkg.Report) reportSettingsRequest {
+	presetID, hasPreset := requestFormValue(r, "__preset")
+	if settings := readReportSettings(r); settings != nil {
+		settings = reportSettingsWithRequestVariant(r, settings)
+		return reportSettingsRequest{Settings: settings, ActivePresetID: presetID}
+	}
+
+	user := currentUserLogin(r)
+	if hasPreset {
+		if presetID == "" || presetID == standardReportPresetID {
+			return reportSettingsRequest{Settings: reportSettingsWithRequestVariant(r, nil), ActivePresetID: standardReportPresetID}
+		}
+		if p, err := s.store.GetReportPreset(r.Context(), rep.Name, user, presetID); err == nil && p != nil {
+			if st, err := reportpkg.ParseUserSettings(p.SettingsJSON); err == nil {
+				return reportSettingsRequest{Settings: st, ActivePresetID: p.ID}
+			}
+		}
+		return reportSettingsRequest{Settings: reportSettingsWithRequestVariant(r, nil), ActivePresetID: standardReportPresetID}
+	}
+
+	if p, err := s.store.GetDefaultReportPreset(r.Context(), rep.Name, user); err == nil && p != nil {
+		if st, err := reportpkg.ParseUserSettings(p.SettingsJSON); err == nil {
+			return reportSettingsRequest{Settings: st, ActivePresetID: p.ID}
+		}
+	}
+
+	// Fallback для баз, где до появления именованных пресетов уже была одна
+	// сохранённая настройка в _settings.
+	if settings := loadUserSettings(r.Context(), s.store, rep.Name, user); settings != nil {
+		settings = reportSettingsWithRequestVariant(r, settings)
+		return reportSettingsRequest{Settings: settings}
+	}
+	return reportSettingsRequest{Settings: reportSettingsWithRequestVariant(r, nil)}
+}
+
+func loadReportPresets(ctx context.Context, store *storage.DB, report, user string) []storage.ReportPreset {
+	if store == nil {
+		return nil
+	}
+	presets, err := store.ListReportPresets(ctx, report, user)
+	if err != nil {
+		return nil
+	}
+	return presets
+}
+
+func activeReportPreset(presets []storage.ReportPreset, id string) *storage.ReportPreset {
+	for i := range presets {
+		if presets[i].ID == id {
+			return &presets[i]
+		}
+	}
+	return nil
+}
+
 // effectiveComposition вычисляет компоновку, по которой строится отчёт.
 //
 // БЕЗОПАСНОСТЬ (issue #1): база компоновки берётся ИСКЛЮЧИТЕЛЬНО из доверенной
@@ -95,6 +159,79 @@ func effectiveComposition(rep *reportpkg.Report, s *reportpkg.UserReportSettings
 		return base
 	}
 	return mergeUserComposition(base, s.Composition)
+}
+
+// reportSettingsPanelJSON возвращает JSON, которым панель «Настройка отчёта»
+// инициализирует чекбоксы и скрытое поле __settings. Важно: это не индикатор
+// пользовательской модификации. Если пользовательских настроек нет, но у отчёта
+// есть базовая composition, панель всё равно должна показать её выбранной.
+func reportSettingsPanelJSON(rep *reportpkg.Report, s *reportpkg.UserReportSettings) string {
+	st := reportSettingsPanelState(rep, s)
+	if st == nil {
+		return ""
+	}
+	raw, err := st.JSON()
+	if err != nil {
+		return ""
+	}
+	return raw
+}
+
+func reportSettingsPanelState(rep *reportpkg.Report, s *reportpkg.UserReportSettings) *reportpkg.UserReportSettings {
+	if rep == nil {
+		return nil
+	}
+	comp := effectiveComposition(rep, s)
+	if comp == nil && s == nil {
+		return nil
+	}
+	out := &reportpkg.UserReportSettings{}
+	if s != nil {
+		out.Variant = s.Variant
+		out.Filters = append([]reportpkg.Filter(nil), s.Filters...)
+	}
+	if comp != nil {
+		out.Composition = panelComposition(comp)
+	}
+	if out.Variant == "" && out.Composition == nil && len(out.Filters) == 0 {
+		return nil
+	}
+	return out
+}
+
+func panelComposition(c *reportpkg.Composition) *reportpkg.Composition {
+	if c == nil {
+		return nil
+	}
+	out := &reportpkg.Composition{
+		Groupings:  append([]string(nil), c.Groupings...),
+		Columns:    append([]string(nil), c.Columns...),
+		Measures:   panelMeasures(c.Measures),
+		Totals:     c.Totals,
+		Detail:     c.Detail,
+		Sort:       append([]reportpkg.SortKey(nil), c.Sort...),
+		Appearance: safeAppearance(c.Appearance),
+	}
+	return out
+}
+
+func panelMeasures(in []reportpkg.Measure) []reportpkg.Measure {
+	if in == nil {
+		return nil
+	}
+	out := make([]reportpkg.Measure, 0, len(in))
+	for _, m := range in {
+		// В панель уходит только презентация показателей. Expr не нужен для UI
+		// и при обратной отправке всё равно берётся только из доверенной YAML-базы.
+		out = append(out, reportpkg.Measure{
+			Field:  m.Field,
+			Agg:    m.Agg,
+			Title:  m.Title,
+			Align:  m.Align,
+			Format: m.Format,
+		})
+	}
+	return out
 }
 
 // mergeUserComposition строит итоговую компоновку на базе доверенной (base) и
@@ -128,17 +265,33 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 
 	out := *base // копия: Conditional/Chart/DetailLink/DetailEntity — из доверенной.
 
-	// Презентационные коллекции берём из пользовательского ввода (это данные).
-	out.Groupings = append([]string(nil), u.Groupings...)
-	out.Columns = append([]string(nil), u.Columns...)
-	out.Sort = append([]reportpkg.SortKey(nil), u.Sort...)
-	out.Totals = u.Totals
-	out.Detail = u.Detail
+	// Презентационные коллекции берём из пользовательского ввода, но только если
+	// поле реально присутствовало. Старый UI отправлял частичный JSON и тем самым
+	// случайно очищал Columns/Sort/Totals/Detail базовой СКД.
+	invalidEmptyMeasures := u.Measures != nil && len(u.Measures) == 0
+	if u.Groupings != nil && !invalidEmptyMeasures {
+		out.Groupings = append([]string(nil), u.Groupings...)
+	}
+	if u.Columns != nil && !invalidEmptyMeasures {
+		out.Columns = append([]string(nil), u.Columns...)
+	}
+	if u.Sort != nil {
+		out.Sort = append([]reportpkg.SortKey(nil), u.Sort...)
+	}
+	// Totals/Detail пока не редактируются в runtime-панели, поэтому пустое
+	// значение не должно стирать доверенную базу. Ненулевое значение применяем
+	// для обратной совместимости с уже существующим JSON настроек.
+	if u.Totals.Grand || u.Totals.Subtotals {
+		out.Totals = u.Totals
+	}
+	if u.Detail {
+		out.Detail = true
+	}
 	out.Appearance = safeAppearance(u.Appearance) // презентация: безопасно из пользователя
 
 	// Показатели: презентация — из пользовательского ввода, Expr — только из
 	// доверенной компоновки (по совпадению Field), иначе обнуляем.
-	if u.Measures != nil {
+	if u.Measures != nil && len(u.Measures) > 0 {
 		measures := make([]reportpkg.Measure, 0, len(u.Measures))
 		for _, m := range u.Measures {
 			safe := reportpkg.Measure{
@@ -199,6 +352,14 @@ func reportFormURL(name string) string {
 	return "/ui/report/" + url.PathEscape(strings.ToLower(name))
 }
 
+func reportFormURLWithPreset(name, presetID string) string {
+	u := reportFormURL(name)
+	if presetID == "" {
+		return u
+	}
+	return u + "?__preset=" + url.QueryEscape(presetID)
+}
+
 // reportSettingsSave сохраняет рантайм-настройки текущего пользователя (POST
 // поля __settings) и возвращает на форму отчёта.
 func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
@@ -209,6 +370,7 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 	if !s.requirePerm(w, r, "report", rep.Name, "run") {
 		return
 	}
+	action := r.FormValue("__preset_action")
 	raw := r.FormValue("__settings")
 	// Лимит размера: не пускаем в _settings произвольно большой ввод (issue #23).
 	if len(raw) > maxUserSettingsBytes {
@@ -229,8 +391,64 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	_ = s.store.SaveReportUserSettings(r.Context(), rep.Name, currentUserLogin(r), canon)
-	http.Redirect(w, r, reportFormURL(rep.Name), http.StatusSeeOther)
+
+	// Обратная совместимость: старые формы без __preset_action по-прежнему
+	// сохраняют единственную настройку в _settings.
+	if action == "" {
+		_ = s.store.SaveReportUserSettings(r.Context(), rep.Name, currentUserLogin(r), canon)
+		http.Redirect(w, r, reportFormURL(rep.Name), http.StatusSeeOther)
+		return
+	}
+
+	user := currentUserLogin(r)
+	presetID := r.FormValue("__preset")
+	name := strings.TrimSpace(r.FormValue("__preset_name"))
+	isDefault := r.FormValue("__preset_default") != ""
+
+	if action == "save" && presetID != "" && presetID != standardReportPresetID {
+		if p, err := s.store.GetReportPreset(r.Context(), rep.Name, user, presetID); err == nil && p != nil {
+			if name == "" {
+				name = p.Name
+			}
+		} else {
+			presetID = ""
+		}
+	}
+	if action == "save_as" {
+		presetID = ""
+	}
+	if name == "" {
+		http.Error(w, s.errText(r, errReportPresetNameRequired), http.StatusBadRequest)
+		return
+	}
+	id, err := s.store.SaveReportPreset(r.Context(), storage.ReportPreset{
+		ID:           presetID,
+		Report:       rep.Name,
+		User:         user,
+		Name:         name,
+		SettingsJSON: canon,
+		IsDefault:    isDefault,
+	})
+	if err != nil {
+		http.Error(w, s.errText(r, err), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, reportFormURLWithPreset(rep.Name, id), http.StatusSeeOther)
+}
+
+func (s *Server) reportPresetDelete(w http.ResponseWriter, r *http.Request) {
+	rep := s.getReport(w, r)
+	if rep == nil {
+		return
+	}
+	if !s.requirePerm(w, r, "report", rep.Name, "run") {
+		return
+	}
+	presetID := r.FormValue("__preset")
+	if presetID != "" && presetID != standardReportPresetID {
+		_ = s.store.DeleteReportPreset(r.Context(), rep.Name, currentUserLogin(r), presetID)
+	}
+	http.Redirect(w, r, reportFormURLWithPreset(rep.Name, standardReportPresetID), http.StatusSeeOther)
 }
 
 // reportSettingsReset удаляет рантайм-настройки текущего пользователя — возврат
@@ -244,5 +462,5 @@ func (s *Server) reportSettingsReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = s.store.DeleteReportUserSettings(r.Context(), rep.Name, currentUserLogin(r))
-	http.Redirect(w, r, reportFormURL(rep.Name), http.StatusSeeOther)
+	http.Redirect(w, r, reportFormURLWithPreset(rep.Name, standardReportPresetID), http.StatusSeeOther)
 }

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -75,6 +75,36 @@ func TestReportSettingsWithRequestVariant(t *testing.T) {
 	}
 }
 
+func TestReportSettingsForRequestPresetKeepsPresetVariant(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-variant.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	rep := &reportpkg.Report{Name: "Продажи"}
+	id, err := db.SaveReportPreset(ctx, storage.ReportPreset{
+		Report:       "Продажи",
+		User:         "",
+		Name:         "Вариант пользователя",
+		SettingsJSON: `{"variant":"YAML-V"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &Server{store: db}
+	req := httptest.NewRequest(http.MethodPost, "/ui/report/Продажи", strings.NewReader("__preset="+url.QueryEscape(id)+"&__variant="))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	got := srv.reportSettingsForRequest(req, rep)
+	if got.ActivePresetID != id {
+		t.Fatalf("active preset: %q", got.ActivePresetID)
+	}
+	if got.Settings == nil || got.Settings.Variant != "YAML-V" {
+		t.Fatalf("preset variant должен сохраниться, got %+v", got.Settings)
+	}
+}
+
 // TestEffectiveCompositionNoDSLExecution: ключевой тест безопасности (issue #1).
 // Пользователь присылает __settings с вычисляемым показателем (Expr) и условием
 // оформления (When), содержащими вредоносное DSL. Эффективная компоновка НЕ
@@ -179,16 +209,83 @@ func TestEffectiveCompositionAppearance(t *testing.T) {
 	}
 }
 
+func TestEffectiveCompositionIgnoresEmptyMeasureOverride(t *testing.T) {
+	trusted := &reportpkg.Composition{
+		Groupings: []string{"Организация", "Номенклатура"},
+		Columns:   []string{"Месяц"},
+		Measures: []reportpkg.Measure{
+			{Field: "Выручка", Agg: "sum", Title: "Выручка"},
+			{Field: "ВаловаяПрибыль", Agg: "sum", Title: "Валовая прибыль"},
+		},
+		Totals: reportpkg.Totals{Grand: true, Subtotals: true},
+		Sort:   []reportpkg.SortKey{{Field: "ВаловаяПрибыль", Dir: "desc"}},
+	}
+	rep := &reportpkg.Report{Composition: trusted}
+
+	// Такой JSON сохранял старый UI, когда чекбоксы не были предзаполнены:
+	// пустые Groupings/Measures перекрывали базовую composition и отчёт
+	// переставал нормально формироваться.
+	userComp := &reportpkg.Composition{
+		Groupings: []string{},
+		Measures:  []reportpkg.Measure{},
+	}
+	eff := effectiveComposition(rep, &reportpkg.UserReportSettings{Composition: userComp})
+	if strings.Join(eff.Groupings, ",") != "Организация,Номенклатура" {
+		t.Fatalf("пустой override не должен стирать группировки: %+v", eff.Groupings)
+	}
+	if strings.Join(eff.Columns, ",") != "Месяц" {
+		t.Fatalf("пустой override не должен стирать колонки: %+v", eff.Columns)
+	}
+	if len(eff.Measures) != 2 || eff.Measures[1].Field != "ВаловаяПрибыль" {
+		t.Fatalf("пустой override не должен стирать показатели: %+v", eff.Measures)
+	}
+	if !eff.Totals.Grand || !eff.Totals.Subtotals {
+		t.Fatalf("пустой override не должен стирать итоги: %+v", eff.Totals)
+	}
+	if len(eff.Sort) != 1 || eff.Sort[0].Field != "ВаловаяПрибыль" {
+		t.Fatalf("пустой override не должен стирать сортировку: %+v", eff.Sort)
+	}
+}
+
+func TestReportSettingsPanelJSONUsesBaseComposition(t *testing.T) {
+	rep := &reportpkg.Report{
+		Name: "ВаловаяПрибыльСКД",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Организация", "Номенклатура"},
+			Columns:   []string{"Месяц"},
+			Measures: []reportpkg.Measure{
+				{Field: "Выручка", Agg: "sum", Title: "Выручка", Format: "#,##0.00"},
+				{Field: "ВаловаяПрибыль", Agg: "sum", Title: "Валовая прибыль", Format: "#,##0.00"},
+			},
+			Totals: reportpkg.Totals{Grand: true, Subtotals: true},
+			Sort:   []reportpkg.SortKey{{Field: "ВаловаяПрибыль", Dir: "desc"}},
+		},
+	}
+	raw := reportSettingsPanelJSON(rep, nil)
+	if raw == "" {
+		t.Fatalf("ожидали JSON предзаполнения панели")
+	}
+	for _, want := range []string{"Организация", "Номенклатура", "ВаловаяПрибыль", "Месяц", "Grand", "Sort"} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("JSON панели не содержит %q: %s", want, raw)
+		}
+	}
+}
+
 // TestReportSettingsPanel: панель «Настройки» рендерится при наличии ReportCols,
 // содержит чекбоксы доступных полей и скрытое поле __settings.
 func TestReportSettingsPanel(t *testing.T) {
 	rep := &reportpkg.Report{Name: "sales", Title: "Продажи"}
+	preset := storage.ReportPreset{ID: "p1", Name: "Мой вариант", IsDefault: true}
 	var buf bytes.Buffer
 	data := map[string]any{
-		"Report":       rep,
-		"ParamValues":  map[string]any{},
-		"ReportParams": []reportParamUI{},
-		"ReportCols":   []string{"Товар", "Сумма"},
+		"Report":         rep,
+		"ParamValues":    map[string]any{},
+		"ReportParams":   []reportParamUI{},
+		"ReportCols":     []string{"Товар", "Сумма"},
+		"ReportPresets":  []storage.ReportPreset{preset},
+		"ActivePresetID": "p1",
+		"ActivePreset":   &preset,
 		"UserSettings": &reportpkg.UserReportSettings{
 			Composition: &reportpkg.Composition{
 				Groupings: []string{"Товар"},
@@ -208,10 +305,84 @@ func TestReportSettingsPanel(t *testing.T) {
 	if !strings.Contains(out, `name="__settings"`) {
 		t.Fatalf("нет скрытого поля __settings")
 	}
+	for _, want := range []string{`name="__preset"`, `Мой вариант`, `name="__preset_action" value="save"`, `name="__preset_action" value="save_as"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("в панели нет элемента пользовательских вариантов %q", want)
+		}
+	}
 	for _, want := range []string{"Товар", "Сумма"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("в панели нет поля %q", want)
 		}
+	}
+}
+
+func TestReportSettingsPanelBasePresetWithoutChangedIndicator(t *testing.T) {
+	rep := &reportpkg.Report{
+		Name:  "profit",
+		Title: "Прибыль",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Организация"},
+			Measures:  []reportpkg.Measure{{Field: "ВаловаяПрибыль", Agg: "sum"}},
+		},
+	}
+	var buf bytes.Buffer
+	data := map[string]any{
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"Организация", "ВаловаяПрибыль"},
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, nil),
+		"Cfg":                Config{},
+		"Lang":               "ru",
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
+		t.Fatalf("execute page-report: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `id="rs-json"`) || !strings.Contains(out, "Организация") || !strings.Contains(out, "ВаловаяПрибыль") {
+		t.Fatalf("панель не получила базовый JSON настроек: %s", out)
+	}
+	if strings.Contains(out, "изменено") {
+		t.Fatalf("базовая composition не должна показываться как пользовательское изменение")
+	}
+	if !strings.Contains(out, "disabled") {
+		t.Fatalf("кнопка сброса должна быть disabled без пользовательских настроек")
+	}
+}
+
+func TestReportParamsFormKeepsActiveSettings(t *testing.T) {
+	rep := &reportpkg.Report{
+		Name:   "profit",
+		Title:  "Прибыль",
+		Params: []reportpkg.Param{{Name: "Начало", Type: "date"}},
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Организация"},
+			Measures:  []reportpkg.Measure{{Field: "ВаловаяПрибыль", Agg: "sum"}},
+		},
+	}
+	settings := &reportpkg.UserReportSettings{
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Организация"},
+			Measures:  []reportpkg.Measure{{Field: "ВаловаяПрибыль", Agg: "sum"}},
+		},
+	}
+	var buf bytes.Buffer
+	data := map[string]any{
+		"Report":             rep,
+		"ParamValues":        map[string]any{"Начало": "2026-07-01"},
+		"ReportParams":       []reportParamUI{{Name: "Начало", Label: "С даты", Type: "date", IsDate: true}},
+		"UserSettings":       settings,
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, settings),
+		"Cfg":                Config{},
+		"Lang":               "ru",
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
+		t.Fatalf("execute page-report: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `name="__settings"`) || !strings.Contains(out, "ВаловаяПрибыль") {
+		t.Fatalf("форма параметров не сохраняет активные настройки: %s", out)
 	}
 }
 
@@ -331,6 +502,70 @@ func TestReportSettingsSaveReset(t *testing.T) {
 	}
 	if got, _ := db.GetReportUserSettings(ctx, "Продажи", ""); got != "" {
 		t.Fatalf("reset: ожидали пусто, получили %q", got)
+	}
+}
+
+func TestReportSettingsSaveNamedPreset(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-save.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	rep := &reportpkg.Report{Name: "Продажи"}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
+	s := &Server{store: db, reg: registry}
+
+	form := url.Values{
+		"__settings":       {`{"variant":"X"}`},
+		"__preset_action":  {"save_as"},
+		"__preset_name":    {"По товарам"},
+		"__preset_default": {"1"},
+	}
+	r := reqWithChi("POST", "/ui/report/Продажи/settings/save", form, map[string]string{"name": "Продажи"})
+	w := httptest.NewRecorder()
+	s.reportSettingsSave(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("save_as: ожидался 303, получен %d: %s", w.Code, w.Body.String())
+	}
+	presets, err := db.ListReportPresets(ctx, "Продажи", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presets) != 1 || presets[0].Name != "По товарам" || !presets[0].IsDefault {
+		t.Fatalf("пресет не сохранён как default: %+v", presets)
+	}
+	if !strings.Contains(presets[0].SettingsJSON, `"variant":"X"`) {
+		t.Fatalf("settings_json не сохранён: %q", presets[0].SettingsJSON)
+	}
+
+	form2 := url.Values{
+		"__settings":      {`{"variant":"Y"}`},
+		"__preset":        {presets[0].ID},
+		"__preset_action": {"save"},
+		"__preset_name":   {"По товарам v2"},
+	}
+	r2 := reqWithChi("POST", "/ui/report/Продажи/settings/save", form2, map[string]string{"name": "Продажи"})
+	w2 := httptest.NewRecorder()
+	s.reportSettingsSave(w2, r2)
+	if w2.Code != http.StatusSeeOther {
+		t.Fatalf("save existing: ожидался 303, получен %d: %s", w2.Code, w2.Body.String())
+	}
+	p, _ := db.GetReportPreset(ctx, "Продажи", "", presets[0].ID)
+	if p == nil || p.Name != "По товарам v2" || !strings.Contains(p.SettingsJSON, `"variant":"Y"`) {
+		t.Fatalf("пресет не обновлён: %+v", p)
+	}
+
+	r3 := reqWithChi("POST", "/ui/report/Продажи/settings/delete", url.Values{"__preset": {presets[0].ID}}, map[string]string{"name": "Продажи"})
+	w3 := httptest.NewRecorder()
+	s.reportPresetDelete(w3, r3)
+	if w3.Code != http.StatusSeeOther {
+		t.Fatalf("delete: ожидался 303, получен %d", w3.Code)
+	}
+	if p, _ := db.GetReportPreset(ctx, "Продажи", "", presets[0].ID); p != nil {
+		t.Fatalf("пресет должен быть удалён: %+v", p)
 	}
 }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -207,6 +207,7 @@ func (s *Server) Mount(r chi.Router) {
 	r.Get("/ui/report/{name}", s.reportForm)
 	r.Post("/ui/report/{name}", s.reportRun)
 	r.Post("/ui/report/{name}/settings/save", s.reportSettingsSave)
+	r.Post("/ui/report/{name}/settings/delete", s.reportPresetDelete)
 	r.Post("/ui/report/{name}/settings/reset", s.reportSettingsReset)
 	r.Get("/ui/processor/{name}", s.processorForm)
 	r.Post("/ui/processor/{name}", s.processorRun)

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -442,6 +442,31 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			}
 			return existing + sep + "__variant=" + url.QueryEscape(vs)
 		},
+		"presetQuery": func(existing string, preset any) string {
+			ps, _ := preset.(string)
+			if ps == "" {
+				return existing
+			}
+			sep := "?"
+			if existing != "" {
+				sep = "&"
+			}
+			return existing + sep + "__preset=" + url.QueryEscape(ps)
+		},
+		"settingsQuery": func(existing string, raw any, active any) string {
+			if active == nil {
+				return existing
+			}
+			rs, _ := raw.(string)
+			if rs == "" {
+				return existing
+			}
+			sep := "?"
+			if existing != "" {
+				sep = "&"
+			}
+			return existing + sep + "__settings=" + url.QueryEscape(rs)
+		},
 		"mul": func(a, b int) int { return a * b },
 		"int": func(v any) int {
 			switch t := v.(type) {
@@ -2629,7 +2654,7 @@ const tplReport = `
 {{/* Кнопки выгрузки отчёта: Excel + PDF (issue #218). output_format: pdf делает
      PDF основной (первой); по умолчанию первой идёт Excel — поведение не меняется. */}}
 {{define "report-export-buttons"}}
-{{$q := variantQuery (reportParamQuery .Report.Params .ParamValues) .ActiveVariant}}
+{{$q := settingsQuery (presetQuery (variantQuery (reportParamQuery .Report.Params .ParamValues) .ActiveVariant) .ActivePresetID) .ReportSettingsJSON .UserSettings}}
 {{$excel := printf "/ui/report/%s/excel%s" (lower .Report.Name) $q}}
 {{$pdf := printf "/ui/report/%s/pdf%s" (lower .Report.Name) $q}}
 <div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:8px">
@@ -2646,14 +2671,24 @@ const tplReport = `
 {{template "head" .}}{{template "nav" .}}
 <main>
 <h2>{{.Report.DisplayName $.Lang}}</h2>
-{{if or .ReportParams .Report.Variants}}
+{{if or .ReportParams .Report.Variants .ReportPresets}}
 <details class="card report-block" data-block="params" open style="margin-bottom:16px">
 <summary>{{t $.Lang "Параметры"}}</summary>
 <form method="POST">
+  {{if .UserSettings}}<input type="hidden" name="__settings" value="{{if .ReportSettingsJSON}}{{.ReportSettingsJSON}}{{else}}{{.UserSettings.JSON}}{{end}}">{{end}}
+  {{if .ReportPresets}}
+  <div class="form-group" style="margin-bottom:16px;max-width:360px">
+    <label>{{t $.Lang "Вариант пользователя"}}</label>
+    <select name="__preset" onchange="var h=this.form.querySelector('input[name=__settings]');if(h)h.remove();this.form.submit()">
+      <option value="__standard" {{if eq $.ActivePresetID "__standard"}}selected{{end}}>{{t $.Lang "Стандартные настройки"}}</option>
+      {{range .ReportPresets}}<option value="{{.ID}}" {{if eq .ID $.ActivePresetID}}selected{{end}}>{{.Name}}{{if .IsDefault}} *{{end}}</option>{{end}}
+    </select>
+  </div>
+  {{end}}
   {{if .Report.Variants}}
   <div class="form-group" style="margin-bottom:16px;max-width:320px">
     <label>{{t $.Lang "Вариант"}}</label>
-    <select name="__variant" onchange="this.form.submit()">
+    <select name="__variant" onchange="var h=this.form.querySelector('input[name=__settings]');if(h)h.remove();var p=this.form.querySelector('select[name=__preset]');if(p)p.value='__standard';this.form.submit()">
       <option value="" {{if not $.ActiveVariant}}selected{{end}}>{{t $.Lang "Основной"}}</option>
       {{range .Report.Variants}}<option value="{{.Name}}" {{if eq .Name $.ActiveVariant}}selected{{end}}>{{.Name}}</option>{{end}}
     </select>
@@ -2706,10 +2741,24 @@ const tplReport = `
 {{if .ReportCols}}
 <details class="card report-block" data-block="settings" style="margin-bottom:16px">
 <summary>{{t $.Lang "Настройка отчёта"}}{{if .UserSettings}} <span style="background:#fef3c7;color:#92400e;border-radius:6px;padding:1px 8px;font-size:12px;font-weight:600">{{t $.Lang "изменено"}}</span>{{end}}</summary>
-<form method="POST" onsubmit="rsCollect()">
+<form method="POST" onsubmit="return rsBeforeSubmit(event)">
   {{range .ReportParams}}<input type="hidden" name="{{.Name}}" value="{{str (index $.ParamValues .Name)}}">{{end}}
   <input type="hidden" name="__variant" value="{{.ActiveVariant}}">
-  <input type="hidden" name="__settings" id="rs-json"{{if .UserSettings}} value="{{.UserSettings.JSON}}"{{end}}>
+  <div style="display:flex;gap:10px;align-items:end;flex-wrap:wrap;margin-bottom:12px">
+    <div class="form-group" style="margin-bottom:0;min-width:220px">
+      <label>{{t $.Lang "Вариант пользователя"}}</label>
+      <select name="__preset" onchange="rsChoosePreset(this)">
+        <option value="__standard" {{if eq $.ActivePresetID "__standard"}}selected{{end}}>{{t $.Lang "Стандартные настройки"}}</option>
+        {{range .ReportPresets}}<option value="{{.ID}}" {{if eq .ID $.ActivePresetID}}selected{{end}}>{{.Name}}{{if .IsDefault}} *{{end}}</option>{{end}}
+      </select>
+    </div>
+    <div class="form-group" style="margin-bottom:0;min-width:220px">
+      <label>{{t $.Lang "Название варианта"}}</label>
+      <input type="text" name="__preset_name" value="{{if .ActivePreset}}{{.ActivePreset.Name}}{{end}}" placeholder="{{t $.Lang "Мой вариант"}}">
+    </div>
+    <label style="display:flex;gap:6px;align-items:center;padding-bottom:8px"><input type="checkbox" name="__preset_default" value="1" {{if .ActivePreset}}{{if .ActivePreset.IsDefault}}checked{{end}}{{end}}> {{t $.Lang "по умолчанию"}}</label>
+  </div>
+  <input type="hidden" name="__settings" id="rs-json"{{if .ReportSettingsJSON}} value="{{.ReportSettingsJSON}}"{{else if .UserSettings}} value="{{.UserSettings.JSON}}"{{end}}>
   <table style="width:auto;margin-bottom:12px">
     <thead><tr>
       <th style="text-align:left">{{t $.Lang "Поле"}}</th>
@@ -2775,13 +2824,27 @@ const tplReport = `
   </div>
   <div style="display:flex;gap:8px;flex-wrap:wrap">
     <button class="btn btn-primary" type="submit">{{t $.Lang "Применить"}}</button>
-    <button class="btn" type="submit" formaction="/ui/report/{{lower .Report.Name}}/settings/save">{{t $.Lang "Сохранить"}}</button>
+    <button class="btn" type="submit" name="__preset_action" value="save" formaction="/ui/report/{{lower .Report.Name}}/settings/save">{{t $.Lang "Сохранить вариант"}}</button>
+    <button class="btn" type="submit" name="__preset_action" value="save_as" formaction="/ui/report/{{lower .Report.Name}}/settings/save">{{t $.Lang "Сохранить как"}}</button>
+    <button class="btn" type="submit" formaction="/ui/report/{{lower .Report.Name}}/settings/delete"{{if not .ActivePreset}} disabled{{end}}>{{t $.Lang "Удалить вариант"}}</button>
     <button class="btn" type="submit" formaction="/ui/report/{{lower .Report.Name}}/settings/reset"{{if not .UserSettings}} disabled{{end}}>{{t $.Lang "Стандартные настройки"}}</button>
   </div>
 </form>
 <script>
 (function(){
   var hidden=document.getElementById('rs-json');
+  window.rsBeforeSubmit=function(ev){
+    var form=ev&&ev.target;
+    if(form&&form.dataset&&form.dataset.skipCollect==="1"){form.dataset.skipCollect="";return true;}
+    rsCollect();
+    return true;
+  };
+  window.rsChoosePreset=function(sel){
+    if(!sel||!sel.form)return;
+    var h=sel.form.querySelector('input[name="__settings"]');if(h)h.remove();
+    sel.form.dataset.skipCollect="1";
+    sel.form.submit();
+  };
   function preset(){
     if(!hidden||!hidden.value) return;
     try{
@@ -2799,8 +2862,21 @@ const tplReport = `
     }catch(e){}
   }
   window.rsCollect=function(){
+    var prev={};
+    if(hidden&&hidden.value){try{prev=JSON.parse(hidden.value)||{};}catch(e){prev={};}}
+    var prevComp=(prev&&prev.composition)||{};
+    var prevMeasures=prevComp.Measures||prevComp.measures||[];
+    var prevByField={};
+    prevMeasures.forEach(function(m){var f=m&&(m.Field||m.field);if(f)prevByField[f]=m;});
     var groupings=[];document.querySelectorAll('.rs-group:checked').forEach(function(c){groupings.push(c.value);});
-    var measures=[];document.querySelectorAll('.rs-measure:checked').forEach(function(c){measures.push({Field:c.value,Agg:"sum"});});
+    var measures=[];document.querySelectorAll('.rs-measure:checked').forEach(function(c){
+      var src=prevByField[c.value]||{};
+      var m={Field:c.value,Agg:src.Agg||src.agg||"sum"};
+      var title=src.Title||src.title;if(title)m.Title=title;
+      var align=src.Align||src.align;if(align)m.Align=align;
+      var format=src.Format||src.format;if(format)m.Format=format;
+      measures.push(m);
+    });
     var filters=[];document.querySelectorAll('.rs-filter-row').forEach(function(row){
       var f=row.querySelector('.rs-f-field'),op=row.querySelector('.rs-f-op'),v=row.querySelector('.rs-f-value');
       if(f&&op&&f.value){ filters.push({field:f.value,op:op.value,value:v?v.value:""}); }
@@ -2808,7 +2884,16 @@ const tplReport = `
     var variantEl=document.querySelector('input[name="__variant"]');
     var lines=(document.getElementById('rs-lines')||{}).value||"";
     var zebra=!!(document.getElementById('rs-zebra')||{}).checked;
-    var s={variant:variantEl?variantEl.value:"",composition:{Groupings:groupings,Measures:measures,appearance:{lines:lines,zebra:zebra}},filters:filters};
+    var columns=prevComp.Columns||prevComp.columns||[];
+    var sort=prevComp.Sort||prevComp.sort||[];
+    var totals=prevComp.Totals||prevComp.totals;
+    var detail=(typeof prevComp.Detail!=="undefined")?prevComp.Detail:prevComp.detail;
+    var nextComp={Groupings:groupings,Measures:measures,Appearance:{lines:lines,zebra:zebra}};
+    if(columns&&columns.length)nextComp.Columns=columns;
+    if(sort&&sort.length)nextComp.Sort=sort;
+    if(totals)nextComp.Totals=totals;
+    if(typeof detail!=="undefined")nextComp.Detail=!!detail;
+    var s={variant:variantEl?variantEl.value:"",composition:nextComp,filters:filters};
     if(hidden)hidden.value=JSON.stringify(s);
   };
   window.rsAddFilter=function(){


### PR DESCRIPTION
## Summary
- add persistent named user report presets in _report_presets
- add report UI controls to select, save, save as, delete, and mark presets default
- keep report export in sync with active user settings

## Tests
- go test ./...
- go run ./cmd/onebase check --project /home/admo/git/PuT