### PR TITLE
fix(report): normalize saved user presets

### DIFF
--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -257,10 +257,15 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 		// пользовательского ввода: возвращаем пустую презентационную компоновку.
 		base = &reportpkg.Composition{}
 	}
-	// Доверенные Expr показателей по имени поля (регистронезависимо, как DSL).
+	// Доверенные показатели по имени поля (регистронезависимо, как DSL).
+	// Expr всегда наследуется только отсюда; презентационные поля служат
+	// дефолтами, если пользовательский JSON пришёл частичным.
 	trustedExpr := make(map[string]string, len(base.Measures))
+	trustedMeasure := make(map[string]reportpkg.Measure, len(base.Measures))
 	for _, m := range base.Measures {
-		trustedExpr[strings.ToLower(m.Field)] = m.Expr
+		key := strings.ToLower(m.Field)
+		trustedExpr[key] = m.Expr
+		trustedMeasure[key] = m
 	}
 
 	out := *base // копия: Conditional/Chart/DetailLink/DetailEntity — из доверенной.
@@ -294,12 +299,13 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 	if u.Measures != nil && len(u.Measures) > 0 {
 		measures := make([]reportpkg.Measure, 0, len(u.Measures))
 		for _, m := range u.Measures {
+			baseMeasure := trustedMeasure[strings.ToLower(m.Field)]
 			safe := reportpkg.Measure{
-				Field:  m.Field,
-				Agg:    m.Agg,
-				Title:  m.Title,
-				Align:  m.Align,
-				Format: m.Format,
+				Field:  firstNonEmpty(m.Field, baseMeasure.Field),
+				Agg:    firstNonEmpty(m.Agg, baseMeasure.Agg),
+				Title:  firstNonEmpty(m.Title, baseMeasure.Title),
+				Align:  firstNonEmpty(m.Align, baseMeasure.Align),
+				Format: firstNonEmpty(m.Format, baseMeasure.Format),
 				// Expr НЕ из пользовательского ввода: берём доверенное значение
 				// по имени поля; если показателя нет в доверенной — Expr пуст.
 				Expr: trustedExpr[strings.ToLower(m.Field)],
@@ -309,6 +315,13 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 		out.Measures = measures
 	}
 	return &out
+}
+
+func firstNonEmpty(v, fallback string) string {
+	if v != "" {
+		return v
+	}
+	return fallback
 }
 
 // safeAppearance канонизирует оформление из пользовательского ввода (__settings —
@@ -384,12 +397,17 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.errText(r, err), http.StatusBadRequest)
 		return
 	}
+	st = reportSettingsWithRequestVariant(r, st)
 	canon := ""
-	if st != nil {
-		if canon, err = st.JSON(); err != nil {
+	if normalized := reportSettingsPanelState(rep, st); normalized != nil {
+		if canon, err = normalized.JSON(); err != nil {
 			http.Error(w, s.errText(r, err), http.StatusBadRequest)
 			return
 		}
+	}
+	if len(canon) > maxUserSettingsBytes {
+		http.Error(w, s.errText(r, errSettingsTooLarge), http.StatusRequestEntityTooLarge)
+		return
 	}
 
 	// Обратная совместимость: старые формы без __preset_action по-прежнему

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -247,6 +247,32 @@ func TestEffectiveCompositionIgnoresEmptyMeasureOverride(t *testing.T) {
 	}
 }
 
+func TestEffectiveCompositionInheritsMeasurePresentationDefaults(t *testing.T) {
+	trusted := &reportpkg.Composition{
+		Groupings: []string{"Организация"},
+		Measures: []reportpkg.Measure{
+			{Field: "ВаловаяПрибыль", Agg: "sum", Title: "Валовая прибыль", Align: "right", Format: "#,##0.00", Expr: "Выручка - Себестоимость"},
+		},
+	}
+	rep := &reportpkg.Report{Composition: trusted}
+
+	userComp := &reportpkg.Composition{
+		Groupings: []string{"Организация"},
+		Measures:  []reportpkg.Measure{{Field: "ВаловаяПрибыль"}},
+	}
+	eff := effectiveComposition(rep, &reportpkg.UserReportSettings{Composition: userComp})
+	if len(eff.Measures) != 1 {
+		t.Fatalf("ожидали один показатель, got %+v", eff.Measures)
+	}
+	m := eff.Measures[0]
+	if m.Title != "Валовая прибыль" || m.Align != "right" || m.Format != "#,##0.00" || m.Agg != "sum" {
+		t.Fatalf("презентационные дефолты из YAML потерялись: %+v", m)
+	}
+	if m.Expr != "Выручка - Себестоимость" {
+		t.Fatalf("доверенный Expr должен наследоваться из YAML, got %q", m.Expr)
+	}
+}
+
 func TestReportSettingsPanelJSONUsesBaseComposition(t *testing.T) {
 	rep := &reportpkg.Report{
 		Name: "ВаловаяПрибыльСКД",
@@ -566,6 +592,65 @@ func TestReportSettingsSaveNamedPreset(t *testing.T) {
 	}
 	if p, _ := db.GetReportPreset(ctx, "Продажи", "", presets[0].ID); p != nil {
 		t.Fatalf("пресет должен быть удалён: %+v", p)
+	}
+}
+
+func TestReportSettingsSaveNamedPresetNormalizesCurrentComposition(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-save-normalized.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	rep := &reportpkg.Report{
+		Name: "ВаловаяПрибыльСКД",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Организация", "Номенклатура"},
+			Measures: []reportpkg.Measure{
+				{Field: "Выручка", Agg: "sum", Title: "Выручка", Format: "#,##0.00"},
+				{Field: "Себестоимость", Agg: "sum", Title: "Себестоимость", Format: "#,##0.00"},
+				{Field: "ВаловаяПрибыль", Agg: "sum", Title: "Валовая прибыль", Format: "#,##0.00"},
+			},
+			Totals: reportpkg.Totals{Grand: true, Subtotals: true},
+			Sort:   []reportpkg.SortKey{{Field: "ВаловаяПрибыль", Dir: "desc"}},
+		},
+	}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
+	s := &Server{store: db, reg: registry}
+
+	form := url.Values{
+		"__settings":      {`{"composition":{"Groupings":[],"Measures":[]}}`},
+		"__preset_action": {"save_as"},
+		"__preset_name":   {"Текущий"},
+	}
+	r := reqWithChi("POST", "/ui/report/ВаловаяПрибыльСКД/settings/save", form, map[string]string{"name": "ВаловаяПрибыльСКД"})
+	w := httptest.NewRecorder()
+	s.reportSettingsSave(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("save_as: ожидался 303, получен %d: %s", w.Code, w.Body.String())
+	}
+	presets, err := db.ListReportPresets(ctx, "ВаловаяПрибыльСКД", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presets) != 1 {
+		t.Fatalf("ожидали один пресет, got %+v", presets)
+	}
+	if strings.Contains(presets[0].SettingsJSON, `"Measures":[]`) {
+		t.Fatalf("пустые показатели не должны сохраняться: %s", presets[0].SettingsJSON)
+	}
+	st, err := reportpkg.ParseUserSettings(presets[0].SettingsJSON)
+	if err != nil {
+		t.Fatalf("ParseUserSettings: %v", err)
+	}
+	eff := effectiveComposition(rep, st)
+	if len(eff.Groupings) != 2 || len(eff.Measures) != 3 {
+		t.Fatalf("сохранённый пресет не восстановил текущую компоновку: %+v", eff)
+	}
+	if eff.Measures[2].Field != "ВаловаяПрибыль" || eff.Measures[2].Format != "#,##0.00" {
+		t.Fatalf("формат показателя потерян: %+v", eff.Measures[2])
 	}
 }
 

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -2758,7 +2758,7 @@ const tplReport = `
     </div>
     <label style="display:flex;gap:6px;align-items:center;padding-bottom:8px"><input type="checkbox" name="__preset_default" value="1" {{if .ActivePreset}}{{if .ActivePreset.IsDefault}}checked{{end}}{{end}}> {{t $.Lang "по умолчанию"}}</label>
   </div>
-  <input type="hidden" name="__settings" id="rs-json"{{if .ReportSettingsJSON}} value="{{.ReportSettingsJSON}}"{{else if .UserSettings}} value="{{.UserSettings.JSON}}"{{end}}>
+  <input type="hidden" name="__settings" id="rs-json"{{if .ReportSettingsJSON}} value="{{.ReportSettingsJSON}}" data-base="{{.ReportSettingsJSON}}"{{else if .UserSettings}} value="{{.UserSettings.JSON}}" data-base="{{.UserSettings.JSON}}"{{end}}>
   <table style="width:auto;margin-bottom:12px">
     <thead><tr>
       <th style="text-align:left">{{t $.Lang "Поле"}}</th>
@@ -2846,13 +2846,17 @@ const tplReport = `
     sel.form.submit();
   };
   function preset(){
-    if(!hidden||!hidden.value) return;
+    if(!hidden) return;
+    var raw=hidden.value||hidden.dataset.base||"";
+    if(!raw) return;
+    if(!hidden.value) hidden.value=raw;
     try{
-      var s=JSON.parse(hidden.value);
+      var s=JSON.parse(raw);
       var comp=(s&&s.composition)||{};
       var groups=comp.Groupings||comp.groupings||[];
       var meas=comp.Measures||comp.measures||[];
       var mf=meas.map(function(m){return m.Field||m.field;});
+      document.querySelectorAll('.rs-group,.rs-measure').forEach(function(el){el.checked=false;});
       document.querySelectorAll('.rs-group').forEach(function(el){ if(groups.indexOf(el.value)>=0) el.checked=true; });
       document.querySelectorAll('.rs-measure').forEach(function(el){ if(mf.indexOf(el.value)>=0) el.checked=true; });
       var ap=comp.Appearance||comp.appearance||{};
@@ -2863,7 +2867,9 @@ const tplReport = `
   }
   window.rsCollect=function(){
     var prev={};
-    if(hidden&&hidden.value){try{prev=JSON.parse(hidden.value)||{};}catch(e){prev={};}}
+    var raw=hidden?(hidden.value||hidden.dataset.base||""):"";
+    if(hidden&&!hidden.value&&raw)hidden.value=raw;
+    if(raw){try{prev=JSON.parse(raw)||{};}catch(e){prev={};}}
     var prevComp=(prev&&prev.composition)||{};
     var prevMeasures=prevComp.Measures||prevComp.measures||[];
     var prevByField={};


### PR DESCRIPTION
## Summary
- normalize report preset saves through the effective current composition so empty client JSON cannot persist empty groupings/measures
- inherit measure presentation defaults from YAML when saved user settings omit title/align/format
- keep the settings panel initialized from its base JSON and clear stale checkbox state before applying it

## Tests
- go test ./internal/ui ./internal/storage
- go test ./...
- go run ./cmd/onebase check --project /home/admo/git/PuT
- git diff --check