### PR TITLE
fix(report): precheck settings fields case-insensitively

### DIFF
--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -257,15 +257,31 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 		// пользовательского ввода: возвращаем пустую презентационную компоновку.
 		base = &reportpkg.Composition{}
 	}
-	// Доверенные показатели по имени поля (регистронезависимо, как DSL).
+	// Доверенные показатели и поля по имени (регистронезависимо, как DSL).
 	// Expr всегда наследуется только отсюда; презентационные поля служат
 	// дефолтами, если пользовательский JSON пришёл частичным.
 	trustedExpr := make(map[string]string, len(base.Measures))
 	trustedMeasure := make(map[string]reportpkg.Measure, len(base.Measures))
+	canonicalField := make(map[string]string)
+	addCanonical := func(field string) {
+		if field != "" {
+			canonicalField[strings.ToLower(field)] = field
+		}
+	}
+	for _, g := range base.Groupings {
+		addCanonical(g)
+	}
+	for _, c := range base.Columns {
+		addCanonical(c)
+	}
 	for _, m := range base.Measures {
 		key := strings.ToLower(m.Field)
 		trustedExpr[key] = m.Expr
 		trustedMeasure[key] = m
+		addCanonical(m.Field)
+	}
+	for _, sk := range base.Sort {
+		addCanonical(sk.Field)
 	}
 
 	out := *base // копия: Conditional/Chart/DetailLink/DetailEntity — из доверенной.
@@ -275,13 +291,13 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 	// случайно очищал Columns/Sort/Totals/Detail базовой СКД.
 	invalidEmptyMeasures := u.Measures != nil && len(u.Measures) == 0
 	if u.Groupings != nil && !invalidEmptyMeasures {
-		out.Groupings = append([]string(nil), u.Groupings...)
+		out.Groupings = canonicalStrings(u.Groupings, canonicalField)
 	}
 	if u.Columns != nil && !invalidEmptyMeasures {
-		out.Columns = append([]string(nil), u.Columns...)
+		out.Columns = canonicalStrings(u.Columns, canonicalField)
 	}
 	if u.Sort != nil {
-		out.Sort = append([]reportpkg.SortKey(nil), u.Sort...)
+		out.Sort = canonicalSortKeys(u.Sort, canonicalField)
 	}
 	// Totals/Detail пока не редактируются в runtime-панели, поэтому пустое
 	// значение не должно стирать доверенную базу. Ненулевое значение применяем
@@ -300,8 +316,12 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 		measures := make([]reportpkg.Measure, 0, len(u.Measures))
 		for _, m := range u.Measures {
 			baseMeasure := trustedMeasure[strings.ToLower(m.Field)]
+			field := m.Field
+			if baseMeasure.Field != "" {
+				field = baseMeasure.Field
+			}
 			safe := reportpkg.Measure{
-				Field:  firstNonEmpty(m.Field, baseMeasure.Field),
+				Field:  field,
 				Agg:    firstNonEmpty(m.Agg, baseMeasure.Agg),
 				Title:  firstNonEmpty(m.Title, baseMeasure.Title),
 				Align:  firstNonEmpty(m.Align, baseMeasure.Align),
@@ -317,11 +337,70 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 	return &out
 }
 
+func canonicalStrings(in []string, canonical map[string]string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if c := canonical[strings.ToLower(v)]; c != "" {
+			out = append(out, c)
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+func canonicalSortKeys(in []reportpkg.SortKey, canonical map[string]string) []reportpkg.SortKey {
+	if in == nil {
+		return nil
+	}
+	out := make([]reportpkg.SortKey, 0, len(in))
+	for _, sk := range in {
+		if c := canonical[strings.ToLower(sk.Field)]; c != "" {
+			sk.Field = c
+		}
+		out = append(out, sk)
+	}
+	return out
+}
+
 func firstNonEmpty(v, fallback string) string {
 	if v != "" {
 		return v
 	}
 	return fallback
+}
+
+func reportGroupChecked(rep *reportpkg.Report, settings *reportpkg.UserReportSettings, field string) bool {
+	state := reportSettingsPanelState(rep, settings)
+	if state == nil || state.Composition == nil {
+		return false
+	}
+	return containsFold(state.Composition.Groupings, field)
+}
+
+func reportMeasureChecked(rep *reportpkg.Report, settings *reportpkg.UserReportSettings, field string) bool {
+	state := reportSettingsPanelState(rep, settings)
+	if state == nil || state.Composition == nil {
+		return false
+	}
+	for _, m := range state.Composition.Measures {
+		if strings.EqualFold(m.Field, field) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(values []string, want string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, want) {
+			return true
+		}
+	}
+	return false
 }
 
 // safeAppearance канонизирует оформление из пользовательского ввода (__settings —

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -257,14 +257,20 @@ func TestEffectiveCompositionInheritsMeasurePresentationDefaults(t *testing.T) {
 	rep := &reportpkg.Report{Composition: trusted}
 
 	userComp := &reportpkg.Composition{
-		Groupings: []string{"Организация"},
-		Measures:  []reportpkg.Measure{{Field: "ВаловаяПрибыль"}},
+		Groupings: []string{"организация"},
+		Measures:  []reportpkg.Measure{{Field: "валоваяприбыль"}},
 	}
 	eff := effectiveComposition(rep, &reportpkg.UserReportSettings{Composition: userComp})
+	if len(eff.Groupings) != 1 || eff.Groupings[0] != "Организация" {
+		t.Fatalf("группировка должна канонизироваться к YAML-регистру: %+v", eff.Groupings)
+	}
 	if len(eff.Measures) != 1 {
 		t.Fatalf("ожидали один показатель, got %+v", eff.Measures)
 	}
 	m := eff.Measures[0]
+	if m.Field != "ВаловаяПрибыль" {
+		t.Fatalf("поле показателя должно канонизироваться к YAML-регистру: %+v", m)
+	}
 	if m.Title != "Валовая прибыль" || m.Align != "right" || m.Format != "#,##0.00" || m.Agg != "sum" {
 		t.Fatalf("презентационные дефолты из YAML потерялись: %+v", m)
 	}
@@ -374,6 +380,40 @@ func TestReportSettingsPanelBasePresetWithoutChangedIndicator(t *testing.T) {
 	}
 	if !strings.Contains(out, "disabled") {
 		t.Fatalf("кнопка сброса должна быть disabled без пользовательских настроек")
+	}
+}
+
+func TestReportSettingsPanelChecksLowercaseQueryColumns(t *testing.T) {
+	rep := &reportpkg.Report{
+		Name:  "profit",
+		Title: "Прибыль",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Организация"},
+			Measures:  []reportpkg.Measure{{Field: "ВаловаяПрибыль", Agg: "sum", Format: "#,##0.00"}},
+		},
+	}
+	var buf bytes.Buffer
+	data := map[string]any{
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"организация", "валоваяприбыль"},
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, nil),
+		"Cfg":                Config{},
+		"Lang":               "ru",
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
+		t.Fatalf("execute page-report: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		`class="rs-group" value="организация" checked`,
+		`class="rs-measure" value="валоваяприбыль" checked`,
+		`function rsNorm`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("панель должна отметить lower-case колонку %q: %s", want, out)
+		}
 	}
 }
 

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -467,6 +467,8 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			}
 			return existing + sep + "__settings=" + url.QueryEscape(rs)
 		},
+		"reportGroupChecked":   reportGroupChecked,
+		"reportMeasureChecked": reportMeasureChecked,
 		"mul": func(a, b int) int { return a * b },
 		"int": func(v any) int {
 			switch t := v.(type) {
@@ -2768,8 +2770,8 @@ const tplReport = `
     <tbody>
     {{range .ReportCols}}<tr>
       <td>{{.}}</td>
-      <td style="text-align:center"><input type="checkbox" class="rs-group" value="{{.}}"></td>
-      <td style="text-align:center"><input type="checkbox" class="rs-measure" value="{{.}}"></td>
+      <td style="text-align:center"><input type="checkbox" class="rs-group" value="{{.}}" {{if reportGroupChecked $.Report $.UserSettings .}}checked{{end}}></td>
+      <td style="text-align:center"><input type="checkbox" class="rs-measure" value="{{.}}" {{if reportMeasureChecked $.Report $.UserSettings .}}checked{{end}}></td>
     </tr>{{end}}
     </tbody>
   </table>
@@ -2845,6 +2847,12 @@ const tplReport = `
     sel.form.dataset.skipCollect="1";
     sel.form.submit();
   };
+  function rsNorm(v){return String(v||"").toLowerCase();}
+  function rsFieldMap(values){
+    var out={};
+    (values||[]).forEach(function(v){if(v)out[rsNorm(v)]=v;});
+    return out;
+  }
   function preset(){
     if(!hidden) return;
     var raw=hidden.value||hidden.dataset.base||"";
@@ -2856,9 +2864,10 @@ const tplReport = `
       var groups=comp.Groupings||comp.groupings||[];
       var meas=comp.Measures||comp.measures||[];
       var mf=meas.map(function(m){return m.Field||m.field;});
+      var groupMap=rsFieldMap(groups), measureMap=rsFieldMap(mf);
       document.querySelectorAll('.rs-group,.rs-measure').forEach(function(el){el.checked=false;});
-      document.querySelectorAll('.rs-group').forEach(function(el){ if(groups.indexOf(el.value)>=0) el.checked=true; });
-      document.querySelectorAll('.rs-measure').forEach(function(el){ if(mf.indexOf(el.value)>=0) el.checked=true; });
+      document.querySelectorAll('.rs-group').forEach(function(el){ if(groupMap[rsNorm(el.value)]) el.checked=true; });
+      document.querySelectorAll('.rs-measure').forEach(function(el){ if(measureMap[rsNorm(el.value)]) el.checked=true; });
       var ap=comp.Appearance||comp.appearance||{};
       var lines=ap.lines||ap.Lines||"";if(lines==="horizontal")lines="";
       var le=document.getElementById('rs-lines');if(le)le.value=lines;
@@ -2871,13 +2880,19 @@ const tplReport = `
     if(hidden&&!hidden.value&&raw)hidden.value=raw;
     if(raw){try{prev=JSON.parse(raw)||{};}catch(e){prev={};}}
     var prevComp=(prev&&prev.composition)||{};
+    var prevGroups=prevComp.Groupings||prevComp.groupings||[];
+    var prevGroupByField=rsFieldMap(prevGroups);
     var prevMeasures=prevComp.Measures||prevComp.measures||[];
     var prevByField={};
-    prevMeasures.forEach(function(m){var f=m&&(m.Field||m.field);if(f)prevByField[f]=m;});
-    var groupings=[];document.querySelectorAll('.rs-group:checked').forEach(function(c){groupings.push(c.value);});
+    var prevMeasureField={};
+    prevMeasures.forEach(function(m){var f=m&&(m.Field||m.field);if(f){prevByField[rsNorm(f)]=m;prevMeasureField[rsNorm(f)]=f;}});
+    var groupings=[];document.querySelectorAll('.rs-group:checked').forEach(function(c){
+      groupings.push(prevGroupByField[rsNorm(c.value)]||c.value);
+    });
     var measures=[];document.querySelectorAll('.rs-measure:checked').forEach(function(c){
-      var src=prevByField[c.value]||{};
-      var m={Field:c.value,Agg:src.Agg||src.agg||"sum"};
+      var key=rsNorm(c.value);
+      var src=prevByField[key]||{};
+      var m={Field:prevMeasureField[key]||c.value,Agg:src.Agg||src.agg||"sum"};
       var title=src.Title||src.title;if(title)m.Title=title;
       var align=src.Align||src.align;if(align)m.Align=align;
       var format=src.Format||src.format;if(format)m.Format=format;


### PR DESCRIPTION
## Summary
- pre-check report settings groupings/measures case-insensitively when SQL returns lower-case columns
- keep saved settings canonicalized back to YAML field casing
- update settings panel JS to match and collect fields case-insensitively

## Tests
- go test ./internal/ui
- go test ./internal/report/compose
- go test ./...
- go run ./cmd/onebase check --project /home/admo/git/PuT
- git diff --check