### PR TITLE
fix(report): ignore empty saved composition overrides

### DIFF
--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -288,12 +288,16 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 
 	// Презентационные коллекции берём из пользовательского ввода, но только если
 	// поле реально присутствовало. Старый UI отправлял частичный JSON и тем самым
-	// случайно очищал Columns/Sort/Totals/Detail базовой СКД.
-	invalidEmptyMeasures := u.Measures != nil && len(u.Measures) == 0
-	if u.Groupings != nil && !invalidEmptyMeasures {
+	// случайно очищал Columns/Sort/Totals/Detail базовой СКД. Пустой набор
+	// группировок или показателей для отчёта, где YAML задаёт их явно, считаем
+	// повреждённой настройкой и не даём ей стереть стандартную компоновку.
+	invalidEmptyGroupings := len(base.Groupings) > 0 && u.Groupings != nil && len(u.Groupings) == 0
+	invalidEmptyMeasures := len(base.Measures) > 0 && u.Measures != nil && len(u.Measures) == 0
+	invalidEmptyComposition := invalidEmptyGroupings || invalidEmptyMeasures
+	if u.Groupings != nil && !invalidEmptyComposition {
 		out.Groupings = canonicalStrings(u.Groupings, canonicalField)
 	}
-	if u.Columns != nil && !invalidEmptyMeasures {
+	if u.Columns != nil && !invalidEmptyComposition {
 		out.Columns = canonicalStrings(u.Columns, canonicalField)
 	}
 	if u.Sort != nil {
@@ -312,7 +316,7 @@ func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition
 
 	// Показатели: презентация — из пользовательского ввода, Expr — только из
 	// доверенной компоновки (по совпадению Field), иначе обнуляем.
-	if u.Measures != nil && len(u.Measures) > 0 {
+	if u.Measures != nil && len(u.Measures) > 0 && !invalidEmptyComposition {
 		measures := make([]reportpkg.Measure, 0, len(u.Measures))
 		for _, m := range u.Measures {
 			baseMeasure := trustedMeasure[strings.ToLower(m.Field)]

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -245,6 +245,17 @@ func TestEffectiveCompositionIgnoresEmptyMeasureOverride(t *testing.T) {
 	if len(eff.Sort) != 1 || eff.Sort[0].Field != "ВаловаяПрибыль" {
 		t.Fatalf("пустой override не должен стирать сортировку: %+v", eff.Sort)
 	}
+
+	userComp = &reportpkg.Composition{
+		Groupings: []string{},
+	}
+	eff = effectiveComposition(rep, &reportpkg.UserReportSettings{Composition: userComp})
+	if strings.Join(eff.Groupings, ",") != "Организация,Номенклатура" {
+		t.Fatalf("пустые группировки без Measures тоже не должны стирать YAML: %+v", eff.Groupings)
+	}
+	if len(eff.Measures) != 2 || eff.Measures[0].Field != "Выручка" {
+		t.Fatalf("повреждённый частичный override не должен стирать показатели: %+v", eff.Measures)
+	}
 }
 
 func TestEffectiveCompositionInheritsMeasurePresentationDefaults(t *testing.T) {
@@ -398,6 +409,7 @@ func TestReportSettingsPanelChecksLowercaseQueryColumns(t *testing.T) {
 		"ParamValues":        map[string]any{},
 		"ReportParams":       []reportParamUI{},
 		"ReportCols":         []string{"организация", "валоваяприбыль"},
+		"UserSettings":       &reportpkg.UserReportSettings{Composition: &reportpkg.Composition{Groupings: []string{}}},
 		"ReportSettingsJSON": reportSettingsPanelJSON(rep, nil),
 		"Cfg":                Config{},
 		"Lang":               "ru",


### PR DESCRIPTION
## Summary
- treat empty saved groupings/measures as damaged overrides when YAML defines a standard composition
- keep standard report settings populated even if old `_settings` or presets contain partial empty JSON
- add regression coverage for empty groupings without measures

## Tests
- go test ./internal/ui
- go test ./internal/report/compose
- go test ./...
- go run ./cmd/onebase check --project /home/admo/git/PuT
- git diff --check