### PR TITLE
fix(report): keep preset save flow on report

### DIFF
--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -29,6 +29,14 @@ func (s *Server) reportForm(w http.ResponseWriter, r *http.Request) {
 	if !s.requirePerm(w, r, "report", rep.Name, "run") {
 		return
 	}
+	if r.URL.Query().Get("__run") == "1" {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, s.errText(r, err), 400)
+			return
+		}
+		s.runReport(w, r, rep, reportParamValuesFromRequest(r, rep))
+		return
+	}
 	user := currentUserLogin(r)
 	presets := loadReportPresets(r.Context(), s.store, rep.Name, user)
 	activePresetID := r.FormValue("__preset")
@@ -67,6 +75,10 @@ func (s *Server) reportRun(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.errText(r, err), 400)
 		return
 	}
+	s.runReport(w, r, rep, reportParamValuesFromRequest(r, rep))
+}
+
+func reportParamValuesFromRequest(r *http.Request, rep *reportpkg.Report) map[string]any {
 	paramValues := make(map[string]any, len(rep.Params))
 	for _, p := range rep.Params {
 		val := r.FormValue(p.Name)
@@ -76,7 +88,7 @@ func (s *Server) reportRun(w http.ResponseWriter, r *http.Request) {
 			paramValues[p.Name] = val
 		}
 	}
-	s.runReport(w, r, rep, paramValues)
+	return paramValues
 }
 
 func (s *Server) getReport(w http.ResponseWriter, r *http.Request) *reportpkg.Report {

--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -126,7 +126,14 @@ func loadReportPresets(ctx context.Context, store *storage.DB, report, user stri
 	if err != nil {
 		return nil
 	}
-	return presets
+	out := presets[:0]
+	for _, p := range presets {
+		if p.ID == standardReportPresetID {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 func activeReportPreset(presets []storage.ReportPreset, id string) *storage.ReportPreset {
@@ -456,6 +463,26 @@ func reportFormURLWithPreset(name, presetID string) string {
 	return u + "?__preset=" + url.QueryEscape(presetID)
 }
 
+func reportRunURLAfterSettingsSave(name string, params []reportpkg.Param, r *http.Request, presetID string) string {
+	u, err := url.Parse(reportFormURL(name))
+	if err != nil {
+		return reportFormURLWithPreset(name, presetID)
+	}
+	q := u.Query()
+	q.Set("__run", "1")
+	if presetID != "" {
+		q.Set("__preset", presetID)
+	}
+	for _, p := range params {
+		val, ok := requestFormValue(r, p.Name)
+		if ok && val != "" {
+			q.Set(p.Name, val)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
 // reportSettingsSave сохраняет рантайм-настройки текущего пользователя (POST
 // поля __settings) и возвращает на форму отчёта.
 func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
@@ -497,7 +524,7 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 	// сохраняют единственную настройку в _settings.
 	if action == "" {
 		_ = s.store.SaveReportUserSettings(r.Context(), rep.Name, currentUserLogin(r), canon)
-		http.Redirect(w, r, reportFormURL(rep.Name), http.StatusSeeOther)
+		http.Redirect(w, r, reportRunURLAfterSettingsSave(rep.Name, rep.Params, r, ""), http.StatusSeeOther)
 		return
 	}
 
@@ -506,8 +533,12 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.FormValue("__preset_name"))
 	isDefault := r.FormValue("__preset_default") != ""
 
-	if action == "save" && presetID != "" && presetID != standardReportPresetID {
-		if p, err := s.store.GetReportPreset(r.Context(), rep.Name, user, presetID); err == nil && p != nil {
+	if presetID == standardReportPresetID {
+		presetID = ""
+		_ = s.store.DeleteReportPreset(r.Context(), rep.Name, user, standardReportPresetID)
+	}
+	if action == "save" && presetID != "" {
+		if p, err := s.store.GetReportPreset(r.Context(), rep.Name, user, presetID); err == nil && p != nil && p.ID != standardReportPresetID {
 			if name == "" {
 				name = p.Name
 			}
@@ -534,7 +565,7 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.errText(r, err), http.StatusBadRequest)
 		return
 	}
-	http.Redirect(w, r, reportFormURLWithPreset(rep.Name, id), http.StatusSeeOther)
+	http.Redirect(w, r, reportRunURLAfterSettingsSave(rep.Name, rep.Params, r, id), http.StatusSeeOther)
 }
 
 func (s *Server) reportPresetDelete(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -647,6 +647,64 @@ func TestReportSettingsSaveNamedPreset(t *testing.T) {
 	}
 }
 
+func TestReportSettingsSaveFromStandardCreatesReachablePreset(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-save-standard.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.SaveReportPreset(ctx, storage.ReportPreset{
+		ID:           standardReportPresetID,
+		Report:       "Продажи",
+		User:         "",
+		Name:         "По товарам",
+		SettingsJSON: `{"variant":"broken"}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := &reportpkg.Report{
+		Name:   "Продажи",
+		Params: []reportpkg.Param{{Name: "Начало", Type: "date"}},
+	}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
+	s := &Server{store: db, reg: registry}
+
+	form := url.Values{
+		"__settings":      {`{"variant":"X"}`},
+		"__preset":        {standardReportPresetID},
+		"__preset_action": {"save"},
+		"__preset_name":   {"По товарам"},
+		"Начало":          {"2026-07-01"},
+	}
+	r := reqWithChi("POST", "/ui/report/Продажи/settings/save", form, map[string]string{"name": "Продажи"})
+	w := httptest.NewRecorder()
+	s.reportSettingsSave(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("save from standard: ожидался 303, получен %d: %s", w.Code, w.Body.String())
+	}
+
+	presets, err := db.ListReportPresets(ctx, "Продажи", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presets) != 1 {
+		t.Fatalf("ожидали один доступный пресет, got %+v", presets)
+	}
+	if presets[0].ID == standardReportPresetID {
+		t.Fatalf("нельзя сохранять пользовательский вариант с reserved id %q", presets[0].ID)
+	}
+	if !strings.Contains(presets[0].SettingsJSON, `"variant":"X"`) {
+		t.Fatalf("settings_json не сохранён: %q", presets[0].SettingsJSON)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "__run=1") || !strings.Contains(loc, "__preset="+url.QueryEscape(presets[0].ID)) || !strings.Contains(loc, "%D0%9D%D0%B0%D1%87%D0%B0%D0%BB%D0%BE=2026-07-01") {
+		t.Fatalf("редирект должен вернуть на сформированный отчёт с параметрами и новым пресетом: %q", loc)
+	}
+}
+
 func TestReportSettingsSaveNamedPresetNormalizesCurrentComposition(t *testing.T) {
 	ctx := context.Background()
 	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-save-normalized.db"))


### PR DESCRIPTION
## Summary
- make "save preset" from the standard report state create a reachable user preset instead of using reserved `__standard`
- hide and clean old broken presets with reserved `__standard` id
- redirect back to the generated report with the same params and selected preset after saving settings

## Tests
- go test ./internal/ui
- go test ./...
- go run ./cmd/onebase check --project /home/admo/git/PuT
- git diff --check