### PR TITLE
fix(report): auto-name saved presets

### DIFF
--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -8,6 +8,7 @@ package ui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,6 +25,7 @@ import (
 const maxUserSettingsBytes = 64 * 1024
 
 const standardReportPresetID = "__standard"
+const defaultReportPresetName = "Мой вариант"
 
 // errSettingsTooLarge — отказ сохранить слишком большой блок __settings (issue #23).
 var errSettingsTooLarge = errors.New("настройки отчёта слишком велики")
@@ -483,6 +485,38 @@ func reportRunURLAfterSettingsSave(name string, params []reportpkg.Param, r *htt
 	return u.String()
 }
 
+func reportPresetNameOrDefault(ctx context.Context, store *storage.DB, report, user, name string) string {
+	name = strings.TrimSpace(name)
+	if name != "" {
+		return name
+	}
+	if store == nil {
+		return defaultReportPresetName
+	}
+	presets, err := store.ListReportPresets(ctx, report, user)
+	if err != nil {
+		return defaultReportPresetName
+	}
+	used := make(map[string]struct{}, len(presets))
+	for _, p := range presets {
+		if p.ID == standardReportPresetID {
+			continue
+		}
+		if n := strings.TrimSpace(p.Name); n != "" {
+			used[strings.ToLower(n)] = struct{}{}
+		}
+	}
+	if _, ok := used[strings.ToLower(defaultReportPresetName)]; !ok {
+		return defaultReportPresetName
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s %d", defaultReportPresetName, i)
+		if _, ok := used[strings.ToLower(candidate)]; !ok {
+			return candidate
+		}
+	}
+}
+
 // reportSettingsSave сохраняет рантайм-настройки текущего пользователя (POST
 // поля __settings) и возвращает на форму отчёта.
 func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
@@ -549,6 +583,7 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 	if action == "save_as" {
 		presetID = ""
 	}
+	name = reportPresetNameOrDefault(r.Context(), s.store, rep.Name, user, name)
 	if name == "" {
 		http.Error(w, s.errText(r, errReportPresetNameRequired), http.StatusBadRequest)
 		return

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -676,7 +676,6 @@ func TestReportSettingsSaveFromStandardCreatesReachablePreset(t *testing.T) {
 		"__settings":      {`{"variant":"X"}`},
 		"__preset":        {standardReportPresetID},
 		"__preset_action": {"save"},
-		"__preset_name":   {"По товарам"},
 		"Начало":          {"2026-07-01"},
 	}
 	r := reqWithChi("POST", "/ui/report/Продажи/settings/save", form, map[string]string{"name": "Продажи"})
@@ -696,12 +695,43 @@ func TestReportSettingsSaveFromStandardCreatesReachablePreset(t *testing.T) {
 	if presets[0].ID == standardReportPresetID {
 		t.Fatalf("нельзя сохранять пользовательский вариант с reserved id %q", presets[0].ID)
 	}
+	if presets[0].Name != defaultReportPresetName {
+		t.Fatalf("пустое имя должно получить автозаголовок %q, got %+v", defaultReportPresetName, presets[0])
+	}
 	if !strings.Contains(presets[0].SettingsJSON, `"variant":"X"`) {
 		t.Fatalf("settings_json не сохранён: %q", presets[0].SettingsJSON)
 	}
 	loc := w.Header().Get("Location")
 	if !strings.Contains(loc, "__run=1") || !strings.Contains(loc, "__preset="+url.QueryEscape(presets[0].ID)) || !strings.Contains(loc, "%D0%9D%D0%B0%D1%87%D0%B0%D0%BB%D0%BE=2026-07-01") {
 		t.Fatalf("редирект должен вернуть на сформированный отчёт с параметрами и новым пресетом: %q", loc)
+	}
+
+	form2 := url.Values{
+		"__settings":      {`{"variant":"Y"}`},
+		"__preset":        {standardReportPresetID},
+		"__preset_action": {"save"},
+	}
+	r2 := reqWithChi("POST", "/ui/report/Продажи/settings/save", form2, map[string]string{"name": "Продажи"})
+	w2 := httptest.NewRecorder()
+	s.reportSettingsSave(w2, r2)
+	if w2.Code != http.StatusSeeOther {
+		t.Fatalf("second save from standard: ожидался 303, получен %d: %s", w2.Code, w2.Body.String())
+	}
+	presets, err = db.ListReportPresets(ctx, "Продажи", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presets) != 2 {
+		t.Fatalf("ожидали два пресета после второго автосохранения, got %+v", presets)
+	}
+	var foundSecond bool
+	for _, p := range presets {
+		if p.Name == defaultReportPresetName+" 2" {
+			foundSecond = true
+		}
+	}
+	if !foundSecond {
+		t.Fatalf("второй пустой save должен получить уникальное имя, got %+v", presets)
 	}
 }
 


### PR DESCRIPTION
## Summary
- auto-name new report presets when saving from standard settings without a typed name
- generate unique names like `Мой вариант`, `Мой вариант 2`
- keep the save flow from returning a validation error page for empty preset name

## Tests
- go test ./internal/ui
- go test ./...
- go run ./cmd/onebase check --project /home/admo/git/PuT
- git diff --check