### PR TITLE
fix(report): harden report preset persistence

### DIFF
--- a/internal/backup/universal.go
+++ b/internal/backup/universal.go
@@ -47,6 +47,7 @@ var systemTables = []string{
 	"_attachments",
 	"_audit",
 	"_scheduled_runs",
+	"_report_presets",
 }
 
 // safeSettingKeys are non-secret _settings values that may travel in a
@@ -984,6 +985,9 @@ func migrateSchema(ctx context.Context, db *storage.DB, configDest, cfgFileDir s
 	}
 	if err := db.EnsureScheduledRunsTable(ctx); err != nil {
 		return fmt.Errorf("ensure scheduled runs: %w", err)
+	}
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		return fmt.Errorf("ensure report presets: %w", err)
 	}
 	if err := db.EnsureAttachmentTable(ctx); err != nil {
 		return fmt.Errorf("ensure attachments: %w", err)

--- a/internal/backup/universal_test.go
+++ b/internal/backup/universal_test.go
@@ -306,6 +306,62 @@ func TestUniversalSafeSettingsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestUniversalReportPresetsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	src := newSQLite(t, "report-presets-src")
+	presetID, err := src.SaveReportPreset(ctx, storage.ReportPreset{
+		Report:       "ВаловаяПрибыльСКД",
+		User:         "alice",
+		Name:         "По номенклатуре",
+		SettingsJSON: `{"composition":{"Groupings":["Номенклатура"],"Measures":[{"Field":"ВаловаяПрибыль"}]}}`,
+		IsDefault:    true,
+	})
+	if err != nil {
+		t.Fatalf("SaveReportPreset: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := ExportUniversal(ctx, src, "file", t.TempDir(), "", "test", &buf); err != nil {
+		t.Fatalf("ExportUniversal: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := extractZip(buf.Bytes(), tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(tmpDir, "system", "_report_presets.jsonl"))
+	if err != nil {
+		t.Fatalf("_report_presets must be exported: %v", err)
+	}
+	if !strings.Contains(string(raw), "По номенклатуре") {
+		t.Fatalf("_report_presets export does not contain saved preset:\n%s", raw)
+	}
+
+	dst := newSQLite(t, "report-presets-dst")
+	if _, err := ImportUniversal(ctx, dst, "file", t.TempDir(), "", bytes.NewReader(buf.Bytes()), int64(buf.Len())); err != nil {
+		t.Fatalf("ImportUniversal: %v", err)
+	}
+	presets, err := dst.ListReportPresets(ctx, "ВаловаяПрибыльСКД", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presets) != 1 {
+		t.Fatalf("expected one restored report preset, got %+v", presets)
+	}
+	if presets[0].ID != presetID || presets[0].Name != "По номенклатуре" || !presets[0].IsDefault {
+		t.Fatalf("restored preset mismatch: %+v", presets[0])
+	}
+	if !strings.Contains(presets[0].SettingsJSON, "ВаловаяПрибыль") {
+		t.Fatalf("settings_json was not restored: %q", presets[0].SettingsJSON)
+	}
+	def, err := dst.GetDefaultReportPreset(ctx, "ВаловаяПрибыльСКД", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def == nil || def.ID != presetID {
+		t.Fatalf("default report preset was not restored: %+v", def)
+	}
+}
+
 func TestDemoResetImportsSafeSettings(t *testing.T) {
 	ctx := context.Background()
 	src := newSQLite(t, "demo-settings-src")

--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -25,6 +25,18 @@ const MaxListPageSize = 1000
 // меню не растягивало страницу. Хранится в _settings (ui.collapsible_nav).
 const DefaultNavCollapsible = true
 
+// StandardReportPresetID is a reserved pseudo-preset used by the UI to request
+// the report composition from configuration instead of a saved user preset.
+const StandardReportPresetID = "__standard"
+
+// ErrReportPresetNameExists is returned when a user tries to save a second
+// preset with the same visible name for the same report.
+var ErrReportPresetNameExists = errors.New("вариант отчёта с таким названием уже существует")
+
+// ErrReservedReportPresetID is returned if caller tries to persist the
+// pseudo-preset id as a real database row.
+var ErrReservedReportPresetID = errors.New("зарезервированный идентификатор варианта отчёта")
+
 // AuditSettings — настройки журнала регистрации (аналог «Журнала регистрации»
 // в 1С). Это свойство конкретной информационной базы, а не git-версионируемой
 // конфигурации, поэтому хранится в служебной таблице _settings.
@@ -508,9 +520,9 @@ func (db *DB) ListReportPresets(ctx context.Context, report, user string) ([]Rep
 	rows, err := db.Query(ctx,
 		fmt.Sprintf(`SELECT id, report_name, user_login, name, settings_json, is_default
 			FROM _report_presets
-			WHERE report_name = %s AND user_login = %s
-			ORDER BY is_default DESC, name ASC`, d.Placeholder(1), d.Placeholder(2)),
-		report, user)
+			WHERE report_name = %s AND user_login = %s AND id <> %s
+			ORDER BY is_default DESC, name ASC`, d.Placeholder(1), d.Placeholder(2), d.Placeholder(3)),
+		report, user, StandardReportPresetID)
 	if err != nil {
 		return nil, fmt.Errorf("settings: list report presets: %w", err)
 	}
@@ -530,7 +542,11 @@ func (db *DB) ListReportPresets(ctx context.Context, report, user string) ([]Rep
 }
 
 func (db *DB) GetReportPreset(ctx context.Context, report, user, id string) (*ReportPreset, error) {
-	if strings.TrimSpace(id) == "" {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, nil
+	}
+	if id == StandardReportPresetID {
 		return nil, nil
 	}
 	if err := db.EnsureReportPresetSchema(ctx); err != nil {
@@ -558,9 +574,9 @@ func (db *DB) GetDefaultReportPreset(ctx context.Context, report, user string) (
 	row := db.QueryRow(ctx,
 		fmt.Sprintf(`SELECT id, report_name, user_login, name, settings_json, is_default
 			FROM _report_presets
-			WHERE report_name = %s AND user_login = %s AND is_default = %s`,
-			d.Placeholder(1), d.Placeholder(2), reportPresetBoolLit(d, true)),
-		report, user)
+			WHERE report_name = %s AND user_login = %s AND is_default = %s AND id <> %s`,
+			d.Placeholder(1), d.Placeholder(2), reportPresetBoolLit(d, true), d.Placeholder(3)),
+		report, user, StandardReportPresetID)
 	p, err := scanReportPresetRow(row)
 	if err != nil {
 		return nil, nil
@@ -574,12 +590,16 @@ func (db *DB) GetDefaultReportPreset(ctx context.Context, report, user string) (
 func (db *DB) SaveReportPreset(ctx context.Context, p ReportPreset) (string, error) {
 	p.Report = strings.TrimSpace(p.Report)
 	p.User = strings.TrimSpace(p.User)
+	p.ID = strings.TrimSpace(p.ID)
 	p.Name = strings.TrimSpace(p.Name)
 	if p.Report == "" {
 		return "", errors.New("report preset: empty report")
 	}
 	if p.Name == "" {
 		return "", errors.New("report preset: empty name")
+	}
+	if p.ID == StandardReportPresetID {
+		return "", ErrReservedReportPresetID
 	}
 	if p.ID == "" {
 		p.ID = uuid.NewString()
@@ -589,6 +609,9 @@ func (db *DB) SaveReportPreset(ctx context.Context, p ReportPreset) (string, err
 	}
 	d := db.dialect
 	err := db.WithTx(ctx, func(txCtx context.Context) error {
+		if reportPresetNameTaken(txCtx, db, d, p) {
+			return ErrReportPresetNameExists
+		}
 		if p.IsDefault {
 			if _, err := db.Exec(txCtx,
 				fmt.Sprintf(`UPDATE _report_presets SET is_default = %s, updated_at = %s WHERE report_name = %s AND user_login = %s`,
@@ -616,6 +639,17 @@ func (db *DB) SaveReportPreset(ctx context.Context, p ReportPreset) (string, err
 		return "", err
 	}
 	return p.ID, nil
+}
+
+func reportPresetNameTaken(ctx context.Context, db *DB, d Dialect, p ReportPreset) bool {
+	var existingID string
+	err := db.QueryRow(ctx,
+		fmt.Sprintf(`SELECT id FROM _report_presets
+			WHERE report_name = %s AND user_login = %s AND name = %s AND id <> %s
+			LIMIT 1`,
+			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4)),
+		p.Report, p.User, p.Name, p.ID).Scan(&existingID)
+	return err == nil && existingID != ""
 }
 
 func (db *DB) DeleteReportPreset(ctx context.Context, report, user, id string) error {

--- a/internal/storage/settings_report_test.go
+++ b/internal/storage/settings_report_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -180,5 +181,82 @@ func TestReportPresets(t *testing.T) {
 	}
 	if deleted, _ := db.GetReportPreset(ctx, "Продажи", "alice", id1); deleted != nil {
 		t.Fatalf("пресет должен быть удалён: %+v", deleted)
+	}
+}
+
+func TestReportPresetRejectsDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-dup.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+
+	if _, err := db.SaveReportPreset(ctx, ReportPreset{
+		Report:       "Продажи",
+		User:         "alice",
+		Name:         "По товарам",
+		SettingsJSON: `{"variant":"A"}`,
+	}); err != nil {
+		t.Fatalf("SaveReportPreset #1: %v", err)
+	}
+	if _, err := db.SaveReportPreset(ctx, ReportPreset{
+		Report:       "Продажи",
+		User:         "alice",
+		Name:         "По товарам",
+		SettingsJSON: `{"variant":"B"}`,
+	}); !errors.Is(err, ErrReportPresetNameExists) {
+		t.Fatalf("duplicate name: got %v, want ErrReportPresetNameExists", err)
+	}
+
+	if _, err := db.SaveReportPreset(ctx, ReportPreset{
+		Report:       "Продажи",
+		User:         "bob",
+		Name:         "По товарам",
+		SettingsJSON: `{"variant":"B"}`,
+	}); err != nil {
+		t.Fatalf("same name for another user must be allowed: %v", err)
+	}
+}
+
+func TestReportPresetReservedIDIsIgnored(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-reserved.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.SaveReportPreset(ctx, ReportPreset{
+		ID:           StandardReportPresetID,
+		Report:       "Продажи",
+		User:         "alice",
+		Name:         "Стандартный",
+		SettingsJSON: `{"variant":"bad"}`,
+	}); !errors.Is(err, ErrReservedReportPresetID) {
+		t.Fatalf("reserved id save: got %v, want ErrReservedReportPresetID", err)
+	}
+
+	if _, err := db.Exec(ctx, `INSERT INTO _report_presets
+		(id, report_name, user_login, name, settings_json, is_default)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		StandardReportPresetID, "Продажи", "alice", "Стандартный", `{"variant":"bad"}`, true); err != nil {
+		t.Fatal(err)
+	}
+	if p, err := db.GetReportPreset(ctx, "Продажи", "alice", StandardReportPresetID); err != nil || p != nil {
+		t.Fatalf("reserved preset must not be loaded by id: preset=%+v err=%v", p, err)
+	}
+	if p, err := db.GetDefaultReportPreset(ctx, "Продажи", "alice"); err != nil || p != nil {
+		t.Fatalf("reserved preset must not become default: preset=%+v err=%v", p, err)
+	}
+	list, err := db.ListReportPresets(ctx, "Продажи", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("reserved preset must not be listed: %+v", list)
 	}
 }

--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -24,7 +24,7 @@ import (
 // разумную презентационную настройку (выбор/порядок колонок, отборы, сортировка).
 const maxUserSettingsBytes = 64 * 1024
 
-const standardReportPresetID = "__standard"
+const standardReportPresetID = storage.StandardReportPresetID
 const defaultReportPresetName = "Мой вариант"
 
 // errSettingsTooLarge — отказ сохранить слишком большой блок __settings (issue #23).
@@ -597,6 +597,10 @@ func (s *Server) reportSettingsSave(w http.ResponseWriter, r *http.Request) {
 		IsDefault:    isDefault,
 	})
 	if err != nil {
+		if errors.Is(err, storage.ErrReportPresetNameExists) {
+			http.Error(w, s.errText(r, err), http.StatusConflict)
+			return
+		}
 		http.Error(w, s.errText(r, err), http.StatusBadRequest)
 		return
 	}

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -654,13 +654,13 @@ func TestReportSettingsSaveFromStandardCreatesReachablePreset(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { db.Close() })
-	if _, err := db.SaveReportPreset(ctx, storage.ReportPreset{
-		ID:           standardReportPresetID,
-		Report:       "Продажи",
-		User:         "",
-		Name:         "По товарам",
-		SettingsJSON: `{"variant":"broken"}`,
-	}); err != nil {
+	if err := db.EnsureReportPresetSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `INSERT INTO _report_presets
+		(id, report_name, user_login, name, settings_json, is_default)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		standardReportPresetID, "Продажи", "", "По товарам", `{"variant":"broken"}`, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -732,6 +732,50 @@ func TestReportSettingsSaveFromStandardCreatesReachablePreset(t *testing.T) {
 	}
 	if !foundSecond {
 		t.Fatalf("второй пустой save должен получить уникальное имя, got %+v", presets)
+	}
+}
+
+func TestReportSettingsSaveDuplicatePresetNameReturnsConflict(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "preset-save-dup.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.SaveReportPreset(ctx, storage.ReportPreset{
+		Report:       "Продажи",
+		User:         "",
+		Name:         "По товарам",
+		SettingsJSON: `{"variant":"A"}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := &reportpkg.Report{Name: "Продажи"}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
+	s := &Server{store: db, reg: registry}
+
+	form := url.Values{
+		"__settings":      {`{"variant":"B"}`},
+		"__preset_action": {"save_as"},
+		"__preset_name":   {"По товарам"},
+	}
+	r := reqWithChi("POST", "/ui/report/Продажи/settings/save", form, map[string]string{"name": "Продажи"})
+	w := httptest.NewRecorder()
+	s.reportSettingsSave(w, r)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate save_as: ожидался 409, получен %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), storage.ErrReportPresetNameExists.Error()) {
+		t.Fatalf("duplicate save_as должен вернуть понятную ошибку, got %q", w.Body.String())
+	}
+	presets, err := db.ListReportPresets(ctx, "Продажи", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(presets) != 1 || presets[0].SettingsJSON != `{"variant":"A"}` {
+		t.Fatalf("duplicate save_as не должен менять существующий пресет: %+v", presets)
 	}
 }
 


### PR DESCRIPTION
## Что изменено

- Добавлен `_report_presets` в universal backup/restore и создание схемы перед импортом system-таблиц.
- Reserved preset `__standard` вынесен на уровень storage: его нельзя сохранить как реальный вариант, он не выбирается через list/get/default даже при legacy/corrupt строке в БД.
- Дубли имён пользовательских вариантов теперь возвращают доменную ошибку и HTTP 409 вместо сырой ошибки unique constraint.

## Проверки

- `go test ./internal/storage ./internal/ui ./internal/backup`
- `go test ./...`
- `go run ./cmd/onebase check --project /home/admo/git/PuT` — OK, 9 существующих предупреждений по legacy printforms