### PR TITLE
fix(report): limit runtime settings to SKD reports

### DIFF
--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -38,9 +38,13 @@ func (s *Server) reportForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	user := currentUserLogin(r)
-	presets := loadReportPresets(r.Context(), s.store, rep.Name, user)
+	supportsSettings := reportSupportsRuntimeSettings(rep)
+	var presets []storage.ReportPreset
+	if supportsSettings {
+		presets = loadReportPresets(r.Context(), s.store, rep.Name, user)
+	}
 	activePresetID := r.FormValue("__preset")
-	if activePresetID == "" {
+	if supportsSettings && s.store != nil && activePresetID == "" {
 		if p, err := s.store.GetDefaultReportPreset(r.Context(), rep.Name, user); err == nil && p != nil {
 			activePresetID = p.ID
 		}
@@ -108,7 +112,10 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 	// Выбранный вариант компоновки (параметр __variant); пусто → основной.
 	variant := r.FormValue("__variant")
 	user := currentUserLogin(r)
-	presets := loadReportPresets(r.Context(), s.store, rep.Name, user)
+	var presets []storage.ReportPreset
+	if reportSupportsRuntimeSettings(rep) {
+		presets = loadReportPresets(r.Context(), s.store, rep.Name, user)
+	}
 	rs := s.reportSettingsForRequest(r, rep)
 	settings := rs.Settings
 	activePreset := activeReportPreset(presets, rs.ActivePresetID)
@@ -183,7 +190,7 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 	s.resolveUUIDsInReport(r.Context(), rows, detailLinkCol)
 
 	// Пользовательские отборы применяются к строкам до компоновки (план 70).
-	if settings != nil && len(settings.Filters) > 0 {
+	if comp != nil && settings != nil && len(settings.Filters) > 0 {
 		rows = compose.ApplyFilters(rows, settings.Filters)
 	}
 
@@ -519,7 +526,7 @@ func (s *Server) reportExportRows(r *http.Request, rep *reportpkg.Report) (heade
 	s.resolveUUIDsInReport(r.Context(), data, detailLinkCol)
 
 	// Пользовательские отборы (план 70) — до компоновки, как в runReport.
-	if settings != nil && len(settings.Filters) > 0 {
+	if comp != nil && settings != nil && len(settings.Filters) > 0 {
 		data = compose.ApplyFilters(data, settings.Filters)
 	}
 

--- a/internal/ui/report_settings.go
+++ b/internal/ui/report_settings.go
@@ -86,10 +86,16 @@ func requestFormValue(r *http.Request, name string) (string, bool) {
 }
 
 func (s *Server) reportSettingsForRequest(r *http.Request, rep *reportpkg.Report) reportSettingsRequest {
+	if !reportSupportsRuntimeSettings(rep) {
+		return reportSettingsRequest{}
+	}
 	presetID, hasPreset := requestFormValue(r, "__preset")
 	if settings := readReportSettings(r); settings != nil {
 		settings = reportSettingsWithRequestVariant(r, settings)
 		return reportSettingsRequest{Settings: settings, ActivePresetID: presetID}
+	}
+	if s.store == nil {
+		return reportSettingsRequest{Settings: reportSettingsWithRequestVariant(r, nil), ActivePresetID: presetID}
 	}
 
 	user := currentUserLogin(r)
@@ -118,6 +124,21 @@ func (s *Server) reportSettingsForRequest(r *http.Request, rep *reportpkg.Report
 		return reportSettingsRequest{Settings: settings}
 	}
 	return reportSettingsRequest{Settings: reportSettingsWithRequestVariant(r, nil)}
+}
+
+func reportSupportsRuntimeSettings(rep *reportpkg.Report) bool {
+	if rep == nil {
+		return false
+	}
+	if rep.Composition != nil {
+		return true
+	}
+	for i := range rep.Variants {
+		if rep.Variants[i].Composition != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func loadReportPresets(ctx context.Context, store *storage.DB, report, user string) []storage.ReportPreset {
@@ -164,6 +185,9 @@ func effectiveComposition(rep *reportpkg.Report, s *reportpkg.UserReportSettings
 		variant = s.Variant
 	}
 	base := rep.ActiveComposition(variant)
+	if base == nil {
+		return nil
+	}
 	if s == nil || s.Composition == nil {
 		return base
 	}
@@ -187,11 +211,11 @@ func reportSettingsPanelJSON(rep *reportpkg.Report, s *reportpkg.UserReportSetti
 }
 
 func reportSettingsPanelState(rep *reportpkg.Report, s *reportpkg.UserReportSettings) *reportpkg.UserReportSettings {
-	if rep == nil {
+	if !reportSupportsRuntimeSettings(rep) {
 		return nil
 	}
 	comp := effectiveComposition(rep, s)
-	if comp == nil && s == nil {
+	if comp == nil {
 		return nil
 	}
 	out := &reportpkg.UserReportSettings{}
@@ -262,9 +286,9 @@ func panelMeasures(in []reportpkg.Measure) []reportpkg.Measure {
 // DetailEntity. Они НИКОГДА не берутся из пользовательского ввода.
 func mergeUserComposition(base, u *reportpkg.Composition) *reportpkg.Composition {
 	if base == nil {
-		// Нет доверенной базы (отчёт без composition) — не исполняем ничего из
-		// пользовательского ввода: возвращаем пустую презентационную компоновку.
-		base = &reportpkg.Composition{}
+		// Нет доверенной базы (отчёт без composition) — пользовательский ввод не
+		// должен переводить плоский отчёт в режим СКД.
+		return nil
 	}
 	// Доверенные показатели и поля по имени (регистронезависимо, как DSL).
 	// Expr всегда наследуется только отсюда; презентационные поля служат

--- a/internal/ui/report_settings_test.go
+++ b/internal/ui/report_settings_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/ivantit66/onebase/internal/storage"
 )
 
+func reportSettingsTestReport(name string) *reportpkg.Report {
+	return &reportpkg.Report{
+		Name: name,
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
+}
+
 func TestEffectiveComposition(t *testing.T) {
 	main := &reportpkg.Composition{Groupings: []string{"Основной"}}
 	variantComp := &reportpkg.Composition{Groupings: []string{"Вариант"}}
@@ -37,6 +47,24 @@ func TestEffectiveComposition(t *testing.T) {
 	// 3) settings == nil → основной composition.
 	if got := effectiveComposition(rep, nil); got != main {
 		t.Fatalf("main: %+v", got)
+	}
+}
+
+func TestEffectiveCompositionRequiresTrustedBase(t *testing.T) {
+	rep := &reportpkg.Report{Name: "plain"}
+	settings := &reportpkg.UserReportSettings{
+		Composition: &reportpkg.Composition{
+			Groupings:  []string{},
+			Measures:   []reportpkg.Measure{},
+			Appearance: reportpkg.Appearance{Lines: "both"},
+		},
+		Filters: []reportpkg.Filter{{Field: "Сумма", Op: "gt", Value: "100"}},
+	}
+	if got := effectiveComposition(rep, settings); got != nil {
+		t.Fatalf("отчёт без YAML-composition не должен переходить в режим СКД: %+v", got)
+	}
+	if raw := reportSettingsPanelJSON(rep, settings); raw != "" {
+		t.Fatalf("панель настроек для плоского отчёта должна быть скрыта, got %s", raw)
 	}
 }
 
@@ -82,7 +110,7 @@ func TestReportSettingsForRequestPresetKeepsPresetVariant(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { db.Close() })
-	rep := &reportpkg.Report{Name: "Продажи"}
+	rep := reportSettingsTestReport("Продажи")
 	id, err := db.SaveReportPreset(ctx, storage.ReportPreset{
 		Report:       "Продажи",
 		User:         "",
@@ -318,25 +346,34 @@ func TestReportSettingsPanelJSONUsesBaseComposition(t *testing.T) {
 // TestReportSettingsPanel: панель «Настройки» рендерится при наличии ReportCols,
 // содержит чекбоксы доступных полей и скрытое поле __settings.
 func TestReportSettingsPanel(t *testing.T) {
-	rep := &reportpkg.Report{Name: "sales", Title: "Продажи"}
+	rep := &reportpkg.Report{
+		Name:  "sales",
+		Title: "Продажи",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
 	preset := storage.ReportPreset{ID: "p1", Name: "Мой вариант", IsDefault: true}
+	settings := &reportpkg.UserReportSettings{
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
 	var buf bytes.Buffer
 	data := map[string]any{
-		"Report":         rep,
-		"ParamValues":    map[string]any{},
-		"ReportParams":   []reportParamUI{},
-		"ReportCols":     []string{"Товар", "Сумма"},
-		"ReportPresets":  []storage.ReportPreset{preset},
-		"ActivePresetID": "p1",
-		"ActivePreset":   &preset,
-		"UserSettings": &reportpkg.UserReportSettings{
-			Composition: &reportpkg.Composition{
-				Groupings: []string{"Товар"},
-				Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
-			},
-		},
-		"Cfg":  Config{},
-		"Lang": "ru",
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"Товар", "Сумма"},
+		"ReportPresets":      []storage.ReportPreset{preset},
+		"ActivePresetID":     "p1",
+		"ActivePreset":       &preset,
+		"UserSettings":       settings,
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, settings),
+		"Cfg":                Config{},
+		"Lang":               "ru",
 	}
 	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
 		t.Fatalf("execute page-report: %v", err)
@@ -467,15 +504,23 @@ func TestReportParamsFormKeepsActiveSettings(t *testing.T) {
 // TestReportSettingsPanelAppearance: панель «Настройки» содержит контролы
 // оформления (линии сетки + зебра), через которые пользователь задаёт вид себе.
 func TestReportSettingsPanelAppearance(t *testing.T) {
-	rep := &reportpkg.Report{Name: "sales", Title: "Продажи"}
+	rep := &reportpkg.Report{
+		Name:  "sales",
+		Title: "Продажи",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
 	var buf bytes.Buffer
 	data := map[string]any{
-		"Report":       rep,
-		"ParamValues":  map[string]any{},
-		"ReportParams": []reportParamUI{},
-		"ReportCols":   []string{"Товар", "Сумма"},
-		"Cfg":          Config{},
-		"Lang":         "ru",
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"Товар", "Сумма"},
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, nil),
+		"Cfg":                Config{},
+		"Lang":               "ru",
 	}
 	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
 		t.Fatalf("execute page-report: %v", err)
@@ -488,17 +533,25 @@ func TestReportSettingsPanelAppearance(t *testing.T) {
 	}
 }
 
-// TestReportSettingsPanelHidden: без ReportCols панель не рендерится
-// (обратная совместимость с отчётами без компоновки).
+// TestReportSettingsPanelHidden: без ReportCols или без composition панель не
+// рендерится (обратная совместимость с плоскими отчётами).
 func TestReportSettingsPanelHidden(t *testing.T) {
-	rep := &reportpkg.Report{Name: "plain", Title: "Простой"}
+	rep := &reportpkg.Report{
+		Name:  "skd",
+		Title: "СКД",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
 	var buf bytes.Buffer
 	data := map[string]any{
-		"Report":       rep,
-		"ParamValues":  map[string]any{},
-		"ReportParams": []reportParamUI{},
-		"Cfg":          Config{},
-		"Lang":         "ru",
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, nil),
+		"Cfg":                Config{},
+		"Lang":               "ru",
 	}
 	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
 		t.Fatalf("execute page-report: %v", err)
@@ -506,23 +559,50 @@ func TestReportSettingsPanelHidden(t *testing.T) {
 	if strings.Contains(buf.String(), `data-block="settings"`) {
 		t.Errorf("панель настроек не должна рендериться без ReportCols")
 	}
+
+	plain := &reportpkg.Report{Name: "plain", Title: "Простой"}
+	buf.Reset()
+	data = map[string]any{
+		"Report":             plain,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"Товар", "Сумма"},
+		"ReportSettingsJSON": reportSettingsPanelJSON(plain, &reportpkg.UserReportSettings{Composition: &reportpkg.Composition{Appearance: reportpkg.Appearance{Lines: "both"}}}),
+		"Cfg":                Config{},
+		"Lang":               "ru",
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
+		t.Fatalf("execute plain page-report: %v", err)
+	}
+	if strings.Contains(buf.String(), `data-block="settings"`) {
+		t.Errorf("панель настроек не должна рендериться у плоского отчёта даже при наличии ReportCols")
+	}
 }
 
 // TestReportSettingsFilters: сохранённые отборы предзаполняют строки панели —
 // select поля, select оператора (с выбранным gt) и значение.
 func TestReportSettingsFilters(t *testing.T) {
-	rep := &reportpkg.Report{Name: "sales", Title: "Продажи"}
+	rep := &reportpkg.Report{
+		Name:  "sales",
+		Title: "Продажи",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
+	settings := &reportpkg.UserReportSettings{
+		Filters: []reportpkg.Filter{{Field: "Сумма", Op: "gt", Value: "100"}},
+	}
 	var buf bytes.Buffer
 	data := map[string]any{
-		"Report":       rep,
-		"ParamValues":  map[string]any{},
-		"ReportParams": []reportParamUI{},
-		"ReportCols":   []string{"Товар", "Сумма"},
-		"UserSettings": &reportpkg.UserReportSettings{
-			Filters: []reportpkg.Filter{{Field: "Сумма", Op: "gt", Value: "100"}},
-		},
-		"Cfg":  Config{},
-		"Lang": "ru",
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"Товар", "Сумма"},
+		"UserSettings":       settings,
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, settings),
+		"Cfg":                Config{},
+		"Lang":               "ru",
 	}
 	if err := tmpl.ExecuteTemplate(&buf, "page-report", data); err != nil {
 		t.Fatalf("execute page-report: %v", err)
@@ -555,7 +635,7 @@ func TestReportSettingsSaveReset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rep := &reportpkg.Report{Name: "Продажи"}
+	rep := reportSettingsTestReport("Продажи")
 	registry := runtime.NewRegistry()
 	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
 	s := &Server{store: db, reg: registry}
@@ -568,8 +648,8 @@ func TestReportSettingsSaveReset(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("save: ожидался 303, получен %d", w.Code)
 	}
-	if got, _ := db.GetReportUserSettings(ctx, "Продажи", ""); got != raw {
-		t.Fatalf("save: хотели %q, получили %q", raw, got)
+	if got, _ := db.GetReportUserSettings(ctx, "Продажи", ""); !strings.Contains(got, `"variant":"X"`) || !strings.Contains(got, "Товар") {
+		t.Fatalf("save: настройки должны сохраниться в каноничном виде, получили %q", got)
 	}
 
 	r2 := reqWithChi("POST", "/ui/report/Продажи/settings/reset", url.Values{}, map[string]string{"name": "Продажи"})
@@ -591,7 +671,7 @@ func TestReportSettingsSaveNamedPreset(t *testing.T) {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	rep := &reportpkg.Report{Name: "Продажи"}
+	rep := reportSettingsTestReport("Продажи")
 	registry := runtime.NewRegistry()
 	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
 	s := &Server{store: db, reg: registry}
@@ -667,6 +747,10 @@ func TestReportSettingsSaveFromStandardCreatesReachablePreset(t *testing.T) {
 	rep := &reportpkg.Report{
 		Name:   "Продажи",
 		Params: []reportpkg.Param{{Name: "Начало", Type: "date"}},
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
 	}
 	registry := runtime.NewRegistry()
 	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
@@ -751,7 +835,7 @@ func TestReportSettingsSaveDuplicatePresetNameReturnsConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rep := &reportpkg.Report{Name: "Продажи"}
+	rep := reportSettingsTestReport("Продажи")
 	registry := runtime.NewRegistry()
 	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
 	s := &Server{store: db, reg: registry}
@@ -850,7 +934,7 @@ func TestReportSettingsSaveRejectsLargeAndInvalid(t *testing.T) {
 	if err := db.EnsureSettingsSchema(ctx); err != nil {
 		t.Fatal(err)
 	}
-	rep := &reportpkg.Report{Name: "Продажи"}
+	rep := reportSettingsTestReport("Продажи")
 	registry := runtime.NewRegistry()
 	registry.Load(runtime.LoadOptions{Reports: []*reportpkg.Report{rep}})
 	s := &Server{store: db, reg: registry}
@@ -920,14 +1004,22 @@ func TestLoadUserSettings(t *testing.T) {
 // TestReportSettingsIndicator: при активных настройках панель показывает
 // пометку «изменено», а кнопка сброса активна; без настроек — кнопка disabled.
 func TestReportSettingsIndicator(t *testing.T) {
-	rep := &reportpkg.Report{Name: "sales", Title: "Продажи"}
+	rep := &reportpkg.Report{
+		Name:  "sales",
+		Title: "Продажи",
+		Composition: &reportpkg.Composition{
+			Groupings: []string{"Товар"},
+			Measures:  []reportpkg.Measure{{Field: "Сумма", Agg: "sum"}},
+		},
+	}
 	base := map[string]any{
-		"Report":       rep,
-		"ParamValues":  map[string]any{},
-		"ReportParams": []reportParamUI{},
-		"ReportCols":   []string{"Товар", "Сумма"},
-		"Cfg":          Config{},
-		"Lang":         "ru",
+		"Report":             rep,
+		"ParamValues":        map[string]any{},
+		"ReportParams":       []reportParamUI{},
+		"ReportCols":         []string{"Товар", "Сумма"},
+		"ReportSettingsJSON": reportSettingsPanelJSON(rep, nil),
+		"Cfg":                Config{},
+		"Lang":               "ru",
 	}
 
 	// С активными настройками.
@@ -935,7 +1027,9 @@ func TestReportSettingsIndicator(t *testing.T) {
 	for k, v := range base {
 		withSettings[k] = v
 	}
-	withSettings["UserSettings"] = &reportpkg.UserReportSettings{Variant: "X"}
+	settings := &reportpkg.UserReportSettings{Variant: "X"}
+	withSettings["UserSettings"] = settings
+	withSettings["ReportSettingsJSON"] = reportSettingsPanelJSON(rep, settings)
 	var b1 bytes.Buffer
 	if err := tmpl.ExecuteTemplate(&b1, "page-report", withSettings); err != nil {
 		t.Fatalf("execute: %v", err)

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -2740,7 +2740,7 @@ const tplReport = `
 </form>
 </details>
 {{end}}
-{{if .ReportCols}}
+{{if and .ReportCols .ReportSettingsJSON}}
 <details class="card report-block" data-block="settings" style="margin-bottom:16px">
 <summary>{{t $.Lang "Настройка отчёта"}}{{if .UserSettings}} <span style="background:#fef3c7;color:#92400e;border-radius:6px;padding:1px 8px;font-size:12px;font-weight:600">{{t $.Lang "изменено"}}</span>{{end}}</summary>
 <form method="POST" onsubmit="return rsBeforeSubmit(event)">


### PR DESCRIPTION
Summary:
- limit runtime report settings and presets to reports with trusted SKD composition
- keep flat reports on the plain-table path even if stale __settings contains appearance/filter settings
- add regressions for hidden settings panel and trusted-base behavior

Tests:
- GOCACHE=/tmp/onebase-go-build go test ./internal/ui ./internal/report ./internal/report/compose -count=1