### PR TITLE
feat(journal): add user column settings

### DIFF
--- a/internal/storage/settings.go
+++ b/internal/storage/settings.go
@@ -466,6 +466,10 @@ func reportSettingsKey(report, user string) string {
 	return fmt.Sprintf("report.settings.%d:%s.%d:%s", len(report), report, len(user), user)
 }
 
+func journalSettingsKey(journal, user string) string {
+	return fmt.Sprintf("journal.settings.%d:%s.%d:%s", len(journal), journal, len(user), user)
+}
+
 // GetReportUserSettings возвращает сырой JSON рантайм-настроек отчёта для
 // пользователя. Отсутствие ключа/таблицы — не ошибка (как GetLLMConfig):
 // возвращается ("", nil), что означает «использовать стандартный вид».
@@ -506,6 +510,49 @@ func (db *DB) DeleteReportUserSettings(ctx context.Context, report, user string)
 		`DELETE FROM _settings WHERE key = `+d.Placeholder(1),
 		reportSettingsKey(report, user)); err != nil {
 		return fmt.Errorf("settings: delete report settings: %w", err)
+	}
+	return nil
+}
+
+// GetJournalUserSettings возвращает сырой JSON пользовательских настроек
+// журнала документов. Отсутствие ключа/таблицы — не ошибка.
+func (db *DB) GetJournalUserSettings(ctx context.Context, journal, user string) (string, error) {
+	d := db.dialect
+	var v string
+	err := db.QueryRow(ctx,
+		`SELECT value FROM _settings WHERE key = `+d.Placeholder(1),
+		journalSettingsKey(journal, user)).Scan(&v)
+	if err != nil {
+		return "", nil
+	}
+	return v, nil
+}
+
+// SaveJournalUserSettings сохраняет пользовательские настройки журнала одним
+// JSON-значением (upsert). Конфигурацию (YAML) не трогает.
+func (db *DB) SaveJournalUserSettings(ctx context.Context, journal, user, raw string) error {
+	if err := db.EnsureSettingsSchema(ctx); err != nil {
+		return err
+	}
+	d := db.dialect
+	q := fmt.Sprintf(
+		`INSERT INTO _settings (key, value) VALUES (%s, %s)
+		 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+		d.Placeholder(1), d.Placeholder(2))
+	if _, err := db.Exec(ctx, q, journalSettingsKey(journal, user), raw); err != nil {
+		return fmt.Errorf("settings: save journal settings: %w", err)
+	}
+	return nil
+}
+
+// DeleteJournalUserSettings удаляет пользовательские настройки журнала —
+// сброс к стандартному виду из YAML.
+func (db *DB) DeleteJournalUserSettings(ctx context.Context, journal, user string) error {
+	d := db.dialect
+	if _, err := db.Exec(ctx,
+		`DELETE FROM _settings WHERE key = `+d.Placeholder(1),
+		journalSettingsKey(journal, user)); err != nil {
+		return fmt.Errorf("settings: delete journal settings: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/settings_report_test.go
+++ b/internal/storage/settings_report_test.go
@@ -97,6 +97,52 @@ func TestReportSettingsKeyNoCollision(t *testing.T) {
 	}
 }
 
+func TestJournalUserSettings(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "journal-settings.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+	if err := db.EnsureSettingsSchema(ctx); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+
+	if got, err := db.GetJournalUserSettings(ctx, "Входящие", "alice"); err != nil || got != "" {
+		t.Fatalf("empty journal settings: got %q err=%v", got, err)
+	}
+	raw := `{"columns":[{"field":"Номер","visible":true}]}`
+	if err := db.SaveJournalUserSettings(ctx, "Входящие", "alice", raw); err != nil {
+		t.Fatalf("SaveJournalUserSettings: %v", err)
+	}
+	if got, err := db.GetJournalUserSettings(ctx, "Входящие", "alice"); err != nil || got != raw {
+		t.Fatalf("GetJournalUserSettings: got %q err=%v", got, err)
+	}
+	if err := db.SaveJournalUserSettings(ctx, "Входящие", "bob", `{"columns":[]}`); err != nil {
+		t.Fatalf("SaveJournalUserSettings bob: %v", err)
+	}
+	if got, _ := db.GetJournalUserSettings(ctx, "Входящие", "alice"); got != raw {
+		t.Fatalf("alice settings overwritten by bob: %q", got)
+	}
+	if err := db.DeleteJournalUserSettings(ctx, "Входящие", "alice"); err != nil {
+		t.Fatalf("DeleteJournalUserSettings: %v", err)
+	}
+	if got, _ := db.GetJournalUserSettings(ctx, "Входящие", "alice"); got != "" {
+		t.Fatalf("journal settings after delete: %q", got)
+	}
+	if got, _ := db.GetJournalUserSettings(ctx, "Входящие", "bob"); got == "" {
+		t.Fatal("DeleteJournalUserSettings(alice) must not delete bob settings")
+	}
+}
+
+func TestJournalSettingsKeyNoCollision(t *testing.T) {
+	k1 := journalSettingsKey("a.b", "c")
+	k2 := journalSettingsKey("a", "b.c")
+	if k1 == k2 {
+		t.Fatalf("journal settings keys collided: %q == %q", k1, k2)
+	}
+}
+
 func TestReportPresets(t *testing.T) {
 	ctx := context.Background()
 	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "presets.db"))

--- a/internal/ui/handlers_journals.go
+++ b/internal/ui/handlers_journals.go
@@ -19,15 +19,12 @@ import (
 )
 
 func (s *Server) journalList(w http.ResponseWriter, r *http.Request) {
-	name := chi.URLParam(r, "name")
-	if dec, err := url.PathUnescape(name); err == nil {
-		name = dec
-	}
-	j := s.reg.GetJournal(name)
+	j := s.getJournal(w, r)
 	if j == nil {
-		http.Error(w, "unknown journal: "+name, 404)
 		return
 	}
+	settings := loadJournalSettings(s.store, r, j)
+	visibleColumns := effectiveJournalColumns(j, settings)
 
 	// Build docs map
 	docs := make(map[string]*metadata.Entity, len(j.Documents))
@@ -88,6 +85,50 @@ func (s *Server) journalList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Compute column formats from entity metadata
+	colFormats := journalColumnFormats(j, docs)
+
+	hasNext := offset+pageSize < total
+	hasPrev := offset > 0
+	prevOffset := offset - pageSize
+	if prevOffset < 0 {
+		prevOffset = 0
+	}
+
+	s.render(w, r, "page-journal", map[string]any{
+		"Journal":                j,
+		"JournalColumns":         visibleColumns,
+		"JournalSettingsColumns": journalSettingsColumns(j, settings),
+		"JournalSettingsJSON":    journalSettingsJSON(j, settings),
+		"JournalSettingsActive":  settings != nil,
+		"Rows":                   rows,
+		"Total":                  total,
+		"Params":                 params,
+		"FilterOptions":          filterOpts,
+		"ColFormats":             colFormats,
+		"Offset":                 offset,
+		"Limit":                  pageSize,
+		"HasPrev":                hasPrev,
+		"HasNext":                hasNext,
+		"PrevOffset":             prevOffset,
+		"NextOffset":             offset + pageSize,
+		"RequestURI":             r.URL.RequestURI(),
+	})
+}
+
+func (s *Server) getJournal(w http.ResponseWriter, r *http.Request) *metadata.Journal {
+	name := chi.URLParam(r, "name")
+	if dec, err := url.PathUnescape(name); err == nil {
+		name = dec
+	}
+	j := s.reg.GetJournal(name)
+	if j == nil {
+		http.Error(w, "unknown journal: "+name, 404)
+		return nil
+	}
+	return j
+}
+
+func journalColumnFormats(j *metadata.Journal, docs map[string]*metadata.Entity) map[string]string {
 	colFormats := make(map[string]string)
 	for _, jcol := range j.Columns {
 		if jcol.Format != "" {
@@ -111,28 +152,7 @@ func (s *Server) journalList(w http.ResponseWriter, r *http.Request) {
 		}
 	nextCol:
 	}
-
-	hasNext := offset+pageSize < total
-	hasPrev := offset > 0
-	prevOffset := offset - pageSize
-	if prevOffset < 0 {
-		prevOffset = 0
-	}
-
-	s.render(w, r, "page-journal", map[string]any{
-		"Journal":       j,
-		"Rows":          rows,
-		"Total":         total,
-		"Params":        params,
-		"FilterOptions": filterOpts,
-		"ColFormats":    colFormats,
-		"Offset":        offset,
-		"Limit":         pageSize,
-		"HasPrev":       hasPrev,
-		"HasNext":       hasNext,
-		"PrevOffset":    prevOffset,
-		"NextOffset":    offset + pageSize,
-	})
+	return colFormats
 }
 
 // resolveJournalRefs resolves UUID values in reference journal columns to display labels.
@@ -186,15 +206,11 @@ func (s *Server) resolveJournalRefs(ctx context.Context, j *metadata.Journal, co
 
 // journalExcel exports a journal as XLSX.
 func (s *Server) journalExcel(w http.ResponseWriter, r *http.Request) {
-	name := chi.URLParam(r, "name")
-	if dec, err := url.PathUnescape(name); err == nil {
-		name = dec
-	}
-	j := s.reg.GetJournal(name)
+	j := s.getJournal(w, r)
 	if j == nil {
-		http.Error(w, "unknown journal: "+name, 404)
 		return
 	}
+	visibleColumns := effectiveJournalColumns(j, loadJournalSettings(s.store, r, j))
 
 	docs := make(map[string]*metadata.Entity, len(j.Documents))
 	for _, docName := range j.Documents {
@@ -223,9 +239,9 @@ func (s *Server) journalExcel(w http.ResponseWriter, r *http.Request) {
 	}
 	s.resolveJournalRefs(r.Context(), j, colRefMap, rows)
 
-	cols := make([]string, 0, len(j.Columns)+2)
+	cols := make([]string, 0, len(visibleColumns)+2)
 	cols = append(cols, "Дата", "Вид")
-	for _, jcol := range j.Columns {
+	for _, jcol := range visibleColumns {
 		cols = append(cols, jcol.Label)
 	}
 
@@ -234,7 +250,7 @@ func (s *Server) journalExcel(w http.ResponseWriter, r *http.Request) {
 		cells := make([]any, len(cols))
 		cells[0] = row["date"]
 		cells[1] = row["doc_type"]
-		for ji, jcol := range j.Columns {
+		for ji, jcol := range visibleColumns {
 			cells[2+ji] = row[jcol.Field]
 		}
 		xlsRows[i] = cells

--- a/internal/ui/journal_settings.go
+++ b/internal/ui/journal_settings.go
@@ -1,0 +1,194 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+const maxJournalSettingsBytes = 32 * 1024
+
+var errJournalSettingsTooLarge = errors.New("настройки журнала слишком велики")
+
+type JournalUserSettings struct {
+	Columns []JournalColumnSetting `json:"columns,omitempty"`
+}
+
+type JournalColumnSetting struct {
+	Field   string `json:"field"`
+	Visible bool   `json:"visible"`
+}
+
+type journalColumnUI struct {
+	Column  metadata.JournalColumn
+	Visible bool
+}
+
+func parseJournalSettings(raw string) (*JournalUserSettings, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var s JournalUserSettings
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (s *JournalUserSettings) JSON() (string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func loadJournalSettings(store journalSettingsStore, r *http.Request, j *metadata.Journal) *JournalUserSettings {
+	if store == nil || j == nil {
+		return nil
+	}
+	raw, err := store.GetJournalUserSettings(r.Context(), j.Name, currentUserLogin(r))
+	if err != nil || raw == "" {
+		return nil
+	}
+	st, err := parseJournalSettings(raw)
+	if err != nil {
+		return nil
+	}
+	return st
+}
+
+type journalSettingsStore interface {
+	GetJournalUserSettings(ctx context.Context, journal, user string) (string, error)
+}
+
+func effectiveJournalColumns(j *metadata.Journal, st *JournalUserSettings) []metadata.JournalColumn {
+	ui := journalSettingsColumns(j, st)
+	out := make([]metadata.JournalColumn, 0, len(ui))
+	for _, c := range ui {
+		if c.Visible {
+			out = append(out, c.Column)
+		}
+	}
+	return out
+}
+
+func journalSettingsColumns(j *metadata.Journal, st *JournalUserSettings) []journalColumnUI {
+	if j == nil {
+		return nil
+	}
+	byField := make(map[string]metadata.JournalColumn, len(j.Columns))
+	for _, c := range j.Columns {
+		byField[strings.ToLower(c.Field)] = c
+	}
+	seen := make(map[string]bool, len(j.Columns))
+	out := make([]journalColumnUI, 0, len(j.Columns))
+	if st != nil {
+		for _, pref := range st.Columns {
+			key := strings.ToLower(pref.Field)
+			col, ok := byField[key]
+			if !ok || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, journalColumnUI{Column: col, Visible: pref.Visible})
+		}
+	}
+	for _, col := range j.Columns {
+		key := strings.ToLower(col.Field)
+		if seen[key] {
+			continue
+		}
+		out = append(out, journalColumnUI{Column: col, Visible: true})
+	}
+	return out
+}
+
+func canonicalJournalSettings(j *metadata.Journal, st *JournalUserSettings) *JournalUserSettings {
+	if j == nil {
+		return nil
+	}
+	cols := journalSettingsColumns(j, st)
+	out := &JournalUserSettings{Columns: make([]JournalColumnSetting, 0, len(cols))}
+	for _, c := range cols {
+		out.Columns = append(out.Columns, JournalColumnSetting{
+			Field:   c.Column.Field,
+			Visible: c.Visible,
+		})
+	}
+	return out
+}
+
+func journalSettingsJSON(j *metadata.Journal, st *JournalUserSettings) string {
+	canon := canonicalJournalSettings(j, st)
+	if canon == nil {
+		return ""
+	}
+	raw, err := canon.JSON()
+	if err != nil {
+		return ""
+	}
+	return raw
+}
+
+func journalReturnURL(r *http.Request, fallback string) string {
+	raw := strings.TrimSpace(r.FormValue("__return"))
+	if raw == "" {
+		return fallback
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.IsAbs() || !strings.HasPrefix(u.Path, "/ui/journal/") {
+		return fallback
+	}
+	return u.RequestURI()
+}
+
+func (s *Server) journalSettingsSave(w http.ResponseWriter, r *http.Request) {
+	j := s.getJournal(w, r)
+	if j == nil {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, s.errText(r, err), http.StatusBadRequest)
+		return
+	}
+	raw := r.FormValue("__journal_settings")
+	if len(raw) > maxJournalSettingsBytes {
+		http.Error(w, s.errText(r, errJournalSettingsTooLarge), http.StatusRequestEntityTooLarge)
+		return
+	}
+	st, err := parseJournalSettings(raw)
+	if err != nil {
+		http.Error(w, s.errText(r, err), http.StatusBadRequest)
+		return
+	}
+	canon := journalSettingsJSON(j, st)
+	if len(canon) > maxJournalSettingsBytes {
+		http.Error(w, s.errText(r, errJournalSettingsTooLarge), http.StatusRequestEntityTooLarge)
+		return
+	}
+	_ = s.store.SaveJournalUserSettings(r.Context(), j.Name, currentUserLogin(r), canon)
+	http.Redirect(w, r, journalReturnURL(r, journalFormURL(j.Name)), http.StatusSeeOther)
+}
+
+func (s *Server) journalSettingsReset(w http.ResponseWriter, r *http.Request) {
+	j := s.getJournal(w, r)
+	if j == nil {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, s.errText(r, err), http.StatusBadRequest)
+		return
+	}
+	_ = s.store.DeleteJournalUserSettings(r.Context(), j.Name, currentUserLogin(r))
+	http.Redirect(w, r, journalReturnURL(r, journalFormURL(j.Name)), http.StatusSeeOther)
+}
+
+func journalFormURL(name string) string {
+	return "/ui/journal/" + url.PathEscape(strings.ToLower(name))
+}

--- a/internal/ui/journal_settings_test.go
+++ b/internal/ui/journal_settings_test.go
@@ -1,0 +1,151 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func testJournal() *metadata.Journal {
+	return &metadata.Journal{
+		Name:  "Журнал",
+		Title: "Журнал",
+		Columns: []metadata.JournalColumn{
+			{Field: "Номер", Label: "Номер"},
+			{Field: "Контрагент", Label: "Контрагент"},
+			{Field: "Сумма", Label: "Сумма"},
+		},
+	}
+}
+
+func TestEffectiveJournalColumns(t *testing.T) {
+	j := testJournal()
+	st := &JournalUserSettings{Columns: []JournalColumnSetting{
+		{Field: "сумма", Visible: true},
+		{Field: "Номер", Visible: false},
+		{Field: "НетТакого", Visible: true},
+		{Field: "Сумма", Visible: false},
+	}}
+
+	visible := effectiveJournalColumns(j, st)
+	if len(visible) != 2 || visible[0].Field != "Сумма" || visible[1].Field != "Контрагент" {
+		t.Fatalf("visible columns: %+v", visible)
+	}
+	panel := journalSettingsColumns(j, st)
+	if len(panel) != 3 {
+		t.Fatalf("panel columns: %+v", panel)
+	}
+	if panel[0].Column.Field != "Сумма" || !panel[0].Visible {
+		t.Fatalf("first panel column should be visible Сумма, got %+v", panel[0])
+	}
+	if panel[1].Column.Field != "Номер" || panel[1].Visible {
+		t.Fatalf("second panel column should be hidden Номер, got %+v", panel[1])
+	}
+	if panel[2].Column.Field != "Контрагент" || !panel[2].Visible {
+		t.Fatalf("new/unseen YAML column should be appended visible, got %+v", panel[2])
+	}
+}
+
+func TestJournalSettingsJSONCanonical(t *testing.T) {
+	j := testJournal()
+	raw := journalSettingsJSON(j, &JournalUserSettings{Columns: []JournalColumnSetting{
+		{Field: "сумма", Visible: true},
+		{Field: "Номер", Visible: false},
+		{Field: "НетТакого", Visible: true},
+	}})
+	for _, want := range []string{`"field":"Сумма"`, `"field":"Номер"`, `"visible":false`, `"field":"Контрагент"`} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("canonical settings do not contain %q: %s", want, raw)
+		}
+	}
+	if strings.Contains(raw, "НетТакого") {
+		t.Fatalf("canonical settings must drop unknown fields: %s", raw)
+	}
+}
+
+func TestJournalSettingsPanelRender(t *testing.T) {
+	j := testJournal()
+	st := &JournalUserSettings{Columns: []JournalColumnSetting{{Field: "Сумма", Visible: true}, {Field: "Номер", Visible: false}}}
+	var buf bytes.Buffer
+	data := map[string]any{
+		"Journal":                j,
+		"JournalColumns":         effectiveJournalColumns(j, st),
+		"JournalSettingsColumns": journalSettingsColumns(j, st),
+		"JournalSettingsJSON":    journalSettingsJSON(j, st),
+		"JournalSettingsActive":  true,
+		"Rows":                   []map[string]any{{"_doc_kind": "Док", "id": "1", "Сумма": "10", "Номер": "N1", "Контрагент": "К"}},
+		"Total":                  1,
+		"Params":                 storage.ListParams{Filters: map[string]storage.FilterValue{}},
+		"FilterOptions":          map[string][]map[string]any{},
+		"ColFormats":             map[string]string{},
+		"RequestURI":             "/ui/journal/журнал",
+		"Cfg":                    Config{},
+		"Lang":                   "ru",
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "page-journal", data); err != nil {
+		t.Fatalf("execute page-journal: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{`data-block="journal-settings"`, `name="__journal_settings"`, `id="jl-columns"`, `data-field="Номер"`, "изменено"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("journal settings panel missing %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, `<th>Сумма</th>`) {
+		t.Fatalf("visible column should be rendered in data table:\n%s", out)
+	}
+	if strings.Contains(out, `<th>Номер</th>`) {
+		t.Fatalf("hidden column should not be rendered in data table:\n%s", out)
+	}
+}
+
+func TestJournalSettingsSaveReset(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "journal-settings.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+
+	j := testJournal()
+	registry := runtime.NewRegistry()
+	registry.LoadJournals([]*metadata.Journal{j})
+	s := &Server{store: db, reg: registry}
+
+	form := url.Values{
+		"__journal_settings": {`{"columns":[{"field":"Сумма","visible":true},{"field":"Номер","visible":false}]}`},
+		"__return":           {"/ui/journal/журнал?f.Номер=42"},
+	}
+	r := reqWithChi(http.MethodPost, "/ui/journal/Журнал/settings/save", form, map[string]string{"name": "Журнал"})
+	w := httptest.NewRecorder()
+	s.journalSettingsSave(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("save status: got %d body=%s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "/ui/journal/") || !strings.Contains(strings.ToLower(loc), "f.%d0%9d%d0%be%d0%bc%d0%b5%d1%80=42") {
+		t.Fatalf("save redirect: %q", loc)
+	}
+	got, _ := db.GetJournalUserSettings(ctx, "Журнал", "")
+	if !strings.Contains(got, `"field":"Сумма"`) || !strings.Contains(got, `"field":"Контрагент"`) || strings.Contains(got, "НетТакого") {
+		t.Fatalf("saved canonical settings: %s", got)
+	}
+
+	r2 := reqWithChi(http.MethodPost, "/ui/journal/Журнал/settings/reset", url.Values{"__return": {"/ui/journal/журнал"}}, map[string]string{"name": "Журнал"})
+	w2 := httptest.NewRecorder()
+	s.journalSettingsReset(w2, r2)
+	if w2.Code != http.StatusSeeOther {
+		t.Fatalf("reset status: got %d body=%s", w2.Code, w2.Body.String())
+	}
+	if got, _ := db.GetJournalUserSettings(ctx, "Журнал", ""); got != "" {
+		t.Fatalf("settings after reset: %s", got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -209,6 +209,8 @@ func (s *Server) Mount(r chi.Router) {
 	r.Post("/ui/report/{name}/settings/save", s.reportSettingsSave)
 	r.Post("/ui/report/{name}/settings/delete", s.reportPresetDelete)
 	r.Post("/ui/report/{name}/settings/reset", s.reportSettingsReset)
+	r.Post("/ui/journal/{name}/settings/save", s.journalSettingsSave)
+	r.Post("/ui/journal/{name}/settings/reset", s.journalSettingsReset)
 	r.Get("/ui/processor/{name}", s.processorForm)
 	r.Post("/ui/processor/{name}", s.processorRun)
 	r.Post("/ui/processor/{name}/form-event", s.handleProcessorFormEvent)

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -3730,11 +3730,62 @@ const tplJournal = `
   </form>
 </details>
 
+<details class="card report-block" data-block="journal-settings" style="margin-bottom:16px">
+  <summary>{{t $.Lang "Настройка списка"}}{{if .JournalSettingsActive}} <span style="background:#fef3c7;color:#92400e;border-radius:6px;padding:1px 8px;font-size:12px;font-weight:600">{{t $.Lang "изменено"}}</span>{{end}}</summary>
+  <form method="POST" action="/ui/journal/{{lower .Journal.Name}}/settings/save" onsubmit="return jlBeforeSubmit(event)">
+    <input type="hidden" name="__return" value="{{.RequestURI}}">
+    <input type="hidden" name="__journal_settings" id="jl-settings-json" value="{{.JournalSettingsJSON}}">
+    <table style="width:auto;margin-bottom:12px">
+      <thead><tr>
+        <th style="text-align:left">{{t $.Lang "Поле"}}</th>
+        <th style="padding:0 10px">{{t $.Lang "Показывать"}}</th>
+        <th style="width:120px"></th>
+      </tr></thead>
+      <tbody id="jl-columns">
+      {{range .JournalSettingsColumns}}
+        <tr class="jl-col-row" data-field="{{.Column.Field}}">
+          <td>{{.Column.DisplayLabel $.Lang}}</td>
+          <td style="text-align:center"><input type="checkbox" class="jl-visible" {{if .Visible}}checked{{end}}></td>
+          <td style="white-space:nowrap;text-align:right">
+            <button type="button" class="btn btn-sm" onclick="jlMove(this,-1)" title="{{t $.Lang "Вверх"}}">↑</button>
+            <button type="button" class="btn btn-sm" onclick="jlMove(this,1)" title="{{t $.Lang "Вниз"}}">↓</button>
+          </td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+    <div style="display:flex;gap:8px;flex-wrap:wrap">
+      <button class="btn btn-primary" type="submit">{{t $.Lang "Сохранить"}}</button>
+      <button class="btn" type="submit" formaction="/ui/journal/{{lower .Journal.Name}}/settings/reset"{{if not .JournalSettingsActive}} disabled{{end}}>{{t $.Lang "Стандартные настройки"}}</button>
+    </div>
+  </form>
+  <script>
+  (function(){
+    window.jlMove=function(btn,dir){
+      var tr=btn&&btn.closest?btn.closest('tr'):null;if(!tr||!tr.parentNode)return;
+      if(dir<0&&tr.previousElementSibling)tr.parentNode.insertBefore(tr,tr.previousElementSibling);
+      if(dir>0&&tr.nextElementSibling)tr.parentNode.insertBefore(tr.nextElementSibling,tr);
+    };
+    window.jlCollect=function(){
+      var rows=document.querySelectorAll('#jl-columns .jl-col-row');
+      var cols=[];
+      rows.forEach(function(row){
+        var cb=row.querySelector('.jl-visible');
+        cols.push({field:row.getAttribute('data-field')||'',visible:!!(cb&&cb.checked)});
+      });
+      var hidden=document.getElementById('jl-settings-json');
+      if(hidden)hidden.value=JSON.stringify({columns:cols});
+    };
+    window.jlBeforeSubmit=function(){jlCollect();return true;};
+  })();
+  </script>
+</details>
+
 <div class="card">
 {{if .Rows}}
 <table><thead><tr>
   <th>{{t $.Lang "Документ"}}</th>
-  {{range $j.Columns}}<th>{{.Label}}</th>{{end}}
+  {{range .JournalColumns}}<th>{{.DisplayLabel $.Lang}}</th>{{end}}
   <th style="width:90px"></th>
 </tr></thead>
 <tbody>
@@ -3743,7 +3794,7 @@ const tplJournal = `
   onclick="if(event.target.tagName!=='A'&&event.target.tagName!=='BUTTON'){window.location='/ui/document/'+encodeURIComponent('{{lower (str (index . "_doc_kind"))}}')+'/'+'{{str (index . "id")}}'}"
 >
   <td>{{index . "_doc_kind"}}</td>
-  {{range $j.Columns}}
+  {{range $.JournalColumns}}
     {{$v := index $row .Field}}
     {{if eq (index $fmts .Field) "date"}}<td>{{fmtDate $v}}</td>
     {{else}}<td>{{$v}}</td>{{end}}


### PR DESCRIPTION
Summary:
- add per-user journal column settings stored in _settings
- apply effective journal columns to both HTML journal tables and Excel export
- add a settings panel with visibility toggles, ordering controls, save/reset, and canonicalization against YAML columns

Tests:
- go test ./...

Closes #235