### PR TITLE
feat(storage): add register load indexes

### DIFF
--- a/internal/configcheck/lint.go
+++ b/internal/configcheck/lint.go
@@ -56,6 +56,7 @@ func CheckLintProject(dir string, proj *project.Project, roles []*auth.Role) []I
 	var issues []Issue
 	issues = append(issues, CheckLintDSL(dir, proj)...)
 	issues = append(issues, CheckLintRoles(proj, roles)...)
+	issues = append(issues, CheckLintIndexes(proj)...)
 	return issues
 }
 
@@ -1224,6 +1225,67 @@ func CheckLintRoles(proj *project.Project, roles []*auth.Role) []Issue {
 		}
 	}
 	return issues
+}
+
+func CheckLintIndexes(proj *project.Project) []Issue {
+	if proj == nil {
+		return nil
+	}
+	var issues []Issue
+	for _, ent := range proj.Entities {
+		if ent == nil || len(ent.ListForm) == 0 {
+			continue
+		}
+		for _, fieldName := range ent.ListForm {
+			f := findLintEntityField(ent, fieldName)
+			if f == nil || !lintFieldNeedsIndex(*f) || hasLeadingIndex(ent, f.Name) {
+				continue
+			}
+			kindDir, kindName := "catalogs", "Справочник"
+			if ent.Kind == metadata.KindDocument {
+				kindDir, kindName = "documents", "Документ"
+			}
+			issues = append(issues, Issue{
+				File:         kindDir + "/" + ent.Name + ".yaml",
+				Object:       ent.Name,
+				Kind:         kindName,
+				Code:         "metadata.list-field-without-index",
+				Message:      fmt.Sprintf("поле %q используется в list_form, но не покрыто ведущим полем indexes:", f.Name),
+				SuggestedFix: fmt.Sprintf("Добавьте в %s/%s.yaml блок `indexes: - fields: [%s]` или составной индекс, где %s идёт первым.", kindDir, ent.Name, f.Name, f.Name),
+			})
+		}
+	}
+	return issues
+}
+
+func findLintEntityField(ent *metadata.Entity, name string) *metadata.Field {
+	for i := range ent.Fields {
+		if strings.EqualFold(ent.Fields[i].Name, name) {
+			return &ent.Fields[i]
+		}
+	}
+	return nil
+}
+
+func lintFieldNeedsIndex(f metadata.Field) bool {
+	if f.RefEntity != "" {
+		return true
+	}
+	switch f.Type {
+	case metadata.FieldTypeString, metadata.FieldTypeDate, metadata.FieldTypeNumber, metadata.FieldTypeBool:
+		return true
+	default:
+		return false
+	}
+}
+
+func hasLeadingIndex(ent *metadata.Entity, fieldName string) bool {
+	for _, idx := range ent.Indexes {
+		if len(idx.Fields) > 0 && strings.EqualFold(idx.Fields[0], fieldName) {
+			return true
+		}
+	}
+	return false
 }
 
 func programLabel(dir string, prog *ast.Program) string {

--- a/internal/configcheck/lint_test.go
+++ b/internal/configcheck/lint_test.go
@@ -108,6 +108,57 @@ indexes:
 	}
 }
 
+func TestLintProject_ListFormFieldWithoutIndex(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "catalogs", "товар.yaml"), `name: Товар
+fields:
+  - name: Артикул
+    type: string
+  - name: Наименование
+    type: string
+list_form: [Артикул, Наименование]
+indexes:
+  - fields: [Наименование]
+`)
+
+	lint := RunFullWithOptions(dir, Options{Lint: true})
+	if !lint.OK {
+		t.Fatalf("lint check should keep OK=true for warnings: %+v", lint.Issues)
+	}
+	var found *Issue
+	for i := range lint.Warnings {
+		if lint.Warnings[i].Code == "metadata.list-field-without-index" {
+			found = &lint.Warnings[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("metadata.list-field-without-index not found; got %+v", lint.Warnings)
+	}
+	if !strings.Contains(found.Message, "Артикул") {
+		t.Fatalf("warning should point to Артикул, got %+v", found)
+	}
+}
+
+func TestLintProject_ListFormLeadingIndexSuppressesWarning(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "catalogs", "товар.yaml"), `name: Товар
+fields:
+  - name: Артикул
+    type: string
+list_form: [Артикул]
+indexes:
+  - fields: [Артикул]
+`)
+
+	lint := RunFullWithOptions(dir, Options{Lint: true})
+	for _, w := range lint.Warnings {
+		if w.Code == "metadata.list-field-without-index" {
+			t.Fatalf("unexpected index warning: %+v", w)
+		}
+	}
+}
+
 func TestLintYAML_JournalConditionalKnown(t *testing.T) {
 	dir := t.TempDir()
 	mkFile(t, filepath.Join(dir, "journals", "ж.yaml"), `name: Ж

--- a/internal/storage/ddl.go
+++ b/internal/storage/ddl.go
@@ -80,6 +80,36 @@ func CreateTablePartParentIndexSQL(entityName, tpName string) string {
 	return CreateEntityIndexSQL(table, []string{"parent_id", "строка"}, false)
 }
 
+func CreateRegisterPeriodIndexSQL(regName string) string {
+	table := metadata.RegisterTableName(regName)
+	return CreateEntityIndexSQL(table, []string{"period"}, false)
+}
+
+func CreateRegisterDimPeriodIndexSQL(reg *metadata.Register) string {
+	table := metadata.RegisterTableName(reg.Name)
+	cols := registerDimPeriodIndexColumns(reg)
+	if len(cols) == 0 {
+		return ""
+	}
+	return CreateEntityIndexSQL(table, cols, false)
+}
+
+func registerDimPeriodIndexColumns(reg *metadata.Register) []string {
+	if reg == nil || len(reg.Dimensions) == 0 {
+		return nil
+	}
+	limit := len(reg.Dimensions)
+	if limit > 3 {
+		limit = 3
+	}
+	cols := make([]string, 0, limit+1)
+	for _, f := range reg.Dimensions[:limit] {
+		cols = append(cols, metadata.ColumnName(f))
+	}
+	cols = append(cols, "period")
+	return cols
+}
+
 func stableIndexName(table string, cols []string, unique bool) string {
 	kind := "n"
 	if unique {

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -77,6 +77,21 @@ func (db *DB) MigrateRegisters(ctx context.Context, registers []*metadata.Regist
 				return fmt.Errorf("migrate register %s.%s: %w", reg.Name, f.Name, err)
 			}
 		}
+		if err := db.ensureRegisterIndexes(ctx, reg); err != nil {
+			return fmt.Errorf("migrate register %s indexes: %w", reg.Name, err)
+		}
+	}
+	return nil
+}
+
+func (db *DB) ensureRegisterIndexes(ctx context.Context, reg *metadata.Register) error {
+	if _, err := db.Exec(ctx, CreateRegisterPeriodIndexSQL(reg.Name)); err != nil {
+		return err
+	}
+	if sql := CreateRegisterDimPeriodIndexSQL(reg); sql != "" {
+		if _, err := db.Exec(ctx, sql); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -300,6 +300,40 @@ func TestSQLiteMigrateCreatesEntityAndTablePartIndexes(t *testing.T) {
 	}
 }
 
+func TestSQLiteMigrateRegistersCreatesPeriodAndDimensionIndexes(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "reg-indexes.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	defer db.Close()
+
+	reg := &metadata.Register{
+		Name: "ОстаткиТоваров",
+		Dimensions: []metadata.Field{
+			{Name: "Склад", Type: "reference:Склады", RefEntity: "Склады"},
+			{Name: "Номенклатура", Type: "reference:Номенклатура", RefEntity: "Номенклатура"},
+			{Name: "Серия", Type: metadata.FieldTypeString},
+			{Name: "Качество", Type: metadata.FieldTypeString},
+		},
+		Resources: []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatalf("MigrateRegisters: %v", err)
+	}
+
+	table := metadata.RegisterTableName(reg.Name)
+	periodIndex := stableIndexName(table, []string{"period"}, false)
+	if !sqliteIndexExists(t, db, table, periodIndex, false, []string{"period"}) {
+		t.Fatalf("period index %s on %s(period) not found", periodIndex, table)
+	}
+	dimCols := []string{"склад_id", "номенклатура_id", "серия", "period"}
+	dimIndex := stableIndexName(table, dimCols, false)
+	if !sqliteIndexExists(t, db, table, dimIndex, false, dimCols) {
+		t.Fatalf("dimension index %s on %s(%v) not found", dimIndex, table, dimCols)
+	}
+}
+
 func sqliteIndexExists(t *testing.T, db *DB, table, index string, unique bool, wantCols []string) bool {
 	t.Helper()
 	rows, err := db.Query(context.Background(), "PRAGMA index_list("+sqliteIdent(table)+")")


### PR DESCRIPTION
Plan76 B/C follow-up.\n\nЧто изменено:\n- MigrateRegisters создаёт идемпотентный индекс по period для регистров накопления.\n- Для первых трёх измерений создаётся составной индекс (dim..., period), чтобы ускорить типовые фильтры/остатки без ручной декларации.\n- onebase lint предупреждает, если явно заданное поле list_form не покрыто ведущим полем indexes:.\n\nПроверки:\n- go test ./internal/storage ./internal/configcheck\n- go test ./...