### PR TITLE
feat(api): add REST API v2 baseline

### DIFF
--- a/Plans/26-rest-api-v2.md
+++ b/Plans/26-rest-api-v2.md
@@ -1,6 +1,13 @@
 # Этап 26 — REST API v2 (фильтры, пагинация, OpenAPI)
 
-**Статус:** ⬜ Не начато
+**Статус:** 🟨 Частично реализовано
+
+**Актуализация 2026-07-06:** первый PR v2 берёт стабильный HTTP-контракт
+`/api/v2/catalog|document/...`: envelope `{data, meta}`, `page/limit`,
+`filter[F]`, CRUD, `post/unpost` и `openapi.json`, переиспользуя текущие
+session/RBAC guardrails и `entityservice.Save`. Bearer API-токены, admin UI
+токенов и JSON-исполнение отчётов остаются отдельными PR, чтобы не смешивать
+контракт API с новой моделью аутентификации и runtime отчётов.
 
 **Актуализация 2026-06-25:** перед полноценным v2 нужно закрыть guardrails из
 плана 76: RBAC в текущем REST API, дефолтные лимиты/пагинацию, caps на размер

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -440,6 +441,208 @@ func TestAPI_List_InvalidLimit(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIV2_ListEnvelopePageAndFilter(t *testing.T) {
+	cat := &metadata.Entity{
+		Name: "Товар",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+		},
+	}
+	h, ctx := newAPITestHandler(t, []*metadata.Entity{cat}, nil)
+	for _, name := range []string{"Молоток 1", "Молоток 2", "Гвоздь"} {
+		if err := h.store.Upsert(ctx, "Товар", uuid.New(), map[string]any{"Наименование": name}, cat); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	target := "/api/v2/catalog/Товар?limit=1&page=2&sort=" + url.QueryEscape("Наименование") +
+		"&filter%5B" + url.QueryEscape("Наименование") + "%5D=" + url.QueryEscape("Молоток")
+	r := reqWithEntity("GET", target, nil, map[string]string{"name": "Товар"}, nil)
+	w := httptest.NewRecorder()
+	h.listObjectsV2(metadata.KindCatalog).ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Data []map[string]any `json:"data"`
+		Meta restV2Meta       `json:"meta"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("len(data) = %d, want 1: %#v", len(resp.Data), resp.Data)
+	}
+	if resp.Data[0]["Наименование"] != "Молоток 2" {
+		t.Fatalf("second page row = %#v, want Молоток 2", resp.Data[0])
+	}
+	if resp.Meta.Total != 2 || resp.Meta.Page != 2 || resp.Meta.Limit != 1 || resp.Meta.TotalPages != 2 {
+		t.Fatalf("bad meta: %+v", resp.Meta)
+	}
+}
+
+func TestAPIV2_CRUDRoundTripEnvelope(t *testing.T) {
+	cat := &metadata.Entity{
+		Name: "Товар",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+		},
+	}
+	h, ctx := newAPITestHandler(t, []*metadata.Entity{cat}, nil)
+
+	createReq := reqWithEntity("POST", "/api/v2/catalog/Товар", []byte(`{"Наименование":"Молоток"}`), map[string]string{"name": "Товар"}, nil)
+	createRec := httptest.NewRecorder()
+	h.createObjectV2(metadata.KindCatalog).ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusOK {
+		t.Fatalf("create: expected 200, got %d: %s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.Data.ID == "" {
+		t.Fatal("create returned empty id")
+	}
+
+	getReq := reqWithEntity("GET", "/api/v2/catalog/Товар/"+created.Data.ID, nil, map[string]string{"name": "Товар", "id": created.Data.ID}, nil)
+	getRec := httptest.NewRecorder()
+	h.getObjectV2(metadata.KindCatalog).ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d: %s", getRec.Code, getRec.Body.String())
+	}
+	var got struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Data["Наименование"] != "Молоток" {
+		t.Fatalf("get data = %#v", got.Data)
+	}
+
+	updateReq := reqWithEntity("PUT", "/api/v2/catalog/Товар/"+created.Data.ID, []byte(`{"Наименование":"Дрель"}`), map[string]string{"name": "Товар", "id": created.Data.ID}, nil)
+	updateRec := httptest.NewRecorder()
+	h.updateObjectV2(metadata.KindCatalog).ServeHTTP(updateRec, updateReq)
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", updateRec.Code, updateRec.Body.String())
+	}
+
+	id := uuid.MustParse(created.Data.ID)
+	row, err := h.store.GetByID(ctx, "Товар", id, cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row["Наименование"] != "Дрель" {
+		t.Fatalf("stored name = %#v", row)
+	}
+
+	deleteReq := reqWithEntity("DELETE", "/api/v2/catalog/Товар/"+created.Data.ID, nil, map[string]string{"name": "Товар", "id": created.Data.ID}, nil)
+	deleteRec := httptest.NewRecorder()
+	h.deleteObjectV2(metadata.KindCatalog).ServeHTTP(deleteRec, deleteReq)
+	if deleteRec.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d: %s", deleteRec.Code, deleteRec.Body.String())
+	}
+	if _, err := h.store.GetByID(ctx, "Товар", id, cat); err == nil {
+		t.Fatal("deleted object is still readable")
+	}
+}
+
+func TestAPIV2_RBAC_DeniesListWithoutRead(t *testing.T) {
+	cat := &metadata.Entity{
+		Name:   "Товар",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	h, ctx := newAPITestHandler(t, []*metadata.Entity{cat}, nil)
+	if err := h.store.Upsert(ctx, "Товар", uuid.New(), map[string]any{"Наименование": "Молоток"}, cat); err != nil {
+		t.Fatal(err)
+	}
+	user := apiUser("writer", auth.Permission{
+		Catalogs: map[string][]string{"Товар": {"write"}},
+	})
+
+	r := reqWithEntity("GET", "/api/v2/catalog/Товар", nil, map[string]string{"name": "Товар"}, nil)
+	r = withUser(r, user)
+	w := httptest.NewRecorder()
+	h.listObjectsV2(metadata.KindCatalog).ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAPIV2_UnpostDocument(t *testing.T) {
+	doc := &metadata.Entity{
+		Name:    "Поступление",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	h, ctx := newAPITestHandler(t, []*metadata.Entity{doc}, nil)
+	id := uuid.New()
+	if err := h.store.Upsert(ctx, "Поступление", id, map[string]any{"Номер": "1"}, doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.store.SetPosted(ctx, "Поступление", id, true); err != nil {
+		t.Fatal(err)
+	}
+
+	r := reqWithEntity("POST", "/api/v2/document/Поступление/"+id.String()+"/unpost", nil, map[string]string{"name": "Поступление", "id": id.String()}, nil)
+	w := httptest.NewRecorder()
+	h.unpostDocumentV2().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	row, err := h.store.GetByID(ctx, "Поступление", id, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row["posted"] != false {
+		t.Fatalf("posted = %#v, want false; row=%#v", row["posted"], row)
+	}
+}
+
+func TestAPIV2_OpenAPIIncludesPathsAndSchemas(t *testing.T) {
+	cat := &metadata.Entity{
+		Name:   "Товар",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	doc := &metadata.Entity{
+		Name:    "Поступление",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	spec := buildOpenAPIV2([]*metadata.Entity{cat, doc})
+
+	if spec["openapi"] != "3.0.3" {
+		t.Fatalf("openapi = %#v", spec["openapi"])
+	}
+	paths := spec["paths"].(map[string]any)
+	if _, ok := paths["/api/v2/catalog/{name}"]; !ok {
+		t.Fatalf("missing catalog path: %#v", paths)
+	}
+	if _, ok := paths["/api/v2/document/{name}/{id}/unpost"]; !ok {
+		t.Fatalf("missing unpost path: %#v", paths)
+	}
+	components := spec["components"].(map[string]any)
+	schemas := components["schemas"].(map[string]any)
+	schema := schemas["catalog_Товар"].(map[string]any)
+	props := schema["properties"].(map[string]any)
+	if _, ok := props["Наименование"]; !ok {
+		t.Fatalf("catalog schema lacks field: %#v", props)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -110,6 +110,9 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 		// Posting/un-posting документа (аналог UI-кнопки «Провести»).
 		r.Post("/documents/{entity}/{id}/post", h.postDocument())
 
+		// REST API v2 — envelope/meta, page/filter[] and OpenAPI contract.
+		h.mountV2(r)
+
 		// Web UI
 		uiSrv.Mount(r)
 

--- a/internal/api/v2.go
+++ b/internal/api/v2.go
@@ -1,0 +1,659 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/entityservice"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+type restV2Envelope struct {
+	Data any         `json:"data"`
+	Meta *restV2Meta `json:"meta,omitempty"`
+}
+
+type restV2Meta struct {
+	Total      int `json:"total"`
+	Page       int `json:"page"`
+	Limit      int `json:"limit"`
+	TotalPages int `json:"total_pages"`
+}
+
+func (h *handler) mountV2(r chi.Router) {
+	r.Route("/api/v2", func(r chi.Router) {
+		r.Get("/openapi.json", h.openapiV2())
+
+		r.Get("/catalog/{name}", h.listObjectsV2(metadata.KindCatalog))
+		r.Post("/catalog/{name}", h.createObjectV2(metadata.KindCatalog))
+		r.Get("/catalog/{name}/{id}", h.getObjectV2(metadata.KindCatalog))
+		r.Put("/catalog/{name}/{id}", h.updateObjectV2(metadata.KindCatalog))
+		r.Delete("/catalog/{name}/{id}", h.deleteObjectV2(metadata.KindCatalog))
+
+		r.Get("/document/{name}", h.listObjectsV2(metadata.KindDocument))
+		r.Post("/document/{name}", h.createObjectV2(metadata.KindDocument))
+		r.Get("/document/{name}/{id}", h.getObjectV2(metadata.KindDocument))
+		r.Put("/document/{name}/{id}", h.updateObjectV2(metadata.KindDocument))
+		r.Delete("/document/{name}/{id}", h.deleteObjectV2(metadata.KindDocument))
+		r.Post("/document/{name}/{id}/post", h.postDocumentV2())
+		r.Post("/document/{name}/{id}/unpost", h.unpostDocumentV2())
+	})
+}
+
+func (h *handler) listObjectsV2(kind metadata.Kind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entity, entityName, ok := h.entityFromV2Route(w, r, kind)
+		if !ok {
+			return
+		}
+		if !requireRESTPerm(w, r, kind, entityName, "read") {
+			return
+		}
+		params, page, err := parseRestListParamsV2(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error(), "", 0)
+			return
+		}
+		rows, err := h.store.List(r.Context(), entityName, entity, params)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			return
+		}
+		total, err := h.store.CountList(r.Context(), entityName, entity, params)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			return
+		}
+		w.Header().Set("X-Total-Count", strconv.Itoa(total))
+		w.Header().Set("X-Limit", strconv.Itoa(params.Limit))
+		w.Header().Set("X-Offset", strconv.Itoa(params.Offset))
+		writeJSONV2(w, http.StatusOK, restV2Envelope{
+			Data: rows,
+			Meta: &restV2Meta{
+				Total:      total,
+				Page:       page,
+				Limit:      params.Limit,
+				TotalPages: totalPages(total, params.Limit),
+			},
+		})
+	}
+}
+
+func (h *handler) getObjectV2(kind metadata.Kind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entity, entityName, ok := h.entityFromV2Route(w, r, kind)
+		if !ok {
+			return
+		}
+		if !requireRESTPerm(w, r, kind, entityName, "read") {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid id", "", 0)
+			return
+		}
+		result, err := h.store.GetByID(r.Context(), entityName, id, entity)
+		if err != nil {
+			writeError(w, http.StatusNotFound, err.Error(), "", 0)
+			return
+		}
+		writeJSONV2(w, http.StatusOK, restV2Envelope{Data: result})
+	}
+}
+
+func (h *handler) createObjectV2(kind metadata.Kind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entity, entityName, ok := h.entityFromV2Route(w, r, kind)
+		if !ok {
+			return
+		}
+		if !requireRESTPerm(w, r, kind, entityName, "write") {
+			return
+		}
+		limitRESTBody(w, r)
+		body, err := decodeBody(r)
+		if err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		if kind == metadata.KindDocument && isPostAction(body.Action) && !requireRESTPerm(w, r, kind, entityName, "post") {
+			return
+		}
+		if kind == metadata.KindDocument {
+			ensureDocumentNumber(r.Context(), h.store, entity, body.Fields)
+		}
+
+		result, err := h.entitySvc.Save(r.Context(), entityservice.SaveRequest{
+			Entity:        entity,
+			ID:            uuid.New(),
+			IsNew:         true,
+			Fields:        body.Fields,
+			TablePartRows: body.TablePartRows,
+			Action:        body.Action,
+		})
+		writeSaveResultV2(w, result, err, result.ID, false)
+	}
+}
+
+func (h *handler) updateObjectV2(kind metadata.Kind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entity, entityName, ok := h.entityFromV2Route(w, r, kind)
+		if !ok {
+			return
+		}
+		if !requireRESTPerm(w, r, kind, entityName, "write") {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid id", "", 0)
+			return
+		}
+		limitRESTBody(w, r)
+		body, err := decodeBody(r)
+		if err != nil {
+			writeDecodeError(w, err)
+			return
+		}
+		if kind == metadata.KindDocument && isPostAction(body.Action) && !requireRESTPerm(w, r, kind, entityName, "post") {
+			return
+		}
+
+		var expectedVersion *int64
+		if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
+			if v, perr := strconv.ParseInt(strings.Trim(ifMatch, `"`), 10, 64); perr == nil {
+				expectedVersion = &v
+			}
+		}
+
+		result, err := h.entitySvc.Save(r.Context(), entityservice.SaveRequest{
+			Entity:          entity,
+			ID:              id,
+			IsNew:           false,
+			Fields:          body.Fields,
+			TablePartRows:   body.TablePartRows,
+			Action:          body.Action,
+			ExpectedVersion: expectedVersion,
+		})
+		writeSaveResultV2(w, result, err, id, false)
+	}
+}
+
+func (h *handler) deleteObjectV2(kind metadata.Kind) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_, entityName, ok := h.entityFromV2Route(w, r, kind)
+		if !ok {
+			return
+		}
+		if !requireRESTPerm(w, r, kind, entityName, "delete") {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid id", "", 0)
+			return
+		}
+		if err := h.store.WithTx(r.Context(), func(ctx context.Context) error {
+			if kind == metadata.KindDocument {
+				if err := h.clearMovements(ctx, entityName, id); err != nil {
+					return err
+				}
+			}
+			return h.store.Delete(ctx, entityName, id)
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (h *handler) postDocumentV2() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entity, entityName, ok := h.entityFromV2Route(w, r, metadata.KindDocument)
+		if !ok {
+			return
+		}
+		if !entity.Posting {
+			writeError(w, http.StatusBadRequest, "entity is not postable: "+entityName, "", 0)
+			return
+		}
+		if !requireRESTPerm(w, r, metadata.KindDocument, entityName, "post") {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid id", "", 0)
+			return
+		}
+
+		fields, tpRows, ok := h.documentPostPayload(w, r, entity, entityName, id)
+		if !ok {
+			return
+		}
+
+		result, err := h.entitySvc.Save(r.Context(), entityservice.SaveRequest{
+			Entity:        entity,
+			ID:            id,
+			IsNew:         false,
+			Fields:        fields,
+			TablePartRows: tpRows,
+			Action:        "post",
+		})
+		writeSaveResultV2(w, result, err, id, true)
+	}
+}
+
+func (h *handler) unpostDocumentV2() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entity, entityName, ok := h.entityFromV2Route(w, r, metadata.KindDocument)
+		if !ok {
+			return
+		}
+		if !entity.Posting {
+			writeError(w, http.StatusBadRequest, "entity is not postable: "+entityName, "", 0)
+			return
+		}
+		if !requireRESTPerm(w, r, metadata.KindDocument, entityName, "unpost") {
+			return
+		}
+		id, err := uuid.Parse(chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid id", "", 0)
+			return
+		}
+		if err := h.store.WithTx(r.Context(), func(ctx context.Context) error {
+			if err := h.clearMovements(ctx, entityName, id); err != nil {
+				return err
+			}
+			return h.store.SetPosted(ctx, entityName, id, false)
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			return
+		}
+		writeJSONV2(w, http.StatusOK, restV2Envelope{Data: map[string]any{
+			"id":     id.String(),
+			"posted": false,
+		}})
+	}
+}
+
+func (h *handler) documentPostPayload(w http.ResponseWriter, r *http.Request, entity *metadata.Entity, entityName string, id uuid.UUID) (map[string]any, map[string][]map[string]any, bool) {
+	if r.ContentLength > 0 {
+		if !requireRESTPerm(w, r, metadata.KindDocument, entityName, "write") {
+			return nil, nil, false
+		}
+		limitRESTBody(w, r)
+		body, err := decodeBody(r)
+		if err != nil {
+			writeDecodeError(w, err)
+			return nil, nil, false
+		}
+		return body.Fields, body.TablePartRows, true
+	}
+
+	fields, err := h.store.GetByID(r.Context(), entityName, id, entity)
+	if err != nil {
+		writeError(w, http.StatusNotFound, err.Error(), "", 0)
+		return nil, nil, false
+	}
+	tpRows := make(map[string][]map[string]any, len(entity.TableParts))
+	for _, tp := range entity.TableParts {
+		rows, err := h.store.GetTablePartRows(r.Context(), entityName, tp.Name, id, tp)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			return nil, nil, false
+		}
+		tpRows[tp.Name] = rows
+	}
+	return fields, tpRows, true
+}
+
+func (h *handler) clearMovements(ctx context.Context, entityName string, id uuid.UUID) error {
+	for _, reg := range h.reg.Registers() {
+		if err := h.store.WriteMovements(ctx, reg.Name, entityName, id, nil, reg, nil); err != nil {
+			return err
+		}
+	}
+	for _, ir := range h.reg.InfoRegisters() {
+		if err := h.store.WriteInfoMovements(ctx, ir.Name, entityName, id, nil, ir, nil); err != nil {
+			return err
+		}
+	}
+	for _, ar := range h.reg.AccountRegisters() {
+		if err := h.store.WriteAccountMovements(ctx, ar.Name, entityName, id, nil, ar, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *handler) entityFromV2Route(w http.ResponseWriter, r *http.Request, kind metadata.Kind) (*metadata.Entity, string, bool) {
+	entityName := capitalize(chi.URLParam(r, "name"))
+	entity := h.reg.GetEntity(entityName)
+	if entity == nil || entity.Kind != kind {
+		writeError(w, http.StatusNotFound, "unknown entity: "+entityName, "", 0)
+		return nil, entityName, false
+	}
+	return entity, entity.Name, true
+}
+
+func ensureDocumentNumber(ctx context.Context, store *storage.DB, entity *metadata.Entity, fields map[string]any) {
+	for _, f := range entity.Fields {
+		if f.Name == "Номер" && f.Type == metadata.FieldTypeString {
+			if v, _ := fields["Номер"].(string); strings.TrimSpace(v) == "" {
+				fields["Номер"] = generateAutoNumber(ctx, store, entity, fields)
+			}
+			return
+		}
+	}
+}
+
+func writeSaveResultV2(w http.ResponseWriter, result entityservice.SaveResult, err error, id uuid.UUID, posted bool) {
+	if err != nil {
+		if errors.Is(err, storage.ErrVersionConflict) {
+			writeError(w, http.StatusConflict, "version conflict: object was modified by another client", "", 0)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+		return
+	}
+	if result.DSLError != "" {
+		writeError(w, http.StatusUnprocessableEntity, result.DSLError, "", 0)
+		return
+	}
+	data := map[string]any{
+		"id":       id.String(),
+		"messages": result.DSLMessages,
+	}
+	if posted {
+		data["posted"] = true
+	}
+	writeJSONV2(w, http.StatusOK, restV2Envelope{Data: data})
+}
+
+func writeJSONV2(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func parseRestListParamsV2(r *http.Request) (storage.ListParams, int, error) {
+	q := r.URL.Query()
+	limit, err := parsePositiveInt(q.Get("limit"), restDefaultLimit)
+	if err != nil {
+		return storage.ListParams{}, 0, errors.New("invalid limit")
+	}
+	if limit > restMaxLimit {
+		limit = restMaxLimit
+	}
+	page, err := parsePositiveInt(q.Get("page"), 1)
+	if err != nil {
+		return storage.ListParams{}, 0, errors.New("invalid page")
+	}
+	offset := (page - 1) * limit
+	if q.Get("offset") != "" {
+		offset, err = parseNonNegativeInt(q.Get("offset"), 0)
+		if err != nil {
+			return storage.ListParams{}, 0, errors.New("invalid offset")
+		}
+		page = offset/limit + 1
+	}
+	params := storage.ListParams{
+		Filters: parseRestFiltersV2(r),
+		Search:  q.Get("q"),
+		Limit:   limit,
+		Offset:  offset,
+	}
+	if s := q.Get("sort"); s != "" {
+		params.Sort = s
+	}
+	if d := q.Get("dir"); d != "" {
+		params.Dir = d
+	}
+	return params, page, nil
+}
+
+func parseRestFiltersV2(r *http.Request) map[string]storage.FilterValue {
+	filters := parseRestFilters(r)
+	for k, vals := range r.URL.Query() {
+		if len(vals) == 0 || !strings.HasPrefix(k, "filter[") || !strings.HasSuffix(k, "]") {
+			continue
+		}
+		key := strings.TrimSuffix(strings.TrimPrefix(k, "filter["), "]")
+		if key == "" {
+			continue
+		}
+		field, attr := splitFilterKey(key)
+		fv := filters[field]
+		switch attr {
+		case "from":
+			fv.From = vals[0]
+		case "to":
+			fv.To = vals[0]
+		default:
+			fv.Value = vals[0]
+		}
+		filters[field] = fv
+	}
+	return filters
+}
+
+func splitFilterKey(key string) (string, string) {
+	if strings.HasSuffix(key, ".from") {
+		return strings.TrimSuffix(key, ".from"), "from"
+	}
+	if strings.HasSuffix(key, ".to") {
+		return strings.TrimSuffix(key, ".to"), "to"
+	}
+	return key, "value"
+}
+
+func totalPages(total, limit int) int {
+	if total <= 0 || limit <= 0 {
+		return 0
+	}
+	return (total + limit - 1) / limit
+}
+
+func (h *handler) openapiV2() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSONV2(w, http.StatusOK, buildOpenAPIV2(h.reg.Entities()))
+	}
+}
+
+func buildOpenAPIV2(entities []*metadata.Entity) map[string]any {
+	components := map[string]any{
+		"schemas": map[string]any{
+			"ListMeta": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"total":       map[string]any{"type": "integer"},
+					"page":        map[string]any{"type": "integer"},
+					"limit":       map[string]any{"type": "integer"},
+					"total_pages": map[string]any{"type": "integer"},
+				},
+			},
+			"Envelope": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"data": map[string]any{},
+					"meta": map[string]any{"$ref": "#/components/schemas/ListMeta"},
+				},
+			},
+		},
+		"securitySchemes": map[string]any{
+			"sessionCookie": map[string]any{"type": "apiKey", "in": "cookie", "name": "onebase_session"},
+		},
+	}
+	schemas := components["schemas"].(map[string]any)
+	for _, e := range entities {
+		schemas[entitySchemaName(e)] = entityOpenAPISchema(e)
+	}
+
+	doc := map[string]any{
+		"openapi": "3.0.3",
+		"info":    map[string]any{"title": "onebase REST API", "version": "v2"},
+		"servers": []any{map[string]any{"url": "/"}},
+		"security": []any{
+			map[string]any{"sessionCookie": []any{}},
+		},
+		"paths":      openAPIV2Paths(),
+		"components": components,
+	}
+	return doc
+}
+
+func openAPIV2Paths() map[string]any {
+	nameParam := map[string]any{"name": "name", "in": "path", "required": true, "schema": map[string]any{"type": "string"}}
+	idParam := map[string]any{"name": "id", "in": "path", "required": true, "schema": map[string]any{"type": "string", "format": "uuid"}}
+	listParams := []any{
+		nameParam,
+		map[string]any{"name": "q", "in": "query", "schema": map[string]any{"type": "string"}},
+		map[string]any{"name": "page", "in": "query", "schema": map[string]any{"type": "integer", "minimum": 1}},
+		map[string]any{"name": "limit", "in": "query", "schema": map[string]any{"type": "integer", "minimum": 1, "maximum": restMaxLimit}},
+		map[string]any{"name": "sort", "in": "query", "schema": map[string]any{"type": "string"}},
+		map[string]any{"name": "dir", "in": "query", "schema": map[string]any{"type": "string", "enum": []string{"asc", "desc"}}},
+		map[string]any{"name": "filter[Field]", "in": "query", "schema": map[string]any{"type": "string"}},
+	}
+	jsonBody := map[string]any{
+		"required": false,
+		"content": map[string]any{
+			"application/json": map[string]any{"schema": map[string]any{"type": "object"}},
+		},
+	}
+	okEnvelope := map[string]any{
+		"description": "OK",
+		"content": map[string]any{
+			"application/json": map[string]any{"schema": map[string]any{"$ref": "#/components/schemas/Envelope"}},
+		},
+	}
+	noContent := map[string]any{"description": "No Content"}
+	crud := func(tag string) map[string]any {
+		return map[string]any{
+			"get": map[string]any{
+				"summary":    "List " + tag,
+				"tags":       []string{tag},
+				"parameters": listParams,
+				"responses":  map[string]any{"200": okEnvelope},
+			},
+			"post": map[string]any{
+				"summary":     "Create " + tag,
+				"tags":        []string{tag},
+				"parameters":  []any{nameParam},
+				"requestBody": jsonBody,
+				"responses":   map[string]any{"200": okEnvelope},
+			},
+		}
+	}
+	item := func(tag string) map[string]any {
+		return map[string]any{
+			"get": map[string]any{
+				"summary":    "Get " + tag,
+				"tags":       []string{tag},
+				"parameters": []any{nameParam, idParam},
+				"responses":  map[string]any{"200": okEnvelope},
+			},
+			"put": map[string]any{
+				"summary":     "Update " + tag,
+				"tags":        []string{tag},
+				"parameters":  []any{nameParam, idParam},
+				"requestBody": jsonBody,
+				"responses":   map[string]any{"200": okEnvelope},
+			},
+			"delete": map[string]any{
+				"summary":    "Delete " + tag,
+				"tags":       []string{tag},
+				"parameters": []any{nameParam, idParam},
+				"responses":  map[string]any{"204": noContent},
+			},
+		}
+	}
+	return map[string]any{
+		"/api/v2/catalog/{name}":              crud("catalog"),
+		"/api/v2/catalog/{name}/{id}":         item("catalog"),
+		"/api/v2/document/{name}":             crud("document"),
+		"/api/v2/document/{name}/{id}":        item("document"),
+		"/api/v2/document/{name}/{id}/post":   actionPath("Post document", nameParam, idParam, okEnvelope),
+		"/api/v2/document/{name}/{id}/unpost": actionPath("Unpost document", nameParam, idParam, okEnvelope),
+		"/api/v2/openapi.json": map[string]any{
+			"get": map[string]any{
+				"summary":   "OpenAPI document",
+				"tags":      []string{"openapi"},
+				"responses": map[string]any{"200": okEnvelope},
+			},
+		},
+	}
+}
+
+func actionPath(summary string, nameParam, idParam, okEnvelope map[string]any) map[string]any {
+	return map[string]any{
+		"post": map[string]any{
+			"summary":    summary,
+			"tags":       []string{"document"},
+			"parameters": []any{nameParam, idParam},
+			"responses":  map[string]any{"200": okEnvelope},
+		},
+	}
+}
+
+func entityOpenAPISchema(e *metadata.Entity) map[string]any {
+	props := map[string]any{
+		"id":            map[string]any{"type": "string", "format": "uuid"},
+		"deletion_mark": map[string]any{"type": "boolean"},
+	}
+	if e.Kind == metadata.KindDocument {
+		props["posted"] = map[string]any{"type": "boolean"}
+	}
+	for _, f := range e.Fields {
+		props[f.Name] = fieldOpenAPISchema(f)
+	}
+	if len(e.TableParts) > 0 {
+		tpProps := map[string]any{}
+		for _, tp := range e.TableParts {
+			rowProps := map[string]any{}
+			for _, f := range tp.Fields {
+				rowProps[f.Name] = fieldOpenAPISchema(f)
+			}
+			tpProps[tp.Name] = map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "object", "properties": rowProps},
+			}
+		}
+		props["__tableparts"] = map[string]any{"type": "object", "properties": tpProps}
+	}
+	return map[string]any{"type": "object", "properties": props}
+}
+
+func fieldOpenAPISchema(f metadata.Field) map[string]any {
+	if f.RefEntity != "" || metadata.IsReference(f.Type) {
+		return map[string]any{"type": "string", "format": "uuid"}
+	}
+	if f.EnumName != "" || metadata.IsEnum(f.Type) {
+		return map[string]any{"type": "string"}
+	}
+	switch f.Type {
+	case metadata.FieldTypeDate:
+		return map[string]any{"type": "string", "format": "date-time"}
+	case metadata.FieldTypeNumber:
+		return map[string]any{"type": "number"}
+	case metadata.FieldTypeBool:
+		return map[string]any{"type": "boolean"}
+	case metadata.FieldTypeImage:
+		return map[string]any{"type": "string", "format": "uuid"}
+	default:
+		return map[string]any{"type": "string"}
+	}
+}
+
+func entitySchemaName(e *metadata.Entity) string {
+	return string(e.Kind) + "_" + e.Name
+}


### PR DESCRIPTION
## Summary
- add protected /api/v2 catalog/document CRUD routes with {data, meta} envelope
- support page/limit, filter[Field], q/sort/dir and OpenAPI 3.0.3 output
- add document post/unpost v2 endpoints reusing entityservice/RBAC guardrails

## Tests
- go test ./internal/api
- go test ./...

## Notes
- Bearer API tokens/admin UI and JSON report execution remain separate Plan 26 follow-up PRs.