### PR TITLE
feat(dsl): add cached reference attribute access

### DIFF
--- a/internal/dsl/interpreter/collections.go
+++ b/internal/dsl/interpreter/collections.go
@@ -21,6 +21,14 @@ type RefManager interface {
 	LoadObject(uuidStr string) (any, error)
 }
 
+// RefAttrResolver is an optional, host-provided resolver for object attributes
+// addressed through a reference value. It deliberately lives in interpreter to
+// avoid importing ui/storage here; concrete implementations are supplied by
+// callers that know how to read metadata-backed objects.
+type RefAttrResolver interface {
+	ResolveRefAttr(ref *Ref, field string) (any, bool)
+}
+
 // Ref represents a DSL reference value: UUID for identity/SQL, Name for display.
 // Строка(ref) returns Name; SQL parameter expansion uses UUID.
 type Ref struct {
@@ -32,6 +40,10 @@ type Ref struct {
 	// Manager — менеджер объекта; задаётся при создании ссылки и позволяет
 	// Ссылка.Удалить() работать. nil → метод поднимет понятную ошибку.
 	Manager RefManager
+	// AttrResolver enables safe host-side single-hop attribute reads such as
+	// Ссылка.Артикул. It is optional; bare references still expose only display
+	// name, UUID and methods.
+	AttrResolver RefAttrResolver
 }
 
 func (r *Ref) String() string     { return r.Name }
@@ -85,6 +97,11 @@ func (r *Ref) Get(field string) any {
 		return r
 	case "уникальныйидентификатор", "уидентификатор", "uuid", "ид", "id":
 		return r.UUID
+	}
+	if r.AttrResolver != nil {
+		if v, ok := r.AttrResolver.ResolveRefAttr(r, field); ok {
+			return v
+		}
 	}
 	return nil
 }
@@ -178,11 +195,11 @@ func (a *Array) SetIndex(i int, val any) {
 	}
 }
 
-func (a *Array) Iterate() []any { return a.items }
-func (a *Array) String() string  { return fmt.Sprintf("Массив[%d]", len(a.items)) }
+func (a *Array) Iterate() []any   { return a.items }
+func (a *Array) String() string   { return fmt.Sprintf("Массив[%d]", len(a.items)) }
 func (a *Array) TypeName() string { return "Массив" }
 
-func (m *Map) Keys() []any            { return m.keys }
+func (m *Map) Keys() []any { return m.keys }
 func (m *Map) Get(key any) any {
 	if idx := m.findIdx(key); idx >= 0 {
 		return m.vals[idx]
@@ -234,8 +251,8 @@ func (s *Struct) Set(field string, v any) {
 	}
 	s.vals[key] = v
 }
-func (s *Struct) String() string          { return fmt.Sprintf("Структура[%d]", len(s.keys)) }
-func (s *Struct) TypeName() string        { return "Структура" }
+func (s *Struct) String() string   { return fmt.Sprintf("Структура[%d]", len(s.keys)) }
+func (s *Struct) TypeName() string { return "Структура" }
 
 func (s *Struct) CallMethod(name string, args []any) any {
 	switch name {
@@ -364,7 +381,7 @@ func (kv *KeyValue) Get(field string) any {
 }
 
 func (kv *KeyValue) Set(field string, val any) {}
-func (kv *KeyValue) TypeName() string           { return "КлючИЗначение" }
+func (kv *KeyValue) TypeName() string          { return "КлючИЗначение" }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 

--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -325,6 +325,13 @@ func (i *Interpreter) execStmt(s ast.Stmt, e *env) {
 					break
 				}
 			}
+		case interface{ IterateThis() []This }:
+			for _, item := range items.IterateThis() {
+				e.set(v.Var.Literal, item)
+				if !i.execLoopBody(v.Body, e) {
+					break
+				}
+			}
 		default:
 			// Поддержка прокси-объектов вроде *formTpProxy: если у значения
 			// есть метод IterateRows() — итерируемся по нему. Без этого

--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -70,12 +70,12 @@ type Service struct {
 	// Справочники и т.п. в нём не будут работать).
 	BuildVars func(ctx context.Context, mc *runtime.MovementsCollector, msgs *[]string) map[string]any
 
-	// MakeThis оборачивает (obj, entity) в this для интерпретатора так, чтобы
+	// MakeThis оборачивает (ctx, obj, entity) в this для интерпретатора так, чтобы
 	// внутри DSL-хука работали методы табличных частей: this.Товары.Добавить(),
 	// this.Товары.Количество(), `Для Каждого Стр Из this.Товары`. Реализация
 	// живёт в ui-слое (formObjectThis), здесь только хук. Если nil — Run
 	// получает obj напрямую, что для документов без ТЧ тоже работает.
-	MakeThis func(obj *runtime.Object, entity *metadata.Entity) interpreter.This
+	MakeThis func(ctx context.Context, obj *runtime.Object, entity *metadata.Entity) interpreter.This
 
 	// Hooks — диспетчер исходящих веб-хуков (план 29). nil = веб-хуки не
 	// настроены. Событие отправляется ПОСЛЕ успешной транзакции (асинхронно):
@@ -222,7 +222,11 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 		if s.BuildVars != nil {
 			vars = s.BuildVars(ctx, mc, &msgs)
 		}
-		if err := s.Interp.Run(proc, obj, vars); err != nil {
+		var thisVal interpreter.This = obj
+		if s.MakeThis != nil {
+			thisVal = s.MakeThis(ctx, obj, req.Entity)
+		}
+		if err := s.Interp.Run(proc, thisVal, vars); err != nil {
 			// DSL-ошибка (бизнес-правило), а не технический сбой: отдаём текст
 			// в DSLError, БД не трогаем. И *interpreter.DSLError, и обычная
 			// ошибка форматируются одинаково через Error().
@@ -437,7 +441,7 @@ func (s *Service) Fill(ctx context.Context, req FillRequest) (FillResult, error)
 	// фабрику; иначе — голый *Object (для документов без ТЧ всё равно работает).
 	var thisVal interpreter.This = recvObj
 	if s.MakeThis != nil {
-		thisVal = s.MakeThis(recvObj, req.Receiver)
+		thisVal = s.MakeThis(ctx, recvObj, req.Receiver)
 	}
 	if err := s.Interp.Run(proc, thisVal, vars); err != nil {
 		normalizeTPRowKeys(recvObj.TablePartRows, req.Receiver)

--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -27,11 +27,11 @@ import (
 // `Объект.Поле`, а в обработках OnPost — `ЭтотОбъект.Поле`. Делаем оба
 // варианта рабочими.
 type formObjectThis struct {
-	obj    *runtime.Object
-	entity *metadata.Entity
-	form    *metadata.FormModule
+	obj         *runtime.Object
+	entity      *metadata.Entity
+	form        *metadata.FormModule
+	refResolver *dslRefAttrResolver
 }
-
 
 func (f *formObjectThis) Get(name string) any {
 	if f == nil || f.obj == nil {
@@ -41,23 +41,32 @@ func (f *formObjectThis) Get(name string) any {
 	// Сначала — табличные части. Возвращаем прокси даже если slice ещё nil,
 	// чтобы .Добавить() мог создать первую строку.
 	if f.entity != nil {
-		for _, tp := range f.entity.TableParts {
+		for i := range f.entity.TableParts {
+			tp := &f.entity.TableParts[i]
 			if strings.ToLower(tp.Name) == nameLower {
-				return &formTpProxy{obj: f.obj, tpName: tp.Name}
+				return &formTpProxy{obj: f.obj, tpName: tp.Name, tp: tp, refResolver: f.refResolver}
 			}
 		}
 	}
-		// Формовые атрибуты-таблицы (ValueTable). Если имя не найдено среди ТЧ сущности,
-		// ищем формовый атрибут ValueTable и возвращаем для него тот же formTpProxy.
-		if f.form != nil {
-			for _, attr := range f.form.Attributes {
-				if strings.EqualFold(attr.Name, name) && strings.EqualFold(attr.TypeRef, "ValueTable") {
-					return &formTpProxy{obj: f.obj, tpName: attr.Name}
-				}
+	// Формовые атрибуты-таблицы (ValueTable). Если имя не найдено среди ТЧ сущности,
+	// ищем формовый атрибут ValueTable и возвращаем для него тот же formTpProxy.
+	if f.form != nil {
+		for _, attr := range f.form.Attributes {
+			if strings.EqualFold(attr.Name, name) && strings.EqualFold(attr.TypeRef, "ValueTable") {
+				return &formTpProxy{obj: f.obj, tpName: attr.Name, refResolver: f.refResolver}
 			}
 		}
+	}
 	// Дальше — обычные поля (через Object.Get который ищет в Fields).
 	v := f.obj.Get(name)
+	if ref, ok := v.(*interpreter.Ref); ok && f.refResolver != nil {
+		if fd := entityField(f.entity, name); fd != nil && fd.RefEntity != "" {
+			return f.refResolver.attachRef(ref, fd.RefEntity)
+		}
+		if f.entity != nil && (strings.EqualFold(name, "Ссылка") || strings.EqualFold(name, "Reference")) {
+			return f.refResolver.attachRef(ref, f.entity.Name)
+		}
+	}
 	// Дефолты по типу: пустой numeric → 0, иначе `Объект.Сумма + 100` в DSL
 	// даст concat-строку «<nil>100» (DSL `+` для nil-операнда склеивает
 	// строкой), потом форма попытается записать её в PostgreSQL numeric →
@@ -91,8 +100,10 @@ func (f *formObjectThis) Set(name string, v any) {
 // docWriter — потому что в обработчиках формы документ ещё не записан и нет
 // открытой транзакции записи.
 type formTpProxy struct {
-	obj    *runtime.Object
-	tpName string
+	obj         *runtime.Object
+	tpName      string
+	tp          *metadata.TablePart
+	refResolver *dslRefAttrResolver
 }
 
 func (t *formTpProxy) Get(_ string) any    { return nil }
@@ -109,7 +120,7 @@ func (t *formTpProxy) CallMethod(method string, args []any) any {
 		}
 		row := map[string]any{}
 		t.obj.TablePartRows[t.tpName] = append(t.obj.TablePartRows[t.tpName], row)
-		return &interpreter.MapThis{M: row}
+		return newRefAwareMapThis(row, t.tp, t.refResolver)
 	case "очистить", "clear":
 		if t.obj.TablePartRows != nil {
 			t.obj.TablePartRows[t.tpName] = nil
@@ -131,4 +142,25 @@ func (t *formTpProxy) IterateRows() []map[string]any {
 		return nil
 	}
 	return t.obj.TablePartRows[t.tpName]
+}
+
+func (t *formTpProxy) IterateThis() []interpreter.This {
+	rows := t.IterateRows()
+	out := make([]interpreter.This, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, newRefAwareMapThis(row, t.tp, t.refResolver))
+	}
+	return out
+}
+
+func entityField(entity *metadata.Entity, name string) *metadata.Field {
+	if entity == nil {
+		return nil
+	}
+	for i := range entity.Fields {
+		if strings.EqualFold(entity.Fields[i].Name, name) {
+			return &entity.Fields[i]
+		}
+	}
+	return nil
 }

--- a/internal/ui/dsl_object_attr_test.go
+++ b/internal/ui/dsl_object_attr_test.go
@@ -26,12 +26,16 @@ func TestObjectAttributeValue(t *testing.T) {
 
 	контрагент := &metadata.Entity{
 		Name: "Контрагент", Kind: metadata.KindCatalog,
-		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "ИНН", Type: metadata.FieldTypeString},
+		},
 	}
 	номенклатура := &metadata.Entity{
 		Name: "Номенклатура", Kind: metadata.KindCatalog,
 		Fields: []metadata.Field{
 			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Артикул", Type: metadata.FieldTypeString},
 			{Name: "СтавкаНДС", Type: metadata.FieldTypeNumber},
 			{Name: "Поставщик", Type: "reference:Контрагент", RefEntity: "Контрагент"},
 		},
@@ -55,9 +59,10 @@ func TestObjectAttributeValue(t *testing.T) {
 		return w.CallMethod("записать", nil).(*interpreter.Ref)
 	}
 
-	постРеф := create("Контрагент", map[string]any{"Наименование": "ООО Поставщик"})
+	постРеф := create("Контрагент", map[string]any{"Наименование": "ООО Поставщик", "ИНН": "7701234567"})
 	номРеф := create("Номенклатура", map[string]any{
 		"Наименование": "Стул",
+		"Артикул":      "A-1",
 		"СтавкаНДС":    float64(20),
 		"Поставщик":    постРеф,
 	})
@@ -140,6 +145,46 @@ func TestObjectAttributeValue(t *testing.T) {
 	}
 	if result != "ООО Поставщик" {
 		t.Errorf("DSL sample result = %v, ожидалось ООО Поставщик", result)
+	}
+
+	doc := &metadata.Entity{
+		Name: "ЗаказПокупателя", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "ОсновнаяНоменклатура", Type: "reference:Номенклатура", RefEntity: "Номенклатура"},
+		},
+		TableParts: []metadata.TablePart{{
+			Name: "Товары",
+			Fields: []metadata.Field{
+				{Name: "Номенклатура", Type: "reference:Номенклатура", RefEntity: "Номенклатура"},
+			},
+		}},
+	}
+	obj := runtime.NewObject(doc.Name, doc.Kind)
+	obj.Fields["ОсновнаяНоменклатура"] = номРеф
+	obj.TablePartRows["Товары"] = []map[string]any{{"Номенклатура": номРеф}}
+	thisObj := s.newFormObjectThis(ctx, obj, doc, nil)
+	src = `Функция Тест()
+  Рез = Объект.ОсновнаяНоменклатура.Артикул;
+  Для Каждого Стр Из Объект.Товары Цикл
+    Рез = Рез + "|" + Стр.Номенклатура.Артикул;
+    Если Стр.Номенклатура.Поставщик.ИНН <> Неопределено Тогда
+      Рез = "double-deref";
+    КонецЕсли;
+  КонецЦикла;
+  Возврат Рез;
+КонецФункции`
+	l = lexer.New(src, "test.os")
+	p = parser.New(l)
+	prog, err = p.ParseProgram()
+	if err != nil {
+		t.Fatalf("parse DSL ref attr sample: %v", err)
+	}
+	result = nil
+	if err := interp.RunWithResult(prog.Procedures[0], thisObj, &result, map[string]any{"Объект": thisObj}); err != nil {
+		t.Fatalf("run DSL ref attr sample: %v", err)
+	}
+	if result != "A-1|A-1" {
+		t.Errorf("DSL ref attr sample result = %v, ожидалось A-1|A-1", result)
 	}
 
 	// Неизвестный реквизит → ошибка, а не тихий nil.

--- a/internal/ui/dsl_ref_attr.go
+++ b/internal/ui/dsl_ref_attr.go
@@ -1,0 +1,275 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+type dslRefAttrResolver struct {
+	s     *Server
+	ctx   context.Context
+	cache map[string]map[string]map[string]any // entity -> uuid -> field name -> value
+}
+
+func (s *Server) newDSLRefAttrResolver(ctx context.Context) *dslRefAttrResolver {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &dslRefAttrResolver{
+		s:     s,
+		ctx:   ctx,
+		cache: map[string]map[string]map[string]any{},
+	}
+}
+
+func (s *Server) newFormObjectThis(ctx context.Context, obj *runtime.Object, entity *metadata.Entity, form *metadata.FormModule) *formObjectThis {
+	var resolver *dslRefAttrResolver
+	if s != nil && s.store != nil && s.reg != nil {
+		resolver = s.newDSLRefAttrResolver(ctx)
+		resolver.attachObject(entity, obj)
+	}
+	return &formObjectThis{obj: obj, entity: entity, form: form, refResolver: resolver}
+}
+
+func (r *dslRefAttrResolver) ResolveRefAttr(ref *interpreter.Ref, field string) (any, bool) {
+	if r == nil || r.s == nil || ref == nil || strings.TrimSpace(ref.UUID) == "" || strings.TrimSpace(ref.Type) == "" {
+		return nil, false
+	}
+	entity := r.s.reg.GetEntity(ref.Type)
+	if entity == nil {
+		return nil, false
+	}
+	fd := findObjectAttributeField(entity, field)
+	if fd == nil {
+		return nil, false
+	}
+	idStr, id, ok := uuidFromValue(ref.UUID)
+	if !ok {
+		return nil, true
+	}
+	if !r.hasRow(entity.Name, idStr) {
+		if err := r.preloadIDs(entity, []uuid.UUID{id}); err != nil {
+			interpreter.RaiseUserError("Чтение реквизита " + entity.Name + "." + fd.Name + ": " + err.Error())
+		}
+	}
+	row := r.cache[entity.Name][idStr]
+	if row == nil {
+		return nil, true
+	}
+	return row[fd.Name], true
+}
+
+func (r *dslRefAttrResolver) attachObject(entity *metadata.Entity, obj *runtime.Object) {
+	if r == nil || entity == nil || obj == nil {
+		return
+	}
+	batch := map[string]map[string]uuid.UUID{}
+	r.collectRefValue(batch, entity.Name, obj.Get("Ссылка"))
+	r.collectRefValue(batch, entity.Name, obj.Get("Reference"))
+
+	for _, fd := range entity.Fields {
+		if fd.RefEntity == "" {
+			continue
+		}
+		if _, v, ok := lookupMapCI(obj.Fields, fd.Name); ok {
+			r.collectRefValue(batch, fd.RefEntity, v)
+		}
+	}
+	for _, tp := range entity.TableParts {
+		rows := obj.TablePartRows[tp.Name]
+		for _, fd := range tp.Fields {
+			if fd.RefEntity == "" {
+				continue
+			}
+			for _, row := range rows {
+				if _, v, ok := lookupMapCI(row, fd.Name); ok {
+					r.collectRefValue(batch, fd.RefEntity, v)
+				}
+			}
+		}
+	}
+	r.preloadBatch(batch)
+}
+
+func (r *dslRefAttrResolver) collectRefValue(batch map[string]map[string]uuid.UUID, entityName string, raw any) {
+	entityName = strings.TrimSpace(entityName)
+	if entityName == "" {
+		return
+	}
+	if ref, ok := raw.(*interpreter.Ref); ok {
+		r.attachRef(ref, entityName)
+	}
+	idStr, id, ok := uuidFromValue(raw)
+	if !ok {
+		return
+	}
+	if batch[entityName] == nil {
+		batch[entityName] = map[string]uuid.UUID{}
+	}
+	batch[entityName][idStr] = id
+}
+
+func (r *dslRefAttrResolver) attachRef(ref *interpreter.Ref, entityName string) *interpreter.Ref {
+	if r == nil || ref == nil {
+		return ref
+	}
+	if ref.Type == "" {
+		ref.Type = entityName
+	}
+	if ref.Manager == nil && r.s != nil {
+		ref.Manager = r.s.refManagerFor(r.s.reg.GetEntity(ref.Type), r.ctx)
+	}
+	ref.AttrResolver = r
+	return ref
+}
+
+func (r *dslRefAttrResolver) preloadBatch(batch map[string]map[string]uuid.UUID) {
+	for entityName, idsByString := range batch {
+		entity := r.s.reg.GetEntity(entityName)
+		if entity == nil || len(idsByString) == 0 {
+			continue
+		}
+		ids := make([]uuid.UUID, 0, len(idsByString))
+		for _, id := range idsByString {
+			ids = append(ids, id)
+		}
+		if err := r.preloadIDs(entity, ids); err != nil {
+			interpreter.RaiseUserError("Предзагрузка реквизитов " + entity.Name + ": " + err.Error())
+		}
+	}
+}
+
+func (r *dslRefAttrResolver) preloadIDs(entity *metadata.Entity, ids []uuid.UUID) error {
+	if r == nil || r.s == nil || entity == nil || len(ids) == 0 {
+		return nil
+	}
+	missing := make([]uuid.UUID, 0, len(ids))
+	seen := map[string]bool{}
+	for _, id := range ids {
+		idStr := id.String()
+		if seen[idStr] || r.hasRow(entity.Name, idStr) {
+			continue
+		}
+		seen[idStr] = true
+		missing = append(missing, id)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	fields := uniqueObjectFields(append(entity.Fields, displayField(entity)...))
+	rows, err := r.s.store.GetFieldsByIDs(r.ctx, entity, missing, fields)
+	if err != nil {
+		return fmt.Errorf("%s: %w", entity.Name, err)
+	}
+	r.cacheRows(entity, rows)
+	return nil
+}
+
+func (r *dslRefAttrResolver) cacheRows(entity *metadata.Entity, rows map[string]map[string]any) {
+	if r.cache[entity.Name] == nil {
+		r.cache[entity.Name] = map[string]map[string]any{}
+	}
+	refNames := r.s.bulkReferenceNames(r.ctx, rows, entity.Fields)
+	for idStr, row := range rows {
+		vals := make(map[string]any, len(entity.Fields))
+		for _, fd := range entity.Fields {
+			raw := row[fd.Name]
+			if fd.RefEntity != "" {
+				vals[fd.Name] = r.s.refFromValueCached(r.ctx, fd.RefEntity, raw, refNames[fd.RefEntity])
+			} else {
+				vals[fd.Name] = normalizeAttrValue(fd.Type, raw)
+			}
+		}
+		r.cache[entity.Name][idStr] = vals
+	}
+}
+
+func (r *dslRefAttrResolver) hasRow(entityName, idStr string) bool {
+	return r != nil && r.cache[entityName] != nil && r.cache[entityName][idStr] != nil
+}
+
+func lookupMapCI(m map[string]any, name string) (string, any, bool) {
+	low := strings.ToLower(name)
+	for k, v := range m {
+		if strings.ToLower(k) == low {
+			return k, v, true
+		}
+	}
+	return "", nil, false
+}
+
+type refAwareMapThis struct {
+	row      map[string]any
+	tp       *metadata.TablePart
+	resolver *dslRefAttrResolver
+}
+
+func newRefAwareMapThis(row map[string]any, tp *metadata.TablePart, resolver *dslRefAttrResolver) interpreter.This {
+	if resolver == nil || tp == nil {
+		return &interpreter.MapThis{M: row}
+	}
+	return &refAwareMapThis{row: row, tp: tp, resolver: resolver}
+}
+
+func (m *refAwareMapThis) Get(name string) any {
+	if m == nil {
+		return nil
+	}
+	_, v, ok := lookupMapCI(m.row, name)
+	if !ok {
+		return nil
+	}
+	return m.wrapValue(name, v)
+}
+
+func (m *refAwareMapThis) Set(name string, v any) {
+	if m == nil {
+		return
+	}
+	low := strings.ToLower(name)
+	for k := range m.row {
+		if strings.ToLower(k) == low {
+			m.row[k] = v
+			return
+		}
+	}
+	m.row[low] = v
+}
+
+func (m *refAwareMapThis) wrapValue(name string, v any) any {
+	fd := tablePartField(m.tp, name)
+	if fd == nil || fd.RefEntity == "" {
+		return v
+	}
+	if ref, ok := v.(*interpreter.Ref); ok {
+		return m.resolver.attachRef(ref, fd.RefEntity)
+	}
+	idStr, _, ok := uuidFromValue(v)
+	if !ok {
+		return v
+	}
+	return m.resolver.attachRef(&interpreter.Ref{
+		UUID:    idStr,
+		Name:    idStr,
+		Type:    fd.RefEntity,
+		Manager: m.resolver.s.refManagerFor(m.resolver.s.reg.GetEntity(fd.RefEntity), m.resolver.ctx),
+	}, fd.RefEntity)
+}
+
+func tablePartField(tp *metadata.TablePart, name string) *metadata.Field {
+	if tp == nil {
+		return nil
+	}
+	for i := range tp.Fields {
+		if strings.EqualFold(tp.Fields[i].Name, name) {
+			return &tp.Fields[i]
+		}
+	}
+	return nil
+}

--- a/internal/ui/fill_test.go
+++ b/internal/ui/fill_test.go
@@ -101,7 +101,7 @@ func TestFill_OnFillHook_CopiesFieldsAndTablePart(t *testing.T) {
 	interp.LookupProc = registry.GetModuleProc
 	svc := &entityservice.Service{
 		Store: db, Reg: registry, Interp: interp,
-		MakeThis: func(obj *runtime.Object, e *metadata.Entity) interpreter.This {
+		MakeThis: func(ctx context.Context, obj *runtime.Object, e *metadata.Entity) interpreter.This {
 			return &formObjectThis{obj: obj, entity: e}
 		},
 	}

--- a/internal/ui/form_server_events.go
+++ b/internal/ui/form_server_events.go
@@ -105,7 +105,7 @@ func (s *Server) runFormReadHook(ctx context.Context, entity *metadata.Entity, f
 	mc := runtime.NewMovementsCollector(entity.Name, obj.ID)
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)
-	thisObj := &formObjectThis{obj: obj, entity: entity, form: form}
+	thisObj := s.newFormObjectThis(ctx, obj, entity, form)
 	vars["Объект"] = thisObj
 	vars["ЭтотОбъект"] = thisObj
 
@@ -150,7 +150,7 @@ func (s *Server) runFormWriteHook(ctx context.Context, entity *metadata.Entity, 
 
 	mc := runtime.NewMovementsCollector(entity.Name, obj.ID)
 	vars := s.buildDSLVarsWithMessages(ctx, mc, msgs)
-	thisObj := &formObjectThis{obj: obj, entity: entity, form: form}
+	thisObj := s.newFormObjectThis(ctx, obj, entity, form)
 	vars["Объект"] = thisObj
 	vars["ЭтотОбъект"] = thisObj
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -783,34 +783,46 @@ func (s *Server) enrichTPRowsWithRefs(ctx context.Context, tp metadata.TablePart
 		if refEntity == nil {
 			continue
 		}
-		// collect unique IDs
-		seen := map[string]bool{}
+		idsByString := map[string]uuid.UUID{}
 		for _, row := range rows {
-			if v := row[f.Name]; v != nil {
-				seen[fmt.Sprintf("%v", v)] = true
+			if _, v, ok := lookupMapCI(row, f.Name); ok {
+				idStr, id, ok := uuidFromValue(v)
+				if ok {
+					idsByString[idStr] = id
+				}
 			}
 		}
-		// resolve each unique ID to a display label
-		labels := make(map[string]string, len(seen))
-		for idStr := range seen {
-			id, err := uuid.Parse(idStr)
-			if err != nil {
-				continue
-			}
-			refRow, err := s.store.GetByID(ctx, refEntity.Name, id, refEntity)
-			if err != nil {
-				continue
-			}
+		if len(idsByString) == 0 {
+			continue
+		}
+		ids := make([]uuid.UUID, 0, len(idsByString))
+		for _, id := range idsByString {
+			ids = append(ids, id)
+		}
+		refRows, err := s.store.GetFieldsByIDs(ctx, refEntity, ids, displayField(refEntity))
+		if err != nil {
+			continue
+		}
+		labels := make(map[string]string, len(refRows))
+		for idStr, refRow := range refRows {
 			labels[idStr] = firstStringField(refRow, refEntity)
 		}
 		// replace plain UUID strings with *interpreter.Ref{UUID, Name, Manager}
 		mgr := s.refManagerFor(refEntity, ctx)
 		for _, row := range rows {
-			if v := row[f.Name]; v != nil {
-				idStr := fmt.Sprintf("%v", v)
-				if name, ok := labels[idStr]; ok {
-					row[f.Name] = &interpreter.Ref{UUID: idStr, Name: name, Type: refEntity.Name, Manager: mgr}
-				}
+			matchKey, v, ok := lookupMapCI(row, f.Name)
+			if !ok || v == nil {
+				continue
+			}
+			if _, isRef := v.(*interpreter.Ref); isRef {
+				continue
+			}
+			idStr, _, ok := uuidFromValue(v)
+			if !ok {
+				continue
+			}
+			if name, ok := labels[idStr]; ok {
+				row[matchKey] = &interpreter.Ref{UUID: idStr, Name: name, Type: refEntity.Name, Manager: mgr}
 			}
 		}
 	}
@@ -855,8 +867,12 @@ func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, 
 		if err != nil {
 			continue
 		}
-		refRow, err := s.store.GetByID(ctx, refEntity.Name, id, refEntity)
+		refRows, err := s.store.GetFieldsByIDs(ctx, refEntity, []uuid.UUID{id}, displayField(refEntity))
 		if err != nil {
+			continue
+		}
+		refRow := refRows[id.String()]
+		if refRow == nil {
 			continue
 		}
 		obj.Fields[matchKey] = &interpreter.Ref{

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -167,7 +167,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	mc := runtime.NewMovementsCollector(entity.Name, obj.ID)
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(r.Context(), mc, &msgs)
-	thisObj := &formObjectThis{obj: obj, entity: entity, form: form}
+	thisObj := s.newFormObjectThis(r.Context(), obj, entity, form)
 	vars["Объект"] = thisObj
 	vars["ЭтотОбъект"] = thisObj
 
@@ -726,7 +726,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 				mc := runtime.NewMovementsCollector("processor", uuid.Nil)
 				var msgs []string
 				vars := s.buildDSLVarsWithMessages(r.Context(), mc, &msgs)
-				thisObj := &formObjectThis{obj: obj, entity: virtEntity}
+				thisObj := s.newFormObjectThis(r.Context(), obj, virtEntity, nil)
 				vars["Объект"] = thisObj
 				vars["ЭтотОбъект"] = thisObj
 				vars["Параметры"] = thisObj

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"html/template"
 	"net/http"
 	"sort"
@@ -112,8 +113,8 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 		// MakeThis — обёртка над *runtime.Object с поддержкой методов ТЧ
 		// (this.Товары.Добавить() и т.п.). Без неё ОбработкаЗаполнения не
 		// смогла бы построить строки табличной части в приёмнике.
-		MakeThis: func(obj *runtime.Object, e *metadata.Entity) interpreter.This {
-			return &formObjectThis{obj: obj, entity: e}
+		MakeThis: func(ctx context.Context, obj *runtime.Object, e *metadata.Entity) interpreter.This {
+			return s.newFormObjectThis(ctx, obj, e, nil)
 		},
 		// Исходящие веб-хуки (план 29): save/post диспетчеризуются из Save.
 		Hooks: cfg.Webhooks,

--- a/internal/ui/submit_test.go
+++ b/internal/ui/submit_test.go
@@ -62,6 +62,9 @@ func newSubmitTestServer(t *testing.T, entities []*metadata.Entity) (*Server, co
 		PrepareHook:  s.enrichHeaderRefs,
 		EnrichTPRows: s.enrichTPRowsWithRefs,
 		BuildVars:    s.buildDSLVarsWithMessages,
+		MakeThis: func(ctx context.Context, obj *runtime.Object, e *metadata.Entity) interpreter.This {
+			return s.newFormObjectThis(ctx, obj, e, nil)
+		},
 	}
 	return s, ctx
 }


### PR DESCRIPTION
## Summary
- add single-hop cached reference attribute access for DSL refs such as `Стр.Номенклатура.Артикул`
- preload reference attributes for form object header/table-part rows and use ref-aware row wrappers in DSL loops
- keep explicit `ЗначенияРеквизитовОбъектов` bulk path and switch reference enrichment to `GetFieldsByIDs`

## Safety
- nested reference attributes are not given the resolver, so `Стр.Номенклатура.Поставщик.ИНН` does not trigger hidden second-hop loading
- `Save` now uses `MakeThis(ctx, ...)` like `Fill`, preserving table-part methods while carrying request context

## Tests
- `go test ./...`