### PR TITLE
ui: bound hierarchical folder options

### DIFF
--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -24,6 +24,7 @@ type ListParams struct {
 	Limit          int    // 0 = no limit
 	Offset         int    // for pagination
 	ExcludeFolders bool   // for hierarchical catalogs: only non-folder elements
+	OnlyFolders    bool   // for hierarchical catalogs: only folder elements
 }
 
 // FilterValue holds a filter for one field.
@@ -293,8 +294,14 @@ func activityWhere(d Dialect, entity *metadata.Entity, scope string) string {
 	}
 }
 
-func excludeFoldersWhere(d Dialect, entity *metadata.Entity, exclude bool) string {
-	if entity == nil || !entity.Hierarchical || !exclude {
+func folderScopeWhere(d Dialect, entity *metadata.Entity, onlyFolders, excludeFolders bool) string {
+	if entity == nil || !entity.Hierarchical {
+		return ""
+	}
+	if onlyFolders {
+		return fmt.Sprintf("is_folder = %s", boolTrueLit(d))
+	}
+	if !excludeFolders {
 		return ""
 	}
 	return fmt.Sprintf("(is_folder IS NULL OR is_folder = %s)", boolFalseLit(d))
@@ -336,7 +343,7 @@ func (db *DB) List(ctx context.Context, entityName string, entity *metadata.Enti
 	if cond := activityWhere(d, entity, params.ActivityScope); cond != "" {
 		whereParts = append(whereParts, cond)
 	}
-	if cond := excludeFoldersWhere(d, entity, params.ExcludeFolders); cond != "" {
+	if cond := folderScopeWhere(d, entity, params.OnlyFolders, params.ExcludeFolders); cond != "" {
 		whereParts = append(whereParts, cond)
 	}
 
@@ -502,7 +509,7 @@ func (db *DB) CountList(ctx context.Context, entityName string, entity *metadata
 	if cond := activityWhere(d, entity, params.ActivityScope); cond != "" {
 		whereParts = append(whereParts, cond)
 	}
-	if cond := excludeFoldersWhere(d, entity, params.ExcludeFolders); cond != "" {
+	if cond := folderScopeWhere(d, entity, params.OnlyFolders, params.ExcludeFolders); cond != "" {
 		whereParts = append(whereParts, cond)
 	}
 

--- a/internal/storage/ddl.go
+++ b/internal/storage/ddl.go
@@ -42,6 +42,13 @@ func boolFalseLit(d Dialect) string {
 	return "FALSE"
 }
 
+func boolTrueLit(d Dialect) string {
+	if d.Name() == "sqlite" {
+		return "1"
+	}
+	return "TRUE"
+}
+
 func CreateTablePartSQL(d Dialect, e *metadata.Entity, tp metadata.TablePart) string {
 	var sb strings.Builder
 	table := metadata.TablePartTableName(e.Name, tp.Name)

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -305,6 +305,67 @@ func TestLoadRefOptionsCapsLegacyHelper(t *testing.T) {
 	}
 }
 
+func TestLoadFolderOptionsCapsAndIncludesSelectedOutsideFirstPage(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ent := &metadata.Entity{
+		Name:         "Группы",
+		Kind:         metadata.KindCatalog,
+		Hierarchical: true,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{ent}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= refPickerDefaultLimit; i++ {
+		id := uuid.MustParse("00000000-0000-0000-0000-" + fmt12(i))
+		if err := db.Upsert(ctx, ent.Name, id, map[string]any{
+			"Наименование": fmt.Sprintf("Папка %03d", i),
+			"is_folder":    true,
+		}, ent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 1; i <= 5; i++ {
+		id := uuid.MustParse("10000000-0000-0000-0000-" + fmt12(i))
+		if err := db.Upsert(ctx, ent.Name, id, map[string]any{
+			"Наименование": fmt.Sprintf("Элемент %03d", i),
+			"is_folder":    false,
+		}, ent); err != nil {
+			t.Fatal(err)
+		}
+	}
+	selected := uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+	if err := db.Upsert(ctx, ent.Name, selected, map[string]any{
+		"Наименование": "Папка 999",
+		"is_folder":    true,
+	}, ent); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{store: db}
+	opts := s.loadFolderOptions(ctx, ent, selected.String())
+
+	if got := len(opts); got != refPickerDefaultLimit+1 {
+		t.Fatalf("loadFolderOptions loaded %d rows, want capped %d plus selected", got, refPickerDefaultLimit)
+	}
+	if !hasOptionWithLabel(opts, selected.String(), "Папка 999") {
+		t.Fatalf("selected folder %s was not added to options: %#v", selected, opts)
+	}
+	for _, row := range opts {
+		if !asBool(row["is_folder"]) {
+			t.Fatalf("non-folder leaked into folder options: %#v", row)
+		}
+	}
+}
+
 func TestLoadInitialTPRefOptionsIncludesSelectedOutsideFirstPage(t *testing.T) {
 	ctx := context.Background()
 	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -726,6 +726,13 @@ func formValues(r *http.Request, entity *metadata.Entity) map[string]string {
 	for _, f := range entity.Fields {
 		vals[f.Name] = r.FormValue(f.Name)
 	}
+	if entity.Hierarchical {
+		vals["parent_id"] = r.FormValue("parent_id")
+		vals["is_folder"] = "false"
+		if r.FormValue("is_folder") == "true" {
+			vals["is_folder"] = "true"
+		}
+	}
 	return vals
 }
 
@@ -908,9 +915,12 @@ func (s *Server) buildHierarchyBreadcrumbs(ctx context.Context, entity *metadata
 	return crumbs
 }
 
-// loadFolderOptions returns all folder items for a hierarchical catalog (for parent select).
-func (s *Server) loadFolderOptions(ctx context.Context, entity *metadata.Entity) []map[string]any {
-	rows, err := s.store.List(ctx, entity.Name, entity, storage.ListParams{})
+// loadFolderOptions returns a bounded folder list for a hierarchical catalog parent select.
+func (s *Server) loadFolderOptions(ctx context.Context, entity *metadata.Entity, selected ...string) []map[string]any {
+	rows, err := s.store.List(ctx, entity.Name, entity, storage.ListParams{
+		Limit:       refPickerDefaultLimit,
+		OnlyFolders: true,
+	})
 	if err != nil {
 		return nil
 	}
@@ -921,7 +931,34 @@ func (s *Server) loadFolderOptions(ctx context.Context, entity *metadata.Entity)
 			folders = append(folders, row)
 		}
 	}
-	return folders
+	return s.appendSelectedFolderOptions(ctx, folders, entity, selected)
+}
+
+func (s *Server) appendSelectedFolderOptions(ctx context.Context, rows []map[string]any, entity *metadata.Entity, selected []string) []map[string]any {
+	seen := make(map[string]bool, len(rows)+len(selected))
+	for _, row := range rows {
+		if id := refValueString(row["id"]); id != "" {
+			seen[id] = true
+		}
+	}
+	for _, idStr := range selected {
+		idStr = strings.TrimSpace(idStr)
+		if idStr == "" || seen[idStr] {
+			continue
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			continue
+		}
+		row, err := s.store.GetByID(ctx, entity.Name, id, entity)
+		if err != nil || row == nil || !asBool(row["is_folder"]) {
+			continue
+		}
+		row["_label"] = firstStringField(row, entity)
+		rows = append(rows, row)
+		seen[idStr] = true
+	}
+	return rows
 }
 
 func listURL(entity *metadata.Entity) string {

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -288,13 +288,13 @@ func (s *Server) form(w http.ResponseWriter, r *http.Request) {
 	}
 	var folderOpts []map[string]any
 	if entity.Hierarchical {
-		folderOpts = s.loadFolderOptions(r.Context(), entity)
 		values["parent_id"] = r.URL.Query().Get("parent")
 		if r.URL.Query().Get("is_folder") == "true" {
 			values["is_folder"] = "true"
 		} else {
 			values["is_folder"] = "false"
 		}
+		folderOpts = s.loadFolderOptions(r.Context(), entity, values["parent_id"])
 	}
 	refOptions, _ := s.loadInitialRefOptions(r.Context(), entity, values)
 	tpRefOpts, _ := s.loadInitialTPRefOptions(r.Context(), entity, tablePartRows)
@@ -494,10 +494,10 @@ func (s *Server) renderObjectFormError(w http.ResponseWriter, r *http.Request, e
 		"TPRefMeta":     tpRefMeta(entity),
 		"TablePartRows": tablePartRows,
 	}
+	if entity.Hierarchical {
+		data["FolderOptions"] = s.loadFolderOptions(r.Context(), entity, values["parent_id"])
+	}
 	if isNew {
-		if entity.Hierarchical {
-			data["FolderOptions"] = s.loadFolderOptions(r.Context(), entity)
-		}
 		data["IsPopup"] = r.FormValue("_popup") == "1"
 	}
 	s.renderEntityForm(w, r, "object", data)
@@ -541,7 +541,7 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 		langErr := s.resolveLang(r)
 		var fOpts []map[string]any
 		if entity.Hierarchical {
-			fOpts = s.loadFolderOptions(r.Context(), entity)
+			fOpts = s.loadFolderOptions(r.Context(), entity, values["parent_id"])
 		}
 		s.renderEntityForm(w, r, "object", map[string]any{
 			"Entity":       entity,
@@ -1008,7 +1008,6 @@ func (s *Server) formEdit(w http.ResponseWriter, r *http.Request) {
 
 	var folderOptsEdit []map[string]any
 	if entity.Hierarchical {
-		folderOptsEdit = s.loadFolderOptions(r.Context(), entity)
 		if v, ok := row["is_folder"]; ok {
 			if asBool(v) {
 				vals["is_folder"] = "true"
@@ -1021,6 +1020,7 @@ func (s *Server) formEdit(w http.ResponseWriter, r *http.Request) {
 		if v, ok := row["parent_id"]; ok && v != nil {
 			vals["parent_id"] = fmt.Sprintf("%v", v)
 		}
+		folderOptsEdit = s.loadFolderOptions(r.Context(), entity, vals["parent_id"])
 	}
 
 	refOptions, _ := s.loadInitialRefOptions(r.Context(), entity, vals)
@@ -1146,6 +1146,10 @@ func (s *Server) submitEdit(w http.ResponseWriter, r *http.Request) {
 		refOptions, _ := s.loadInitialRefOptions(r.Context(), entity, values)
 		tpRefOpts2, _ := s.loadInitialTPRefOptions(r.Context(), entity, tablePartRows)
 		langSubmit := s.resolveLang(r)
+		var fOpts []map[string]any
+		if entity.Hierarchical {
+			fOpts = s.loadFolderOptions(r.Context(), entity, values["parent_id"])
+		}
 		s.renderEntityForm(w, r, "object", map[string]any{
 			"Entity":       entity,
 			"IsNew":        false,
@@ -1160,6 +1164,7 @@ func (s *Server) submitEdit(w http.ResponseWriter, r *http.Request) {
 			// См. submit: проведение могло обогатить tpRows до *Ref —
 			// сериализуем к UUID-строкам, иначе грид покажет «[object Object]».
 			"TablePartRows": tablePartRows,
+			"FolderOptions": fOpts,
 		})
 		return
 	}


### PR DESCRIPTION
## Summary
- add an `OnlyFolders` list scope and use it for hierarchical catalog parent options
- cap parent-folder options at the ref picker initial limit while preserving the selected parent outside the first page
- keep hierarchy fields in form values on error re-render and cover the behavior with a focused UI test

## Tests
- go test ./internal/ui -run 'Test(LoadFolderOptionsCapsAndIncludesSelectedOutsideFirstPage|LoadRefOptionsCapsLegacyHelper|LoadInitialRefOptionsIncludesSelectedOutsideFirstPage|RefOptionsJSON_SearchLimitAndExcludeFolders)'
- go test ./internal/storage
- git diff --check
- go test ./...