### PR TITLE
fix(converter): import enum aliases from 1c dumps

### DIFF
--- a/internal/converter/convert_test.go
+++ b/internal/converter/convert_test.go
@@ -247,6 +247,73 @@ func TestConvertEnumFieldResolution(t *testing.T) {
 	}
 }
 
+func TestConvertEnumAliasSectionResolution(t *testing.T) {
+	src := t.TempDir()
+	out := t.TempDir()
+
+	catXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject>
+  <Catalog>
+    <Properties><Name>Currency</Name></Properties>
+    <ChildObjects>
+      <Attribute><Properties>
+        <Name>RateType</Name>
+        <Type><Type xmlns="http://v8.1c.ru/8.1/data/core">cfg:EnumRef.RateType</Type></Type>
+      </Properties></Attribute>
+    </ChildObjects>
+  </Catalog>
+</MetaDataObject>`
+	enumXML := `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject>
+  <Enum>
+    <Properties><Name>RateType</Name></Properties>
+    <ChildObjects>
+      <EnumValue><Properties><Name>Fixed</Name></Properties></EnumValue>
+      <EnumValue><Properties><Name>Floating</Name></Properties></EnumValue>
+    </ChildObjects>
+  </Enum>
+</MetaDataObject>`
+
+	if err := os.MkdirAll(filepath.Join(src, "Catalogs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "Catalogs", "Currency.xml"), []byte(catXML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "Enums"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "Enums", "RateType.xml"), []byte(enumXML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := converter.Convert(converter.Options{SourceDir: src, OutDir: out})
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if report.Enums != 1 {
+		t.Fatalf("converted enums = %d, want 1", report.Enums)
+	}
+
+	catData, err := os.ReadFile(filepath.Join(out, "catalogs", "currency.yaml"))
+	if err != nil {
+		t.Fatalf("каталог не записан: %v", err)
+	}
+	if y := string(catData); !strings.Contains(y, "type: enum:RateType") {
+		t.Fatalf("enum reference degraded, yaml:\n%s", y)
+	}
+	enumData, err := os.ReadFile(filepath.Join(out, "enums", "ratetype.yaml"))
+	if err != nil {
+		t.Fatalf("перечисление не записано: %v", err)
+	}
+	enumYAML := string(enumData)
+	for _, want := range []string{"name: RateType", "- Fixed", "- Floating"} {
+		if !strings.Contains(enumYAML, want) {
+			t.Fatalf("enum yaml does not contain %q:\n%s", want, enumYAML)
+		}
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/converter/parser1c/metadata.go
+++ b/internal/converter/parser1c/metadata.go
@@ -26,9 +26,9 @@ type xmlLang struct {
 }
 
 type xmlAttribute struct {
-	Name    string   `xml:"Properties>Name"`
-	Synonym xmlLang  `xml:"Properties>Synonym"`
-	Type    xmlType  `xml:"Properties>Type"`
+	Name    string  `xml:"Properties>Name"`
+	Synonym xmlLang `xml:"Properties>Synonym"`
+	Type    xmlType `xml:"Properties>Type"`
 }
 
 type xmlTabularSection struct {
@@ -43,18 +43,19 @@ type xmlType struct {
 
 // v8.3 MDClasses XML structures (sibling .xml files, MetaDataObject root)
 type xmlV8Root struct {
-	Catalog          *xmlV8Obj      `xml:"Catalog"`
-	Document         *xmlV8Obj      `xml:"Document"`
-	Task             *xmlV8Obj      `xml:"Task"`
-	DataProcessor    *xmlV8Obj      `xml:"DataProcessor"`
-	BusinessProcess  *xmlV8Obj      `xml:"BusinessProcess"`
-	AccReg           *xmlV8Obj      `xml:"AccumulationRegister"`
-	InfoReg          *xmlV8Obj      `xml:"InformationRegister"`
-	AcctReg          *xmlV8Obj      `xml:"AccountingRegister"`
-	Enum             *xmlV8Enum     `xml:"Enumeration"`
-	Constant         *xmlV8Const    `xml:"Constant"`
-	ChartOfAccounts  *xmlV8Obj      `xml:"ChartOfAccounts"`
-	ScheduledJob     *xmlV8SchedJob `xml:"ScheduledJob"`
+	Catalog         *xmlV8Obj      `xml:"Catalog"`
+	Document        *xmlV8Obj      `xml:"Document"`
+	Task            *xmlV8Obj      `xml:"Task"`
+	DataProcessor   *xmlV8Obj      `xml:"DataProcessor"`
+	BusinessProcess *xmlV8Obj      `xml:"BusinessProcess"`
+	AccReg          *xmlV8Obj      `xml:"AccumulationRegister"`
+	InfoReg         *xmlV8Obj      `xml:"InformationRegister"`
+	AcctReg         *xmlV8Obj      `xml:"AccountingRegister"`
+	Enum            *xmlV8Enum     `xml:"Enumeration"`
+	EnumAlias       *xmlV8Enum     `xml:"Enum"`
+	Constant        *xmlV8Const    `xml:"Constant"`
+	ChartOfAccounts *xmlV8Obj      `xml:"ChartOfAccounts"`
+	ScheduledJob    *xmlV8SchedJob `xml:"ScheduledJob"`
 }
 
 type xmlV8Obj struct {
@@ -112,8 +113,8 @@ type xmlV8Const struct {
 }
 
 type xmlV8SchedJobProps struct {
-	Name     string `xml:"Name"`
-	Schedule string `xml:"Schedule"`
+	Name       string `xml:"Name"`
+	Schedule   string `xml:"Schedule"`
 	MethodName string `xml:"MethodName"`
 }
 
@@ -139,11 +140,21 @@ func parseV83File(path string) (*xmlV8Root, error) {
 	if root.Catalog == nil && root.Document == nil && root.Task == nil &&
 		root.DataProcessor == nil && root.BusinessProcess == nil &&
 		root.AccReg == nil && root.InfoReg == nil && root.AcctReg == nil &&
-		root.Enum == nil && root.Constant == nil && root.ChartOfAccounts == nil &&
+		root.enumObject() == nil && root.Constant == nil && root.ChartOfAccounts == nil &&
 		root.ScheduledJob == nil {
 		return nil, nil
 	}
 	return &root, nil
+}
+
+func (r *xmlV8Root) enumObject() *xmlV8Enum {
+	if r == nil {
+		return nil
+	}
+	if r.Enum != nil {
+		return r.Enum
+	}
+	return r.EnumAlias
 }
 
 func convertV83Attrs(attrs []xmlV8Attr) []Attribute {
@@ -195,7 +206,7 @@ func ParseDir(dir string) (*ConfigDump, error) {
 			}
 			dump.Registers = append(dump.Registers, regs...)
 
-		case "Enumerations":
+		case "Enumerations", "Enums":
 			enums, err := parseEnumerations(subDir)
 			if err != nil {
 				return nil, err
@@ -323,9 +334,15 @@ func parseCatalogs(dir string) ([]*CatalogMeta, error) {
 
 		if v8, _ := parseV83File(filepath.Join(dir, name+".xml")); v8 != nil {
 			obj := v8.Catalog
-			if obj == nil { obj = v8.Task }
-			if obj == nil { obj = v8.DataProcessor }
-			if obj == nil { obj = v8.BusinessProcess }
+			if obj == nil {
+				obj = v8.Task
+			}
+			if obj == nil {
+				obj = v8.DataProcessor
+			}
+			if obj == nil {
+				obj = v8.BusinessProcess
+			}
 			if obj != nil {
 				cat := &CatalogMeta{
 					Name:       orDefault(obj.Props.Name, name),
@@ -550,9 +567,10 @@ func orDefault(s, def string) string {
 func parseEnumerations(dir string) ([]*EnumMeta, error) {
 	var result []*EnumMeta
 	for _, name := range objectNames(dir) {
-		if v8, _ := parseV83File(filepath.Join(dir, name+".xml")); v8 != nil && v8.Enum != nil {
-			em := &EnumMeta{Name: orDefault(v8.Enum.Props.Name, name)}
-			for _, v := range v8.Enum.ChildObjects.Values {
+		if v8, _ := parseV83File(filepath.Join(dir, name+".xml")); v8 != nil && v8.enumObject() != nil {
+			enumObj := v8.enumObject()
+			em := &EnumMeta{Name: orDefault(enumObj.Props.Name, name)}
+			for _, v := range enumObj.ChildObjects.Values {
 				em.Values = append(em.Values, v.Props.Name)
 			}
 			result = append(result, em)

--- a/internal/converter/parser1c/parsedir_test.go
+++ b/internal/converter/parser1c/parsedir_test.go
@@ -149,6 +149,17 @@ const enumXML = `<?xml version="1.0" encoding="UTF-8"?>
   </Enumeration>
 </MetaDataObject>`
 
+const enumAliasXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject>
+  <Enum>
+    <Properties><Name>RateType</Name></Properties>
+    <ChildObjects>
+      <EnumValue><Properties><Name>Fixed</Name></Properties></EnumValue>
+      <EnumValue><Properties><Name>Floating</Name></Properties></EnumValue>
+    </ChildObjects>
+  </Enum>
+</MetaDataObject>`
+
 // Перечисление в выгрузке 1С часто лежит ОДНИМ файлом «Имя.xml» без папки.
 // Раньше parseEnumerations перебирал только подкаталоги и пропускал такой enum
 // (issue #16: «Перечислений: 0 → 0»). Проверяем оба представления.
@@ -175,6 +186,32 @@ func TestParseDirEnumerations(t *testing.T) {
 		t.Errorf("имя перечисления: %q", em.Name)
 	}
 	if len(em.Values) != 2 || em.Values[0] != "ЮрЛицо" || em.Values[1] != "ФизЛицо" {
+		t.Fatalf("значения перечисления разобраны неверно: %+v", em.Values)
+	}
+}
+
+func TestParseDirEnumsAliasSectionAndTag(t *testing.T) {
+	src := t.TempDir()
+	enumsDir := filepath.Join(src, "Enums")
+	if err := os.MkdirAll(enumsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(enumsDir, "RateType.xml"), []byte(enumAliasXML), 0o644); err != nil {
+		t.Fatalf("write enum xml: %v", err)
+	}
+
+	dump, err := ParseDir(src)
+	if err != nil {
+		t.Fatalf("ParseDir: %v", err)
+	}
+	if len(dump.Enums) != 1 {
+		t.Fatalf("ожидалось 1 перечисление из Enums/<Enum>, получено %d", len(dump.Enums))
+	}
+	em := dump.Enums[0]
+	if em.Name != "RateType" {
+		t.Errorf("имя перечисления: %q", em.Name)
+	}
+	if len(em.Values) != 2 || em.Values[0] != "Fixed" || em.Values[1] != "Floating" {
 		t.Fatalf("значения перечисления разобраны неверно: %+v", em.Values)
 	}
 }


### PR DESCRIPTION
## Summary
- recognize 1C enum dumps that use the `Enums` section name
- recognize enum metadata XML that uses `<Enum>` instead of `<Enumeration>`
- keep `cfg:EnumRef.X` fields as `enum:X` instead of downgrading them to `string`

Fixes #247.

## Tests
- go test ./internal/converter/parser1c -run 'TestParseDir(EnumsAliasSectionAndTag|Enumerations)'
- go test ./internal/converter -run 'TestConvertEnum(AliasSectionResolution|FieldResolution)'
- git diff --check
- go test ./...