### PR TITLE
test(load): add postgres validation runner

### DIFF
--- a/Plans/76-multi-user-scale-readiness.md
+++ b/Plans/76-multi-user-scale-readiness.md
@@ -271,6 +271,18 @@ Acceptance:
 - slow operation log для отчётов пишет `sql_hash`, duration, rows, route/user;
 - обновлён `docs/users-load-limits.md`.
 
+Реализация load validation 2026-07-07:
+- k6-сценарии параметризованы env-переменными для короткого `smoke` и более
+  длинного `validation` профиля;
+- `list_query` ходит с `limit`/`offset` и проверяет REST pagination headers;
+- добавлен `loadtest/run-postgres-validation.sh`, который поднимает PostgreSQL
+  compose-стенд, сидит данные, запускает выбранные k6-сценарии и печатает
+  Prometheus-сводку по pool/limited/slow operation metrics.
+- Локальный `RESET_STACK=1 ./loadtest/run-postgres-validation.sh smoke` прошёл:
+  `post_document` p95 13.55ms, `list_query` p95 7.65ms / p99 9.1ms,
+  `catalog_crud` p95 5.62ms, failures 0%; pool high-water 5/8 connections,
+  limited/slow operation metrics без данных.
+
 ### Этап G — путь к горизонтальному масштабированию (future)
 
 Это не нужно для MVP 100 активных пользователей, но важно для архитектурного
@@ -302,11 +314,11 @@ Acceptance:
 
 ## Рекомендуемый порядок после текущего `onebase lint`
 
-1. **Load validation:** k6 PostgreSQL прогон на демо/реальной конфигурации с
-   проверкой p95/p99, pool saturation и runtime operation metrics.
-2. **G future:** shared file storage, external pub-sub и scheduler leader
+1. **G future:** shared file storage, external pub-sub и scheduler leader
    election только когда один процесс с PostgreSQL и настроенным пулом перестанет
    хватать.
+2. **Row-level security:** отдельная платформенная модель строковых ограничений,
+   если продуктовые сценарии требуют "видит только свои строки".
 
 ## Связанные планы
 

--- a/Plans/README.md
+++ b/Plans/README.md
@@ -20,8 +20,9 @@
 > конфигурации), **65** (richtext), **74** (AI/dev tools 2.0) фактически закрыты.
 > Сверка 2026-07-07: **34 F3** (автодоступ к реквизитам ссылок `this.X.Y` /
 > `Стр.X.Y`) закрыт PR #261 через безопасный single-hop доступ с предзагрузкой
-> и кэшем; **76 A/B/C/D/E/F core** и background export UX закрыты серией PR до #267,
-> кроме future horizontal scale и нагрузочной PostgreSQL-валидации;
+> и кэшем; **76 A/B/C/D/E/F core**, background export UX и k6 PostgreSQL
+> validation runner закрыты текущей серией работ,
+> кроме future horizontal scale и row-level security;
 > мультисессионность из плана 76 пока отложена.
 
 ## Текущий приоритет, 2026-07-07
@@ -32,7 +33,8 @@
    RBAC/list limits, optimistic locking, индексы, server-side reference picker,
    bounded parent-folder options, runtime limits/backpressure, metrics и
    PostgreSQL advisory locks для Save-хуков, а также background export UX для
-   Excel/PDF отчётов. Осталась нагрузочная валидация на PostgreSQL.
+   Excel/PDF отчётов и k6 PostgreSQL validation runner. Остались future
+   horizontal scale и row-level security как отдельные решения.
 2. **План 60B:** marketplace конфигураций. Часть A (история/diff/rollback/UI)
    уже реализована, shipped examples/templates проходят CI lint-gate.
 3. **План 55, этап 3:** разбор монолитных UI templates/JS.

--- a/Plans/current-priority-2026-06-25.md
+++ b/Plans/current-priority-2026-06-25.md
@@ -10,9 +10,9 @@
    indexes + tablepart/register indexes, server-side reference picker,
    bounded parent-folder options, runtime limits/backpressure, metrics и
    PostgreSQL advisory locks для `БлокировкаДанных` в Save-хуках. UI-кнопки
-   Excel/PDF отчётов уже запускают background export job со страницей статуса.
-   В очереди остаются нагрузочная валидация на PostgreSQL и документирование
-   остаточных лимитов.
+   Excel/PDF отчётов уже запускают background export job со страницей статуса,
+   а k6 PostgreSQL validation получил smoke/validation runner. В очереди
+   остаются future horizontal scale и row-level security как отдельные решения.
 
 2. **План 60B — marketplace конфигураций.**
    Версионирование конфигурации в БД и UI истории уже реализованы, а shipped
@@ -39,8 +39,8 @@
   активного списка.
 - **План 76 стоит зафиксировать как следующий guardrail-план.** Текущий REST API,
   большие списки, reference-options, конкурентная запись и тяжёлые отчёты
-  требуют ограничителей; core-срез A/B/C/D/E/F и background export UX уже
-  реализованы, остатки описаны выше.
+  требуют ограничителей; core-срез A/B/C/D/E/F, background export UX и k6
+  PostgreSQL validation runner уже реализованы, остатки описаны выше.
 - **`onebase lint` по shipped examples/templates теперь закреплен в CI.**
   PR #263 собирает CLI и прогоняет `onebase lint --json` по `examples/*` и
   `templates/*`, падая на любых issues/warnings.

--- a/docs/users-load-limits.md
+++ b/docs/users-load-limits.md
@@ -153,12 +153,33 @@ background export UX: 2026-07-07.
 
 - `loadtest/docker-compose.yml` поднимает PostgreSQL, onebase, Prometheus,
   Grafana и k6 runner;
+- `loadtest/run-postgres-validation.sh` запускает smoke/validation профиль
+  поверх docker-compose;
 - `loadtest/seed/main.go` наполняет базу через REST;
 - `loadtest/k6/scenarios/post_document.js` создает и проводит документы;
 - `loadtest/k6/scenarios/catalog_crud.js` проверяет справочник;
 - `loadtest/k6/scenarios/list_query.js` проверяет чтение списков.
 
-Базовый запуск через Docker:
+Короткая PostgreSQL-проверка:
+
+```bash
+./loadtest/run-postgres-validation.sh smoke
+```
+
+Более длинный профиль с дефолтными целями сценариев:
+
+```bash
+./loadtest/run-postgres-validation.sh validation
+```
+
+Runner оставляет стенд поднятым, чтобы открыть Prometheus/Grafana и HTML-отчёты.
+Для автоматической очистки:
+
+```bash
+CLEANUP=1 ./loadtest/run-postgres-validation.sh smoke
+```
+
+Ручной запуск через Docker:
 
 ```bash
 docker compose -f loadtest/docker-compose.yml up -d --build
@@ -237,6 +258,9 @@ docker compose -f loadtest/docker-compose.yml run --rm --service-ports \
   `onebase_operation_duration_seconds`, `onebase_slow_operation_total`,
   `onebase_limited_operation_total`, `onebase_webhook_inflight`,
   `onebase_webhook_retry_total`.
+- PostgreSQL pool: `onebase_db_pool_acquired_conns`,
+  `onebase_db_pool_max_conns`, `onebase_db_pool_empty_acquire_total`,
+  `onebase_db_pool_canceled_acquire_total`.
 
 Ориентир:
 
@@ -288,11 +312,12 @@ docker compose -f loadtest/docker-compose.yml run --rm --service-ports \
 
 Минимальный список:
 
-1. Сделать атомарную optimistic locking операцию для PostgreSQL.
-2. Определить стратегию row-level security, если пользователи не должны видеть
+1. Определить стратегию row-level security, если пользователи не должны видеть
    чужие строки.
-3. Настроить PostgreSQL pool и индексы под реальные списки.
-4. Обновить k6-профили под реальные пользовательские сценарии проекта.
+2. Настроить PostgreSQL pool и индексы под реальные списки.
+3. Обновить k6-профили под реальные пользовательские сценарии проекта.
+4. Для горизонтального режима вынести background export jobs/realtime/files во
+   внешние хранилища или явно остаться на single-process.
 5. За reverse proxy/HTTPS выставлять cookie только по защищенному каналу.
 
 Развёрнутый план работ зафиксирован в `Plans/76-multi-user-scale-readiness.md`.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -16,6 +16,7 @@
 loadtest/
 ├── Dockerfile            # образ onebase для стенда (контекст сборки — корень репо)
 ├── docker-compose.yml    # PostgreSQL + onebase + Prometheus + Grafana + k6
+├── run-postgres-validation.sh # smoke/validation runner поверх docker-compose
 ├── prometheus.yml        # scrape-конфиг (/metrics закрыт токеном — шлём ?token=)
 ├── seed/main.go          # Go-сидер: наполняет базу через REST, пишет id в JSON
 └── k6/
@@ -31,6 +32,44 @@ loadtest/
 `k6/lib/common.js` и `seed/main.go`.
 
 ## Быстрый старт (Docker)
+
+Одной командой для короткой проверки PostgreSQL-стенда:
+
+```bash
+./loadtest/run-postgres-validation.sh smoke
+```
+
+`smoke` поднимает compose-стенд, сидит небольшой набор данных, прогоняет
+`post_document`, `list_query` и `catalog_crud`, пишет HTML-отчёты в
+`loadtest/reports/` и печатает краткую Prometheus-сводку по пулу/лимитам.
+Prometheus поднимается всегда; Grafana для быстрого smoke не обязательна и
+стартует только по `START_GRAFANA=1`.
+Для более длинного профиля используйте:
+
+```bash
+./loadtest/run-postgres-validation.sh validation
+```
+
+Ограничить набор сценариев можно так:
+
+```bash
+SCENARIOS="list_query post_document" ./loadtest/run-postgres-validation.sh smoke
+```
+
+После прогона стенд остаётся поднятым для просмотра Prometheus и, если включали,
+Grafana. Удалить его можно вручную или сразу после прогона:
+
+```bash
+CLEANUP=1 ./loadtest/run-postgres-validation.sh smoke
+```
+
+Запустить на чистой базе, удалив старые контейнеры/volume перед стартом:
+
+```bash
+RESET_STACK=1 ./loadtest/run-postgres-validation.sh smoke
+```
+
+Ручной запуск тех же шагов:
 
 ```bash
 # 1. Поднять стенд (PostgreSQL + onebase + Prometheus + Grafana)
@@ -123,10 +162,20 @@ Prometheus в `docker-compose.yml` уже запущен с
 
 - `post_document.js` — ramping-vus 0→20→50, порог `p95<800мс`, ошибок `<1%`.
 - `catalog_crud.js` — постоянные 30 VU, 70% чтений / 30% записей, `p95<300мс`.
-- `list_query.js` — ramping-arrival-rate до 200 rps, `p95<500мс`, `p99<1500мс`.
+- `list_query.js` — ramping-arrival-rate до 200 rps, `p95<500мс`, `p99<1500мс`;
+  запросы идут с `limit`/`offset` и проверяют `X-Limit`/`X-Offset`/
+  `X-Total-Count`.
 
-Пороги в `options.thresholds` каждого файла — правьте под свои SLA. Для сайзинга
-поднимайте `target`/`stages` ступенями и смотрите, где p95 пробивает SLA.
+Пороги и длительности можно менять env-переменными без правки JS:
+
+- `POST_TARGET_1`, `POST_TARGET_2`, `POST_P95_MS`, `POST_RAMP_1`,
+  `POST_HOLD_1`, `POST_RAMP_2`, `POST_HOLD_2`, `POST_SLEEP`;
+- `LIST_START_RPS`, `LIST_TARGET_1`, `LIST_TARGET_2`, `LIST_LIMIT`,
+  `LIST_P95_MS`, `LIST_P99_MS`;
+- `CATALOG_VUS`, `CATALOG_DURATION`, `CATALOG_P95_MS`.
+
+Для сайзинга поднимайте target/stages ступенями и смотрите, где p95 пробивает
+SLA или растёт `onebase_db_pool_empty_acquire_total`.
 
 ## Поиск узких мест
 
@@ -142,3 +191,11 @@ go tool pprof "http://localhost:8080/debug/pprof/heap?token=loadtest"
 В Prometheus/Grafana смотрите `onebase_http_request_duration_seconds` (латентность
 по маршрутам) и `onebase_db_pool_*` (насыщение пула соединений pgx) — это
 разделяет «упёрлись в интерпретатор/CPU» и «упёрлись в БД/пул».
+
+`run-postgres-validation.sh` после сценариев печатает быстрый срез:
+
+- `max_over_time(onebase_db_pool_acquired_conns[30m])`;
+- `max_over_time(onebase_db_pool_max_conns[30m])`;
+- `increase(onebase_db_pool_empty_acquire_total[30m])`;
+- `increase(onebase_limited_operation_total[30m])`;
+- `increase(onebase_slow_operation_total[30m])`.

--- a/loadtest/k6/lib/env.js
+++ b/loadtest/k6/lib/env.js
@@ -1,0 +1,17 @@
+export function envInt(name, fallback) {
+  const raw = __ENV[name];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function envFloat(name, fallback) {
+  const raw = __ENV[name];
+  if (!raw) return fallback;
+  const n = Number.parseFloat(raw);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function envDuration(name, fallback) {
+  return __ENV[name] || fallback;
+}

--- a/loadtest/k6/scenarios/catalog_crud.js
+++ b/loadtest/k6/scenarios/catalog_crud.js
@@ -8,27 +8,32 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 import { u, CATALOG_COUNTERPARTY, GET_HEADERS, createCounterparty } from '../lib/common.js';
+import { envDuration, envFloat, envInt } from '../lib/env.js';
+
+const CATALOG_LIST_LIMIT = envInt('CATALOG_LIST_LIMIT', 100);
 
 export const options = {
   scenarios: {
     crud: {
       executor: 'constant-vus',
-      vus: 30,
-      duration: '2m',
+      vus: envInt('CATALOG_VUS', 30),
+      duration: envDuration('CATALOG_DURATION', '2m'),
     },
   },
   thresholds: {
-    http_req_duration: ['p(95)<300'],
-    http_req_failed: ['rate<0.01'],
+    http_req_duration: [`p(95)<${envInt('CATALOG_P95_MS', 300)}`],
+    http_req_failed: [`rate<${envFloat('CATALOG_ERROR_RATE', 0.01)}`],
   },
 };
 
 export default function () {
   // 70% чтений, 30% записей — типичный профиль справочника.
   if (Math.random() < 0.7) {
-    // Список возвращает полный набор (REST-список не пагинируется), с сортировкой.
-    const res = http.get(u(`/catalogs/${CATALOG_COUNTERPARTY}?sort=${encodeURIComponent('Наименование')}&dir=asc`), GET_HEADERS);
-    check(res, { 'список 200': (r) => r.status === 200 });
+    const res = http.get(u(`/catalogs/${CATALOG_COUNTERPARTY}?limit=${CATALOG_LIST_LIMIT}&offset=0&sort=${encodeURIComponent('Наименование')}&dir=asc`), GET_HEADERS);
+    check(res, {
+      'список 200': (r) => r.status === 200,
+      'есть X-Limit': (r) => r.headers['X-Limit'] !== undefined,
+    });
   } else {
     createCounterparty(`${__VU}-${__ITER}`);
   }

--- a/loadtest/k6/scenarios/list_query.js
+++ b/loadtest/k6/scenarios/list_query.js
@@ -8,37 +8,47 @@
 import http from 'k6/http';
 import { check } from 'k6';
 import { u, CATALOG_COUNTERPARTY, DOCUMENT_POSTING, GET_HEADERS } from '../lib/common.js';
+import { envDuration, envFloat, envInt } from '../lib/env.js';
+
+const LIST_LIMIT = envInt('LIST_LIMIT', 100);
+const LIST_OFFSET_PAGES = envInt('LIST_OFFSET_PAGES', 10);
 
 export const options = {
   scenarios: {
     listing: {
       executor: 'ramping-arrival-rate',
-      startRate: 20,
+      startRate: envInt('LIST_START_RPS', 20),
       timeUnit: '1s',
-      preAllocatedVUs: 50,
-      maxVUs: 200,
+      preAllocatedVUs: envInt('LIST_PREALLOCATED_VUS', 50),
+      maxVUs: envInt('LIST_MAX_VUS', 200),
       stages: [
-        { duration: '30s', target: 50 },   // 50 запросов/сек
-        { duration: '1m', target: 200 },   // до 200 запросов/сек — ищем потолок
-        { duration: '30s', target: 200 },
-        { duration: '20s', target: 0 },
+        { duration: envDuration('LIST_RAMP_1', '30s'), target: envInt('LIST_TARGET_1', 50) },
+        { duration: envDuration('LIST_RAMP_2', '1m'), target: envInt('LIST_TARGET_2', 200) },
+        { duration: envDuration('LIST_HOLD_2', '30s'), target: envInt('LIST_TARGET_2', 200) },
+        { duration: envDuration('LIST_RAMP_DOWN', '20s'), target: 0 },
       ],
     },
   },
   thresholds: {
-    http_req_duration: ['p(95)<500', 'p(99)<1500'],
-    http_req_failed: ['rate<0.01'],
+    http_req_duration: [`p(95)<${envInt('LIST_P95_MS', 500)}`, `p(99)<${envInt('LIST_P99_MS', 1500)}`],
+    http_req_failed: [`rate<${envFloat('LIST_ERROR_RATE', 0.01)}`],
   },
 };
 
 export default function () {
-  // REST-список не пагинируется — возвращает весь набор; варьируем сортировку.
   const dir = Math.random() < 0.5 ? 'asc' : 'desc';
+  const offset = Math.floor(Math.random() * LIST_OFFSET_PAGES) * LIST_LIMIT;
+  const page = `limit=${LIST_LIMIT}&offset=${offset}`;
   let res;
   if (Math.random() < 0.5) {
-    res = http.get(u(`/catalogs/${CATALOG_COUNTERPARTY}?sort=${encodeURIComponent('Наименование')}&dir=${dir}`), GET_HEADERS);
+    res = http.get(u(`/catalogs/${CATALOG_COUNTERPARTY}?${page}&sort=${encodeURIComponent('Наименование')}&dir=${dir}`), GET_HEADERS);
   } else {
-    res = http.get(u(`/documents/${DOCUMENT_POSTING}?sort=${encodeURIComponent('Дата')}&dir=${dir}`), GET_HEADERS);
+    res = http.get(u(`/documents/${DOCUMENT_POSTING}?${page}&sort=${encodeURIComponent('Дата')}&dir=${dir}`), GET_HEADERS);
   }
-  check(res, { 'список 200': (r) => r.status === 200 });
+  check(res, {
+    'список 200': (r) => r.status === 200,
+    'есть X-Limit': (r) => r.headers['X-Limit'] !== undefined,
+    'есть X-Offset': (r) => r.headers['X-Offset'] !== undefined,
+    'есть X-Total-Count': (r) => r.headers['X-Total-Count'] !== undefined,
+  });
 }

--- a/loadtest/k6/scenarios/post_document.js
+++ b/loadtest/k6/scenarios/post_document.js
@@ -8,13 +8,15 @@
 //          -e SEED_FILE=../../seed/counterparties.json \
 //          loadtest/k6/scenarios/post_document.js
 
-import { check } from 'k6';
+import { check, sleep } from 'k6';
 import { SharedArray } from 'k6/data';
 import { createCounterparty, postReceipt } from '../lib/common.js';
+import { envDuration, envFloat, envInt } from '../lib/env.js';
 
 // Загружаем id контрагентов из seed-файла. open() — только в init-контексте,
 // поэтому оборачиваем в try/catch: без файла упадём на fallback в setup().
 const SEED_FILE = __ENV.SEED_FILE || '../../seed/counterparties.json';
+const POST_SLEEP = envFloat('POST_SLEEP', 0);
 const seeded = new SharedArray('counterparties', function () {
   try {
     return JSON.parse(open(SEED_FILE));
@@ -29,19 +31,19 @@ export const options = {
       executor: 'ramping-vus',
       startVUs: 0,
       stages: [
-        { duration: '30s', target: 20 },  // разгон
-        { duration: '1m', target: 20 },   // плато
-        { duration: '30s', target: 50 },  // ступень выше — ищем предел
-        { duration: '1m', target: 50 },
-        { duration: '20s', target: 0 },   // остывание
+        { duration: envDuration('POST_RAMP_1', '30s'), target: envInt('POST_TARGET_1', 20) },
+        { duration: envDuration('POST_HOLD_1', '1m'), target: envInt('POST_TARGET_1', 20) },
+        { duration: envDuration('POST_RAMP_2', '30s'), target: envInt('POST_TARGET_2', 50) },
+        { duration: envDuration('POST_HOLD_2', '1m'), target: envInt('POST_TARGET_2', 50) },
+        { duration: envDuration('POST_RAMP_DOWN', '20s'), target: 0 },
       ],
       gracefulRampDown: '10s',
     },
   },
   thresholds: {
     // SLA: 95% проведений быстрее 800 мс, ошибок < 1%.
-    http_req_duration: ['p(95)<800'],
-    http_req_failed: ['rate<0.01'],
+    http_req_duration: [`p(95)<${envInt('POST_P95_MS', 800)}`],
+    http_req_failed: [`rate<${envFloat('POST_ERROR_RATE', 0.01)}`],
   },
 };
 
@@ -63,4 +65,7 @@ export default function (data) {
       try { return !!r.json('id'); } catch (_) { return false; }
     },
   });
+  if (POST_SLEEP > 0) {
+    sleep(POST_SLEEP);
+  }
 }

--- a/loadtest/run-postgres-validation.sh
+++ b/loadtest/run-postgres-validation.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile="${1:-smoke}"
+compose_file="${COMPOSE_FILE:-loadtest/docker-compose.yml}"
+host_url="${BASE_URL_HOST:-http://localhost:8080}"
+reports_dir="${REPORTS_DIR:-loadtest/reports}"
+seed_file_host="${SEED_FILE_HOST:-loadtest/seed/counterparties.json}"
+seed_file_k6="${SEED_FILE:-/seed/counterparties.json}"
+scenarios="${SCENARIOS:-post_document list_query catalog_crud}"
+
+case "$profile" in
+  smoke)
+    : "${SEED_COUNTERPARTIES:=60}"
+    : "${SEED_DOCUMENTS:=80}"
+    : "${POST_RAMP_1:=5s}" "${POST_HOLD_1:=10s}" "${POST_RAMP_2:=5s}" "${POST_HOLD_2:=10s}" "${POST_RAMP_DOWN:=5s}"
+    : "${POST_TARGET_1:=4}" "${POST_TARGET_2:=8}" "${POST_P95_MS:=1500}"
+    : "${POST_SLEEP:=0.05}"
+    : "${LIST_RAMP_1:=5s}" "${LIST_RAMP_2:=10s}" "${LIST_HOLD_2:=10s}" "${LIST_RAMP_DOWN:=5s}"
+    : "${LIST_START_RPS:=5}" "${LIST_TARGET_1:=15}" "${LIST_TARGET_2:=30}" "${LIST_PREALLOCATED_VUS:=20}" "${LIST_MAX_VUS:=80}"
+    : "${CATALOG_VUS:=5}" "${CATALOG_DURATION:=20s}" "${CATALOG_P95_MS:=800}"
+    ;;
+  validation)
+    : "${SEED_COUNTERPARTIES:=200}"
+    : "${SEED_DOCUMENTS:=500}"
+    ;;
+  *)
+    echo "usage: $0 [smoke|validation]" >&2
+    exit 2
+    ;;
+esac
+
+export POST_RAMP_1 POST_HOLD_1 POST_RAMP_2 POST_HOLD_2 POST_RAMP_DOWN
+export POST_TARGET_1 POST_TARGET_2 POST_P95_MS POST_ERROR_RATE POST_SLEEP
+export LIST_RAMP_1 LIST_RAMP_2 LIST_HOLD_2 LIST_RAMP_DOWN
+export LIST_START_RPS LIST_TARGET_1 LIST_TARGET_2 LIST_PREALLOCATED_VUS LIST_MAX_VUS
+export LIST_LIMIT LIST_OFFSET_PAGES LIST_P95_MS LIST_P99_MS LIST_ERROR_RATE
+export CATALOG_VUS CATALOG_DURATION CATALOG_LIST_LIMIT CATALOG_P95_MS CATALOG_ERROR_RATE
+
+mkdir -p "$reports_dir" "$(dirname "$seed_file_host")"
+
+if [[ "${RESET_STACK:-0}" == "1" ]]; then
+  echo "==> resetting PostgreSQL loadtest stack"
+  docker compose -f "$compose_file" down -v
+fi
+
+echo "==> starting PostgreSQL loadtest stack ($profile)"
+services=(postgres onebase prometheus)
+if [[ "${START_GRAFANA:-0}" == "1" ]]; then
+  services+=(grafana)
+fi
+docker compose -f "$compose_file" up -d --build "${services[@]}"
+
+echo "==> waiting for onebase health"
+ready=0
+for _ in $(seq 1 60); do
+  if curl -fsS "$host_url/health" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+if [[ "$ready" != "1" ]]; then
+  echo "onebase did not become healthy at $host_url/health" >&2
+  docker compose -f "$compose_file" ps
+  docker compose -f "$compose_file" logs --tail=120 onebase
+  exit 1
+fi
+
+echo "==> seeding $SEED_COUNTERPARTIES counterparties and $SEED_DOCUMENTS documents"
+go run ./loadtest/seed \
+  -url "$host_url" \
+  -counterparties "$SEED_COUNTERPARTIES" \
+  -documents "$SEED_DOCUMENTS" \
+  -out "$seed_file_host"
+
+run_k6() {
+  local name="$1"
+  local script="$2"
+  local report="/reports/${name}-${profile}.html"
+  echo "==> k6 $name"
+  docker compose -f "$compose_file" run --rm --service-ports \
+    -e BASE_URL=http://onebase:8080 \
+    -e SEED_FILE="$seed_file_k6" \
+    -e OB_SESSION_COOKIE \
+    -e K6_WEB_DASHBOARD="${K6_WEB_DASHBOARD:-false}" \
+    -e K6_WEB_DASHBOARD_HOST=0.0.0.0 \
+    -e K6_WEB_DASHBOARD_EXPORT="$report" \
+    -e POST_RAMP_1 -e POST_HOLD_1 -e POST_RAMP_2 -e POST_HOLD_2 -e POST_RAMP_DOWN \
+    -e POST_TARGET_1 -e POST_TARGET_2 -e POST_P95_MS -e POST_ERROR_RATE -e POST_SLEEP \
+    -e LIST_RAMP_1 -e LIST_RAMP_2 -e LIST_HOLD_2 -e LIST_RAMP_DOWN \
+    -e LIST_START_RPS -e LIST_TARGET_1 -e LIST_TARGET_2 -e LIST_PREALLOCATED_VUS -e LIST_MAX_VUS \
+    -e LIST_LIMIT -e LIST_OFFSET_PAGES -e LIST_P95_MS -e LIST_P99_MS -e LIST_ERROR_RATE \
+    -e CATALOG_VUS -e CATALOG_DURATION -e CATALOG_LIST_LIMIT -e CATALOG_P95_MS -e CATALOG_ERROR_RATE \
+    k6 run -o experimental-prometheus-rw "/scripts/scenarios/$script"
+  echo "    report: ${reports_dir}/${name}-${profile}.html"
+}
+
+for scenario in $scenarios; do
+  case "$scenario" in
+    post_document) run_k6 post_document post_document.js ;;
+    list_query) run_k6 list_query list_query.js ;;
+    catalog_crud) run_k6 catalog_crud catalog_crud.js ;;
+    *) echo "unknown scenario in SCENARIOS: $scenario" >&2; exit 2 ;;
+  esac
+done
+
+echo "==> Prometheus summary"
+python3 - <<'PY'
+import json
+import urllib.parse
+import urllib.request
+
+queries = [
+    "max_over_time(onebase_db_pool_acquired_conns[30m])",
+    "max_over_time(onebase_db_pool_max_conns[30m])",
+    "increase(onebase_db_pool_empty_acquire_total[30m])",
+    "increase(onebase_limited_operation_total[30m])",
+    "increase(onebase_slow_operation_total[30m])",
+]
+
+for q in queries:
+    url = "http://localhost:9090/api/v1/query?query=" + urllib.parse.quote(q)
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            payload = json.load(resp)
+    except Exception as exc:
+        print(f"{q}: {exc}")
+        continue
+    result = payload.get("data", {}).get("result", [])
+    if not result:
+        print(f"{q}: no data")
+        continue
+    values = [r.get("value", [None, ""])[1] for r in result]
+    print(f"{q}: {', '.join(values[:5])}")
+PY
+
+if [[ "${CLEANUP:-0}" == "1" ]]; then
+  echo "==> cleanup"
+  docker compose -f "$compose_file" down -v
+else
+  echo "==> stack left running; cleanup with: docker compose -f $compose_file down -v"
+fi


### PR DESCRIPTION
## Summary
- add a PostgreSQL load validation runner with smoke/validation profiles over docker compose
- parameterize k6 scenarios through env vars and verify REST pagination headers in list scenarios
- document how to run smoke/validation profiles and how to read pool/limited/slow operation metrics
- record the local smoke result in Plan 76

## Tests
- bash -n loadtest/run-postgres-validation.sh
- go test ./loadtest/seed
- go test ./...
- git diff --check
- RESET_STACK=1 ./loadtest/run-postgres-validation.sh smoke