### PR TITLE
fix: находки внимательного ревью недели (recover экспорта, порядок версий, вебхуки API, лимиты локов и формул)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/ivantit66/onebase/internal/webhook"
 )
 
 const (
@@ -30,6 +31,19 @@ type handler struct {
 	store     *storage.DB
 	interp    *interpreter.Interpreter
 	entitySvc *entityservice.Service // разделяем с ui — см. ui.Server.EntitySvc()
+	hooks     *webhook.Dispatcher    // исходящие веб-хуки (план 29); nil-safe
+}
+
+// dispatchHook шлёт исходящий веб-хук после успешной операции. REST-путь
+// обязан оповещать интеграции так же, как UI (план 29): save/post идут через
+// entityservice и событие шлют, а unpost/delete раньше уходили молча.
+func (h *handler) dispatchHook(ctx context.Context, name, entity string, id uuid.UUID) {
+	if h.hooks.Enabled() {
+		h.hooks.Dispatch(webhook.Event{
+			Name: name, Entity: entity, ID: id.String(),
+			User: storage.AuditUserLogin(ctx),
+		})
+	}
 }
 
 // createUpdateBody — JSON-контракт для POST/PUT. Шапка — flat-поля (как раньше),
@@ -284,6 +298,7 @@ func (h *handler) deleteObject(kind metadata.Kind) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
 			return
 		}
+		h.dispatchHook(r.Context(), string(kind)+".delete", entityName, id)
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/api/report_eval.go
+++ b/internal/api/report_eval.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/shopspring/decimal"
 
@@ -49,13 +50,26 @@ func (e *reportEvaluator) compile(expr string) (*ast.ProcedureDecl, error) {
 	return proc, nil
 }
 
+// composeExprProfile ограничивает одну формулу композиции по времени и
+// итерациям: формула вычисляется на каждую строку отчёта и обязана быть
+// мгновенной. Без лимитов «Пока Истина Цикл» в формуле вешал хендлер навсегда
+// (ctx-таймаут интерпретатор не прерывает) и навечно занимал слот
+// concurrency-лимита отчётов. Запреты возможностей не включаем: формулы —
+// доверенный код конфигурации, как и запрос отчёта.
+func composeExprProfile() interpreter.SandboxProfile {
+	return interpreter.SandboxProfile{
+		MaxWallClock: 10 * time.Second,
+		MaxLoopIters: 1_000_000,
+	}
+}
+
 func (e *reportEvaluator) EvalBool(expr string, row compose.Row) (bool, error) {
 	proc, err := e.compile(expr)
 	if err != nil {
 		return false, err
 	}
-	var result any
-	if err := e.interp.RunWithResult(proc, &interpreter.MapThis{M: row}, &result, map[string]any(row)); err != nil {
+	result, err := e.interp.CallSandboxed(proc, &interpreter.MapThis{M: row}, nil, composeExprProfile(), map[string]any(row))
+	if err != nil {
 		if errors.Is(err, interpreter.ErrDivisionByZero) {
 			return false, nil
 		}
@@ -70,8 +84,8 @@ func (e *reportEvaluator) EvalNum(expr string, row compose.Row) (decimal.Decimal
 	if err != nil {
 		return decimal.Zero, false, err
 	}
-	var result any
-	if err := e.interp.RunWithResult(proc, &interpreter.MapThis{M: row}, &result, map[string]any(row)); err != nil {
+	result, err := e.interp.CallSandboxed(proc, &interpreter.MapThis{M: row}, nil, composeExprProfile(), map[string]any(row))
+	if err != nil {
 		if errors.Is(err, interpreter.ErrDivisionByZero) {
 			return decimal.Zero, false, nil
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -45,7 +45,7 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 	if metricsReg != nil {
 		registerRuntimeMetrics(metricsReg, authRepo, uiSrv, sched, uiCfg.Webhooks)
 	}
-	h := &handler{reg: reg, store: store, interp: interp, entitySvc: uiSrv.EntitySvc()}
+	h := &handler{reg: reg, store: store, interp: interp, entitySvc: uiSrv.EntitySvc(), hooks: uiCfg.Webhooks}
 	r := chi.NewRouter()
 	r.Use(requestLogger()) // как middleware.Logger, но режет токены/коды из URI (план 53)
 	r.Use(middleware.Recoverer)

--- a/internal/api/v2.go
+++ b/internal/api/v2.go
@@ -230,6 +230,7 @@ func (h *handler) deleteObjectV2(kind metadata.Kind) http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
 			return
 		}
+		h.dispatchHook(r.Context(), string(kind)+".delete", entityName, id)
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
@@ -297,6 +298,7 @@ func (h *handler) unpostDocumentV2() http.HandlerFunc {
 			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
 			return
 		}
+		h.dispatchHook(r.Context(), "document.unpost", entityName, id)
 		writeJSONV2(w, http.StatusOK, restV2Envelope{Data: map[string]any{
 			"id":     id.String(),
 			"posted": false,

--- a/internal/auth/api_tokens.go
+++ b/internal/auth/api_tokens.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -112,9 +113,27 @@ func (r *Repo) LookupAPIToken(ctx context.Context, raw string) (*User, error) {
 		u.Roles = roles
 	}
 
+	r.touchAPIToken(ctx, tokenID, time.Now())
+	return u, nil
+}
+
+// apiTokenTouch троттлит запись last_used_at: интеграции ходят в REST с
+// высоким RPS, и UPDATE на каждый запрос давал бы постоянный writer-трафик
+// (актуально для SQLite). Тот же приём, что touchThrottle у сессий.
+var apiTokenTouch sync.Map // map[tokenID]time.Time
+
+const apiTokenTouchInterval = 5 * time.Minute
+
+// touchAPIToken обновляет last_used_at не чаще apiTokenTouchInterval.
+// now передаётся параметром ради детерминизма в тестах.
+func (r *Repo) touchAPIToken(ctx context.Context, tokenID string, now time.Time) {
+	if last, ok := apiTokenTouch.Load(tokenID); ok && now.Sub(last.(time.Time)) < apiTokenTouchInterval {
+		return
+	}
+	apiTokenTouch.Store(tokenID, now)
+	d := r.db.Dialect()
 	upd := fmt.Sprintf(`UPDATE _api_tokens SET last_used_at = %s WHERE id = %s`, d.Now(), d.Placeholder(1))
 	_, _ = r.db.Exec(ctx, upd, tokenID)
-	return u, nil
 }
 
 func (r *Repo) ListAPITokens(ctx context.Context) ([]*APIToken, error) {

--- a/internal/auth/api_tokens_touch_test.go
+++ b/internal/auth/api_tokens_touch_test.go
@@ -1,0 +1,66 @@
+package auth
+
+// White-box тест троттлинга last_used_at API-токенов: интеграции ходят с
+// высоким RPS, UPDATE на каждый запрос давал бы постоянный writer-трафик.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func TestTouchAPITokenThrottled(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "auth.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+	repo := NewRepo(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	user, err := repo.Create(ctx, "api", "pass", "", false)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	tok, _, err := repo.CreateAPIToken(ctx, "интеграция", user.ID, nil)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	lastUsed := func() *time.Time {
+		t.Helper()
+		tokens, err := repo.ListAPITokens(ctx)
+		if err != nil || len(tokens) != 1 {
+			t.Fatalf("ListAPITokens: %v (%d)", err, len(tokens))
+		}
+		return tokens[0].LastUsedAt
+	}
+
+	base := time.Now()
+	repo.touchAPIToken(ctx, tok.ID, base)
+	first := lastUsed()
+	if first == nil {
+		t.Fatal("last_used_at должен быть заполнен после первого touch")
+	}
+
+	// Затираем метку напрямую: если бы touch писал каждый раз, значение бы
+	// восстановилось. Троттлинг обязан пропустить запись внутри 5 минут.
+	if _, err := db.Exec(ctx, `UPDATE _api_tokens SET last_used_at = NULL WHERE id = ?`, tok.ID); err != nil {
+		t.Fatalf("сброс last_used_at: %v", err)
+	}
+	repo.touchAPIToken(ctx, tok.ID, base.Add(time.Minute))
+	if lastUsed() != nil {
+		t.Fatal("троттлинг: повторный touch внутри 5 минут не должен писать в БД")
+	}
+
+	// После интервала — запись проходит.
+	repo.touchAPIToken(ctx, tok.ID, base.Add(6*time.Minute))
+	if lastUsed() == nil {
+		t.Fatal("после интервала touch обязан обновить last_used_at")
+	}
+}

--- a/internal/configdb/version_clock_test.go
+++ b/internal/configdb/version_clock_test.go
@@ -1,0 +1,19 @@
+package configdb
+
+// White-box тест монотонных created_at версий: системный таймер (особенно на
+// Windows) может вернуть одинаковый time.Now() для подряд идущих версий, и
+// раньше порядок решал тай-брейк по случайному UUID — история конфигурации
+// становилась недетерминированной (флак TestRepoVersions_SaveDiffRollback).
+
+import "testing"
+
+func TestNextVersionTimeStrictlyIncreasing(t *testing.T) {
+	prev := nextVersionTime()
+	for i := 0; i < 10_000; i++ {
+		cur := nextVersionTime()
+		if !cur.After(prev) {
+			t.Fatalf("итерация %d: %v не позже %v", i, cur, prev)
+		}
+		prev = cur
+	}
+}

--- a/internal/configdb/versions.go
+++ b/internal/configdb/versions.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -31,6 +32,27 @@ type VersionOptions struct {
 
 // versionTimeLayout keeps SQLite TEXT timestamps lexicographically sortable.
 const versionTimeLayout = "2006-01-02T15:04:05.000000000Z07:00"
+
+// versionClock выдаёт строго возрастающие created_at внутри процесса. Системный
+// таймер (особенно на Windows) может вернуть одинаковый time.Now() для
+// нескольких подряд созданных версий; тогда порядок решал тай-брейк по
+// СЛУЧАЙНОМУ UUID — история конфигурации могла показать «последней» не ту
+// версию, а откат взять не тот снимок (флак TestRepoVersions_SaveDiffRollback).
+var versionClock struct {
+	mu   sync.Mutex
+	last time.Time
+}
+
+func nextVersionTime() time.Time {
+	versionClock.mu.Lock()
+	defer versionClock.mu.Unlock()
+	now := time.Now().UTC()
+	if !now.After(versionClock.last) {
+		now = versionClock.last.Add(time.Nanosecond)
+	}
+	versionClock.last = now
+	return now
+}
 
 // DiffKind describes how a file differs between two versions.
 type DiffKind string
@@ -86,7 +108,7 @@ func (r *Repo) CreateVersion(ctx context.Context, opts VersionOptions) (*Version
 	}
 	v := &Version{
 		ID:          uuid.NewString(),
-		CreatedAt:   time.Now().UTC(),
+		CreatedAt:   nextVersionTime(),
 		AuthorID:    opts.AuthorID,
 		AuthorLogin: opts.AuthorLogin,
 		Message:     opts.Message,

--- a/internal/configdb/versions_test.go
+++ b/internal/configdb/versions_test.go
@@ -3,10 +3,37 @@ package configdb_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ivantit66/onebase/internal/configdb"
 )
+
+// Порядок версий стабилен даже при создании многих версий в один момент
+// таймера: ListVersions обязан вернуть их строго в обратном порядке создания.
+func TestListVersionsOrderStableUnderCoarseTimer(t *testing.T) {
+	repo, _, ctx := newSQLiteRepo(t)
+
+	const n = 25
+	for i := 0; i < n; i++ {
+		if _, err := repo.CreateVersion(ctx, configdb.VersionOptions{Message: fmt.Sprintf("v%03d", i)}); err != nil {
+			t.Fatalf("CreateVersion %d: %v", i, err)
+		}
+	}
+	versions, err := repo.ListVersions(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+	if len(versions) != n {
+		t.Fatalf("versions len = %d, want %d", len(versions), n)
+	}
+	for i, v := range versions {
+		want := fmt.Sprintf("v%03d", n-1-i)
+		if v.Message != want {
+			t.Fatalf("позиция %d: message = %q, want %q (порядок версий недетерминирован)", i, v.Message, want)
+		}
+	}
+}
 
 func TestRepoVersions_SaveDiffRollback(t *testing.T) {
 	repo, _, ctx := newSQLiteRepo(t)

--- a/internal/storage/advisory_lock.go
+++ b/internal/storage/advisory_lock.go
@@ -11,6 +11,12 @@ import (
 
 var ErrAdvisoryLockRequiresTx = errors.New("postgres advisory transaction lock requires active storage transaction")
 
+// advisoryLockTimeout ограничивает ожидание pg_advisory_xact_lock: без него
+// зависшая транзакция-держатель блокировала бы все конкурирующие проведения
+// бессрочно и без диагностики. SET LOCAL действует только на текущую
+// транзакцию и не влияет на остальные запросы соединения.
+const advisoryLockTimeout = "30s"
+
 // AdvisoryXactLock takes PostgreSQL transaction-scoped advisory locks for the
 // provided logical keys. SQLite has no equivalent and treats this as a no-op.
 func (db *DB) AdvisoryXactLock(ctx context.Context, keys []string) error {
@@ -21,12 +27,30 @@ func (db *DB) AdvisoryXactLock(ctx context.Context, keys []string) error {
 	if !HasTx(ctx) {
 		return ErrAdvisoryLockRequiresTx
 	}
+	if _, err := db.Exec(ctx, "SET LOCAL lock_timeout = '"+advisoryLockTimeout+"'"); err != nil {
+		return fmt.Errorf("advisory lock timeout: %w", err)
+	}
 	for _, key := range keys {
 		if _, err := db.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", advisoryLockKey(key)); err != nil {
+			if isLockTimeoutErr(err) {
+				return fmt.Errorf("блокировка данных %q не получена за %s — её держит другое проведение: %w", key, advisoryLockTimeout, err)
+			}
 			return fmt.Errorf("advisory lock %q: %w", key, err)
 		}
 	}
+	// SET LOCAL живёт до конца транзакции — возвращаем безлимит (0), чтобы
+	// таймаут advisory-ожидания не распространился на обычные row-локи
+	// последующих UPDATE в той же транзакции проведения.
+	if _, err := db.Exec(ctx, "SET LOCAL lock_timeout = '0'"); err != nil {
+		return fmt.Errorf("advisory lock timeout reset: %w", err)
+	}
 	return nil
+}
+
+// isLockTimeoutErr распознаёт истечение lock_timeout (SQLSTATE 55P03).
+func isLockTimeoutErr(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "55P03") || strings.Contains(strings.ToLower(s), "lock timeout")
 }
 
 func normalizeAdvisoryKeys(keys []string) []string {

--- a/internal/storage/advisory_lock_timeout_test.go
+++ b/internal/storage/advisory_lock_timeout_test.go
@@ -1,0 +1,22 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsLockTimeoutErr(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{errors.New("ERROR: canceling statement due to lock timeout (SQLSTATE 55P03)"), true},
+		{errors.New("Lock timeout while waiting"), true},
+		{errors.New("connection refused"), false},
+	}
+	for _, c := range cases {
+		if got := isLockTimeoutErr(c.err); got != c.want {
+			t.Errorf("isLockTimeoutErr(%q) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}

--- a/internal/ui/dsl_ref_attr.go
+++ b/internal/ui/dsl_ref_attr.go
@@ -162,7 +162,11 @@ func (r *dslRefAttrResolver) preloadIDs(entity *metadata.Entity, ids []uuid.UUID
 	if len(missing) == 0 {
 		return nil
 	}
-	fields := uniqueObjectFields(append(entity.Fields, displayField(entity)...))
+	// Только uniqueObjectFields(entity.Fields): displayField возвращает поле,
+	// уже входящее в entity.Fields (дедуп его выкидывал), а append к слайсу
+	// реестра при cap>len писал в разделяемый backing array метаданных из
+	// конкурентных запросов (гонка под -race).
+	fields := uniqueObjectFields(entity.Fields)
 	rows, err := r.s.store.GetFieldsByIDs(r.ctx, entity, missing, fields)
 	if err != nil {
 		return fmt.Errorf("%s: %w", entity.Name, err)
@@ -239,7 +243,9 @@ func (m *refAwareMapThis) Set(name string, v any) {
 			return
 		}
 	}
-	m.row[low] = v
+	// Новый ключ — с исходным регистром, как interpreter.MapThis: lowercase
+	// давал бы строки ТЧ с ключами, не совпадающими с именами полей метаданных.
+	m.row[name] = v
 }
 
 func (m *refAwareMapThis) wrapValue(name string, v any) any {

--- a/internal/ui/export_jobs.go
+++ b/internal/ui/export_jobs.go
@@ -53,7 +53,24 @@ func newExportJobStore(ttl time.Duration) *exportJobStore {
 	if ttl <= 0 {
 		ttl = defaultExportJobTTL
 	}
-	return &exportJobStore{jobs: make(map[string]*exportJob), ttl: ttl}
+	s := &exportJobStore{jobs: make(map[string]*exportJob), ttl: ttl}
+	// Готовые файлы лежат в памяти (Data []byte), а уборка раньше происходила
+	// только при create/get: если к джобе никто не обращался, большой экспорт
+	// висел в RAM бессрочно. Фоновый sweeper снимает это ограничение.
+	interval := ttl / 3
+	if interval < time.Second {
+		interval = time.Second
+	}
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for range t.C {
+			s.mu.Lock()
+			s.cleanupLocked(time.Now())
+			s.mu.Unlock()
+		}
+	}()
+	return s
 }
 
 func (s *exportJobStore) create(owner, kind, name, format string) exportJob {
@@ -160,6 +177,15 @@ func (s *Server) reportExportJobStart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) runReportExportJob(r *http.Request, jobID string, rep *reportpkg.Report, format string) {
+	// Горутина живёт вне HTTP-цепочки — chi Recoverer её не прикрывает, а
+	// внутри генерация Excel/PDF по произвольным данным. Без recover одна
+	// паника роняла весь процесс базы вместе со всеми сессиями.
+	defer func() {
+		if p := recover(); p != nil {
+			s.exportJobStore().markError(jobID, fmt.Sprintf("внутренняя ошибка выгрузки: %v", p))
+		}
+	}()
+
 	ctx, finish, ok := s.beginQueuedOperation(r, opReportExport, rep.Name)
 	if !ok {
 		msg := "слишком много одновременно выполняемых выгрузок, задача не дождалась свободного слота"

--- a/internal/ui/export_jobs_panic_test.go
+++ b/internal/ui/export_jobs_panic_test.go
@@ -1,0 +1,51 @@
+package ui
+
+// Паника в фоновой горутине экспорта не должна ронять процесс: она вне
+// HTTP-цепочки, chi Recoverer её не прикрывает. runReportExportJob обязан
+// перехватить панику и перевести джобу в статус «Ошибка».
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRunReportExportJobRecoversPanic(t *testing.T) {
+	s := &Server{}
+	jobs := s.exportJobStore()
+	job := jobs.create("tester", "report", "Сломанный", "excel")
+
+	r := httptest.NewRequest("POST", "/ui/report/x/export-job/excel", nil)
+	// rep == nil → паника при обращении к rep.Name внутри джобы; recover
+	// обязан пометить джобу ошибкой, а не уронить тестовый процесс.
+	s.runReportExportJob(r, job.ID, nil, "excel")
+
+	got, ok := jobs.get(job.ID)
+	if !ok {
+		t.Fatal("джоба пропала из стора")
+	}
+	if got.Status != exportJobError {
+		t.Fatalf("статус = %q, ожидался error", got.Status)
+	}
+	if got.Error == "" {
+		t.Fatal("текст ошибки должен быть заполнен")
+	}
+}
+
+// Sweeper стора экспортов убирает просроченные джобы без обращений к API стора.
+func TestExportJobStoreSweeper(t *testing.T) {
+	jobs := newExportJobStore(50 * time.Millisecond)
+	job := jobs.create("tester", "report", "R", "pdf")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		jobs.mu.Lock()
+		_, exists := jobs.jobs[job.ID]
+		jobs.mu.Unlock()
+		if !exists {
+			return // sweeper убрал сам, get() не вызывался
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("sweeper не убрал просроченную джобу за 5 секунд")
+}


### PR DESCRIPTION
Фиксы по итогам внимательного ревью изменений недели (`ef13ec0..main`, ~9 100 строк: REST v2 + токены, guardrails, advisory-локи, DSL-кэш реквизитов, фоновые экспорты, план 78).

## Исправления

1. **Паника в фоновом экспорте роняла весь сервер.** `go runReportExportJob(...)` живёт вне HTTP-цепочки — chi `Recoverer` его не прикрывает, а внутри генерация Excel/PDF по произвольным данным. Добавлен `defer recover` → джоба переводится в «Ошибка», процесс живёт. Тест: паника внутри джобы → статус `error`.

2. **Недетерминированный порядок версий конфигурации** (пойман как флак `TestRepoVersions_SaveDiffRollback` на полном прогоне). Системный таймер (особенно на Windows) возвращает одинаковый `time.Now()` для подряд созданных версий, и порядок решал тай-брейк по **случайному UUID**: история могла показать «последней» не ту версию, а откат — взять не тот снимок. Введён монотонный `nextVersionTime()` (строго возрастающие `created_at` внутри процесса). Тесты: 10 000 вызовов строго возрастают; 25 версий подряд листингуются ровно в обратном порядке создания; `-count=25` прогон пакета зелёный.

3. **REST v1/v2 не слали веб-хуки `*.delete` / `document.unpost`** — UI шлёт (план 29), save/post шли через entityservice для всех путей, а удаление/распроведение через API уходили молча: интеграция не оповещала другие интеграции. В `api.handler` добавлен nil-safe `dispatchHook`, события отправляются после успешной транзакции в v1 `deleteObject`, v2 `deleteObjectV2`/`unpostDocumentV2` — тот же формат события, что в UI (`storage.AuditUserLogin` в `User`).

4. **PG advisory-локи ждали бесконечно.** Зависшая транзакция-держатель блокировала конкурирующие проведения без диагностики. Теперь `SET LOCAL lock_timeout='30s'` на время взятия advisory-локов (после — возврат в `0`, чтобы таймаут не распространился на row-локи остальной транзакции) и понятная ошибка «блокировка данных не получена — её держит другое проведение» при SQLSTATE 55P03.

5. **Формулы композиции отчётов обходили runtime-лимиты.** `report_eval.go` исполнял выражения через `RunWithResult` без deadline: `Пока Истина Цикл` в формуле вешал хендлер навсегда (ctx-таймаут интерпретатор не прерывает) и навечно съедал слот concurrency отчётов. Переведено на `CallSandboxed` с профилем (10 с wall-clock, 1 млн итераций); запреты возможностей не включаются — формулы, как и запрос отчёта, доверенный код конфигурации.

6. **Гонка на разделяемых метаданных в кэше реквизитов ссылок.** `preloadIDs` делал `append(entity.Fields, displayField(entity)...)` — при `cap>len` (типично после yaml-декода) запись уходила в общий backing array реестра из конкурентных запросов (`-race`). К тому же append был бесполезен: `displayField` возвращает поле, уже входящее в `entity.Fields`. Оставлен `uniqueObjectFields(entity.Fields)`.

7. **`_api_tokens.last_used_at` писался на каждый запрос.** Интеграция с высоким RPS давала постоянный writer-трафик (чувствительно на SQLite). Добавлен троттлинг 5 минут — тот же приём, что `touchThrottle` у сессий (план 78). Тест: повторный touch внутри окна не пишет, после окна — пишет.

8. **Готовые файлы экспорта могли висеть в RAM бессрочно.** Уборка стора джоб происходила только при `create/get`; если к джобе никто не обращался, большой экспорт оставался в памяти. Добавлен фоновый sweeper (интервал TTL/3). Тест: просроченная джоба исчезает без обращений к стору.

9. Мелочь: `refAwareMapThis.Set` создавал новые ключи строк ТЧ в lowercase — выровнено с `interpreter.MapThis` (исходный регистр).

## Проверка

- `go build ./...`, `go vet`, `go test ./...` — зелёные; `internal/configdb -count=25` — зелёный (раньше флакал).
- Новые тесты: recover джобы, sweeper, монотонные версии (unit + порядок 25 версий), троттлинг токенов, распознавание 55P03.

## Отмечено в ревью, но сознательно не трогалось

- `scanLocalTimePtr` (локальная TZ срока токена) — унификация TZ-политики отдельной задачей.
- `CREATE INDEX` регистров без `CONCURRENTLY` — миграция офлайн-шаг.
- `ExportMaxRows`/`ExportConcurrency` нулевые по умолчанию — осознанный default «без лимитов».

🤖 Generated with [Claude Code](https://claude.com/claude-code)
