### PR TITLE
Delegate managed form event handlers

### DIFF
--- a/Plans/55-monolith-split-embed-frontend.md
+++ b/Plans/55-monolith-split-embed-frontend.md
@@ -1,6 +1,6 @@
 # План 55 — Раскол монолитов и фронт в go:embed
 
-**Статус:** 🟡 Этап 1 реализован (2026-06-10, ветка `refactor/split-ui-handlers`); этап 2 **Фаза 1** (конфигуратор на `html/template`, XSS-долг плана 47 §1.3 закрыт) — реализована 2026-06-19 (ветка `feature/55-configurator-htmltemplate`, см. `55-impl-htmltemplate-embed.md`); этап 2 **Фаза 2** (вынос CSS/JS конфигуратора в `/static` + go:embed, bootstrap `window.__cfg`/`__cfgI18n`) — реализована 2026-06-19 (`configurator_tmpl.go` 6726→2443 строк; `static/configurator.{css,js}`); этап 3 **Фаза 3a** (глобальные UI-скрипты из `tplHead` + общий reference picker в `/static/ui.js` через `go:embed`) — реализована 2026-07-07; этап 3 **Фаза 3b** (nav drawer/collapsible nav, dashboard/page/report charts через JSON bootstrap, runtime-настройки отчётов, сворачивание отчётов, dirty-watch формы и вложения) — реализована 2026-07-07; этап 3 **Фаза 3c** (`form-shared-js`: richtext/image/tablepart helpers/item picker + runtime списка: selection/context menu/tree lazy-load/feed) — реализована 2026-07-07; этап 3 **Фаза 3d** (runtime управляемых форм: `obFire`, ValueTable, SlickGrid, авто-`ПриОткрытии`, восстановление вкладок) — реализована 2026-07-07; остаток этапа 3 — мелкие inline handlers в шаблонах, журналы, query/dev tools и админки.
+**Статус:** 🟡 Этап 1 реализован (2026-06-10, ветка `refactor/split-ui-handlers`); этап 2 **Фаза 1** (конфигуратор на `html/template`, XSS-долг плана 47 §1.3 закрыт) — реализована 2026-06-19 (ветка `feature/55-configurator-htmltemplate`, см. `55-impl-htmltemplate-embed.md`); этап 2 **Фаза 2** (вынос CSS/JS конфигуратора в `/static` + go:embed, bootstrap `window.__cfg`/`__cfgI18n`) — реализована 2026-06-19 (`configurator_tmpl.go` 6726→2443 строк; `static/configurator.{css,js}`); этап 3 **Фаза 3a** (глобальные UI-скрипты из `tplHead` + общий reference picker в `/static/ui.js` через `go:embed`) — реализована 2026-07-07; этап 3 **Фаза 3b** (nav drawer/collapsible nav, dashboard/page/report charts через JSON bootstrap, runtime-настройки отчётов, сворачивание отчётов, dirty-watch формы и вложения) — реализована 2026-07-07; этап 3 **Фаза 3c** (`form-shared-js`: richtext/image/tablepart helpers/item picker + runtime списка: selection/context menu/tree lazy-load/feed) — реализована 2026-07-07; этап 3 **Фаза 3d** (runtime управляемых форм: `obFire`, ValueTable, SlickGrid, авто-`ПриОткрытии`, восстановление вкладок) — реализована 2026-07-07; этап 3 **Фаза 3e** (inline handlers `templates_managed.go` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; остаток этапа 3 — inline handlers в `templates.go`, журналы, query/dev tools и админки.
 
 > **Как реализовано (этап 1).** `ui/handlers.go` разнесён механически (as-is,
 > вместе с doc-комментариями) с 3908 до 660 строк: `handlers_entity.go` (CRUD
@@ -119,11 +119,15 @@ JSON через `template.JS(jsonBytes)` (как уже делается в `dev
   частей/ValueTable, file picker, dirty/Esc handling, SlickGrid initializer,
   авто-`ПриОткрытии` и восстановление активной вкладки; шаблон оставляет JSON
   bootstrap (`ob-managed-*`) и vendor-подключения SlickGrid;
-- оставшийся долг — мелкие inline handlers (`onclick`/`onchange` на кнопках,
-  фильтрах, picker-close и т.п.) и специализированные экраны журналов,
-  query/dev tools и админок. Их нужно выносить отдельными PR через явный
-  bootstrap JSON/data-атрибуты и браузерную проверку конкретных экранов, а не
-  механическим копированием.
+- следующим срезом `templates_managed.go` очищен от inline event attributes:
+  `onclick`/`onchange`/`oninput`/`onfocus`/`onsubmit` заменены на `data-ob-*`,
+  а `/static/managed.js` получил delegated listeners для `obFire`, ref picker,
+  file picker, добавления/удаления строк, пересчёта ТЧ, dropdown toggle,
+  popup cancel, confirm и `obGridSync`;
+- оставшийся долг — inline handlers в `templates.go` и специализированные
+  экраны журналов, query/dev tools и админок. Их нужно выносить отдельными PR
+  через явный bootstrap JSON/data-атрибуты и браузерную проверку конкретных
+  экранов, а не механическим копированием.
 
 ---
 

--- a/internal/ui/choice_list_test.go
+++ b/internal/ui/choice_list_test.go
@@ -58,7 +58,7 @@ func TestLoadChoiceOptions(t *testing.T) {
 
 // При рендере managed-формы элемент ПолеСписка отрисовывается как <select> с
 // опциями из ChoiceOptions, текущее значение помечается selected, а при наличии
-// обработчика навешивается onchange→obFire('ПриИзменении').
+// обработчика навешивается data-ob-fire-change для delegated runtime.
 func TestManagedFormChoiceListRenders(t *testing.T) {
 	form := &metadata.FormModule{
 		Name:       "ФормаОбъекта",
@@ -106,8 +106,8 @@ func TestManagedFormChoiceListRenders(t *testing.T) {
 	if !strings.Contains(html, `value="high" selected`) {
 		t.Error("текущее значение high не помечено selected")
 	}
-	if !strings.Contains(html, `onchange="obFire('ПолеПриоритет','ПриИзменении')"`) {
-		t.Error("нет onchange→obFire('ПриИзменении') у поля со списком значений")
+	if !strings.Contains(html, `data-ob-fire-change="ПолеПриоритет"`) {
+		t.Error("нет data-ob-fire-change у поля со списком значений")
 	}
 }
 

--- a/internal/ui/dynamic_choice_test.go
+++ b/internal/ui/dynamic_choice_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // При объявленном НачалоВыбора у ПолеСписка рендер навешивает data-el и
-// onfocus=obStartListChoice — крючок для динамического списка значений.
+// data-ob-list-choice — крючок для динамического списка значений.
 func TestManagedFormChoiceListDynamicAttrs(t *testing.T) {
 	form := &metadata.FormModule{
 		Name:       "ФормаОбъекта",
@@ -61,8 +61,8 @@ func TestManagedFormChoiceListDynamicAttrs(t *testing.T) {
 	if !strings.Contains(html, `data-el="ПолеВалюта"`) {
 		t.Error("нет data-el у ПолеСписка с НачалоВыбора")
 	}
-	if !strings.Contains(html, `onfocus="obStartListChoice('ПолеВалюта')"`) {
-		t.Error("нет onfocus→obStartListChoice у ПолеСписка с НачалоВыбора")
+	if !strings.Contains(html, `data-ob-list-choice="ПолеВалюта"`) {
+		t.Error("нет data-ob-list-choice у ПолеСписка с НачалоВыбора")
 	}
 }
 

--- a/internal/ui/managed_form_test.go
+++ b/internal/ui/managed_form_test.go
@@ -130,6 +130,17 @@ func TestPageManagedForm_Renders(t *testing.T) {
 			t.Errorf("managed runtime должен жить в /static/managed.js, но HTML содержит %q", old)
 		}
 	}
+	for _, old := range []string{
+		"onclick=",
+		"onchange=",
+		"oninput=",
+		"onfocus=",
+		"onsubmit=",
+	} {
+		if strings.Contains(tplManagedForm, old) {
+			t.Errorf("templates_managed.go не должен содержать inline handler %q", old)
+		}
+	}
 }
 
 // ГруппаФормы с orientation: horizontal раскладывает дочерние реквизиты в ряд

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -511,11 +511,152 @@ function addVtRow(vtName, fields) {
   var tdDel = document.createElement("td");
   var btn = document.createElement("button");
   btn.type = "button"; btn.className = "del-btn"; btn.textContent = "×";
-  btn.onclick = function(){ tr.remove(); };
+  btn.setAttribute("data-ob-remove-row", "");
   tdDel.appendChild(btn);
   tr.appendChild(tdDel);
   tbody.appendChild(tr);
 }
+
+function obManagedClosestSelect(btn) {
+  var target = btn.getAttribute('data-ob-ref-picker') || btn.getAttribute('data-ob-ref-current') || '';
+  if (target && target !== 'closest') return document.getElementById(target);
+  var root = btn.parentElement || (btn.closest && btn.closest('td')) || document;
+  return root && root.querySelector ? root.querySelector('select') : null;
+}
+
+function obManagedParseFieldMeta(raw) {
+  return String(raw || '').split(',').filter(Boolean).map(function (s) {
+    var idx = s.indexOf('|');
+    if (idx < 0) return { name: s, type: 'string' };
+    var rest = s.slice(idx + 1);
+    var refIdx = rest.indexOf(':');
+    return { name: s.slice(0, idx), type: refIdx >= 0 ? rest.slice(0, refIdx) : rest };
+  }).filter(function (f) { return f.name !== ''; });
+}
+
+function obManagedAddTpRow(btn) {
+  var tpName = btn.getAttribute('data-ob-add-tp') || '';
+  var tbody = document.getElementById('tp-body-' + tpName);
+  if (!tpName || !tbody || typeof addTpRow !== 'function') return;
+  var meta = obManagedParseFieldMeta(tbody.getAttribute('data-tp-fields') || '');
+  var fields = meta.map(function (f) { return f.name; });
+  var nums = meta.filter(function (f) { return f.type === 'number'; }).map(function (f) { return f.name; });
+  addTpRow(tpName, fields, nums, tbody.rows.length);
+}
+
+function obManagedAddVtRow(btn) {
+  var vtName = btn.getAttribute('data-ob-add-vt') || '';
+  var tbody = document.getElementById('vt-body-' + vtName);
+  if (!vtName || !tbody || typeof addVtRow !== 'function') return;
+  var fields = obManagedParseFieldMeta(tbody.getAttribute('data-vt-fields') || '').map(function (f) { return f.name; });
+  addVtRow(vtName, fields);
+}
+
+function obManagedInitDelegates() {
+  document.addEventListener('click', function (e) {
+    var btn = e.target && e.target.closest ? e.target.closest('[data-ob-ref-picker],[data-ob-ref-current],[data-ob-file-trigger],[data-ob-fire-click],[data-ob-grid-add],[data-ob-grid-del],[data-ob-add-tp],[data-ob-add-vt],[data-ob-remove-row],[data-ob-ref-cancel],[data-ob-toggle-next]') : null;
+    if (!btn) return;
+
+    if (btn.hasAttribute('data-ob-ref-cancel')) {
+      e.preventDefault();
+      try { parent.postMessage({ source: 'obRefCancel' }, '*'); } catch (_) {}
+      return;
+    }
+    if (btn.hasAttribute('data-ob-toggle-next')) {
+      e.preventDefault();
+      var d = btn.nextElementSibling;
+      if (d) d.style.display = d.style.display === 'none' ? 'block' : 'none';
+      return;
+    }
+    if (btn.hasAttribute('data-ob-ref-picker')) {
+      e.preventDefault();
+      var pickSel = obManagedClosestSelect(btn);
+      if (pickSel && typeof openRefPicker === 'function') openRefPicker(pickSel);
+      return;
+    }
+    if (btn.hasAttribute('data-ob-ref-current')) {
+      e.preventDefault();
+      var curSel = obManagedClosestSelect(btn);
+      if (curSel && typeof openRefCurrent === 'function') openRefCurrent(curSel);
+      return;
+    }
+    if (btn.hasAttribute('data-ob-file-trigger')) {
+      e.preventDefault();
+      var file = document.getElementById(btn.getAttribute('data-ob-file-trigger') || '');
+      if (file) file.click();
+      return;
+    }
+    if (btn.hasAttribute('data-ob-fire-click')) {
+      e.preventDefault();
+      var params = {};
+      var tp = btn.getAttribute('data-ob-fire-tp') || '';
+      if (tp) params._tp = tp;
+      if (window.obFire) window.obFire(btn.getAttribute('data-ob-fire-click') || '', 'Нажатие', params);
+      return;
+    }
+    if (btn.hasAttribute('data-ob-grid-add')) {
+      e.preventDefault();
+      if (window.obGridAddRow) window.obGridAddRow(btn.getAttribute('data-ob-grid-add') || '');
+      return;
+    }
+    if (btn.hasAttribute('data-ob-grid-del')) {
+      e.preventDefault();
+      if (window.obGridDelRow) window.obGridDelRow(btn.getAttribute('data-ob-grid-del') || '');
+      return;
+    }
+    if (btn.hasAttribute('data-ob-add-tp')) {
+      e.preventDefault();
+      obManagedAddTpRow(btn);
+      return;
+    }
+    if (btn.hasAttribute('data-ob-add-vt')) {
+      e.preventDefault();
+      obManagedAddVtRow(btn);
+      return;
+    }
+    if (btn.hasAttribute('data-ob-remove-row')) {
+      e.preventDefault();
+      var tr = btn.closest && btn.closest('tr');
+      if (tr) tr.remove();
+    }
+  });
+
+  document.addEventListener('change', function (e) {
+    var el = e.target;
+    if (!el || !el.getAttribute) return;
+    if (el.hasAttribute('data-ob-file-pick-path') && window.obFilePick) {
+      window.obFilePick(el, el.getAttribute('data-ob-file-pick-path') || '', el.getAttribute('data-ob-file-pick-content') || '');
+      return;
+    }
+    var fire = el.getAttribute('data-ob-fire-change');
+    if (fire && window.obFire) window.obFire(fire, 'ПриИзменении');
+  });
+
+  document.addEventListener('input', function (e) {
+    var el = e.target;
+    if (el && el.hasAttribute && el.hasAttribute('data-ob-recalc-tp-row') && typeof recalcTpRow === 'function') recalcTpRow(el);
+  });
+
+  document.addEventListener('focusin', function (e) {
+    var el = e.target;
+    var name = el && el.getAttribute ? el.getAttribute('data-ob-list-choice') : '';
+    if (name && window.obStartListChoice) window.obStartListChoice(name);
+  });
+
+  document.addEventListener('submit', function (e) {
+    var form = e.target;
+    if (!form || !form.getAttribute) return;
+    var msg = form.getAttribute('data-ob-confirm');
+    if (msg && !confirm(msg)) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+    if (form.hasAttribute('data-ob-grid-sync') && window.obGridSync) window.obGridSync();
+  });
+}
+
+obManagedReady(obManagedInitDelegates);
 
 // SlickGrid initializer for managed-form table parts (plan 48).
 // Grids are stored in window._obGrids = {tpName: {grid, dataView, columns}}.

--- a/internal/ui/static_test.go
+++ b/internal/ui/static_test.go
@@ -67,6 +67,9 @@ func TestStaticManagedJS(t *testing.T) {
 		"function addVtRow",
 		"window.obGridSync",
 		"function gridCellEventParams",
+		"function obManagedInitDelegates",
+		"data-ob-fire-click",
+		"data-ob-add-tp",
 		"obManagedSwitchTab",
 		"ПриОткрытии",
 	} {

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -61,26 +61,26 @@ const tplManagedForm = `
     {{if $f}}
       {{if isRef (str $f.Type)}}
         <div style="display:flex;gap:6px;align-items:center">
-          <select id="ref-{{$fn}}" name="{{$fn}}" style="flex:1" data-ref-entity="{{$f.RefEntity}}"{{if $f.InlineCreateEnabled false}} data-ref-allow-create="1"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+          <select id="ref-{{$fn}}" name="{{$fn}}" style="flex:1" data-ref-entity="{{$f.RefEntity}}"{{if $f.InlineCreateEnabled false}} data-ref-allow-create="1"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
             <option value="">— выбрать —</option>
             {{range index $ctx.RefOptions $fn}}
             <option value="{{index . "id"}}" {{if eq (index . "id") (index $ctx.Values $fn)}}selected{{end}}>{{index . "_label"}}</option>
             {{end}}
           </select>
-          <button type="button" onclick="openRefPicker('ref-{{$fn}}')" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
-          <button type="button" onclick="openRefCurrent('ref-{{$fn}}')" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
+          <button type="button" data-ob-ref-picker="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
+          <button type="button" data-ob-ref-current="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
         </div>
       {{else if isEnum (str $f.Type)}}
-        <select name="{{$fn}}"{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+        <select name="{{$fn}}"{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
           <option value="">— выбрать —</option>
           {{range index $ctx.EnumOptions $fn}}
           <option value="{{.Value}}" {{if eq .Value (index $ctx.Values $fn)}}selected{{end}}>{{.Label}}</option>
           {{end}}
         </select>
       {{else if eq (str $f.Type) "date"}}
-        <input type="datetime-local" name="{{$fn}}" value="{{index $ctx.Values $fn}}"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+        <input type="datetime-local" name="{{$fn}}" value="{{index $ctx.Values $fn}}"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{else if eq (str $f.Type) "bool"}}
-        <select name="{{$fn}}"{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+        <select name="{{$fn}}"{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
           <option value="false" {{if eq (index $ctx.Values $fn) "false"}}selected{{end}}>Нет</option>
           <option value="true" {{if eq (index $ctx.Values $fn) "true"}}selected{{end}}>Да</option>
         </select>
@@ -94,26 +94,26 @@ const tplManagedForm = `
         <div style="display:flex;gap:6px;align-items:center">
           <input type="text" name="{{$fn}}" id="file-path-{{$fn}}" placeholder="Путь к файлу или выберите …" style="flex:1"{{if $el.ReadOnly}} readonly{{end}}>
           <textarea name="_fc_{{$fn}}" id="file-content-{{$fn}}" style="display:none"></textarea>
-          <input type="file" id="file-pick-{{$fn}}" style="display:none" onchange="obFilePick(this,'file-path-{{$fn}}','file-content-{{$fn}}')">
-          <button type="button" onclick="document.getElementById('file-pick-{{$fn}}').click()" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;white-space:nowrap" title="Выбрать файл">…</button>
+          <input type="file" id="file-pick-{{$fn}}" style="display:none" data-ob-file-pick-path="file-path-{{$fn}}" data-ob-file-pick-content="file-content-{{$fn}}">
+          <button type="button" data-ob-file-trigger="file-pick-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;white-space:nowrap" title="Выбрать файл">…</button>
         </div>
       {{else if $el.Multiline}}
-        <textarea name="{{$fn}}" rows="5" style="width:100%"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>{{index $ctx.Values $fn}}</textarea>
+        <textarea name="{{$fn}}" rows="5" style="width:100%"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>{{index $ctx.Values $fn}}</textarea>
       {{else}}
-        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}"{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}"{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{end}}
     {{else if eq (str $el.Type) "file"}}
       {{/* Поле не найдено в Entity, но элемент объявлен как file */}}
       <div style="display:flex;gap:6px;align-items:center">
         <input type="text" name="{{$fn}}" id="file-path-{{$fn}}" placeholder="Путь к файлу или выберите …" style="flex:1">
         <textarea name="_fc_{{$fn}}" id="file-content-{{$fn}}" style="display:none"></textarea>
-        <input type="file" id="file-pick-{{$fn}}" style="display:none" onchange="obFilePick(this,'file-path-{{$fn}}','file-content-{{$fn}}')">
-        <button type="button" onclick="document.getElementById('file-pick-{{$fn}}').click()" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;white-space:nowrap" title="Выбрать файл">…</button>
+        <input type="file" id="file-pick-{{$fn}}" style="display:none" data-ob-file-pick-path="file-path-{{$fn}}" data-ob-file-pick-content="file-content-{{$fn}}">
+        <button type="button" data-ob-file-trigger="file-pick-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;white-space:nowrap" title="Выбрать файл">…</button>
       </div>
     {{else}}
       {{/* Поле не найдено в Entity (возможно реквизит формы, ещё не привязан) */}}
       <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}" style="background:#fef9c3"
-        title="Реквизит формы '{{$el.DataPath}}' не найден среди полей сущности"{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+        title="Реквизит формы '{{$el.DataPath}}' не найден среди полей сущности"{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
     {{end}}
     {{if $el.Hint}}<small style="color:#94a3b8;font-size:11px">{{$el.Hint}}</small>{{end}}
   </div>
@@ -126,7 +126,7 @@ const tplManagedForm = `
   {{$hChg := hasHandler $el "ПриИзменении"}}
   <div class="form-group">
     <label>{{fieldTitleRU $el.TitleMap $fn}}{{if $el.Required}} <span style="color:#dc2626">*</span>{{end}}</label>
-    <select name="{{$fn}}"{{if hasHandler $el "НачалоВыбора"}} data-el="{{$el.Name}}" onfocus="obStartListChoice('{{$el.Name}}')"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+    <select name="{{$fn}}"{{if hasHandler $el "НачалоВыбора"}} data-el="{{$el.Name}}" data-ob-list-choice="{{$el.Name}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       <option value="">— выбрать —</option>
       {{range index $ctx.ChoiceOptions $el.Name}}
       <option value="{{.Value}}" {{if eq .Value (index $ctx.Values $fn)}}selected{{end}}>{{.Label}}</option>
@@ -146,7 +146,7 @@ const tplManagedForm = `
     {{fieldTitleRU $el.TitleMap $el.Name}}
   </div>
 {{else if eq (str $el.Kind) "Кнопка"}}
-  <button type="button" class="btn btn-secondary" style="margin:6px 4px 6px 0"{{if $el.ReadOnly}} disabled{{end}}{{if hasHandler $el "Нажатие"}} onclick="obFire('{{$el.Name}}','Нажатие')"{{end}}>
+  <button type="button" class="btn btn-secondary" style="margin:6px 4px 6px 0"{{if $el.ReadOnly}} disabled{{end}}{{if hasHandler $el "Нажатие"}} data-ob-fire-click="{{$el.Name}}"{{end}}>
     {{fieldTitleRU $el.TitleMap $el.Name}}
   </button>
 {{else if eq (str $el.Kind) "ПолеКартинки"}}
@@ -172,7 +172,7 @@ const tplManagedForm = `
   <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:6px">
     {{range $tpCmds}}
     <button type="button" class="btn btn-sm" style="background:#eef2ff;color:#3730a3;border:1px solid #c7d2fe"
-      {{if $el.ReadOnly}}disabled{{end}}{{if hasHandler . "Нажатие"}} onclick="obFire('{{.Name}}','Нажатие',{_tp:'{{$tpName}}'})"{{end}}>
+      {{if $el.ReadOnly}}disabled{{end}}{{if hasHandler . "Нажатие"}} data-ob-fire-click="{{.Name}}" data-ob-fire-tp="{{$tpName}}"{{end}}>
       {{fieldTitleRU .TitleMap .Name}}
     </button>
     {{end}}
@@ -195,9 +195,9 @@ const tplManagedForm = `
   <input type="hidden" name="tp_json.{{$tpName}}" id="tp-json-{{$tpName}}" value="">
   <div style="display:flex;gap:6px;margin-top:4px">
     <button type="button" class="btn btn-sm" style="background:#e2e8f0;color:#475569"
-      onclick="obGridAddRow('{{$tpName}}')">+ Добавить строку</button>
+      data-ob-grid-add="{{$tpName}}">+ Добавить строку</button>
     <button type="button" class="btn btn-sm" style="background:#fee2e2;color:#991b1b"
-      onclick="obGridDelRow('{{$tpName}}')">− Удалить строку</button>
+      data-ob-grid-del="{{$tpName}}">− Удалить строку</button>
   </div>
 {{else}}
 <table class="tp-table" data-tp="{{$tpName}}">
@@ -223,17 +223,17 @@ const tplManagedForm = `
                 <option value="{{index . "id"}}" {{if eq (str (index . "id")) (refID $v)}}selected{{end}}>{{index . "_label"}}</option>
                 {{end}}
               </select>
-              <button type="button" onclick="openRefPicker(this.parentElement.querySelector('select'))" style="padding:4px 8px;border:1px solid #e2e8f0;border-radius:5px;background:#f8fafc;cursor:pointer;font-size:12px;flex-shrink:0" title="Выбрать из списка">...</button>
-              <button type="button" onclick="openRefCurrent(this.parentElement.querySelector('select'))" style="padding:4px 7px;border:1px solid #e2e8f0;border-radius:5px;background:#f8fafc;cursor:pointer;font-size:12px;flex-shrink:0" title="Открыть карточку">🔍</button>
+              <button type="button" data-ob-ref-picker="closest" style="padding:4px 8px;border:1px solid #e2e8f0;border-radius:5px;background:#f8fafc;cursor:pointer;font-size:12px;flex-shrink:0" title="Выбрать из списка">...</button>
+              <button type="button" data-ob-ref-current="closest" style="padding:4px 7px;border:1px solid #e2e8f0;border-radius:5px;background:#f8fafc;cursor:pointer;font-size:12px;flex-shrink:0" title="Открыть карточку">🔍</button>
             </div>
           {{else if eq (str $f.Type) "number"}}
-            <input type="number" step="any" name="tp.{{$tpName}}.{{$i}}.{{$f.Name}}" value="{{$v}}" data-tp-num="{{$f.Name}}" oninput="recalcTpRow(this)">
+            <input type="number" step="any" name="tp.{{$tpName}}.{{$i}}.{{$f.Name}}" value="{{$v}}" data-tp-num="{{$f.Name}}" data-ob-recalc-tp-row>
           {{else}}
-            <input type="text" name="tp.{{$tpName}}.{{$i}}.{{$f.Name}}" value="{{$v}}" oninput="recalcTpRow(this)">
+            <input type="text" name="tp.{{$tpName}}.{{$i}}.{{$f.Name}}" value="{{$v}}" data-ob-recalc-tp-row>
           {{end}}
         </td>
         {{end}}
-        <td><button type="button" class="del-btn" onclick="this.closest('tr').remove()">×</button></td>
+        <td><button type="button" class="del-btn" data-ob-remove-row>×</button></td>
       </tr>
     {{end}}
     </tbody>
@@ -243,7 +243,7 @@ const tplManagedForm = `
     </tr></tfoot>
   </table>
   <button type="button" class="btn btn-sm" style="background:#e2e8f0;color:#475569;margin:0 0 12px"
-    onclick="addTpRow('{{$tpName}}', [{{range $tpMeta.Fields}}'{{.Name}}',{{end}}], [{{range $tpMeta.Fields}}{{if eq (str .Type) "number"}}'{{.Name}}',{{end}}{{end}}], document.getElementById('tp-body-{{$tpName}}').rows.length)">
+    data-ob-add-tp="{{$tpName}}">
     + Добавить строку
 {{end}}
   </button>
@@ -258,7 +258,7 @@ const tplManagedForm = `
   <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:6px">
     {{range $vtCmds}}
     <button type="button" class="btn btn-sm" style="background:#eef2ff;color:#3730a3;border:1px solid #c7d2fe"
-      onclick="obFire('{{.Name}}','Нажатие',{_tp:'{{$tpName}}'})">
+      data-ob-fire-click="{{.Name}}" data-ob-fire-tp="{{$tpName}}">
       {{fieldTitleRU .TitleMap .Name}}
     </button>
     {{end}}
@@ -286,13 +286,13 @@ const tplManagedForm = `
           {{end}}
         </td>
         {{end}}
-        <td><button type="button" class="del-btn" onclick="this.closest('tr').remove()">×</button></td>
+        <td><button type="button" class="del-btn" data-ob-remove-row>×</button></td>
       </tr>
     {{end}}
     </tbody>
   </table>
   <button type="button" class="btn btn-sm" style="background:#e2e8f0;color:#475569;margin:0 0 12px"
-    onclick="addVtRow('{{$tpName}}', [{{range $vtCols}}'{{.Name}}',{{end}}])">
+    data-ob-add-vt="{{$tpName}}">
     + Добавить строку
   </button>
   {{else}}
@@ -310,7 +310,7 @@ const tplManagedForm = `
   {{$dv := index $ctx.Values $fn}}
   <div class="form-group">
     <label>{{fieldTitleRU $el.TitleMap $fn}}{{if $el.Required}} <span style="color:#dc2626">*</span>{{end}}</label>
-    <input type="date" name="{{$fn}}" value="{{if ge (len $dv) 10}}{{slice $dv 0 10}}{{else}}{{$dv}}{{end}}"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+    <input type="date" name="{{$fn}}" value="{{if ge (len $dv) 10}}{{slice $dv 0 10}}{{else}}{{$dv}}{{end}}"{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
   </div>
 {{else if eq (str $el.Kind) "Переключатель"}}
   {{/* Поле с набором значений: радио-переключатель (по умолчанию) или список
@@ -325,7 +325,7 @@ const tplManagedForm = `
   <div class="form-group">
     <label>{{fieldTitleRU $el.TitleMap $fn}}{{if $el.Required}} <span style="color:#dc2626">*</span>{{end}}</label>
     {{if eq $el.View "select"}}
-      <select name="{{$fn}}"{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}>
+      <select name="{{$fn}}"{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
         <option value="">— выбрать —</option>
         {{if $enum}}
           {{range index $ctx.EnumOptions $fn}}<option value="{{.Value}}" {{if eq .Value $cur}}selected{{end}}>{{.Label}}</option>{{end}}
@@ -336,9 +336,9 @@ const tplManagedForm = `
     {{else}}
       <div class="switch-options" style="display:flex;flex-wrap:wrap;gap:12px;padding:4px 0">
         {{if $enum}}
-          {{range index $ctx.EnumOptions $fn}}<label style="display:inline-flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="{{$fn}}" value="{{.Value}}"{{if eq .Value $cur}} checked{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}> {{.Label}}</label>{{end}}
+          {{range index $ctx.EnumOptions $fn}}<label style="display:inline-flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="{{$fn}}" value="{{.Value}}"{{if eq .Value $cur}} checked{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}> {{.Label}}</label>{{end}}
         {{else}}
-          {{range $el.Options}}<label style="display:inline-flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="{{$fn}}" value="{{.ValueStr}}"{{if eq .ValueStr $cur}} checked{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} onchange="obFire('{{$el.Name}}','ПриИзменении')"{{end}}> {{.Label}}</label>{{end}}
+          {{range $el.Options}}<label style="display:inline-flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="{{$fn}}" value="{{.ValueStr}}"{{if eq .ValueStr $cur}} checked{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}> {{.Label}}</label>{{end}}
         {{end}}
       </div>
     {{end}}
@@ -391,7 +391,7 @@ const tplManagedForm = `
     <span style="font-size:11px;color:#10b981;background:#d1fae5;padding:2px 8px;border-radius:10px;vertical-align:middle;font-weight:500" title="Управляемая форма из forms/{{if .IsProcessor}}{{lower .Processor.Name}}{{else}}{{lower .Entity.Name}}{{end}}/">◇ managed</span>
   </h2>
   {{if .IsPopup}}
-  <a href="javascript:void(0)" onclick="try{parent.postMessage({source:'obRefCancel'}, '*')}catch(e){}" title="Закрыть" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
+  <a href="#" data-ob-ref-cancel title="Закрыть" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{else}}
   <a href="{{if .IsProcessor}}/ui/{{else}}/ui/{{lower (str .Entity.Kind)}}/{{lower .Entity.Name}}{{end}}" title="Закрыть" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{end}}
@@ -436,7 +436,7 @@ const tplManagedForm = `
     <a href="/ui/{{lower (str .Entity.Kind)}}/{{.Entity.Name}}/{{.ID}}/history" class="btn btn-sm btn-secondary">История</a>
     {{if or .AllPrintForms .HasPrintProc}}
     <div style="position:relative">
-      <button type="button" class="btn btn-sm btn-secondary" onclick="var d=this.nextElementSibling;d.style.display=d.style.display==='none'?'block':'none'">{{t $.Lang "Печать"}} ▾</button>
+      <button type="button" class="btn btn-sm btn-secondary" data-ob-toggle-next>{{t $.Lang "Печать"}} ▾</button>
       <div style="display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #e2e8f0;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.1);min-width:200px;z-index:50;margin-top:4px">
         {{range .AllPrintForms}}
         <div style="display:flex;align-items:center;border-bottom:1px solid #f1f5f9">
@@ -455,7 +455,7 @@ const tplManagedForm = `
     {{end}}
     {{if .Receivers}}
     <div style="position:relative;display:inline-block">
-      <button type="button" class="btn btn-sm btn-secondary" onclick="var d=this.nextElementSibling;d.style.display=d.style.display==='none'?'block':'none'">{{t $.Lang "Ввести на основании"}} ▾</button>
+      <button type="button" class="btn btn-sm btn-secondary" data-ob-toggle-next>{{t $.Lang "Ввести на основании"}} ▾</button>
       <div style="display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #e2e8f0;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.1);min-width:200px;z-index:50;margin-top:4px">
         {{range .Receivers}}
         <a href="/ui/{{lower (str .Kind)}}/{{.Name}}/new?based_on={{$.Entity.Name}}&based_on_id={{$.ID}}"
@@ -466,7 +466,7 @@ const tplManagedForm = `
     {{end}}
     {{if and .CanDelete (not (deleteHidden .Form))}}
     <form method="POST" action="/ui/{{lower (str .Entity.Kind)}}/{{.Entity.Name}}/{{.ID}}/delete"
-          onsubmit="return confirm('{{if .IsAdmin}}Удалить запись навсегда?{{else}}Пометить запись на удаление?{{end}}')" style="margin-left:auto">
+          data-ob-confirm="{{if .IsAdmin}}Удалить запись навсегда?{{else}}Пометить запись на удаление?{{end}}" style="margin-left:auto">
       <button class="btn btn-danger btn-sm" type="submit">{{if .IsAdmin}}Удалить{{else}}Пометить на удаление{{end}}</button>
     </form>
     {{end}}
@@ -508,7 +508,7 @@ const tplManagedForm = `
 {{end}}
 
 <div class="card">
-<form id="main-form" method="POST" onsubmit="if(window.obGridSync)obGridSync()" {{if .IsProcessor}}action="/ui/processor/{{lower .Processor.Name}}" enctype="multipart/form-data"{{end}}>
+<form id="main-form" method="POST" data-ob-grid-sync {{if .IsProcessor}}action="/ui/processor/{{lower .Processor.Name}}" enctype="multipart/form-data"{{end}}>
 {{if and (not .IsNew) (index .Values "_version")}}<input type="hidden" name="_version" value="{{index .Values "_version"}}">{{end}}
 {{if .IsPopup}}<input type="hidden" name="_popup" value="1">{{end}}
 
@@ -520,7 +520,7 @@ const tplManagedForm = `
 <div style="margin-top:16px">
   {{if .IsPopup}}
   {{if .CanWrite}}<button class="btn btn-primary" type="submit" name="_action" value="" form="main-form">Записать и выбрать</button>{{end}}
-  <a href="javascript:void(0)" onclick="try{parent.postMessage({source:'obRefCancel'}, '*')}catch(e){}" class="btn btn-cancel">Отмена</a>
+  <a href="#" data-ob-ref-cancel class="btn btn-cancel">Отмена</a>
   {{else if .IsProcessor}}
   {{/* Кнопка «Выполнить» скрыта: managed-форма использует свои кнопки */}}
   <a href="/ui/" class="btn btn-cancel">Отмена</a>


### PR DESCRIPTION
## Что сделано
- Смержен PR #279 с выносом managed runtime в `/static/managed.js`.
- В `templates_managed.go` убраны inline event attributes: `onclick`, `onchange`, `oninput`, `onfocus`, `onsubmit`.
- Управляемый шаблон теперь использует `data-ob-*` для `obFire`, ref picker, file picker, строк ТЧ/ValueTable, dropdown toggle, popup cancel, confirm и `obGridSync`.
- В `/static/managed.js` добавлен delegated runtime для этих `data-ob-*` атрибутов.
- Обновлены тесты и статус плана 55.

## Проверки
- `git diff --check`
- `node --check internal/ui/static/managed.js`
- `go test ./internal/ui`
- `go test ./...`
- `go run ./tools/i18ncheck`
