### PR TITLE
Delegate registry and utility UI handlers

### DIFF
--- a/Plans/55-monolith-split-embed-frontend.md
+++ b/Plans/55-monolith-split-embed-frontend.md
@@ -1,6 +1,6 @@
 # План 55 — Раскол монолитов и фронт в go:embed
 
-**Статус:** 🟡 Этап 1 реализован (2026-06-10, ветка `refactor/split-ui-handlers`); этап 2 **Фаза 1** (конфигуратор на `html/template`, XSS-долг плана 47 §1.3 закрыт) — реализована 2026-06-19 (ветка `feature/55-configurator-htmltemplate`, см. `55-impl-htmltemplate-embed.md`); этап 2 **Фаза 2** (вынос CSS/JS конфигуратора в `/static` + go:embed, bootstrap `window.__cfg`/`__cfgI18n`) — реализована 2026-06-19 (`configurator_tmpl.go` 6726→2443 строк; `static/configurator.{css,js}`); этап 3 **Фаза 3a** (глобальные UI-скрипты из `tplHead` + общий reference picker в `/static/ui.js` через `go:embed`) — реализована 2026-07-07; этап 3 **Фаза 3b** (nav drawer/collapsible nav, dashboard/page/report charts через JSON bootstrap, runtime-настройки отчётов, сворачивание отчётов, dirty-watch формы и вложения) — реализована 2026-07-07; этап 3 **Фаза 3c** (`form-shared-js`: richtext/image/tablepart helpers/item picker + runtime списка: selection/context menu/tree lazy-load/feed) — реализована 2026-07-07; этап 3 **Фаза 3d** (runtime управляемых форм: `obFire`, ValueTable, SlickGrid, авто-`ПриОткрытии`, восстановление вкладок) — реализована 2026-07-07; этап 3 **Фаза 3e** (inline handlers `templates_managed.go` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3f** (layout/list inline handlers в `templates.go` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3g** (inline handlers обычной `page-form` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3h** (inline handlers `page-report` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; остаток этапа 3 — inline handlers в регистрах, процессорах, константах, журналах, query/dev tools и админках.
+**Статус:** 🟡 Этап 1 реализован (2026-06-10, ветка `refactor/split-ui-handlers`); этап 2 **Фаза 1** (конфигуратор на `html/template`, XSS-долг плана 47 §1.3 закрыт) — реализована 2026-06-19 (ветка `feature/55-configurator-htmltemplate`, см. `55-impl-htmltemplate-embed.md`); этап 2 **Фаза 2** (вынос CSS/JS конфигуратора в `/static` + go:embed, bootstrap `window.__cfg`/`__cfgI18n`) — реализована 2026-06-19 (`configurator_tmpl.go` 6726→2443 строк; `static/configurator.{css,js}`); этап 3 **Фаза 3a** (глобальные UI-скрипты из `tplHead` + общий reference picker в `/static/ui.js` через `go:embed`) — реализована 2026-07-07; этап 3 **Фаза 3b** (nav drawer/collapsible nav, dashboard/page/report charts через JSON bootstrap, runtime-настройки отчётов, сворачивание отчётов, dirty-watch формы и вложения) — реализована 2026-07-07; этап 3 **Фаза 3c** (`form-shared-js`: richtext/image/tablepart helpers/item picker + runtime списка: selection/context menu/tree lazy-load/feed) — реализована 2026-07-07; этап 3 **Фаза 3d** (runtime управляемых форм: `obFire`, ValueTable, SlickGrid, авто-`ПриОткрытии`, восстановление вкладок) — реализована 2026-07-07; этап 3 **Фаза 3e** (inline handlers `templates_managed.go` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3f** (layout/list inline handlers в `templates.go` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3g** (inline handlers обычной `page-form` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3h** (inline handlers `page-report` заменены на `data-ob-*` + delegated runtime) — реализована 2026-07-07; этап 3 **Фаза 3i** (inline handlers регистров, процессоров, констант и удаления помеченных заменены на `data-ob-*`) — реализована 2026-07-07; остаток этапа 3 — inline handlers в журналах, query/dev tools и админках.
 
 > **Как реализовано (этап 1).** `ui/handlers.go` разнесён механически (as-is,
 > вместе с doc-комментариями) с 3908 до 660 строк: `handlers_entity.go` (CRUD
@@ -137,10 +137,12 @@ JSON через `template.JS(jsonBytes)` (как уже делается в `dev
 - следующим срезом очищена `page-report`: autosubmit выбора пресета/варианта,
   ref picker/current параметров отчёта, `rsBeforeSubmit`, `rsChoosePreset`,
   добавление и удаление строк отбора переведены на `data-ob-*` delegation;
-- оставшийся долг — inline handlers в регистрах, процессорах, константах,
-  журналах, query/dev tools и админках. Их нужно выносить отдельными PR через
-  явный bootstrap JSON/data-атрибуты и браузерную проверку конкретных экранов,
-  а не механическим копированием.
+- следующим срезом очищены шаблоны регистров, обработок, констант и удаления
+  помеченных: ref picker/current и confirm переведены на уже существующие
+  `data-ob-ref-picker`, `data-ob-ref-current`, `data-ob-confirm`;
+- оставшийся долг — inline handlers в журналах, query/dev tools и админках. Их
+  нужно выносить отдельными PR через явный bootstrap JSON/data-атрибуты и
+  браузерную проверку конкретных экранов, а не механическим копированием.
 
 ---
 

--- a/internal/ui/register_processor_constant_delegates_test.go
+++ b/internal/ui/register_processor_constant_delegates_test.go
@@ -1,0 +1,40 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegisterProcessorConstantDelegatedHandlers(t *testing.T) {
+	html := tplRegister + tplDeleteMarked + tplProcessor + tplInfoReg + tplConstants
+	for _, want := range []string{
+		`data-ob-ref-picker="regflt-`,
+		`data-ob-confirm="{{t $.Lang "Удалить все помеченные записи без ссылок?"}}"`,
+		`data-ob-ref-picker="pp-`,
+		`data-ob-ref-current="pp-`,
+		`data-ob-confirm="{{t $.Lang "Удалить запись?"}}"`,
+		`data-ob-ref-picker="ird-`,
+		`data-ob-ref-current="ird-`,
+		`data-ob-ref-picker="const-`,
+		`data-ob-ref-current="const-`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("templates do not contain delegated marker %q", want)
+		}
+	}
+	for _, old := range []string{
+		`onclick="openRefPicker('regflt-`,
+		`onclick="openRefPicker('pp-`,
+		`onclick="openRefCurrent('pp-`,
+		`onclick="openRefPicker('ird-`,
+		`onclick="openRefCurrent('ird-`,
+		`onclick="openRefPicker('const-`,
+		`onclick="openRefCurrent('const-`,
+		`onsubmit="return confirm('{{t $.Lang "Удалить все помеченные записи без ссылок?"}}')"`,
+		`onsubmit="return confirm('{{t $.Lang "Удалить запись?"}}')"`,
+	} {
+		if strings.Contains(html, old) {
+			t.Fatalf("templates still contain inline handler %q", old)
+		}
+	}
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1838,7 +1838,7 @@ const tplRegister = `
         <option value="">— {{t $.Lang "все"}} —</option>
         {{$cur := index $flt .Name}}{{range index $refOpts .Name}}<option value="{{index . "id"}}" {{if eq (str (index . "id")) $cur}}selected{{end}}>{{index . "_label"}}</option>{{end}}
       </select>
-      <button type="button" onclick="openRefPicker('regflt-{{.Name}}')" style="padding:6px 9px;border:1px solid #e2e8f0;border-radius:6px;background:#f8fafc;cursor:pointer;font-size:12px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
+      <button type="button" data-ob-ref-picker="regflt-{{.Name}}" style="padding:6px 9px;border:1px solid #e2e8f0;border-radius:6px;background:#f8fafc;cursor:pointer;font-size:12px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
     </div>
     {{else}}
     <input type="text" name="flt_{{.Name}}" value="{{index $flt .Name}}" style="padding:6px 10px;border:1px solid #e2e8f0;border-radius:6px;font-size:13px">
@@ -1939,7 +1939,7 @@ const tplDeleteMarked = `
 </tbody></table>
 </div>
 <form method="POST" action="/ui/delete-marked"
-      onsubmit="return confirm('{{t $.Lang "Удалить все помеченные записи без ссылок?"}}')">
+      data-ob-confirm="{{t $.Lang "Удалить все помеченные записи без ссылок?"}}">
   <button class="btn btn-danger" type="submit">{{t $.Lang "Удалить помеченные без ссылок"}}</button>
   <a class="btn btn-secondary" href="/ui" style="margin-left:8px">{{t $.Lang "Отмена"}}</a>
 </form>
@@ -1996,8 +1996,8 @@ const tplProcessor = `
             <option value="">{{t $.Lang "— выбрать —"}}</option>
             {{with index $.RefOptions $pname}}{{range .}}<option value="{{index . "id"}}" {{if eq (index . "id") (index $.ParamValues $pname)}}selected{{end}}>{{index . "_label"}}</option>{{end}}{{end}}
           </select>
-          <button type="button" onclick="openRefPicker('pp-{{$pname}}')" style="padding:6px 10px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
-          <button type="button" onclick="openRefCurrent('pp-{{$pname}}')" style="padding:6px 9px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Открыть карточку"}}">🔍</button>
+          <button type="button" data-ob-ref-picker="pp-{{$pname}}" style="padding:6px 10px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
+          <button type="button" data-ob-ref-current="pp-{{$pname}}" style="padding:6px 9px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Открыть карточку"}}">🔍</button>
         </div>
       {{else}}
         <input type="text" name="{{$pname}}" value="{{index $.ParamValues $pname}}">
@@ -2318,7 +2318,7 @@ const tplInfoReg = `
   {{range $.InfoReg.Resources}}<td style="font-weight:600">{{$lbl := index $row (printf "%s_label" .Name)}}{{if $lbl}}{{$lbl}}{{else}}{{index $row .Name}}{{end}}</td>{{end}}
   {{if $.CanDelete}}<td>
     <form method="POST" action="/ui/inforeg/{{lower $.InfoReg.Name}}/delete" style="display:inline"
-          onsubmit="return confirm('{{t $.Lang "Удалить запись?"}}')">
+          data-ob-confirm="{{t $.Lang "Удалить запись?"}}">
       {{if $.InfoReg.Periodic}}<input type="hidden" name="period" value="{{index $row "period_key"}}">{{end}}
       {{range $.InfoReg.Dimensions}}<input type="hidden" name="{{.Name}}" value="{{index $row .Name}}">{{end}}
       <button class="btn btn-danger btn-sm" type="submit">×</button>
@@ -2353,8 +2353,8 @@ const tplInfoReg = `
         <option value="">{{t $.Lang "— выбрать —"}}</option>
         {{range index $.RefOpts $dn}}<option value="{{index . "id"}}" {{if eq (index $.Values $dn) (index . "id")}}selected{{end}}>{{index . "_label"}}</option>{{end}}
       </select>
-      <button type="button" onclick="openRefPicker('ird-{{$dn}}')" style="padding:6px 10px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
-      <button type="button" onclick="openRefCurrent('ird-{{$dn}}')" style="padding:6px 9px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Открыть карточку"}}">🔍</button>
+      <button type="button" data-ob-ref-picker="ird-{{$dn}}" style="padding:6px 10px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
+      <button type="button" data-ob-ref-current="ird-{{$dn}}" style="padding:6px 9px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Открыть карточку"}}">🔍</button>
     </div>
     {{else}}
     <input type="text" name="{{$dn}}" value="{{index $.Values $dn}}">
@@ -2396,8 +2396,8 @@ const tplConstants = `
         <option value="{{index . "id"}}" {{if eq (index . "id") (index $.Values $c.Name)}}selected{{end}}>{{index . "_label"}}</option>
         {{end}}
       </select>
-      <button type="button" onclick="openRefPicker('const-{{$c.Name}}')" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
-      <button type="button" onclick="openRefCurrent('const-{{$c.Name}}')" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Открыть карточку"}}">🔍</button>
+      <button type="button" data-ob-ref-picker="const-{{$c.Name}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Выбрать из списка"}}">...</button>
+      <button type="button" data-ob-ref-current="const-{{$c.Name}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px;flex-shrink:0" title="{{t $.Lang "Открыть карточку"}}">🔍</button>
     </div>
   {{else if eq (str .Type) "date"}}
     <input type="date" name="{{.Name}}" value="{{index $.Values .Name}}">


### PR DESCRIPTION
## Что сделано
- Регистровые фильтры, обработка с ссылочными параметрами, форма инфорегистра, константы и подтверждения удаления переведены с inline handlers на `data-ob-*`.
- Переиспользован уже существующий delegated runtime: `data-ob-ref-picker`, `data-ob-ref-current`, `data-ob-confirm`.
- Добавлен smoke-test на эти шаблоны и обновлён план 55 фазой 3i.

## Проверки
- `node --check internal/ui/static/ui.js`
- `go test ./internal/ui -run 'TestRegisterProcessorConstantDelegatedHandlers|TestStaticUIJS|TestPageForm_DelegatedHandlers'`
- `git diff --check`
- `go test ./internal/ui`
- `go run ./tools/i18ncheck`
- `go test ./...`