### PR TITLE
fix: кэш приложенческого JS + защита строковых политик (ревью недели)

### DIFF
--- a/internal/access/row_access_test.go
+++ b/internal/access/row_access_test.go
@@ -1,0 +1,193 @@
+package access_test
+
+import (
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/access"
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+)
+
+func dealEntity() *metadata.Entity {
+	return &metadata.Entity{
+		Name: "Сделка",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Ответственный", Type: metadata.FieldTypeString},
+			{Name: "Автор", Type: metadata.FieldTypeString},
+		},
+	}
+}
+
+// docRole строит роль с object-level правами на документ entity и, если задано,
+// строковой политикой для операций.
+func docRole(entity string, ops []string, policies auth.RowPolicies) *auth.Role {
+	ra := auth.RowAccess{}
+	if policies != nil {
+		ra.Documents = map[string]auth.RowPolicies{entity: policies}
+	}
+	return &auth.Role{Permissions: auth.Permission{
+		Documents: map[string][]string{entity: ops},
+		RowAccess: ra,
+	}}
+}
+
+func respPolicy() auth.RowPolicies {
+	return auth.RowPolicies{"read": auth.RowPolicy{Field: "Ответственный", Op: "eq", Value: auth.RowValue{User: "id"}}}
+}
+
+func authorPolicy() auth.RowPolicies {
+	return auth.RowPolicies{"read": auth.RowPolicy{Field: "Автор", Op: "eq", Value: auth.RowValue{User: "login"}}}
+}
+
+func TestDecide_AdminAndOpenDeploymentAreUnrestricted(t *testing.T) {
+	meta := dealEntity()
+	for _, u := range []*auth.User{nil, {IsAdmin: true}} {
+		dec, err := access.Decide(u, "document", "Сделка", "read", meta)
+		if err != nil {
+			t.Fatalf("Decide: %v", err)
+		}
+		if !dec.Allowed || !dec.Unrestricted || dec.Predicate != nil {
+			t.Fatalf("admin/open must be allowed+unrestricted without predicate, got %+v", dec)
+		}
+	}
+}
+
+func TestDecide_GrantedWithoutPolicyIsUnrestricted(t *testing.T) {
+	u := &auth.User{ID: "u1", Roles: []*auth.Role{docRole("Сделка", []string{"read"}, nil)}}
+	dec, err := access.Decide(u, "document", "Сделка", "read", dealEntity())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !dec.Allowed || !dec.Unrestricted || dec.Predicate != nil {
+		t.Fatalf("granted-but-unrestricted role must give open access, got %+v", dec)
+	}
+}
+
+func TestDecide_RestrictedSingleRole(t *testing.T) {
+	u := &auth.User{ID: "u1", Roles: []*auth.Role{docRole("Сделка", []string{"read"}, respPolicy())}}
+	dec, err := access.Decide(u, "document", "Сделка", "read", dealEntity())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !dec.Allowed || dec.Unrestricted {
+		t.Fatalf("restricted role must be allowed but not unrestricted, got %+v", dec)
+	}
+	if dec.Predicate == nil || dec.Predicate.Field != "Ответственный" || dec.Predicate.Op != "eq" || dec.Predicate.Value != "u1" {
+		t.Fatalf("predicate = %+v, want Ответственный eq u1", dec.Predicate)
+	}
+}
+
+func TestDecide_TwoRestrictedRolesMergeWithOR(t *testing.T) {
+	u := &auth.User{
+		ID:    "u1",
+		Login: "ivan",
+		Roles: []*auth.Role{
+			docRole("Сделка", []string{"read"}, respPolicy()),
+			docRole("Сделка", []string{"read"}, authorPolicy()),
+		},
+	}
+	dec, err := access.Decide(u, "document", "Сделка", "read", dealEntity())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if dec.Unrestricted || dec.Predicate == nil {
+		t.Fatalf("two restricted roles must stay restricted, got %+v", dec)
+	}
+	if len(dec.Predicate.Any) != 2 {
+		t.Fatalf("restricted roles must be OR-merged into Any, got %+v", dec.Predicate)
+	}
+	if dec.Predicate.Any[0].Value != "u1" || dec.Predicate.Any[1].Value != "ivan" {
+		t.Fatalf("OR members = %+v, want [id=u1, login=ivan]", dec.Predicate.Any)
+	}
+}
+
+func TestDecide_UnrestrictedRoleOverridesRestricted(t *testing.T) {
+	// Одна роль ограничивает, другая даёт read без политики — итог открытый (OR).
+	u := &auth.User{
+		ID: "u1",
+		Roles: []*auth.Role{
+			docRole("Сделка", []string{"read"}, respPolicy()),
+			docRole("Сделка", []string{"read"}, nil),
+		},
+	}
+	dec, err := access.Decide(u, "document", "Сделка", "read", dealEntity())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if !dec.Allowed || !dec.Unrestricted || dec.Predicate != nil {
+		t.Fatalf("an unrestricted granting role must win, got %+v", dec)
+	}
+}
+
+func TestDecide_NoObjectPermissionIsNotAllowed(t *testing.T) {
+	// Роль даёт права только на другой документ — на Сделку прав нет.
+	u := &auth.User{ID: "u1", Roles: []*auth.Role{docRole("Заявка", []string{"read"}, nil)}}
+	dec, err := access.Decide(u, "document", "Сделка", "read", dealEntity())
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if dec.Allowed {
+		t.Fatalf("no object-level grant must yield not-allowed, got %+v", dec)
+	}
+}
+
+func TestDecide_InvalidPolicyFieldFailsClosed(t *testing.T) {
+	bad := auth.RowPolicies{"read": auth.RowPolicy{Field: "НетТакогоПоля", Op: "eq", Value: auth.RowValue{User: "id"}}}
+	u := &auth.User{ID: "u1", Roles: []*auth.Role{docRole("Сделка", []string{"read"}, bad)}}
+	_, err := access.Decide(u, "document", "Сделка", "read", dealEntity())
+	if err == nil {
+		t.Fatal("policy on unknown field must fail closed with an error, got nil")
+	}
+}
+
+func TestHasRestrictedPolicy(t *testing.T) {
+	restricted := &auth.User{ID: "u1", Roles: []*auth.Role{docRole("Сделка", []string{"read"}, respPolicy())}}
+	if !access.HasRestrictedPolicy(restricted, "document", "Сделка", "read") {
+		t.Fatal("single restricted role must report restricted")
+	}
+	unrestricted := &auth.User{ID: "u1", Roles: []*auth.Role{docRole("Сделка", []string{"read"}, nil)}}
+	if access.HasRestrictedPolicy(unrestricted, "document", "Сделка", "read") {
+		t.Fatal("granted-but-unrestricted role must not report restricted")
+	}
+	mixed := &auth.User{ID: "u1", Roles: []*auth.Role{
+		docRole("Сделка", []string{"read"}, respPolicy()),
+		docRole("Сделка", []string{"read"}, nil),
+	}}
+	if access.HasRestrictedPolicy(mixed, "document", "Сделка", "read") {
+		t.Fatal("an unrestricted role among restricted must not report restricted")
+	}
+	if access.HasRestrictedPolicy(&auth.User{IsAdmin: true}, "document", "Сделка", "read") {
+		t.Fatal("admin must never be restricted")
+	}
+	if access.HasRestrictedPolicy(nil, "document", "Сделка", "read") {
+		t.Fatal("open deployment must never be restricted")
+	}
+}
+
+func TestQueryRowFilters_OnlyRestrictedSources(t *testing.T) {
+	deal := dealEntity()
+	other := &metadata.Entity{Name: "Заявка", Kind: metadata.KindDocument, Fields: []metadata.Field{{Name: "Автор", Type: metadata.FieldTypeString}}}
+	u := &auth.User{
+		ID: "u1",
+		Roles: []*auth.Role{
+			docRole("Сделка", []string{"read"}, respPolicy()), // restricted
+			docRole("Заявка", []string{"read"}, nil),           // granted, unrestricted
+		},
+	}
+	filters, err := access.QueryRowFilters(u, []*metadata.Entity{deal, other}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("QueryRowFilters: %v", err)
+	}
+	if pred := filters[query.SourceRef{Kind: "document", Name: "Сделка"}]; pred == nil || pred.Field != "Ответственный" {
+		t.Fatalf("restricted source Сделка must have a predicate, got %+v", pred)
+	}
+	if _, ok := filters[query.SourceRef{Kind: "document", Name: "Заявка"}]; ok {
+		t.Fatal("unrestricted source Заявка must not get a row filter")
+	}
+	// Убедимся, что admin не получает фильтров вовсе.
+	if got, _ := access.QueryRowFilters(&auth.User{IsAdmin: true}, []*metadata.Entity{deal}, nil, nil, nil); got != nil {
+		t.Fatalf("admin must get no row filters, got %+v", got)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -474,6 +474,7 @@ type translator struct {
 	rowFilters  []pendingRowFilter            // RLS-фильтры обычных источников, внедряемые в WHERE
 	rowsScoped  bool                          // true после внедрения rowFilters в outer WHERE
 	rowApplied  []SourceRef                   // источники, к которым RLS-предикат реально внедрён (для финальной сверки)
+	parenDepth  int                           // глубина незакрытых '(' в основном потоке (VT-аргументы считает parseVTArgs)
 }
 
 type pendingRowFilter struct {
@@ -582,6 +583,14 @@ func (tr *translator) addPendingRowFilter(typeUpper, name, alias string) error {
 	pred := tr.sourceRowFilter(kind, name)
 	if pred == nil {
 		return nil
+	}
+	// Отложенный фильтр главной таблицы внедряется в outer WHERE. Если источник
+	// оказался первым, но лежит внутри подзапроса ИЗ (parenDepth>0), внешний
+	// WHERE ссылался бы на таблицу вне области видимости — раньше это давало
+	// битый SQL. Отказываем явно (fail-closed): alias-aware внедрение в
+	// подзапросы — отдельный этап (план 79, 79E).
+	if tr.parenDepth > 0 {
+		return fmt.Errorf("строковая политика источника %s.%s: фильтрация подзапроса в ИЗ пока не поддерживается", kind, name)
 	}
 	meta := tr.predicateEntityForSource(typeUpper, name)
 	if meta == nil {
@@ -2148,6 +2157,15 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		// Punctuation
 		if t.kind == tComma || t.kind == tLParen || t.kind == tRParen {
 			tr.prevWasDot = false
+			// Считаем глубину подзапросов/группировок: источник ИЗ, встреченный
+			// при parenDepth>0, лежит внутри подзапроса, а не в верхнем FROM.
+			// (Скобки виртуальных таблиц регистров съедает parseVTArgs — сюда не
+			// попадают, баланс не нарушают.)
+			if t.kind == tLParen {
+				tr.parenDepth++
+			} else if t.kind == tRParen && tr.parenDepth > 0 {
+				tr.parenDepth--
+			}
 			tr.advance()
 			tr.emit(t.val)
 			continue

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -473,6 +473,7 @@ type translator struct {
 	sources     []SourceRef                   // объекты-источники запроса (для RBAC, план 54)
 	rowFilters  []pendingRowFilter            // RLS-фильтры обычных источников, внедряемые в WHERE
 	rowsScoped  bool                          // true после внедрения rowFilters в outer WHERE
+	rowApplied  []SourceRef                   // источники, к которым RLS-предикат реально внедрён (для финальной сверки)
 }
 
 type pendingRowFilter struct {
@@ -507,6 +508,46 @@ func (tr *translator) sourceRowFilter(kind, name string) *storage.Predicate {
 	for src, pred := range tr.opts.RowFilters {
 		if src.Kind == kind && strings.EqualFold(src.Name, name) {
 			return pred
+		}
+	}
+	return nil
+}
+
+// markRowApplied фиксирует, что RLS-предикат источника реально внедрён в SQL.
+// Матчинг по kind+EqualFold(name) — как в sourceRowFilter, чтобы регистр имени
+// источника (токен запроса vs metadata) не расходился со сверкой.
+func (tr *translator) markRowApplied(kind, name string) {
+	if tr.rowFilterApplied(kind, name) {
+		return
+	}
+	tr.rowApplied = append(tr.rowApplied, SourceRef{Kind: kind, Name: name})
+}
+
+func (tr *translator) rowFilterApplied(kind, name string) bool {
+	for _, s := range tr.rowApplied {
+		if s.Kind == kind && strings.EqualFold(s.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// assertRowFiltersApplied — финальная защита: если у источника запроса есть
+// активная строковая политика, но предикат не был внедрён ни одним из путей
+// (главная таблица / скоуп-подзапрос джойна / условие авто-JOIN), запрос
+// отклоняется. Так неучтённая форма запроса даёт fail-closed отказ, а не тихую
+// утечку чужих строк в отчётах/AI, где object-gate ограниченный источник
+// пропускает (право read у пользователя есть). См. план 79, этап 79E.
+func (tr *translator) assertRowFiltersApplied() error {
+	if len(tr.opts.RowFilters) == 0 {
+		return nil
+	}
+	for _, src := range tr.sources {
+		if tr.sourceRowFilter(src.Kind, src.Name) == nil {
+			continue
+		}
+		if !tr.rowFilterApplied(src.Kind, src.Name) {
+			return fmt.Errorf("строковая политика источника %s.%s не внедрена в запрос", src.Kind, src.Name)
 		}
 	}
 	return nil
@@ -552,6 +593,7 @@ func (tr *translator) addPendingRowFilter(typeUpper, name, alias string) error {
 		meta:   meta,
 		filter: pred,
 	})
+	tr.markRowApplied(kind, name)
 	return nil
 }
 
@@ -568,6 +610,7 @@ func (tr *translator) rowFilterCondition(kind, name string, meta *metadata.Entit
 		return "", err
 	}
 	tr.args = append(tr.args, args...)
+	tr.markRowApplied(kind, name)
 	return sql, nil
 }
 
@@ -586,6 +629,7 @@ func (tr *translator) rowFilteredSourceSQL(typeUpper, name, tableName, alias str
 		return "", false, fmt.Errorf("row filter %s.%s: %w", kind, name, err)
 	}
 	tr.args = append(tr.args, args...)
+	tr.markRowApplied(kind, name)
 	return fmt.Sprintf("(SELECT * FROM %s WHERE %s) AS %s", tableName, sql, alias), true, nil
 }
 
@@ -2220,6 +2264,9 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		tr.advance()
 	}
 	if err := tr.emitPendingRowFiltersAsWhere(); err != nil {
+		return Result{}, err
+	}
+	if err := tr.assertRowFiltersApplied(); err != nil {
 		return Result{}, err
 	}
 	return Result{SQL: tr.build(), Args: tr.args, Sources: tr.sources}, nil

--- a/internal/query/row_filters_test.go
+++ b/internal/query/row_filters_test.go
@@ -112,3 +112,49 @@ func TestCompile_RowFiltersJoinedSourceScopedBeforeOn(t *testing.T) {
 		t.Fatalf("args = %#v, want one joined row filter arg", res.Args)
 	}
 }
+
+// TestCompile_RowFiltersSubqueryInFromFailClosed: у ограниченного источника,
+// оказавшегося главной таблицей внутри подзапроса ИЗ, отложенный фильтр нельзя
+// корректно поместить в outer WHERE (раньше выходил битый SQL). Теперь — явный
+// fail-closed отказ, а не тихая утечка/поломка.
+func TestCompile_RowFiltersSubqueryInFromFailClosed(t *testing.T) {
+	cat := &metadata.Entity{
+		Name:   "Товар",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Owner", Type: metadata.FieldTypeString}},
+	}
+	_, err := query.Compile(`ВЫБРАТЬ * ИЗ (ВЫБРАТЬ Ссылка ИЗ Справочник.Товар) КАК П`, query.CompileOpts{
+		Entities: []*metadata.Entity{cat},
+		Dialect:  storage.SQLiteDialect{},
+		RowFilters: map[query.SourceRef]*storage.Predicate{
+			{Kind: "catalog", Name: "Товар"}: {Field: "Owner", Op: "eq", Value: "u"},
+		},
+	})
+	if err == nil {
+		t.Fatal("restricted source inside a FROM subquery must fail closed, got nil error")
+	}
+	if !strings.Contains(err.Error(), "подзапрос") {
+		t.Fatalf("error must explain the FROM-subquery limitation, got: %v", err)
+	}
+}
+
+// TestCompile_SubqueryInFromOpenDeployment: без активных строковых политик
+// подзапрос в ИЗ по-прежнему компилируется (отказ касается только ограниченных
+// источников — pred!=nil).
+func TestCompile_SubqueryInFromOpenDeployment(t *testing.T) {
+	cat := &metadata.Entity{
+		Name:   "Товар",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	res, err := query.Compile(`ВЫБРАТЬ * ИЗ (ВЫБРАТЬ Ссылка ИЗ Справочник.Товар) КАК П`, query.CompileOpts{
+		Entities: []*metadata.Entity{cat},
+		Dialect:  storage.SQLiteDialect{},
+	})
+	if err != nil {
+		t.Fatalf("open deployment must still compile FROM subqueries: %v", err)
+	}
+	if !strings.Contains(res.SQL, "SELECT id FROM товар") {
+		t.Fatalf("FROM subquery must survive without row filters, got:\n%s", res.SQL)
+	}
+}

--- a/internal/ui/static.go
+++ b/internal/ui/static.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	"crypto/sha256"
 	_ "embed"
+	"encoding/hex"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -14,6 +16,34 @@ var uiJS []byte
 //go:embed static/managed.js
 var managedJS []byte
 
+// ETag'и приложенческого JS считаются один раз при старте по содержимому.
+var (
+	uiJSETag      = assetETag(uiJS)
+	managedJSETag = assetETag(managedJS)
+)
+
+func assetETag(b []byte) string {
+	sum := sha256.Sum256(b)
+	return `"` + hex.EncodeToString(sum[:8]) + `"`
+}
+
+// serveAppJS отдаёт встроенный JS приложения с ревалидацией по ETag. Путь
+// фиксирован (/static/ui.js) и не содержит хэша, а сам код меняется с каждым
+// билдом, поэтому immutable-кэш на год отдавал бы устаревший скрипт после
+// обновления (старый JS против нового HTML-bootstrap → тихо сломанные формы).
+// no-cache заставляет клиента ревалидировать: при совпадении ETag ответ — 304
+// без повторной передачи тела, поэтому свежесть не стоит лишнего трафика.
+func serveAppJS(w http.ResponseWriter, r *http.Request, body []byte, etag string) {
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Cache-Control", "no-cache")
+	if match := r.Header.Get("If-None-Match"); match != "" && match == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	_, _ = w.Write(body)
+}
+
 // mountStatic регистрирует отдачу общих встроенных ассетов. Самохостинг вместо
 // CDN: графики и редактор работают офлайн — десктопная база не должна зависеть
 // от интернета. ECharts и Monaco вендорятся один раз в webassets и раздаются
@@ -21,14 +51,10 @@ var managedJS []byte
 // предпросмотр виджетов рисовались идентично.
 func mountStatic(r chi.Router) {
 	r.Get("/static/ui.js", func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
-		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-		_, _ = w.Write(uiJS)
+		serveAppJS(w, req, uiJS, uiJSETag)
 	})
 	r.Get("/static/managed.js", func(w http.ResponseWriter, req *http.Request) {
-		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
-		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-		_, _ = w.Write(managedJS)
+		serveAppJS(w, req, managedJS, managedJSETag)
 	})
 	r.Handle("/vendor/echarts/*", http.StripPrefix("/vendor/echarts/", webassets.EChartsHandler()))
 	// Monaco editor — инструменты разработчика (консоль кода/запросов, отладчик)

--- a/internal/ui/static_test.go
+++ b/internal/ui/static_test.go
@@ -99,3 +99,39 @@ func TestStaticManagedJS(t *testing.T) {
 		t.Error("/static/managed.js содержит Go-template маркеры")
 	}
 }
+
+// TestStaticJSRevalidates проверяет, что приложенческий JS отдаётся с ETag и
+// ревалидацией (а не immutable-кэшем на год по неверсионированному пути): после
+// обновления билда клиент не должен залипнуть на старом скрипте.
+func TestStaticJSRevalidates(t *testing.T) {
+	r := chi.NewRouter()
+	mountStatic(r)
+
+	for _, path := range []string{"/static/ui.js", "/static/managed.js"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s status = %d", path, rr.Code)
+		}
+		etag := rr.Header().Get("ETag")
+		if etag == "" {
+			t.Fatalf("%s не отдаёт ETag", path)
+		}
+		if cc := rr.Header().Get("Cache-Control"); strings.Contains(cc, "immutable") {
+			t.Fatalf("%s: immutable-кэш по неверсионированному пути залипает после обновления, Cache-Control=%q", path, cc)
+		}
+
+		// Повторный запрос с If-None-Match должен вернуть 304 без тела.
+		req2 := httptest.NewRequest(http.MethodGet, path, nil)
+		req2.Header.Set("If-None-Match", etag)
+		rr2 := httptest.NewRecorder()
+		r.ServeHTTP(rr2, req2)
+		if rr2.Code != http.StatusNotModified {
+			t.Fatalf("%s с совпавшим ETag: status = %d, ожидался 304", path, rr2.Code)
+		}
+		if rr2.Body.Len() != 0 {
+			t.Fatalf("%s: 304 не должен нести тело (%d байт)", path, rr2.Body.Len())
+		}
+	}
+}


### PR DESCRIPTION
Follow-up к ревью влитого за сутки (RLS/план 79 + рефакторинг выноса JS в статику). Независимые коммиты.

## 1. fix(ui): ревалидация приложенческого JS по ETag
`/static/ui.js` и `/static/managed.js` отдавались с `Cache-Control: public, max-age=31536000, immutable` по **неверсионированному** пути. Код приложения меняется каждый билд → после обновления браузер/WebView2 держали устаревший скрипт до года без ревалидации (старый JS против нового HTML-bootstrap → тихо сломанные формы). Теперь ETag по содержимому + `no-cache`: клиент ревалидирует, при совпадении — дешёвый 304 без повторной передачи тела.

## 2. test(access): юнит-тесты решателя строковых политик
Ядро `internal/access` (`Decide`/`HasRestrictedPolicy`/`QueryRowFilters`) не имело прямых тестов. Добавлено 9: admin/открытый деплой, object-право без политики → неограниченно, одна/две ограниченные роли (OR-объединение), неограниченная роль поверх ограниченной, отсутствие object-права, политика по несуществующему полю → fail-closed.

## 3. feat(query): fail-closed сверка внедрения строковых политик
Безопасность отчётов/AI для ограниченных источников держалась только на внедрении предиката компилятором (object-gate такой источник пропускает — read есть), явный fail-closed был лишь для UNION. Компилятор теперь помечает источники с реально внедрённым предикатом и перед возвратом сверяет: источник с активной политикой без внедрённого предиката → запрос отклоняется.

## 4. fix(query): явный отказ вместо битого SQL для подзапроса в ИЗ
Ограниченный источник как главная таблица внутри подзапроса `ИЗ (ВЫБРАТЬ … ИЗ Справочник.Х) КАК П` получал отложенный фильтр во внешнем WHERE вне области видимости → битый SQL. Транслятор считает глубину скобок и при `parenDepth>0` отказывает понятной ошибкой. Открытый деплой и запросы без политик компилируют подзапросы в ИЗ как раньше; подзапрос в ГДЕ фильтруется корректно. Полноценное alias-aware внедрение в подзапросы — отдельный этап (план 79, 79E).

## Проверки
- `go build ./...` — чисто; `go test ./...` — зелёно (включая новые тесты access, static revalidation, subquery fail-closed).
- Эмпирически прогнаны формы с ограниченным фильтром: справочник (list/where/count/group by/distinct/подзапрос-в-ГДЕ), регистр накопления (Остатки/Обороты/plain), регистр сведений (СрезПоследних/plain) — предикат внедряется корректно, ложных срабатываний сверки нет; подзапрос-в-ИЗ у ограниченного источника даёт аккуратный отказ, у открытого — компилируется.

Generated-with: Claude Code