### PR TITLE
fix(query): ОстаткиИОбороты(&нач,&кон) с датами-параметрами на SQLite

### DIFF
--- a/internal/query/oio_sqlite_exec_test.go
+++ b/internal/query/oio_sqlite_exec_test.go
@@ -1,0 +1,136 @@
+package query_test
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// ОстаткиИОбороты(&Начало, &Конец) с датами-ПАРАМЕТРАМИ должна исполняться на
+// SQLite и давать корректные значения. Раньше границы транслировались один раз,
+// а анонимный '?' вставлялся многократно → «missing argument». Регрессионный тест
+// сверяет все колонки с эталоном, вычисленным в Go напрямую из движений.
+func TestBalancesAndTurnovers_ParamDatesSQLite(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	reg := &metadata.Register{
+		Name:       "ОИ",
+		Dimensions: []metadata.Field{{Name: "Товар", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Кол", Type: metadata.FieldTypeNumber}},
+	}
+	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatal(err)
+	}
+	type mvRec struct {
+		nom, vid string
+		period   time.Time
+		qty      float64
+	}
+	var all []mvRec
+	rng := rand.New(rand.NewSource(3))
+	noms := []string{"A", "B", "C"}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 40; i++ {
+		p := base.AddDate(0, 0, rng.Intn(180))
+		vid := "Приход"
+		if rng.Intn(2) == 0 {
+			vid = "Расход"
+		}
+		nom := noms[rng.Intn(len(noms))]
+		qty := float64(1 + rng.Intn(10))
+		all = append(all, mvRec{nom, vid, p, qty})
+		pp := p
+		if err := db.WriteMovements(ctx, reg.Name, "Д", uuid.New(),
+			[]map[string]any{{"ВидДвижения": vid, "Товар": nom, "Кол": qty}}, reg, &pp); err != nil {
+			t.Fatal(err)
+		}
+	}
+	golden := func(start, end time.Time) map[string][4]float64 {
+		out := map[string][4]float64{}
+		for _, m := range all {
+			signed := m.qty
+			if m.vid == "Расход" {
+				signed = -m.qty
+			}
+			v := out[m.nom]
+			if m.period.Before(start) {
+				v[0] += signed
+			}
+			if !m.period.Before(start) && !m.period.After(end) {
+				if m.vid == "Приход" {
+					v[1] += m.qty
+				} else {
+					v[2] += m.qty
+				}
+			}
+			if !m.period.After(end) {
+				v[3] += signed
+			}
+			out[m.nom] = v
+		}
+		for nom := range out {
+			has := false
+			for _, m := range all {
+				if m.nom == nom && !m.period.After(end) {
+					has = true
+					break
+				}
+			}
+			if !has {
+				delete(out, nom)
+			}
+		}
+		return out
+	}
+	for i := 0; i < 25; i++ {
+		s := base.AddDate(0, 0, rng.Intn(150))
+		e := s.AddDate(0, 0, 1+rng.Intn(90))
+		r, err := query.Compile(
+			"ВЫБРАТЬ Товар, Колначальный, Колприход, Колрасход, Колконечный ИЗ РегистрНакопления.ОИ.ОстаткиИОбороты(&Н, &К)",
+			query.CompileOpts{Registers: []*metadata.Register{reg}, Params: map[string]any{"Н": s, "К": e}, Dialect: storage.SQLiteDialect{}})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		rows, err := db.Query(ctx, r.SQL, r.Args...)
+		if err != nil {
+			t.Fatalf("exec (баг плейсхолдеров?): %v\nSQL: %s\nArgs: %v", err, r.SQL, r.Args)
+		}
+		got := map[string][4]float64{}
+		for rows.Next() {
+			var n string
+			var a, b, c, dd float64
+			if err := rows.Scan(&n, &a, &b, &c, &dd); err != nil {
+				rows.Close()
+				t.Fatal(err)
+			}
+			got[n] = [4]float64{a, b, c, dd}
+		}
+		rows.Close()
+		want := golden(s, e)
+		if len(got) != len(want) {
+			t.Fatalf("период %d [%s..%s]: строк got=%d want=%d\ngot=%v\nwant=%v",
+				i, s.Format("01-02"), e.Format("01-02"), len(got), len(want), got, want)
+		}
+		for k, w := range want {
+			g := got[k]
+			for j := 0; j < 4; j++ {
+				if math.Abs(g[j]-w[j]) > 1e-9 {
+					t.Errorf("период %d [%s..%s] %s поле %d: got=%v want=%v",
+						i, s.Format("01-02"), e.Format("01-02"), k, j, g[j], w[j])
+				}
+			}
+		}
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1325,53 +1325,77 @@ func filterArg(idx int, periodLevel string, args [][]tok) []tok {
 	return nil
 }
 
+// filterPresent сообщает, задан ли аргумент-условие (граница/отбор) непусто и
+// не «пусто» (одиночный &Param с nil/пустым списком). Проверяет структурно, БЕЗ
+// трансляции — чтобы не добавить аргумент раньше времени (иначе плейсхолдеры и
+// аргументы разъедутся при повторной трансляции границ).
+func (tr *translator) filterPresent(tokens []tok) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if len(tokens) == 1 && tokens[0].kind == tParam {
+		v := tr.paramValues[tokens[0].val]
+		if v == nil {
+			return false
+		}
+		if arr, ok := v.([]any); ok && len(arr) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (tr *translator) genBalancesAndTurnovers(reg *metadata.Register, args [][]tok) (string, string, error) {
 	tableName := metadata.RegisterTableName(reg.Name)
 	alias := "остаткиоборотов_" + strings.ToLower(reg.Name)
 	dims := dimCols(reg.Dimensions)
 	selDims := dimSelCols(reg.Dimensions)
 
-	var startSQL, endSQL, filterSQL string
-	if len(args) > 0 && len(args[0]) > 0 {
-		if s := tr.translateFilterTokens(args[0]); s != "NULL" {
-			startSQL = s
+	// Границы начало/конец транслируются заново на КАЖДОЕ вхождение (start()/
+	// end()/periodCond()), а не один раз. На SQLite плейсхолдер '?' анонимный и
+	// позиционный: один startSQL/endSQL, вставленный в SQL многократно, давал бы
+	// больше '?', чем привязанных аргументов, — запрос падал с «missing
+	// argument». Повторная трансляция добавляет аргумент под каждый плейсхолдер;
+	// порядок добавления совпадает с порядком плейсхолдеров в собираемом SQL
+	// (столбцы SELECT слева направо, затем WHERE). На PostgreSQL это лишь
+	// дублирует значение под разными $N — результат тот же.
+	hasStart := len(args) > 0 && tr.filterPresent(args[0])
+	hasEnd := len(args) > 1 && tr.filterPresent(args[1])
+	hasFilter := len(args) > 2 && tr.filterPresent(args[2])
+	start := func() string { return tr.translateFilterTokens(args[0]) }
+	end := func() string { return tr.translateFilterTokens(args[1]) }
+	periodCond := func() string {
+		switch {
+		case hasStart && hasEnd:
+			return " AND period >= " + start() + " AND period <= " + end()
+		case hasStart:
+			return " AND period >= " + start()
+		case hasEnd:
+			return " AND period <= " + end()
 		}
-	}
-	if len(args) > 1 && len(args[1]) > 0 {
-		if s := tr.translateFilterTokens(args[1]); s != "NULL" {
-			endSQL = s
-		}
-	}
-	if len(args) > 2 && len(args[2]) > 0 {
-		filterSQL = tr.translateFilterTokens(args[2])
+		return ""
 	}
 
 	var cols []string
 	cols = append(cols, selDims...)
 	for _, r := range reg.Resources {
 		col := strings.ToLower(r.Name)
-		if startSQL != "" {
+		if hasStart {
 			cols = append(cols,
-				"SUM(CASE WHEN вид_движения = 'Приход' AND period < "+startSQL+
-					" THEN "+col+" WHEN вид_движения = 'Расход' AND period < "+startSQL+
+				"SUM(CASE WHEN вид_движения = 'Приход' AND period < "+start()+
+					" THEN "+col+" WHEN вид_движения = 'Расход' AND period < "+start()+
 					" THEN -"+col+" ELSE 0 END) AS "+col+"начальный")
 		}
-		periodCond := ""
-		if startSQL != "" && endSQL != "" {
-			periodCond = " AND period >= " + startSQL + " AND period <= " + endSQL
-		} else if startSQL != "" {
-			periodCond = " AND period >= " + startSQL
-		} else if endSQL != "" {
-			periodCond = " AND period <= " + endSQL
-		}
+		// periodCond() вызывается отдельно для прихода и расхода — каждый со
+		// своими плейсхолдерами (нельзя переиспользовать одну строку на SQLite).
 		cols = append(cols,
-			"SUM(CASE WHEN вид_движения = 'Приход'"+periodCond+" THEN "+col+" ELSE 0 END) AS "+col+"приход",
-			"SUM(CASE WHEN вид_движения = 'Расход'"+periodCond+" THEN "+col+" ELSE 0 END) AS "+col+"расход",
+			"SUM(CASE WHEN вид_движения = 'Приход'"+periodCond()+" THEN "+col+" ELSE 0 END) AS "+col+"приход",
+			"SUM(CASE WHEN вид_движения = 'Расход'"+periodCond()+" THEN "+col+" ELSE 0 END) AS "+col+"расход",
 		)
-		if endSQL != "" {
+		if hasEnd {
 			cols = append(cols,
-				"SUM(CASE WHEN вид_движения = 'Приход' AND period <= "+endSQL+
-					" THEN "+col+" WHEN вид_движения = 'Расход' AND period <= "+endSQL+
+				"SUM(CASE WHEN вид_движения = 'Приход' AND period <= "+end()+
+					" THEN "+col+" WHEN вид_движения = 'Расход' AND period <= "+end()+
 					" THEN -"+col+" ELSE 0 END) AS "+col+"конечный")
 		}
 	}
@@ -1384,11 +1408,11 @@ func (tr *translator) genBalancesAndTurnovers(reg *metadata.Register, args [][]t
 	sb.WriteString(tableName)
 
 	var conds []string
-	if endSQL != "" {
-		conds = append(conds, "period <= "+endSQL)
+	if hasEnd {
+		conds = append(conds, "period <= "+end())
 	}
-	if filterSQL != "" {
-		conds = append(conds, filterSQL)
+	if hasFilter {
+		conds = append(conds, tr.translateFilterTokens(args[2]))
 	}
 	if s, err := tr.rowFilterCondition("register", reg.Name, storage.RegisterPredicateEntity(reg), ""); err != nil {
 		return "", "", fmt.Errorf("row filter %s: %w", reg.Name, err)


### PR DESCRIPTION
Исправляет предсуществующий баг, обнаруженный при работе над планом 80.

## Симптом

`ОстаткиИОбороты(&Начало, &Конец)` с границами-**параметрами** на **SQLite** падает при исполнении:

```
missing argument with index 3
```

## Причина

`genBalancesAndTurnovers` транслировал границы `начало`/`конец` **один раз** (`translateFilterTokens` добавляет аргумент и возвращает плейсхолдер), а затем вставлял этот плейсхолдер в SQL **многократно** — в колонки начальный/приход/расход/конечный и в `WHERE`. На SQLite `?` анонимный и позиционный, поэтому плейсхолдеров получалось больше (9 для двух границ), чем привязанных аргументов (2). На PostgreSQL (`$n`) переиспользование одного номера работает — баг там не проявлялся, а существующий тест зовёт `ОстаткиИОбороты()` **без аргументов** и этот путь не покрывал.

## Фикс

Границы транслируются **заново на каждое вхождение** (`start()` / `end()` / `periodCond()`): каждый плейсхолдер получает свой аргумент, а порядок добавления совпадает с порядком плейсхолдеров в собираемом SQL (столбцы SELECT слева направо, затем WHERE). На PostgreSQL это лишь дублирует значение под разными `$n` — результат тот же. Наличие границы/отбора определяется структурно (`filterPresent`), **без** трансляции, чтобы не сдвинуть аргументы.

## Тест

`TestBalancesAndTurnovers_ParamDatesSQLite` — `ОстаткиИОбороты(&Н,&К)` исполняется на SQLite и совпадает со всеми колонками (начальный/приход/расход/конечный) эталона, вычисленного в Go напрямую из движений, на случайных данных × 25 периодов. Без фикса тест падает на «missing argument».

## Проверка
- `go build ./...`, `go vet`, `go test ./...` — зелёные (существующий `ОстаткиИОбороты()` без аргументов и прочие balances-тесты не затронуты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)