### PR TITLE
fix(metrics): statusRecorder пробрасывает Flush — чинит SSE под лаунчером

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -193,6 +193,25 @@ func (sr *statusRecorder) Write(b []byte) (int, error) {
 	return sr.ResponseWriter.Write(b)
 }
 
+// Flush проксирует http.Flusher к обёрнутому writer'у. Без него обёртка
+// «съедала» бы интерфейс Flusher (проверка w.(http.Flusher) в SSE-эндпоинтах
+// возвращала бы false), и потоковые ответы падали бы с «стриминг не
+// поддерживается сервером»: real-time-уведомления (/ui/events, план 74) и поток
+// сканера ШК. Проявлялось только на базах, запущенных с ONEBASE_DEBUG_TOKEN
+// (лаунчер/GUI включает этот middleware), а плоский `onebase run` — нет.
+func (sr *statusRecorder) Flush() {
+	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap открывает нижележащий writer для http.ResponseController (Go 1.20+),
+// чтобы прочие возможности (Hijack, SetWriteDeadline и т.п.) оставались
+// доступны сквозь обёртку.
+func (sr *statusRecorder) Unwrap() http.ResponseWriter {
+	return sr.ResponseWriter
+}
+
 // Middleware записывает по каждому запросу счётчик и латентность. Метку route
 // берём из chi RoutePattern (доступен после маршрутизации) — это шаблон вида
 // «/documents/{entity}/{id}/post», что держит кардинальность меток низкой

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -96,6 +96,35 @@ func TestRegistry_FuncMetrics(t *testing.T) {
 	}
 }
 
+// Middleware не должен «съедать» http.Flusher: SSE-эндпоинты (real-time-
+// уведомления /ui/events, поток сканера ШК) делают w.(http.Flusher), и без
+// проксирования Flush через statusRecorder падали бы с «стриминг не
+// поддерживается сервером» на любой базе с ONEBASE_DEBUG_TOKEN (лаунчер/GUI).
+func TestRegistry_MiddlewarePreservesFlusher(t *testing.T) {
+	reg := New()
+	r := chi.NewRouter()
+	r.Use(reg.Middleware)
+	var sawFlusher bool
+	r.Get("/ui/events", func(w http.ResponseWriter, _ *http.Request) {
+		f, ok := w.(http.Flusher)
+		sawFlusher = ok
+		if ok {
+			w.WriteHeader(http.StatusOK)
+			f.Flush()
+		}
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ui/events", nil))
+
+	if !sawFlusher {
+		t.Fatal("хендлер за metrics-middleware не увидел http.Flusher — SSE-стриминг сломан")
+	}
+	if !rec.Flushed {
+		t.Error("Flush() не проброшен до нижележащего ResponseWriter")
+	}
+}
+
 // Незаматченный путь группируется под route="other", а не плодит серию.
 func TestRegistry_UnmatchedRouteIsOther(t *testing.T) {
 	reg := New()


### PR DESCRIPTION
## Проблема

Real-time-уведомления (тосты, план 74) не приходят **ни в одно** окно, открытое
из лаунчера / `onebase-gui.exe`. Тот же код через плоский `onebase run` работает,
поэтому баг не проявлялся при проверках через CLI (в т.ч. у коммита `fix toasts`).

## Причина

Лаунчер поднимает базу подпроцессом с `ONEBASE_DEBUG_TOKEN` (секрет для прокси
отладчика, `runner.go`). Наличие токена включает сбор HTTP-метрик:

```go
// internal/api/server.go
if debugToken != "" {
    r.Use(metricsReg.Middleware)   // оборачивает ResponseWriter в statusRecorder
}
```

`statusRecorder` (перехват кода ответа для метрик) реализовывал `WriteHeader`/
`Write`, но не `Flush`. SSE-эндпоинт первым делом проверяет `http.Flusher`:

```go
// internal/ui/handlers_events.go
flusher, ok := w.(http.Flusher)
if !ok { http.Error(w, "стриминг не поддерживается сервером", 500); return }
```

Сквозь обёртку проверка проваливалась → `/ui/events` (уведомления) и поток
сканера ШК отвечали 500, SSE-соединение не устанавливалось вовсе.

## Фикс

`statusRecorder` теперь проксирует `Flush()` к нижележащему writer'у и отдаёт
`Unwrap()` для `http.ResponseController` (Go 1.20+). Одна правка чинит все
потоковые эндпоинты под лаунчером.

## Проверка

`onebase run` с `ONEBASE_DEBUG_TOKEN` (эмуляция лаунчера), пример `examples/crm`:

| Сценарий | `GET /ui/events` |
|---|---|
| без токена (`onebase run`) | ✅ событие доставлено |
| с токеном (как GUI) — **до фикса** | ❌ `стриминг не поддерживается сервером` |
| с токеном — **после фикса** | ✅ `data: {"data":"…","name":"уведомление"}` |

Два подписчика на один сервер получают одно `ОтправитьУведомление("*", …)` оба.
Регресс-тест `TestRegistry_MiddlewarePreservesFlusher` проверяет, что
`metricsReg.Middleware` сохраняет `http.Flusher` сквозь обёртку. Тесты
`metrics` / `ui` / `realtime` / `api` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
