### PR TITLE
fix(ui): dropdown «Печать ▾» на managed-формах документа (#309)

### DIFF
--- a/internal/ui/managed_form_test.go
+++ b/internal/ui/managed_form_test.go
@@ -139,6 +139,7 @@ func TestPageManagedForm_Renders(t *testing.T) {
 		`id="ob-managed-config"`,
 		`id="ob-managed-tp-ref-opts"`,
 		`src="/static/managed.js"`,
+		`src="/static/ui.js"`, // managed-форма грузит и ui.js (из "head"): делегат data-ob-toggle-next живёт только там (issue #309)
 	}
 	for _, e := range expects {
 		if !strings.Contains(html, e) {

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -554,18 +554,16 @@ function obManagedAddVtRow(btn) {
 
 function obManagedInitDelegates() {
   document.addEventListener('click', function (e) {
-    var btn = e.target && e.target.closest ? e.target.closest('[data-ob-ref-picker],[data-ob-ref-current],[data-ob-file-trigger],[data-ob-fire-click],[data-ob-grid-add],[data-ob-grid-del],[data-ob-add-tp],[data-ob-add-vt],[data-ob-remove-row],[data-ob-ref-cancel],[data-ob-toggle-next]') : null;
+    // data-ob-toggle-next НЕ обрабатываем здесь: managed-форма всегда грузит и
+    // ui.js (из шаблона "head"), где этот же делегат уже висит на document.
+    // Дублирование переключало бы display дважды (none→block→none) за один клик
+    // и dropdown «Печать ▾»/«Ввести на основании» не открывался бы — issue #309.
+    var btn = e.target && e.target.closest ? e.target.closest('[data-ob-ref-picker],[data-ob-ref-current],[data-ob-file-trigger],[data-ob-fire-click],[data-ob-grid-add],[data-ob-grid-del],[data-ob-add-tp],[data-ob-add-vt],[data-ob-remove-row],[data-ob-ref-cancel]') : null;
     if (!btn) return;
 
     if (btn.hasAttribute('data-ob-ref-cancel')) {
       e.preventDefault();
       try { parent.postMessage({ source: 'obRefCancel' }, '*'); } catch (_) {}
-      return;
-    }
-    if (btn.hasAttribute('data-ob-toggle-next')) {
-      e.preventDefault();
-      var d = btn.nextElementSibling;
-      if (d) d.style.display = d.style.display === 'none' ? 'block' : 'none';
       return;
     }
     if (btn.hasAttribute('data-ob-ref-picker')) {

--- a/internal/ui/static_test.go
+++ b/internal/ui/static_test.go
@@ -108,6 +108,22 @@ func TestStaticManagedJS(t *testing.T) {
 	}
 }
 
+// TestToggleNextSingleHandler фиксирует инвариант issue #309: делегат
+// data-ob-toggle-next (dropdown «Печать ▾» / «Ввести на основании») должен
+// висеть на document ровно один раз. managed-форма грузит и ui.js (из шаблона
+// "head"), и managed.js — если бы оба вешали этот обработчик, один клик
+// переключал бы display дважды (none→block→none) и dropdown не открывался бы.
+// Владелец — ui.js (грузится на всех страницах); managed.js не должен дублировать.
+func TestToggleNextSingleHandler(t *testing.T) {
+	if !strings.Contains(string(uiJS), "[data-ob-toggle-next]") {
+		t.Fatal("ui.js должен обрабатывать data-ob-toggle-next (единственный владелец делегата)")
+	}
+	if strings.Contains(string(managedJS), "[data-ob-toggle-next]") {
+		t.Fatal("managed.js не должен дублировать делегат data-ob-toggle-next: " +
+			"managed-форма грузит и ui.js, двойной обработчик ломает dropdown (issue #309)")
+	}
+}
+
 func TestStaticQueryBuilderJS(t *testing.T) {
 	r := chi.NewRouter()
 	mountStatic(r)


### PR DESCRIPTION
## Проблема (#309)

На документной **managed**-форме (`kind: object`) split-button **«Печать ▾»** / «Ввести на основании» не разворачивает dropdown — клик уходит «в пустоту», JS-ошибок и записей в `server.err.log` нет.

## Диагноз (отличается от «Suggested fix» в issue)

Обработчик `data-ob-toggle-next` **не отсутствует — он дублируется**.

- `ui.js` подключается в шаблоне `head` на **всех** страницах и вешает делегат `data-ob-toggle-next` на `document`.
- Managed-форма через тот же `head` грузит `ui.js` **и дополнительно** `managed.js`, где висела **та же** ветка обработчика.
- Кнопка dropdown имеет inline `display:none`. На один клик срабатывают **оба** document-листенера по очереди: первый `none→block`, второй `block→none`. Итог — `none`, список визуально не открывается. Оба зовут `preventDefault`, ошибок нет — ровно как в отчёте.
- На списках/журналах `managed.js` не грузится → работает единственный обработчик `ui.js` → баг не проявляется (репортёр это и наблюдал, приняв за «другой render-path»).

## Фикс

Убрал ветку `data-ob-toggle-next` из `managed.js` (селектор + обработчик). Единственным владельцем делегата остался `ui.js`, который есть на каждой странице. Поведение переключения сохранено 1:1.

## Тесты

- `TestToggleNextSingleHandler` — инвариант «делегат ровно в одном месте: `ui.js` владеет, `managed.js` не дублирует».
- `TestPageManagedForm_Renders` — добавлена проверка, что managed-форма грузит **оба** скрипта (фиксирует предпосылку бага).
- `go test ./internal/ui/` — зелёный; `go vet` чист; бинарь собирается.

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)