### PR TITLE
fix(launcher): защита импорта конфигурации/бэкапа от zip-slip (CWE-22/23)

### DIFF
--- a/internal/backup/demo_reset.go
+++ b/internal/backup/demo_reset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ivantit66/onebase/internal/storage"
 )
@@ -71,6 +72,13 @@ func DemoReset(ctx context.Context, db *storage.DB, backupPath string) (*ImportR
 			continue
 		}
 		outPath := filepath.Join(tmpDir, filepath.FromSlash(zf.Name))
+		// Zip-slip guard (как в universal.go): путь распаковки не должен выходить
+		// за пределы tmpDir. Источник .obz здесь — локальный файл, но защита от
+		// «../» в именах записей архива нужна и тут — для консистентности.
+		if rel, err := filepath.Rel(tmpDir, outPath); err != nil ||
+			rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("недопустимый путь в архиве: %s", zf.Name)
+		}
 		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 			return nil, err
 		}

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -60,6 +60,33 @@ func safeBackupPath(dir, file string) (string, error) {
 	return fp, nil
 }
 
+// safeArchivePath joins dir with a ZIP/OBZ archive entry name, guaranteeing the
+// result stays inside dir. Unlike safeBackupPath (flat backup file names), an
+// archive entry may legitimately contain subdirectories (config/module.yaml),
+// but must never escape dir via "../" or an absolute path — that would be a
+// zip-slip (CWE-22/CWE-23), letting a crafted archive overwrite arbitrary files.
+func safeArchivePath(dir, name string) (string, error) {
+	if name == "" || strings.ContainsRune(name, 0) {
+		return "", i18nerr.Errorf("недопустимое имя записи архива: %s", name)
+	}
+	// Записи бывают с «\» вместо «/» — нормализуем, чтобы обратный слэш не
+	// проскочил мимо проверок на не-Windows хостах (там «\» — обычный символ).
+	norm := strings.ReplaceAll(name, `\`, "/")
+	clean := filepath.FromSlash(norm)
+	// Абсолютные пути в записях архива недопустимы: ни «/etc/passwd»,
+	// ни «C:\Windows\...» (иначе — запись вне каталога распаковки).
+	if filepath.IsAbs(clean) || strings.HasPrefix(norm, "/") {
+		return "", i18nerr.Errorf("недопустимое имя записи архива: %s", name)
+	}
+	outPath := filepath.Join(dir, clean)
+	// «../» не должен выводить за пределы dir (собственно zip-slip).
+	rel, err := filepath.Rel(dir, outPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", i18nerr.Errorf("недопустимое имя записи архива: %s", name)
+	}
+	return outPath, nil
+}
+
 func (h *handler) loadBackupDirSetting(b *Base) string {
 	if b.ConfigSource == "database" {
 		db, err := OpenDB(context.Background(), b)
@@ -586,11 +613,14 @@ func (h *handler) backupFullImport(w http.ResponseWriter, r *http.Request) {
 	var configDir string
 
 	for _, f := range reader.File {
+		outPath, err := safeArchivePath(tmpDir, f.Name)
+		if err != nil {
+			continue // zip-slip: запись с выходом за пределы tmpDir — пропускаем
+		}
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(filepath.Join(tmpDir, f.Name), 0o755)
+			os.MkdirAll(outPath, 0o755)
 			continue
 		}
-		outPath := filepath.Join(tmpDir, f.Name)
 		os.MkdirAll(filepath.Dir(outPath), 0o755)
 		rc, err := f.Open()
 		if err != nil {

--- a/internal/launcher/config_handlers.go
+++ b/internal/launcher/config_handlers.go
@@ -121,15 +121,18 @@ func (h *handler) configImportZip(w http.ResponseWriter, r *http.Request) {
 	defer os.RemoveAll(tmpDir)
 
 	for _, f := range reader.File {
+		outPath, err := safeArchivePath(tmpDir, f.Name)
+		if err != nil {
+			continue // zip-slip: запись с выходом за пределы tmpDir — пропускаем
+		}
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(filepath.Join(tmpDir, f.Name), 0o755)
+			os.MkdirAll(outPath, 0o755)
 			continue
 		}
 		rc, err := f.Open()
 		if err != nil {
 			continue
 		}
-		outPath := filepath.Join(tmpDir, f.Name)
 		os.MkdirAll(filepath.Dir(outPath), 0o755)
 		outFile, err := os.Create(outPath)
 		if err != nil {

--- a/internal/launcher/safe_archive_path_test.go
+++ b/internal/launcher/safe_archive_path_test.go
@@ -1,0 +1,51 @@
+package launcher
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// safeArchivePath защищает распаковку ZIP/OBZ-архивов (config/import-zip,
+// backup/full-import) от zip-slip (CWE-22/CWE-23): записи с «../», абсолютные
+// пути и обратные слэши не должны выходить за пределы каталога распаковки,
+// но валидные подкаталоги (config/module.yaml) обязаны проходить.
+func TestSafeArchivePath(t *testing.T) {
+	dir := t.TempDir()
+
+	good := []string{
+		"somefile.yaml",
+		"config/module.yaml",
+		"database.db",
+		"data/documents/order.json",
+	}
+	for _, name := range good {
+		fp, err := safeArchivePath(dir, name)
+		if err != nil {
+			t.Errorf("ожидался валидный путь для %q, got err: %v", name, err)
+			continue
+		}
+		want := filepath.Join(dir, filepath.FromSlash(name))
+		if fp != want {
+			t.Errorf("для %q: got %q, want %q", name, fp, want)
+		}
+	}
+
+	bad := []string{
+		"",
+		"..",
+		"../secret",
+		"../../etc/passwd",
+		"config/../../etc/passwd",
+		`..\..\windows\system32`, // обратный слэш — traversal при распаковке на Windows
+		"a\x00b",
+	}
+	if runtime.GOOS == "windows" {
+		bad = append(bad, `C:\Windows\system.ini`)
+	}
+	for _, name := range bad {
+		if _, err := safeArchivePath(dir, name); err == nil {
+			t.Errorf("ожидалась ошибка для опасного имени %q, но путь принят", name)
+		}
+	}
+}


### PR DESCRIPTION
## Что и почему

Два эндпоинта импорта в конфигураторе распаковывали загруженный ZIP/OBZ, подставляя имя записи архива напрямую в `filepath.Join(tmpDir, f.Name)` и вызывая `os.Create` без проверки на обход каталога (`../`):

- `POST /bases/{id}/configurator/config/import-zip` — `configImportZip`
- `POST /bases/{id}/configurator/backup/full-import` — `backupFullImport` (legacy-формат)

Специально сформированный архив с записями вида `../../../…` позволял **аутентифицированному администратору конфигуратора** записать файл за пределы временного каталога распаковки — перезаписать базу/конфигурацию, подложить `~/.ssh/authorized_keys` или cron/systemd drop-in, вплоть до выполнения кода от имени сервисного пользователя OneBase. Классический zip-slip (CWE-22/CWE-23). В мульти-базовой установке это ещё и выход за границу «управляй только своей базой».

В том же файле уже есть корректный guard `safeBackupPath`, но он применялся только к `{file}` из URL скачивания/удаления, а не к именам записей внутри архива.

## Что сделано

- Добавлен общий guard `safeArchivePath(dir, name)` рядом с `safeBackupPath`: отклоняет пустые/NUL-имена, абсолютные пути и `../`-обход (через `filepath.Rel`), но разрешает валидные подкаталоги (`config/module.yaml`). Нормализует `\`→`/`, чтобы обратный слэш не проскочил на не-Windows хостах.
- Применён в обоих циклах импорта — опасные записи пропускаются (`continue`), корректный архив импортируется как прежде.
- Тем же приёмом (по образцу уже защищённого `universal.go`) закрыт распаковочный цикл в `backup.DemoReset`. Источник там — локальный файл, добавлено для консистентности/защиты в глубину.
- Юнит-тест `TestSafeArchivePath`: валидные подкаталоги (`somefile.yaml`, `config/module.yaml`, `database.db`) проходят; traversal, абсолютные и backslash-варианты отклоняются.

## Проверка

- `go test ./internal/launcher/ ./internal/backup/` — зелёные.
- `go vet ./internal/launcher/ ./internal/backup/` — чисто.

## Благодарность

Уязвимость нашёл и приватно сообщил (ответственное раскрытие) независимый исследователь **tonghuaroot**. Спасибо за аккуратный репорт!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
