### PR TITLE
fix(cli): исправить установку Windows-сервиса (#326)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.bug.st/serial v1.7.1
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1
@@ -45,7 +46,6 @@ require (
 	github.com/xuri/efp v0.0.1 // indirect
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/cli/ibases.go
+++ b/internal/cli/ibases.go
@@ -80,6 +80,8 @@ var ibasesAddCmd = &cobra.Command{
 			b.DBPath = sqlitePath
 			b.DB = ""
 		}
+		warnMappedNetworkPath(os.Stderr, "файл SQLite", b.DBPath, detectMappedNetworkDrive)
+		warnMappedNetworkPath(os.Stderr, "каталог проекта", b.Path, detectMappedNetworkDrive)
 		if err := store.Add(b); err != nil {
 			return err
 		}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -21,6 +21,11 @@ var serviceCmd = &cobra.Command{
 var serviceInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install onebase as a system service (systemd on Linux, sc.exe on Windows)",
+	Long: `Install onebase as a system service (systemd on Linux, sc.exe on Windows).
+
+На Windows сервис запускается от LocalSystem. Эта учётная запись не видит
+сетевые диски, подключённые в пользовательской сессии (Z:, X: и т.п.). Для
+проекта и SQLite используйте локальный путь или UNC (\\server\share\...).`,
 	Example: `  onebase service install --id <base-id>
   onebase service install --db "postgres://..." --port 8080 --name myapp
   onebase service install --sqlite ./base.db --project ./project --config-source file --port 8080 --name myapp`,
@@ -226,31 +231,59 @@ func installSystemd(exe, svcName, displayName, dsn, sqlitePath, dbType, configSo
 // ── Windows service ───────────────────────────────────────────────────────────
 
 func installWindowsService(exe, svcName, displayName, dsn, sqlitePath, dbType, configSource, proj string, port int, watch, printOnly bool) error {
-	dbArg := fmt.Sprintf(`--db "%s"`, dsn)
+	servicePaths := []namedPath{{Label: "каталог проекта", Path: proj}}
 	if dbType == "sqlite" {
-		dbArg = fmt.Sprintf(`--sqlite "%s"`, sqlitePath)
+		servicePaths = append(servicePaths, namedPath{Label: "файл SQLite", Path: sqlitePath})
 	}
-	args := fmt.Sprintf(`run --config-source %s %s --port %d`, configSource, dbArg, port)
-	if proj != "" {
-		args += fmt.Sprintf(` --project "%s"`, proj)
+	mapped, err := findMappedNetworkPaths(servicePaths, detectMappedNetworkDrive)
+	if err != nil {
+		return fmt.Errorf("проверка путей Windows-сервиса: %w", err)
 	}
-	if watch {
-		args += " --watch"
+	if len(mapped) > 0 {
+		advice := mappedDriveAdvice(mapped)
+		if !printOnly {
+			return fmt.Errorf("%s", advice)
+		}
+		fmt.Fprintln(os.Stderr, "Предупреждение:", advice)
 	}
 
-	scCmd := fmt.Sprintf(`sc.exe create "%s" binPath= "%s %s" start= auto DisplayName= "OneBase — %s"`,
-		svcName, exe, args, displayName)
+	dbFlag, dbValue := "--db", dsn
+	if dbType == "sqlite" {
+		dbFlag, dbValue = "--sqlite", sqlitePath
+	}
+	serviceArgs := []string{
+		"run", "--config-source", quoteWindowsCommandArg(configSource),
+		dbFlag, quoteWindowsCommandArgAlways(dbValue),
+		"--port", fmt.Sprint(port),
+	}
+	if proj != "" {
+		serviceArgs = append(serviceArgs, "--project", quoteWindowsCommandArgAlways(proj))
+	}
+	if watch {
+		serviceArgs = append(serviceArgs, "--watch")
+	}
+
+	// SCM хранит binPath как готовую командную строку. Кавычки должны окружать
+	// только executable, иначе CreateProcess обрежет путь на первом пробеле.
+	// Значение остаётся отдельным аргументом exec.Command — shell не участвует.
+	binPath := quoteWindowsCommandArgAlways(exe) + " " + strings.Join(serviceArgs, " ")
+	scCmd := strings.Join([]string{
+		"sc.exe", "create", quoteWindowsCommandArg(svcName),
+		"binPath=", quoteWindowsCommandArg(binPath),
+		"start=", "auto",
+		"DisplayName=", quoteWindowsCommandArg("OneBase — " + displayName),
+	}, " ")
 
 	if printOnly {
 		fmt.Println("# Выполните от имени администратора:")
 		fmt.Println(scCmd)
-		fmt.Printf(`sc.exe description "%s" "OneBase business platform"`+"\n", svcName)
-		fmt.Printf(`sc.exe start "%s"`+"\n", svcName)
+		fmt.Printf("sc.exe description %s %s\n", quoteWindowsCommandArg(svcName), quoteWindowsCommandArg("OneBase business platform"))
+		fmt.Printf("sc.exe start %s\n", quoteWindowsCommandArg(svcName))
 		return nil
 	}
 
 	out, err := exec.Command("sc.exe", "create", svcName,
-		"binPath=", exe+" "+args,
+		"binPath=", binPath,
 		"start=", "auto",
 		"DisplayName=", "OneBase — "+displayName).CombinedOutput()
 	if err != nil {

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -32,7 +32,7 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 func TestInstallWindowsServicePrintUsesSQLite(t *testing.T) {
 	out, err := captureStdout(t, func() error {
 		return installWindowsService(
-			`C:\onebase\bin\onebase.exe`,
+			`C:\Program Files\OneBase\onebase.exe`,
 			"onebase-docflow",
 			"docflow",
 			"",
@@ -48,14 +48,65 @@ func TestInstallWindowsServicePrintUsesSQLite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(out, `--sqlite "C:\onebase\data\docflow.db"`) {
+	if !strings.Contains(out, `--sqlite \"C:\onebase\data\docflow.db\"`) {
 		t.Fatalf("windows service command must use --sqlite, got:\n%s", out)
 	}
 	if strings.Contains(out, `--db ""`) {
 		t.Fatalf("windows service command must not include empty --db, got:\n%s", out)
 	}
-	if !strings.Contains(out, `--project "C:\onebase\project"`) || !strings.Contains(out, "--watch") {
+	if !strings.Contains(out, `--project \"C:\onebase\project\"`) || !strings.Contains(out, "--watch") {
 		t.Fatalf("windows service command lost project/watch args:\n%s", out)
+	}
+	if !strings.Contains(out, `binPath= "\"C:\Program Files\OneBase\onebase.exe\" run`) {
+		t.Fatalf("binPath must preserve quotes around executable with spaces, got:\n%s", out)
+	}
+}
+
+func TestFindMappedNetworkPaths(t *testing.T) {
+	detect := func(path string) (bool, error) {
+		return strings.HasPrefix(strings.ToUpper(path), `Z:`), nil
+	}
+	mapped, err := findMappedNetworkPaths([]namedPath{
+		{Label: "SQLite", Path: `Z:\DocFlow\app.db`},
+		{Label: "проект", Path: `C:\DocFlow`},
+		{Label: "UNC", Path: `\\server\share\DocFlow`},
+	}, detect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mapped) != 1 || mapped[0].Path != `Z:\DocFlow\app.db` {
+		t.Fatalf("mapped paths = %+v, want only Z:", mapped)
+	}
+	if advice := mappedDriveAdvice(mapped); !strings.Contains(advice, "LocalSystem") || !strings.Contains(advice, "UNC") {
+		t.Fatalf("неинформативная подсказка: %s", advice)
+	}
+}
+
+func TestInstallWindowsServiceRejectsMappedDrive(t *testing.T) {
+	old := detectMappedNetworkDrive
+	detectMappedNetworkDrive = func(path string) (bool, error) {
+		return strings.HasPrefix(strings.ToUpper(path), `Z:`), nil
+	}
+	t.Cleanup(func() { detectMappedNetworkDrive = old })
+
+	err := installWindowsService(
+		`C:\Program Files\OneBase\onebase.exe`, "onebase-docflow", "docflow", "",
+		`Z:\DocFlow\app.db`, "sqlite", "file", `Z:\DocFlow`, 8080, false, false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "LocalSystem") || !strings.Contains(err.Error(), "UNC") {
+		t.Fatalf("mapped drive должен остановить установку с подсказкой, got %v", err)
+	}
+}
+
+func TestQuoteWindowsCommandArg(t *testing.T) {
+	binPath := `"C:\Program Files\OneBase\onebase.exe" run --sqlite "C:\My Data\app.db"`
+	got := quoteWindowsCommandArg(binPath)
+	want := `"\"C:\Program Files\OneBase\onebase.exe\" run --sqlite \"C:\My Data\app.db\""`
+	if got != want {
+		t.Fatalf("quoteWindowsCommandArg:\n got: %s\nwant: %s", got, want)
+	}
+	if got := quoteWindowsCommandArgAlways(`C:\My Data\`); got != `"C:\My Data\\"` {
+		t.Fatalf("trailing slash before closing quote was not escaped: %s", got)
 	}
 }
 

--- a/internal/cli/windows_paths.go
+++ b/internal/cli/windows_paths.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type namedPath struct {
+	Label string
+	Path  string
+}
+
+type networkDriveDetector func(path string) (bool, error)
+
+var detectMappedNetworkDrive networkDriveDetector = isMappedNetworkDrive
+
+func findMappedNetworkPaths(paths []namedPath, detect networkDriveDetector) ([]namedPath, error) {
+	var mapped []namedPath
+	for _, item := range paths {
+		if strings.TrimSpace(item.Path) == "" {
+			continue
+		}
+		isMapped, err := detect(item.Path)
+		if err != nil {
+			return nil, fmt.Errorf("%s %q: %w", item.Label, item.Path, err)
+		}
+		if isMapped {
+			mapped = append(mapped, item)
+		}
+	}
+	return mapped, nil
+}
+
+func mappedDriveAdvice(paths []namedPath) string {
+	items := make([]string, 0, len(paths))
+	for _, item := range paths {
+		items = append(items, fmt.Sprintf("%s %q", item.Label, item.Path))
+	}
+	return fmt.Sprintf("%s находится на подключённом сетевом диске. Windows-сервис запускается от LocalSystem и не видит mapped drives. Используйте UNC-путь (\\\\server\\share\\...) или локальный диск.", strings.Join(items, ", "))
+}
+
+func warnMappedNetworkPath(w io.Writer, label, path string, detect networkDriveDetector) {
+	mapped, err := findMappedNetworkPaths([]namedPath{{Label: label, Path: path}}, detect)
+	if err != nil || len(mapped) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Предупреждение:", mappedDriveAdvice(mapped))
+}
+
+// quoteWindowsCommandArg формирует один аргумент для команды, которую
+// пользователь может скопировать из --print в cmd.exe. Алгоритм совпадает с
+// правилами CommandLineToArgvW: кавычки внутри аргумента экранируются, а
+// обратные слэши перед ними и перед закрывающей кавычкой удваиваются.
+func quoteWindowsCommandArg(s string) string {
+	return quoteWindowsCommandArgMode(s, false)
+}
+
+func quoteWindowsCommandArgAlways(s string) string {
+	return quoteWindowsCommandArgMode(s, true)
+}
+
+func quoteWindowsCommandArgMode(s string, always bool) string {
+	if s == "" {
+		return `""`
+	}
+	if !always && !strings.ContainsAny(s, " \t\"") {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	slashes := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			slashes++
+		case '"':
+			b.WriteString(strings.Repeat("\\", slashes*2+1))
+			b.WriteByte('"')
+			slashes = 0
+		default:
+			b.WriteString(strings.Repeat("\\", slashes))
+			slashes = 0
+			b.WriteByte(s[i])
+		}
+	}
+	b.WriteString(strings.Repeat("\\", slashes*2))
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/cli/windows_paths_other.go
+++ b/internal/cli/windows_paths_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package cli
+
+func isMappedNetworkDrive(string) (bool, error) { return false, nil }

--- a/internal/cli/windows_paths_windows.go
+++ b/internal/cli/windows_paths_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func isMappedNetworkDrive(path string) (bool, error) {
+	volume := filepath.VolumeName(strings.TrimSpace(path))
+	if len(volume) != 2 || volume[1] != ':' {
+		return false, nil // локальный/UNC/относительный путь
+	}
+	root, err := windows.UTF16PtrFromString(strings.ToUpper(volume) + `\`)
+	if err != nil {
+		return false, err
+	}
+	return windows.GetDriveType(root) == windows.DRIVE_REMOTE, nil
+}


### PR DESCRIPTION
## Что исправлено

- `binPath` теперь хранит кавычки только вокруг пути к executable, поэтому пути с пробелами корректно разбираются SCM.
- Прямой `exec.Command("sc.exe", ...)` сохранён — без `cmd.exe /c` и shell-инъекций.
- Аргументы Windows-командной строки экранируются с учётом кавычек и завершающих обратных слэшей.
- Mapped network drives определяются через `GetDriveType`: `service install` останавливается с подсказкой про UNC, `ibases add` предупреждает заранее.
- Ограничение LocalSystem добавлено в `service install --help`.

## Проверка

- `go test ./...`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/onebase`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./internal/cli`

Fixes #326