### PR TITLE
fix(ui): показать расположения и сгруппировать системное меню

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -216,7 +216,18 @@ func runDev(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	uiCfg := ui.Config{DSN: dsn, PlatVersion: version.String(), PlatCommit: version.Commit(), PlatDate: version.CommitDate(), PlatAuthor: version.Author, PlatLicense: version.License}
+	uiCfg := ui.Config{
+		DSN:              dsn,
+		DatabaseType:     "postgres",
+		DatabaseLocation: runtimeDatabaseLocation("postgres", dsn, ""),
+		ConfigSource:     configSource,
+		ConfigLocation:   runtimeConfigLocation(configSource, dir, "postgres", dsn, ""),
+		PlatVersion:      version.String(),
+		PlatCommit:       version.Commit(),
+		PlatDate:         version.CommitDate(),
+		PlatAuthor:       version.Author,
+		PlatLicense:      version.License,
+	}
 	if appCfg != nil {
 		uiCfg.AppName = appCfg.Name
 		uiCfg.AppVersion = appCfg.Version

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -240,12 +240,16 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		runLog.Warn("apply app ai setting failed", "err", err)
 	}
 	uiCfg := ui.Config{
-		DSN:         dsn,
-		PlatVersion: version.String(),
-		PlatCommit:  version.Commit(),
-		PlatDate:    version.CommitDate(),
-		PlatAuthor:  version.Author,
-		PlatLicense: version.License,
+		DSN:              dsn,
+		DatabaseType:     runtimeDatabaseType(dbType),
+		DatabaseLocation: runtimeDatabaseLocation(dbType, dsn, sqlitePath),
+		ConfigSource:     configSource,
+		ConfigLocation:   runtimeConfigLocation(configSource, dir, dbType, dsn, sqlitePath),
+		PlatVersion:      version.String(),
+		PlatCommit:       version.Commit(),
+		PlatDate:         version.CommitDate(),
+		PlatAuthor:       version.Author,
+		PlatLicense:      version.License,
 	}
 	if appCfg != nil {
 		uiCfg.AppName = appCfg.Name

--- a/internal/cli/runtime_locations.go
+++ b/internal/cli/runtime_locations.go
@@ -1,0 +1,38 @@
+package cli
+
+import "path/filepath"
+
+func runtimeDatabaseType(dbType string) string {
+	if dbType == "sqlite" {
+		return "sqlite"
+	}
+	return "postgres"
+}
+
+// runtimeDatabaseLocation returns a stable, useful location for diagnostics.
+// File paths are made absolute; PostgreSQL connection strings are masked later
+// by the UI immediately before rendering.
+func runtimeDatabaseLocation(dbType, dsn, sqlitePath string) string {
+	if dbType == "sqlite" {
+		return absoluteRuntimePath(sqlitePath)
+	}
+	return dsn
+}
+
+func runtimeConfigLocation(configSource, projectDir, dbType, dsn, sqlitePath string) string {
+	if configSource == "database" {
+		return runtimeDatabaseLocation(dbType, dsn, sqlitePath)
+	}
+	return absoluteRuntimePath(projectDir)
+}
+
+func absoluteRuntimePath(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return filepath.Clean(abs)
+}

--- a/internal/cli/runtime_locations_test.go
+++ b/internal/cli/runtime_locations_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeLocations_FileConfigAndSQLiteAreAbsolute(t *testing.T) {
+	wantProject, err := filepath.Abs("project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDB, err := filepath.Abs(filepath.Join("data", "app.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := runtimeConfigLocation("file", "project", "sqlite", "", filepath.Join("data", "app.db")); got != wantProject {
+		t.Errorf("config location = %q, want %q", got, wantProject)
+	}
+	if got := runtimeDatabaseLocation("sqlite", "", filepath.Join("data", "app.db")); got != wantDB {
+		t.Errorf("database location = %q, want %q", got, wantDB)
+	}
+}
+
+func TestRuntimeLocations_DatabaseConfigUsesDatabaseLocation(t *testing.T) {
+	dsn := "postgres://onebase:secret@db.example/production"
+	if got := runtimeConfigLocation("database", "ignored", "postgres", dsn, ""); got != dsn {
+		t.Errorf("database-backed config location = %q, want %q", got, dsn)
+	}
+	if got := runtimeDatabaseType(""); got != "postgres" {
+		t.Errorf("empty legacy database type = %q, want postgres", got)
+	}
+}

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -1,4 +1,12 @@
 {
+  "Профиль и интерфейс": "Profile and interface",
+  "Администрирование": "Administration",
+  "Интеграции и задания": "Integrations and jobs",
+  "Обслуживание базы": "Database maintenance",
+  "Расширения и оборудование": "Extensions and equipment",
+  "Хранение конфигурации": "Configuration storage",
+  "Расположение конфигурации": "Configuration location",
+  "Платформенные возможности": "Platform features",
   "Вкладки": "Tabs",
   "Режим открытия форм": "Form opening mode",
   "Отдельные страницы": "Separate pages",

--- a/internal/launcher/admin_about_test.go
+++ b/internal/launcher/admin_about_test.go
@@ -1,0 +1,99 @@
+package launcher
+
+import (
+	"context"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func renderCfgAdminAbout(t *testing.T, b *Base) string {
+	t.Helper()
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	if err := store.save([]*Base{b}); err != nil {
+		t.Fatalf("store.save: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/bases/"+b.ID+"/configurator/admin/about", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", b.ID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	(&handler{store: store}).cfgAdminAbout(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("cfgAdminAbout status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+func TestCfgAdminAbout_ShowsSQLiteAndFileConfigLocations(t *testing.T) {
+	b := &Base{
+		ID:           "about-file",
+		Name:         "File base",
+		ConfigSource: "file",
+		Path:         `/srv/configs/<trade>`,
+		DBType:       "sqlite",
+		DBPath:       `/srv/data/<trade>.db`,
+		Port:         8080,
+	}
+	html := renderCfgAdminAbout(t, b)
+
+	for _, want := range []string{
+		"Расположение конфигурации",
+		"Файлы",
+		`/srv/configs/&lt;trade&gt;`,
+		"База данных",
+		`/srv/data/&lt;trade&gt;.db`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("в окне «О программе» нет %q", want)
+		}
+	}
+	if strings.Contains(html, "<trade>") {
+		t.Error("пути в окне «О программе» должны быть HTML-экранированы")
+	}
+}
+
+func TestCfgAdminAbout_DatabaseConfigShowsItsSQLiteFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "application.db")
+	b := &Base{
+		ID:           "about-database",
+		Name:         "Database base",
+		ConfigSource: "database",
+		DBType:       "sqlite",
+		DBPath:       dbPath,
+		Port:         8081,
+	}
+	html := renderCfgAdminAbout(t, b)
+
+	if !strings.Contains(html, "В базе данных") {
+		t.Error("не показан режим хранения конфигурации в базе данных")
+	}
+	if strings.Count(html, dbPath) != 2 {
+		t.Errorf("путь SQLite должен быть указан и для конфигурации, и для данных; HTML: %s", html)
+	}
+}
+
+func TestCfgAdminAbout_MasksPostgresPassword(t *testing.T) {
+	b := &Base{
+		ID:           "about-postgres",
+		Name:         "Postgres base",
+		ConfigSource: "file",
+		Path:         "/srv/onebase/config",
+		DBType:       "postgres",
+		DB:           "postgres://onebase:very-secret@db.example/production",
+		Port:         8082,
+	}
+	html := renderCfgAdminAbout(t, b)
+
+	if !strings.Contains(html, "postgres://onebase:***@db.example/production") {
+		t.Error("в окне «О программе» нет маскированного PostgreSQL DSN")
+	}
+	if strings.Contains(html, "very-secret") {
+		t.Error("окно «О программе» раскрыло пароль PostgreSQL")
+	}
+}

--- a/internal/launcher/admin_handlers.go
+++ b/internal/launcher/admin_handlers.go
@@ -950,7 +950,21 @@ func (h *handler) cfgAdminAbout(w http.ResponseWriter, r *http.Request) {
 		platVer += `</span>`
 	}
 
-	html := fmt.Sprintf(`<div style="padding:24px;max-width:400px">
+	dbLocation := baseDatabaseLocation(b)
+	configMode := "Файлы"
+	configLocation := b.Path
+	if b.ConfigSource == "database" {
+		configMode = "В базе данных"
+		configLocation = dbLocation
+	}
+	if configLocation == "" {
+		configLocation = "—"
+	}
+	if dbLocation == "" {
+		dbLocation = "—"
+	}
+
+	html := fmt.Sprintf(`<div style="padding:24px;max-width:560px">
 	<div style="text-align:center;margin-bottom:20px">
 	  %s
 	  <div style="font-size:18px;font-weight:600;color:#1a5fa8">OneBase</div>
@@ -960,7 +974,8 @@ func (h *handler) cfgAdminAbout(w http.ResponseWriter, r *http.Request) {
 	<tr><td style="padding:6px 0;color:#888;width:140px">Версия платформы</td><td style="padding:6px 0">%s</td></tr>
 	%s
 	<tr><td style="padding:6px 0;color:#888">Режим конфигурации</td><td style="padding:6px 0">%s</td></tr>
-	<tr><td style="padding:6px 0;color:#888">База данных</td><td style="padding:6px 0">%s</td></tr>
+	<tr><td style="padding:6px 0;color:#888">Расположение конфигурации</td><td style="padding:6px 0;word-break:break-all">%s</td></tr>
+	<tr><td style="padding:6px 0;color:#888">База данных</td><td style="padding:6px 0;word-break:break-all">%s</td></tr>
 	<tr><td style="padding:6px 0;color:#888">Порт</td><td style="padding:6px 0">:%d</td></tr>
 	</table>
 	</div>`,
@@ -968,8 +983,9 @@ func (h *handler) cfgAdminAbout(w http.ResponseWriter, r *http.Request) {
 		userRow,
 		platVer,
 		cfgRows,
-		escHTML(b.ConfigSource),
-		maskDSN(escHTML(b.DB)),
+		escHTML(configMode),
+		escHTML(configLocation),
+		escHTML(dbLocation),
 		b.Port)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
@@ -1081,4 +1097,17 @@ func maskDSN(dsn string) string {
 		return dsn[:end] + "***"
 	}
 	return dsn
+}
+
+// baseDatabaseLocation returns the same database location the launcher uses,
+// including the actual file path for SQLite and a password-masked PostgreSQL
+// connection string. The empty DBType/DB fallback mirrors OpenDB.
+func baseDatabaseLocation(b *Base) string {
+	if b.DBType == "sqlite" || (b.DBType == "" && b.DB == "") {
+		if b.DBPath != "" {
+			return b.DBPath
+		}
+		return filepath.Join(os.TempDir(), "onebase_"+b.ID+".db")
+	}
+	return maskDSN(b.DB)
 }

--- a/internal/ui/about_locations_test.go
+++ b/internal/ui/about_locations_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func renderAbout(t *testing.T, cfg Config, isAdmin bool) string {
+	t.Helper()
+	var buf bytes.Buffer
+	data := map[string]any{
+		"Cfg":       prepareAboutConfig(cfg),
+		"Lang":      "ru",
+		"IsAdmin":   isAdmin,
+		"Catalogs":  0,
+		"Documents": 0,
+		"Registers": 0,
+		"Reports":   0,
+	}
+	if err := tmpl.ExecuteTemplate(&buf, "page-about", data); err != nil {
+		t.Fatalf("render page-about: %v", err)
+	}
+	return buf.String()
+}
+
+func TestAbout_AdminSeesFileConfigAndSQLiteLocations(t *testing.T) {
+	html := renderAbout(t, Config{
+		ConfigSource:     "file",
+		ConfigLocation:   `/srv/configs/<trade>`,
+		DatabaseType:     "sqlite",
+		DatabaseLocation: `/srv/data/<trade>.db`,
+	}, true)
+
+	for _, want := range []string{
+		"Хранение конфигурации",
+		"Файлы",
+		"Расположение конфигурации",
+		`/srv/configs/&lt;trade&gt;`,
+		"SQLite · /srv/data/&lt;trade&gt;.db",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("в пользовательском «О программе» нет %q", want)
+		}
+	}
+	if strings.Contains(html, "<trade>") {
+		t.Error("пути должны быть HTML-экранированы")
+	}
+}
+
+func TestAbout_DatabaseConfigUsesMaskedDatabaseLocation(t *testing.T) {
+	html := renderAbout(t, Config{
+		ConfigSource:     "database",
+		DatabaseType:     "postgres",
+		DatabaseLocation: "postgres://onebase:very-secret@db.example/production",
+	}, true)
+
+	if strings.Count(html, "postgres://onebase:***@db.example/production") != 2 {
+		t.Errorf("маскированный DSN должен обозначать расположение конфигурации и базы: %s", html)
+	}
+	if strings.Contains(html, "very-secret") {
+		t.Error("страница «О программе» раскрыла пароль PostgreSQL")
+	}
+}
+
+func TestAbout_RegularUserDoesNotSeeServerPaths(t *testing.T) {
+	html := renderAbout(t, Config{
+		ConfigSource:     "file",
+		ConfigLocation:   "/srv/private/config",
+		DatabaseType:     "sqlite",
+		DatabaseLocation: "/srv/private/data.db",
+	}, false)
+
+	if !strings.Contains(html, "Файлы") || !strings.Contains(html, "SQLite") {
+		t.Error("обычному пользователю должны быть видны типы хранения")
+	}
+	for _, hidden := range []string{"/srv/private/config", "/srv/private/data.db", "Расположение конфигурации"} {
+		if strings.Contains(html, hidden) {
+			t.Errorf("обычному пользователю раскрыто %q", hidden)
+		}
+	}
+}

--- a/internal/ui/equipment_ui_test.go
+++ b/internal/ui/equipment_ui_test.go
@@ -50,12 +50,45 @@ func TestUI_IndexChartsUseJSONBootstrap(t *testing.T) {
 	}
 }
 
-// Пункты меню РМК и настроек агента попадают в общий nav.
-func TestUI_NavLinks(t *testing.T) {
+// РМК — платформенная функция: администратор открывает её через «Все
+// функции», но прежний доступ обычного кассира не пропадает. Настройки агента
+// остаются в системной группе администратора.
+func TestUI_PlatformLinks(t *testing.T) {
 	html := renderPage(t, "page-index")
-	for _, want := range []string{`href="/ui/pos"`, `href="/ui/settings/agent"`} {
+	if !strings.Contains(html, `href="/ui/settings/agent"`) {
+		t.Error("в меню нет настроек агента оборудования")
+	}
+	if strings.Contains(html, `href="/ui/pos"`) {
+		t.Error("у администратора РМК не должен оставаться отдельным пунктом меню «Система»")
+	}
+	userNav := renderNav(t, false)
+	if !strings.Contains(userNav, `href="/ui/pos"`) || !strings.Contains(userNav, "Платформенные возможности") {
+		t.Error("обычный пользователь потерял доступ к РМК после переноса в «Все функции» администратора")
+	}
+
+	allFunctions := renderPage(t, "page-all-functions")
+	for _, want := range []string{"Платформенные возможности", `href="/ui/pos"`, "Рабочее место кассира (РМК)"} {
+		if !strings.Contains(allFunctions, want) {
+			t.Errorf("в «Все функции» нет %q", want)
+		}
+	}
+}
+
+func TestUI_SystemMenuIsGroupedAndScrollable(t *testing.T) {
+	html := renderPage(t, "page-index")
+	for _, want := range []string{
+		`class="sys-group"`,
+		"Профиль и интерфейс",
+		"Администрирование",
+		"Интеграции и задания",
+		"Обслуживание базы",
+		"Расширения и оборудование",
+		"Инструменты разработчика",
+		"max-height:calc(100vh - 50px)",
+		"overflow-y:auto",
+	} {
 		if !strings.Contains(html, want) {
-			t.Errorf("в меню нет ссылки %s", want)
+			t.Errorf("сгруппированное меню «Система» не содержит %q", want)
 		}
 	}
 }

--- a/internal/ui/handlers_home.go
+++ b/internal/ui/handlers_home.go
@@ -27,8 +27,7 @@ func (s *Server) about(w http.ResponseWriter, r *http.Request) {
 			docs++
 		}
 	}
-	cfg := s.cfg
-	cfg.DSN = maskDSN(cfg.DSN)
+	cfg := prepareAboutConfig(s.cfg)
 	user := auth.UserFromContext(r.Context())
 	s.render(w, r, "page-about", map[string]any{
 		"Cfg":       cfg,
@@ -38,6 +37,19 @@ func (s *Server) about(w http.ResponseWriter, r *http.Request) {
 		"Reports":   len(s.reg.Reports()),
 		"User":      user,
 	})
+}
+
+func prepareAboutConfig(cfg Config) Config {
+	if cfg.DatabaseLocation == "" {
+		cfg.DatabaseLocation = cfg.DSN
+	}
+	cfg.DatabaseLocation = maskDSN(cfg.DatabaseLocation)
+	// В database-режиме конфигурация находится там же, где данные. Значение
+	// собираем здесь после маскирования DSN, чтобы пароль не попал в HTML.
+	if cfg.ConfigSource == "database" {
+		cfg.ConfigLocation = cfg.DatabaseLocation
+	}
+	return cfg
 }
 
 func maskDSN(dsn string) string {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -29,25 +29,29 @@ import (
 
 // Config holds static info shown in «О программе».
 type Config struct {
-	AppName       string
-	AppVersion    string
-	AppAuthor     string // автор конфигурации (app.yaml: author)
-	AppCopyright  string // правообладатель конфигурации (app.yaml: copyright)
-	AppLicense    string // лицензия конфигурации (app.yaml: license)
-	PlatAuthor    string // правообладатель платформы (version.Author)
-	PlatLicense   string // лицензия платформы (version.License)
-	DSN           string
-	PlatVersion   string
-	PlatCommit    string // короткий git SHA сборки (version.Commit())
-	PlatDate      string // дата коммита сборки, дд.мм.гг (version.CommitDate())
-	Logo          string // path to logo file (png/svg/jpg)
-	Mailer        *mailer.Mailer
-	MaxFileSizeMB int      // 0 = use default 50
-	AllowedTypes  []string // attachments.allowed_types (расширения); пусто = без ограничений
-	DemoMode      bool
-	DemoMessage   string
-	Lang          string       // base language from config
-	Bundle        *i18n.Bundle // translations
+	AppName          string
+	AppVersion       string
+	AppAuthor        string // автор конфигурации (app.yaml: author)
+	AppCopyright     string // правообладатель конфигурации (app.yaml: copyright)
+	AppLicense       string // лицензия конфигурации (app.yaml: license)
+	PlatAuthor       string // правообладатель платформы (version.Author)
+	PlatLicense      string // лицензия платформы (version.License)
+	DSN              string // legacy PostgreSQL location; use DatabaseLocation in UI
+	DatabaseType     string // "postgres" or "sqlite"
+	DatabaseLocation string // PostgreSQL DSN or absolute SQLite file path
+	ConfigSource     string // "file" or "database"
+	ConfigLocation   string // absolute project path or database location
+	PlatVersion      string
+	PlatCommit       string // короткий git SHA сборки (version.Commit())
+	PlatDate         string // дата коммита сборки, дд.мм.гг (version.CommitDate())
+	Logo             string // path to logo file (png/svg/jpg)
+	Mailer           *mailer.Mailer
+	MaxFileSizeMB    int      // 0 = use default 50
+	AllowedTypes     []string // attachments.allowed_types (расширения); пусто = без ограничений
+	DemoMode         bool
+	DemoMessage      string
+	Lang             string       // base language from config
+	Bundle           *i18n.Bundle // translations
 	// DebugToken — общий секрет для debug API. Пустой → debug-маршруты не
 	// монтируются (см. api.New). Непустой → каждый запрос к /debug/global/*
 	// должен нести его в заголовке X-OneBase-Debug-Token.

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -579,17 +579,26 @@ body{font-family:system-ui,sans-serif;display:flex;flex-direction:column;min-hei
 .sys-menu{position:relative}
 .sys-btn{background:none;border:none;color:#cbd5e1;cursor:pointer;font-size:15px;padding:6px 10px;border-radius:5px;line-height:1}
 .sys-btn:hover{background:#334155;color:#fff}
-.sys-drop{display:none;position:absolute;right:0;top:calc(100% + 4px);background:#fff;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.18);min-width:170px;padding:4px 0;z-index:200}
+.sys-drop{display:none;position:absolute;right:0;top:calc(100% + 4px);background:#fff;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.18);width:300px;max-width:calc(100vw - 16px);max-height:calc(100vh - 50px);max-height:calc(100dvh - 50px);overflow-y:auto;overscroll-behavior:contain;padding:4px 0;z-index:200}
 .sys-drop.open{display:block}
-.sys-drop>a,.sys-drop>button,.sys-drop>.sys-sub>a{display:block;padding:10px 16px;color:#334155;text-decoration:none;font-size:14px;width:100%;text-align:left;background:none;border:none;cursor:pointer;border-bottom:1px solid #f1f5f9}
+.sys-drop>a,.sys-drop>button{display:block;padding:10px 16px;color:#334155;text-decoration:none;font-size:14px;width:100%;text-align:left;background:none;border:none;cursor:pointer;border-bottom:1px solid #f1f5f9}
 .sys-drop>:last-child>a,.sys-drop>a:last-child,.sys-drop>button:last-child{border-bottom:none}
-.sys-drop>a:hover,.sys-drop>button:hover,.sys-drop>.sys-sub:hover>a{background:#f1f5f9}
-.sys-sub{position:relative}
-.sys-sub>.sys-submenu{display:none;position:absolute;right:100%;top:-4px;background:#fff;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.18);min-width:220px;padding:4px 0;z-index:200}
-.sys-sub:hover>.sys-submenu{display:block}
-.sys-submenu a{display:block;padding:10px 16px;color:#334155;text-decoration:none;font-size:14px;border-bottom:1px solid #f1f5f9;white-space:nowrap}
-.sys-submenu a:last-child{border-bottom:none}
-.sys-submenu a:hover{background:#f1f5f9}
+.sys-drop>a:hover,.sys-drop>button:hover{background:#f1f5f9}
+.sys-drop details.sys-group{margin:0;max-width:none;background:#fff;border-radius:0;box-shadow:none;border-bottom:1px solid #f1f5f9}
+.sys-drop .sys-group>summary{display:flex;align-items:center;gap:8px;padding:10px 16px;color:#334155;font-size:14px;font-weight:600;cursor:pointer;list-style:none;user-select:none}
+.sys-drop .sys-group>summary::-webkit-details-marker{display:none}
+.sys-drop .sys-group>summary::before{content:""}
+.sys-drop .sys-group>summary::after{content:"▸";margin-left:auto;color:#94a3b8;font-size:12px;transition:transform .12s ease}
+.sys-drop .sys-group[open]>summary::after{content:"▸";transform:rotate(90deg)}
+.sys-drop .sys-group>summary:hover{background:#f8fafc;color:#1d4ed8}
+.sys-group-body{padding:2px 0 5px;background:#f8fafc}
+.sys-group-body>a{display:block;padding:8px 16px 8px 34px;color:#475569;text-decoration:none;font-size:13px;border-top:1px solid #f1f5f9}
+.sys-group-body>a:hover{background:#eef2ff;color:#1d4ed8}
+.sys-mode-block{padding:9px 16px 10px 34px;border-top:1px solid #f1f5f9}
+.sys-mode-title{font-size:12px;color:#64748b;margin-bottom:6px;font-weight:600}
+.sys-mode-block label{display:block;font-size:13px;padding:2px 0;cursor:pointer;color:#475569}
+.sys-mode-block .sys-btn{margin-top:6px;background:#e2e8f0;color:#334155;font-size:12px;padding:6px 10px}
+.sys-logout{position:sticky;bottom:-4px;background:#fff;z-index:1;margin:0;padding:0;box-shadow:0 -3px 8px rgba(15,23,42,.06)}
 .tbl{width:100%;border-collapse:collapse}
 .tbl th{text-align:left;padding:8px 10px;border-bottom:2px solid #e2e8f0;color:#64748b;font-weight:600;font-size:12px;position:sticky;top:0;background:#fff}
 .tbl td{padding:6px 10px;border-bottom:1px solid #f1f5f9;color:#334155;font-size:13px}
@@ -783,43 +792,76 @@ const tplNav = `
     <button class="sys-btn" type="button" data-ob-toggle-target="sysd">&#9881; {{t $.Lang "Система"}} &#9660;</button>
     <div class="sys-drop" id="sysd">
       <a href="/ui/about">{{t $.Lang "О программе"}}</a>
-      {{if .IsAdmin}}
-      <a href="/ui/admin/users">{{t $.Lang "Пользователи"}}</a>
-      <a href="/ui/admin/roles">{{t $.Lang "Роли и права"}}</a>
-      <a href="/ui/admin/sessions">{{t $.Lang "Активные пользователи"}}</a>
-	      <a href="/ui/admin/api-tokens">{{t $.Lang "API-токены"}}</a>
-	      <a href="/ui/admin/audit">{{t $.Lang "Журнал изменений"}}</a>
-	      <a href="/ui/admin/rls">{{t $.Lang "Диагностика RLS"}}</a>
-	      <a href="/ui/admin/webhooks">{{t $.Lang "Журнал веб-хуков"}}</a>
-      <a href="/ui/admin/exchange">{{t $.Lang "Обмен данными"}}</a>
-      <a href="/ui/admin/scheduled">{{t $.Lang "Регламентные задания"}}</a>
-      <a href="/ui/delete-marked">{{t $.Lang "Удалить помеченные"}}</a>
-      <a href="/ui/admin/cleanup">{{t $.Lang "Очистка регистров"}}</a>
+      <details class="sys-group">
+        <summary>{{t $.Lang "Профиль и интерфейс"}}</summary>
+        <div class="sys-group-body">
+          <div class="sys-mode-block">
+            <div class="sys-mode-title">{{t $.Lang "Режим открытия форм"}}</div>
+            <form method="post" action="/ui/form-mode" style="margin:0;padding:0">
+              <label><input type="radio" name="mode" value="pages" {{if eq (printf "%v" .FormOpenModePersonal) "pages"}}checked{{end}}> {{t $.Lang "Отдельные страницы"}}</label>
+              <label><input type="radio" name="mode" value="tabs" {{if eq (printf "%v" .FormOpenModePersonal) "tabs"}}checked{{end}}> {{t $.Lang "Вкладки"}}</label>
+              <label><input type="radio" name="mode" value="default" {{if eq (printf "%v" .FormOpenModePersonal) ""}}checked{{end}}> {{t $.Lang "По умолчанию (глобально)"}}</label>
+              <button type="submit" class="sys-btn">{{t $.Lang "Применить"}}</button>
+            </form>
+          </div>
+          {{if .HasAuth}}{{if not .DenyPasswdChange}}<a href="/ui/profile/passwd">{{t $.Lang "Сменить пароль"}}</a>{{end}}{{end}}
+        </div>
+      </details>
+      {{if not .IsAdmin}}
+      <details class="sys-group">
+        <summary>{{t $.Lang "Платформенные возможности"}}</summary>
+        <div class="sys-group-body">
+          <a href="/ui/pos">{{t $.Lang "Рабочее место кассира (РМК)"}}</a>
+        </div>
+      </details>
       {{end}}
-      <a href="/ui/pos">{{t $.Lang "Рабочее место кассира (РМК)"}}</a>
-      {{if .IsAdmin}}<a href="/ui/settings/agent">{{t $.Lang "Настройки агента оборудования"}}</a>{{end}}
-      {{if .IsAdmin}}<a href="/ui/admin/extforms">{{t $.Lang "Внешние печатные формы"}}</a>{{end}}
-      {{if .IsAdmin}}<a href="/ui/admin/extreports">{{t $.Lang "Внешние отчёты"}}</a>{{end}}
-      {{if .IsAdmin}}<a href="/ui/admin/extprocessors">{{t $.Lang "Внешние обработки"}}</a>{{end}}
-      {{if .IsAdmin}}<a href="/ui/all-functions">{{t $.Lang "Все функции"}}</a>{{end}}
-      {{if .IsAdmin}}<div class="sys-sub"><a href="#" data-ob-prevent>{{t $.Lang "Инструменты разработчика"}} &#9654;</a>
-      <div class="sys-submenu">
-        <a href="/ui/dev/query-console">{{t $.Lang "Консоль запросов"}}</a>
-        <a href="/ui/dev/code-console">{{t $.Lang "Консоль кода"}}</a>
-        <a href="/ui/dev/gengen">{{t $.Lang "Gengen"}}</a>
-      </div>
-    </div>{{end}}
-      <div style="border-top:1px solid #f1f5f9;padding:10px 16px">
-        <div style="font-size:12px;color:#64748b;margin-bottom:6px;font-weight:600">{{t $.Lang "Режим открытия форм"}}</div>
-        <form method="post" action="/ui/form-mode" style="margin:0;padding:0">
-          <label style="display:block;font-size:13px;padding:2px 0;cursor:pointer"><input type="radio" name="mode" value="pages" {{if eq (printf "%v" .FormOpenModePersonal) "pages"}}checked{{end}}> {{t $.Lang "Отдельные страницы"}}</label>
-          <label style="display:block;font-size:13px;padding:2px 0;cursor:pointer"><input type="radio" name="mode" value="tabs" {{if eq (printf "%v" .FormOpenModePersonal) "tabs"}}checked{{end}}> {{t $.Lang "Вкладки"}}</label>
-          <label style="display:block;font-size:13px;padding:2px 0;cursor:pointer"><input type="radio" name="mode" value="default" {{if eq (printf "%v" .FormOpenModePersonal) ""}}checked{{end}}> {{t $.Lang "По умолчанию (глобально)"}}</label>
-          <button type="submit" class="sys-btn" style="margin-top:6px">{{t $.Lang "Применить"}}</button>
-        </form>
-      </div>
-      {{if .HasAuth}}{{if not .DenyPasswdChange}}<a href="/ui/profile/passwd">{{t $.Lang "Сменить пароль"}}</a>{{end}}{{end}}
-      <form method="POST" action="/logout" style="margin:0;padding:0"><button type="submit" style="display:block;width:100%;padding:10px 16px;color:#dc2626;text-decoration:none;font-size:14px;text-align:left;background:none;border:none;border-top:1px solid #f1f5f9;cursor:pointer">{{t $.Lang "Выйти"}}</button></form>
+      {{if .IsAdmin}}
+      <details class="sys-group">
+        <summary>{{t $.Lang "Администрирование"}}</summary>
+        <div class="sys-group-body">
+          <a href="/ui/admin/users">{{t $.Lang "Пользователи"}}</a>
+          <a href="/ui/admin/roles">{{t $.Lang "Роли и права"}}</a>
+          <a href="/ui/admin/sessions">{{t $.Lang "Активные пользователи"}}</a>
+          <a href="/ui/admin/api-tokens">{{t $.Lang "API-токены"}}</a>
+          <a href="/ui/admin/audit">{{t $.Lang "Журнал изменений"}}</a>
+          <a href="/ui/admin/rls">{{t $.Lang "Диагностика RLS"}}</a>
+        </div>
+      </details>
+      <details class="sys-group">
+        <summary>{{t $.Lang "Интеграции и задания"}}</summary>
+        <div class="sys-group-body">
+          <a href="/ui/admin/exchange">{{t $.Lang "Обмен данными"}}</a>
+          <a href="/ui/admin/scheduled">{{t $.Lang "Регламентные задания"}}</a>
+          <a href="/ui/admin/webhooks">{{t $.Lang "Журнал веб-хуков"}}</a>
+        </div>
+      </details>
+      <details class="sys-group">
+        <summary>{{t $.Lang "Обслуживание базы"}}</summary>
+        <div class="sys-group-body">
+          <a href="/ui/delete-marked">{{t $.Lang "Удалить помеченные"}}</a>
+          <a href="/ui/admin/cleanup">{{t $.Lang "Очистка регистров"}}</a>
+        </div>
+      </details>
+      <details class="sys-group">
+        <summary>{{t $.Lang "Расширения и оборудование"}}</summary>
+        <div class="sys-group-body">
+          <a href="/ui/settings/agent">{{t $.Lang "Настройки агента оборудования"}}</a>
+          <a href="/ui/admin/extforms">{{t $.Lang "Внешние печатные формы"}}</a>
+          <a href="/ui/admin/extreports">{{t $.Lang "Внешние отчёты"}}</a>
+          <a href="/ui/admin/extprocessors">{{t $.Lang "Внешние обработки"}}</a>
+        </div>
+      </details>
+      <details class="sys-group">
+        <summary>{{t $.Lang "Инструменты разработчика"}}</summary>
+        <div class="sys-group-body">
+          <a href="/ui/all-functions">{{t $.Lang "Все функции"}}</a>
+          <a href="/ui/dev/query-console">{{t $.Lang "Консоль запросов"}}</a>
+          <a href="/ui/dev/code-console">{{t $.Lang "Консоль кода"}}</a>
+          <a href="/ui/dev/gengen">{{t $.Lang "Gengen"}}</a>
+        </div>
+      </details>
+      {{end}}
+      <form class="sys-logout" method="POST" action="/logout"><button type="submit" style="display:block;width:100%;padding:10px 16px;color:#dc2626;text-decoration:none;font-size:14px;text-align:left;background:none;border:none;border-top:1px solid #f1f5f9;cursor:pointer">{{t $.Lang "Выйти"}}</button></form>
     </div>
   </div>
 </header>
@@ -2293,10 +2335,24 @@ const tplAbout = `
       <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;font-size:14px">{{.Cfg.AppLicense}}</td>
     </tr>
     {{end}}
+    {{if .Cfg.ConfigSource}}
+    <tr>
+      <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;color:#64748b;font-size:14px">{{t $.Lang "Хранение конфигурации"}}</td>
+      <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;font-size:14px;color:#475569">{{if eq .Cfg.ConfigSource "database"}}{{t $.Lang "В базе данных"}}{{else}}{{t $.Lang "Файлы"}}{{end}}</td>
+    </tr>
+    {{end}}
+    {{if and .IsAdmin .Cfg.ConfigLocation}}
+    <tr>
+      <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;color:#64748b;font-size:14px">{{t $.Lang "Расположение конфигурации"}}</td>
+      <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;font-size:13px;color:#475569;word-break:break-all">{{.Cfg.ConfigLocation}}</td>
+    </tr>
+    {{end}}
+    {{if .Cfg.DatabaseLocation}}
     <tr>
       <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;color:#64748b;font-size:14px">{{t $.Lang "База данных"}}</td>
-      <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;font-size:13px;color:#475569;word-break:break-all">{{.Cfg.DSN}}</td>
+      <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;font-size:13px;color:#475569;word-break:break-all">{{if eq .Cfg.DatabaseType "sqlite"}}SQLite{{else}}PostgreSQL{{end}}{{if .IsAdmin}} · {{.Cfg.DatabaseLocation}}{{end}}</td>
     </tr>
+    {{end}}
     <tr>
       <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;color:#64748b;font-size:14px">{{t $.Lang "Метаданные"}}</td>
       <td style="padding:14px 0;border-bottom:1px solid #f1f5f9;font-size:14px">

--- a/internal/ui/tpl_all_functions.go
+++ b/internal/ui/tpl_all_functions.go
@@ -10,6 +10,13 @@ const tplAllFunctions = `
     style="width:100%;padding:9px 14px;border:1px solid #d0d7e3;border-radius:6px;font-size:14px">
 </div>
 
+<div class="af-group" data-group="Платформенные возможности">
+  <div class="af-group-hd" data-ob-af-toggle>{{t $.Lang "Платформенные возможности"}} <span class="af-cnt">1</span></div>
+  <div class="af-group-body">
+    <a class="af-link" href="/ui/pos" data-name="РМК Рабочее место кассира">{{t $.Lang "Рабочее место кассира (РМК)"}}</a>
+  </div>
+</div>
+
 {{if .Catalogs}}
 <div class="af-group" data-group="Справочники">
   <div class="af-group-hd" data-ob-af-toggle>{{t $.Lang "Справочники"}} <span class="af-cnt">{{len .Catalogs}}</span></div>


### PR DESCRIPTION
## Что изменено

- добавлены расположения базы данных и конфигурации в окна «О программе»
- меню «Система» сгруппировано и ограничено высотой с прокруткой
- РМК перенесён в «Все функции → Платформенные возможности» с сохранением доступа обычных пользователей
- PostgreSQL-пароли маскируются, файловые пути нормализуются

## Проверка

- `go test ./...`