### PR TITLE
fix(configurator): кнопки ИИ-помощника не показывались после настройки

### DIFF
--- a/internal/launcher/configurator_ai_buttons_test.go
+++ b/internal/launcher/configurator_ai_buttons_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ivantit66/onebase/internal/webassets"
 )
 
 // TestConfiguratorJS_AiBootWaitsForDOMReady — регрессия: плавающие кнопки ИИ
@@ -32,11 +34,16 @@ func TestConfiguratorJS_AiBootWaitsForDOMReady(t *testing.T) {
 // обычный F5 против этого бессилен (это и маскировало регрессию выше). noStore
 // должен ставить Cache-Control: no-store на каждый ответ embed-handler'а.
 func TestNoStore_DisablesCacheForEmbedAssets(t *testing.T) {
+	// EChartsHandler intentionally sets an immutable year-long cache policy.
+	// Test the real composition used by the launcher, not a dummy handler that
+	// never tries to overwrite Cache-Control.
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/static/configurator.js", nil)
-	noStore(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})).ServeHTTP(rec, req)
+	req := httptest.NewRequest(http.MethodGet, "/vendor/echarts/echarts.min.js", nil)
+	h := noStore(http.StripPrefix("/vendor/echarts/", webassets.EChartsHandler()))
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET ECharts: status=%d", rec.Code)
+	}
 	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
 		t.Errorf("Cache-Control: want %q, got %q", "no-store", got)
 	}

--- a/internal/launcher/configurator_ai_buttons_test.go
+++ b/internal/launcher/configurator_ai_buttons_test.go
@@ -1,0 +1,43 @@
+package launcher
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestConfiguratorJS_AiBootWaitsForDOMReady — регрессия: плавающие кнопки ИИ
+// (cfgai-btn/cfggen-btn) подключены в шаблоне НИЖЕ <script src=configurator.js>,
+// поэтому IIFE конфигуратора выполняется, когда их ещё нет в DOM. Раньше
+// initAiHandlers() падал на null.addEventListener, и автозапуск cfgAiRefresh()
+// не доходил — кнопки не появлялись, пока не вызвать cfgAiRefresh() вручную
+// (куратор чата при этом тоже не открывался на клик). Фикс: автозапуск ждёт
+// готовности DOM через bootCfgAi — так же, как initTree/initResizers выше по
+// файлу. См. configurator_tmpl_shell.go: <script> идёт раньше cfgai-btn/cfggen-btn.
+func TestConfiguratorJS_AiBootWaitsForDOMReady(t *testing.T) {
+	js := configuratorJS(t)
+	if !strings.Contains(js, "function bootCfgAi") {
+		t.Fatal("нет функции bootCfgAi: автозапуск cfgAi не обёрнут в DOMContentLoaded-гард")
+	}
+	if !strings.Contains(js, "document.readyState") || !strings.Contains(js, "DOMContentLoaded") {
+		t.Fatal("ожидалась проверка document.readyState с регистрацией bootCfgAi на DOMContentLoaded")
+	}
+}
+
+// TestNoStore_DisablesCacheForEmbedAssets — embed-статика (configurator.js,
+// Monaco, ECharts, SlickGrid) живёт в бинаре и обновляется только при пересборке.
+// embed.FS отдаёт стабильный Last-Modified, поэтому WebView2/браузер отвечают
+// 304 Not Modified и бесконечно переиспользуют копию из предыдущей сборки —
+// обычный F5 против этого бессилен (это и маскировало регрессию выше). noStore
+// должен ставить Cache-Control: no-store на каждый ответ embed-handler'а.
+func TestNoStore_DisablesCacheForEmbedAssets(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/static/configurator.js", nil)
+	noStore(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rec, req)
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control: want %q, got %q", "no-store", got)
+	}
+}

--- a/internal/launcher/server.go
+++ b/internal/launcher/server.go
@@ -32,9 +32,26 @@ var staticHTTP http.Handler
 // тянуть свежие байты после обновления onebase-gui.exe.
 func noStore(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "no-store")
-		h.ServeHTTP(w, r)
+		h.ServeHTTP(&noStoreResponseWriter{ResponseWriter: w}, r)
 	})
+}
+
+// noStoreResponseWriter applies the policy at the moment headers are written.
+// This matters for vendor handlers: they set their own immutable cache policy
+// inside ServeHTTP and would otherwise overwrite a header set by middleware
+// before the call.
+type noStoreResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (w *noStoreResponseWriter) WriteHeader(statusCode int) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *noStoreResponseWriter) Write(p []byte) (int, error) {
+	w.Header().Set("Cache-Control", "no-store")
+	return w.ResponseWriter.Write(p)
 }
 
 // Server is the launcher HTTP server (list of registered bases).

--- a/internal/launcher/server.go
+++ b/internal/launcher/server.go
@@ -24,6 +24,19 @@ func init() {
 
 var staticHTTP http.Handler
 
+// noStore гасит кэширование embed-статики (configurator.js, Monaco, ECharts,
+// SlickGrid). Эти байты живут в бинаре и обновляются только при пересборке, а
+// embed.FS отдаёт стабильный Last-Modified — поэтому WebView2/браузер отвечают
+// 304 Not Modified и бесконечно переиспользуют копию из предыдущей сборки
+// (обычный F5 против этого бессилен). no-store заставляет клиента всегда
+// тянуть свежие байты после обновления onebase-gui.exe.
+func noStore(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		h.ServeHTTP(w, r)
+	})
+}
+
 // Server is the launcher HTTP server (list of registered bases).
 type Server struct {
 	h       *handler
@@ -75,18 +88,19 @@ func (s *Server) ListenAndServe() error {
 	r.Use(websec.SecurityHeaders)
 	r.Use(websec.CSRFProtect)
 
-	// Static assets (embedded)
-	r.Handle("/static/*", http.StripPrefix("/static/", staticHTTP))
+	// Static assets (embedded). noStore — чтобы после пересборки бинаря клиент
+	// не обслуживал прошивку embed-статики из кэша (см. комментарий у noStore).
+	r.Handle("/static/*", noStore(http.StripPrefix("/static/", staticHTTP)))
 	// Monaco editor (shared vendored tree) — отдельный путь, чтобы не
 	// конфликтовать с catch-all /static/*. Конфигуратор и редактор форм
 	// грузят его офлайн вместо CDN.
-	r.Handle("/vendor/monaco/*", http.StripPrefix("/vendor/monaco/", webassets.MonacoHandler()))
+	r.Handle("/vendor/monaco/*", noStore(http.StripPrefix("/vendor/monaco/", webassets.MonacoHandler())))
 	// ECharts (тот же вендоренный пакет, что и у базы) — предпросмотр виджета
 	// в конфигураторе рисуется тем же графическим движком, что и рабочий стол.
-	r.Handle("/vendor/echarts/*", http.StripPrefix("/vendor/echarts/", webassets.EChartsHandler()))
+	r.Handle("/vendor/echarts/*", noStore(http.StripPrefix("/vendor/echarts/", webassets.EChartsHandler())))
 	// SlickGrid (6pac fork, MIT) — грид для редактируемых табличных частей в
 	// managed-формах. Самохостинг вместо CDN: UI работает офлайн.
-	r.Handle("/vendor/slickgrid/*", http.StripPrefix("/vendor/slickgrid/", webassets.SlickGridHandler()))
+	r.Handle("/vendor/slickgrid/*", noStore(http.StripPrefix("/vendor/slickgrid/", webassets.SlickGridHandler())))
 
 	// Launcher pages (no auth)
 	r.Get("/", s.h.index)

--- a/internal/launcher/static/configurator.js
+++ b/internal/launcher/static/configurator.js
@@ -4042,9 +4042,15 @@ document.querySelectorAll('details.cfg-tree').forEach(function(d){
       document.getElementById('cfggen-btn').style.display=on?'':'none';
     }).catch(function(){});
   };
-  initAiHandlers();
-  initGenHandlers();
-  cfgAiRefresh();
+  // Скрипт подключён в шаблоне ВЫШЕ кнопок cfgai-btn/cfggen-btn и панелей
+  // (configurator_tmpl_shell.go: <script src=configurator.js> идёт раньше этих
+  // элементов). На момент разбора IIFE их в DOM ещё нет — голый initAiHandlers
+  // падал на null.addEventListener, и cfgAiRefresh() не вызывался: кнопки ИИ
+  // не появлялись, пока не вызвать cfgAiRefresh() вручную. Поэтому ждём готовности
+  // DOM — так же, как initTree/initResizers выше по файлу.
+  function bootCfgAi(){ initAiHandlers(); initGenHandlers(); cfgAiRefresh(); }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', bootCfgAi);
+  else bootCfgAi();
 
   function initAiHandlers(){
     var btn=document.getElementById('cfgai-btn');


### PR DESCRIPTION
## Что случалось

В конфигураторе не появлялись плавающие кнопки ИИ **🤖** (помощник разработчика, план 51) и **🏗️** (генерация каркаса, план 57), хотя ИИ-помощник в базе настроен корректно. Воспроизводилось и в webview (GUI), и в обычном браузере; F5 не помогал.

## Root cause

`GET /bases/{id}/configurator/ai-enabled` честно возвращал `{enabled: true}` (конфиг в `_settings` валиден). Бэкенд невиновен — проблема в JS.

В шаблоне `configurator_tmpl_shell.go` `<script src="/static/configurator.js">` подключён **выше** кнопок `cfgai-btn`/`cfggen-btn` и их панелей. При синхронном выполнении IIFE ([`configurator.js:4016`](../blob/fix/configurator-ai-buttons-not-shown/internal/launcher/static/configurator.js)) этих элементов **ещё нет в DOM**:

- `initAiHandlers()` (стр. 4045) падал на `cfgai-btn.addEventListener` (`btn === null`) → `TypeError`;
- автозапуск `cfgAiRefresh()` (стр. 4047) не доходил → кнопки оставались `display:none`;
- клик по кнопке, показанной ручным `cfgAiRefresh()`, не открывал панель (обработчик не был повешен).

**Регрессия** пришла в `81dfd33` (план 55, фаза 2b-2 «вынести JS в /static/configurator.js»): до этого JS был инлайном в конце шаблона (после кнопок) и IIFE работал при готовом DOM. При выносе остальные инициализации (`initTree`, `initResizers`, `initAllLayoutEditors`) обернули в `DOMContentLoaded`, а cfgAi IIFE — забыли.

**Почему не замечали раньше:** пока ИИ в базе не настроен (`enabled:false`), кнопок нет в принципе, и падающий `initAiHandlers` был невидим.

## Изменения

1. **`configurator.js`** — автозапуск cfgAi обёрнут в `DOMContentLoaded`-гард через `bootCfgAi` (как `initTree`), чтобы `initAiHandlers`/`cfgAiRefresh` звались после появления кнопок в DOM.
2. **`server.go`** — `Cache-Control: no-store` на embed-статику (`/static/*` и `/vendor/*`: Monaco/ECharts/SlickGrid). `embed.FS` отдаёт стабильный `Last-Modified` → WebView2/браузер отвечают `304 Not Modified` и переиспользуют копию из предыдущей сборки (F5 против этого бессилен). `no-store` гарантирует, что после пересборки `onebase-gui.exe` клиент всегда тянет свежие байты. Это и затушило регрессию в webview.

## Как проверить

- `go test ./internal/launcher/ -run 'TestConfiguratorJS_AiBootWaitsForDOMReady|TestNoStore_DisablesCacheForEmbedAssets'` — зелёные.
- Пересобрать `onebase-gui.exe` (`go build -tags webview -ldflags="-H windowsgui" ./cmd/onebase`), открыть конфигуратор базы с настроенным ИИ → обе кнопки 🤖/🏗️ появляются сами, открываются на клик. В DevTools больше нет `TypeError … null … addEventListener`.
- В Network на `/static/configurator.js` — заголовок `cache-control: no-store`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)