### PR TITLE
Ревью недели: Windows-гигиена (EOL embed-ассетов, file-URI бэкапа) + слепые зоны ИИ-генератора

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,15 @@ internal/sheet/fonts/*.ttf binary
 # (рендер sheet.HTML даёт \n). Без -text Windows autocrlf конвертирует в CRLF
 # при checkout и бит-в-бит сравнение в тестах падает.
 internal/dsl/interpreter/testdata/golden/*.html -text
+
+# Первопартийные go:embed-ассеты — принудительно LF в рабочей копии: их
+# содержимое вкомпилируется в бинарь (детерминизм сборки на всех платформах,
+# стабильные content-хэши immutable-кэша /static) и сверяется инвариант-
+# тестами с точными "\n"-строками. Без eol=lf Windows-чекаут (autocrlf=true)
+# давал CRLF → другой бинарь и красный TestTabShellSingleSSEAndEventForwarding.
+internal/ui/static/*.js text eol=lf
+internal/launcher/static/*.js text eol=lf
+internal/launcher/static/*.css text eol=lf
+internal/ui/pwa/sw.js text eol=lf
+internal/ui/pwa/offline.html text eol=lf
+internal/ui/pwa/manifest.webmanifest text eol=lf

--- a/internal/backup/sqlite.go
+++ b/internal/backup/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ivantit66/onebase/internal/storage"
@@ -114,7 +115,14 @@ func validateSQLiteBackup(ctx context.Context, path string) error {
 	if readErr != nil || !bytes.Equal(header, []byte(sqliteHeader)) {
 		return fmt.Errorf("sqlite restore: файл не является SQLite database")
 	}
-	dsn := (&url.URL{Scheme: "file", Path: filepath.ToSlash(path), RawQuery: "mode=ro&immutable=1"}).String()
+	// Windows-путь «C:\…» после ToSlash не начинается с «/»: url.URL печатает
+	// его как file://C:/… — диск попадает в authority и SQLite отвергает URI
+	// («invalid uri authority: C:»). Корректная форма — file:///C:/… .
+	p := filepath.ToSlash(path)
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	dsn := (&url.URL{Scheme: "file", Path: p, RawQuery: "mode=ro&immutable=1"}).String()
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return fmt.Errorf("sqlite restore: открыть подготовленную копию: %w", err)

--- a/internal/launcher/ai_apply.go
+++ b/internal/launcher/ai_apply.go
@@ -34,6 +34,8 @@ var applyableSubdirs = map[string]bool{
 	"roles":       true,
 	"services":    true,
 	"scheduled":   true,
+	"constants":   true,
+	"printforms":  true,
 	"forms":       true,
 	"src":         true,
 }

--- a/internal/launcher/ai_apply_test.go
+++ b/internal/launcher/ai_apply_test.go
@@ -21,6 +21,8 @@ func TestSafeConfigPath_Valid(t *testing.T) {
 		"enums/статус.yaml",
 		"accounts/основной.yaml",
 		"accountregs/хозрасчётный.yaml",
+		"constants/общие.yaml",
+		"printforms/счёт.layout.yaml",
 		"src/модуль.os",
 		"forms/клиент/ФормаОбъекта.form.yaml",
 	} {

--- a/internal/launcher/ai_examples.go
+++ b/internal/launcher/ai_examples.go
@@ -164,6 +164,70 @@ filters:
   - {field: Контрагент, label: Контрагент, type: reference:Контрагент}
 `
 
+const exProcessor = `name: ПересчётЦен
+title: Пересчёт цен
+# Код — отдельный файл src/пересчётцен.proc.os (нижний регистр, пробелы → «_»):
+#   Процедура Выполнить()
+#       Сообщить("Пересчёт цен выполнен");
+#   КонецПроцедуры
+`
+
+const exConstants = `constants:
+  - {name: ОсновнойСклад, type: reference:Склад, label: Основной склад}
+  - {name: КонтролироватьОстатки, type: bool, default: true, label: Контролировать остатки}
+  - {name: НазваниеОрганизации, type: string, label: Название организации}
+`
+
+const exPrintform = `# printforms/счётнаоплату.layout.yaml — имя формы берётся из имени файла
+name: СчётНаОплату
+document: РеализацияТоваров
+columns:
+  - {width: 40px}
+  - {}
+  - {}
+  - {}
+areas:
+  - name: Заголовок
+    rows:
+      - cells:
+          - {text: "Счёт № {{Номер}} от {{Дата | date}}", bold: true, align: center, colspan: 4}
+  - name: Шапка
+    rows:
+      - cells:
+          - {text: "Покупатель: {{Контрагент.Наименование}}", colspan: 4}
+  - name: ШапкаТаблицы
+    rows:
+      - cells:
+          - {text: "№", bold: true, border: all}
+          - {text: Наименование, bold: true, border: all}
+          - {text: Кол-во, bold: true, align: right, border: all}
+          - {text: Сумма, bold: true, align: right, border: all}
+  - name: Строка
+    rows:
+      - cells:
+          - {parameter: Кол0, border: all}
+          - {parameter: Кол1, border: all}
+          - {parameter: Кол2, align: right, border: all}
+          - {parameter: Кол3, align: right, border: all}
+  - name: Итоги
+    rows:
+      - cells:
+          - {}
+          - {}
+          - {}
+          - {text: "Итого: {{Итог.Товары.Сумма | number:2}}", bold: true, align: right, border: all}
+binding:
+  sequence: [Заголовок, Шапка, ШапкаТаблицы, Строка, Итоги]
+  repeat:
+    - area: Строка
+      source: Товары
+      parameters:
+        Кол0: "@row"
+        Кол1: Номенклатура.Наименование
+        Кол2: Количество
+        Кол3: Сумма | number:2
+`
+
 const exSubsystem = `name: Продажи
 title: Продажи
 icon: shopping-cart
@@ -237,7 +301,7 @@ func exampleForType(kind string) (string, bool) {
 		return exAccountReg, true
 	case "роль", "role":
 		return exRole, true
-	case "http-сервис", "сервис", "service":
+	case "http-сервис", "http service", "сервис", "service":
 		return exService, true
 	case "регламентное задание", "задание", "scheduled", "job":
 		return exScheduled, true
@@ -247,6 +311,12 @@ func exampleForType(kind string) (string, bool) {
 		return exJournal, true
 	case "подсистема", "subsystem":
 		return exSubsystem, true
+	case "обработка", "processor":
+		return exProcessor, true
+	case "константы", "константа", "constants":
+		return exConstants, true
+	case "печатная форма", "печатнаяформа", "printform":
+		return exPrintform, true
 	case "форма", "управляемая форма", "form":
 		return exForm, true
 	case "проведение", "обработкапроведения", "posting":
@@ -262,6 +332,7 @@ func exampleTypeNames() []string {
 		"справочник", "документ", "регистр", "регистр сведений", "перечисление",
 		"отчёт", "виджет", "план счетов", "регистр бухгалтерии", "роль", "сервис",
 		"задание", "страница", "журнал", "подсистема", "форма", "проведение",
+		"обработка", "константы", "печатная форма",
 	}
 	sort.Strings(names)
 	return names

--- a/internal/launcher/ai_examples_test.go
+++ b/internal/launcher/ai_examples_test.go
@@ -1,0 +1,95 @@
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/configcheck"
+)
+
+// TestExamples_PassCheck — эталоны «пример_объекта» обязаны проходить ПОЛНЫЙ
+// check (RunFull — та же линейка, которой генератор меряет свой результат) как
+// связный проект: модель копирует их дословно, и устаревший формат молча учил
+// бы её ошибкам. Стабы ниже — только объекты, на которые эталоны ссылаются,
+// но которых нет среди самих эталонов (Контрагент, Склад и т.п.).
+func TestExamples_PassCheck(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel, body string) {
+		t.Helper()
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Все эталоны — по тем же путям, по которым их пишет генератор.
+	write("catalogs/номенклатура.yaml", exCatalog)
+	write("documents/реализациятоваров.yaml", exDocument)
+	write("registers/остаткитоваров.yaml", exRegister)
+	write("inforegs/ценыноменклатуры.yaml", exInfoReg)
+	write("enums/статусзаказа.yaml", exEnum)
+	write("reports/остаткитоваров.yaml", exReport)
+	write("widgets/выручкамесяца.yaml", exWidget)
+	write("accounts/основной.yaml", exChartOfAccounts)
+	write("accountregs/бухучёт.yaml", exAccountReg)
+	write("roles/менеджер.yaml", exRole)
+	write("services/api.yaml", exService)
+	write("scheduled/пересчётцен.yaml", exScheduled)
+	write("pages/панельруководителя.yaml", exPage)
+	write("journals/журналпродаж.yaml", exJournal)
+	write("subsystems/продажи.yaml", exSubsystem)
+	write("processors/пересчётцен.yaml", exProcessor)
+	write("constants/константы.yaml", exConstants)
+	write("printforms/счётнаоплату.layout.yaml", exPrintform)
+	write("forms/реализациятоваров/ФормаОбъекта.form.yaml", exForm)
+	write("src/реализациятоваров.posting.os", exPosting)
+
+	// Стабы ссылок эталонов (в примерах их нет, но check требует существования).
+	write("catalogs/единицаизмерения.yaml", "name: ЕдиницаИзмерения\nfields:\n  - {name: Наименование, type: string}\n")
+	write("catalogs/контрагент.yaml", "name: Контрагент\nfields:\n  - {name: Наименование, type: string}\n")
+	write("catalogs/склад.yaml", "name: Склад\nfields:\n  - {name: Наименование, type: string}\n")
+	write("documents/заказпокупателя.yaml", "name: ЗаказПокупателя\nposting: true\nfields:\n  - {name: Дата, type: date}\n  - {name: Контрагент, type: reference:Контрагент}\n  - {name: Сумма, type: number}\n")
+	write("registers/взаиморасчеты.yaml", "name: Взаиморасчеты\ndimensions:\n  - {name: Контрагент, type: reference:Контрагент}\nresources:\n  - {name: Сумма, type: number}\n")
+	write("src/пересчётцен.proc.os", "Процедура Выполнить()\n    Сообщить(\"ок\");\nКонецПроцедуры\n")
+	write("src/api.service.os", "Функция Здоровье(Запрос) Экспорт\n    Возврат \"ok\";\nКонецФункции\n\nФункция НоменклатураПоАртикулу(Запрос) Экспорт\n    Возврат \"ok\";\nКонецФункции\n")
+	write("src/панельруководителя.page.os", "Процедура ПриФормировании(Страница, Параметры) Экспорт\n    Страница.Заголовок(\"Сводка\");\nКонецПроцедуры\n")
+
+	res := configcheck.RunFull(dir)
+	for _, is := range res.Issues {
+		t.Errorf("check: [%s] %s: %s", is.Kind, is.File, is.Message)
+	}
+}
+
+// TestKindAndExampleSynonymsAligned — каждый тип, который «создать_объект»
+// умеет создавать, обязан отдавать эталон в «пример_объекта» под тем же
+// синонимом (и наоборот для типов «только пример»). Регресс: «задание»
+// принималось примером, но не создавалось.
+func TestKindAndExampleSynonymsAligned(t *testing.T) {
+	creatable := []string{
+		"справочник", "документ", "регистр", "регистр сведений", "перечисление",
+		"план счетов", "регистр бухгалтерии", "отчёт", "виджет", "журнал",
+		"обработка", "страница", "подсистема", "роль", "сервис",
+		"задание", "регламентное задание", "константы", "печатная форма",
+	}
+	for _, kind := range creatable {
+		if _, ok := kindSubdir(kind); !ok {
+			t.Errorf("kindSubdir(%q) = false — тип не создаётся", kind)
+		}
+		if _, ok := exampleForType(kind); !ok {
+			t.Errorf("exampleForType(%q) = false — у создаваемого типа нет эталона", kind)
+		}
+	}
+	// Только пример: создаются через «создать_файл» (двухфайловые/модульные).
+	for _, kind := range []string{"форма", "проведение"} {
+		if _, ok := exampleForType(kind); !ok {
+			t.Errorf("exampleForType(%q) = false", kind)
+		}
+		if _, ok := kindSubdir(kind); ok {
+			t.Errorf("kindSubdir(%q) = true — ожидался тип «только пример»", kind)
+		}
+	}
+}

--- a/internal/launcher/ai_generate.go
+++ b/internal/launcher/ai_generate.go
@@ -95,8 +95,12 @@ func kindSubdir(kind string) (string, bool) {
 		return "roles", true
 	case "http-сервис", "http service", "сервис", "service":
 		return "services", true
-	case "регламентное задание", "scheduled", "job":
+	case "регламентное задание", "задание", "scheduled", "job":
 		return "scheduled", true
+	case "константы", "константа", "constants":
+		return "constants", true
+	case "печатная форма", "печатнаяформа", "printform":
+		return "printforms", true
 	default:
 		return "", false
 	}
@@ -143,6 +147,11 @@ func (g *genSession) createObject(kind, name, yamlText string) error {
 	fname, err := safeFileName(name)
 	if err != nil {
 		return err
+	}
+	if subdir == "printforms" {
+		// Печатная форма живёт в <имя>.layout.yaml — имя формы загрузчик берёт
+		// из имени файла (printform.LoadDir).
+		fname = strings.TrimSuffix(fname, ".yaml") + ".layout.yaml"
 	}
 	rel := subdir + "/" + fname
 	full, err := safeGeneratedFullPath(g.overlay, rel)
@@ -635,7 +644,7 @@ func (g *genSession) tools() ([]llm.Tool, llm.ToolExecutor) {
 		},
 		{
 			Name:        "пример_объекта",
-			Description: "Показать эталонный пример формата для типа объекта: справочник|документ|регистр|регистр сведений|перечисление|отчёт|виджет|план счетов|регистр бухгалтерии|роль|сервис|задание|страница|журнал|подсистема|форма|проведение. Копируй формат из примера, не угадывай.",
+			Description: "Показать эталонный пример формата для типа объекта: справочник|документ|регистр|регистр сведений|перечисление|отчёт|виджет|план счетов|регистр бухгалтерии|роль|сервис|задание|страница|журнал|подсистема|форма|проведение|обработка|константы|печатная форма. Копируй формат из примера, не угадывай.",
 			Schema: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{"тип": map[string]any{"type": "string"}},
@@ -807,19 +816,23 @@ const otherFormatGuides = `Схемы прочих объектов (по одн
 - Роль (roles/<Имя>.yaml): name, description, permissions: {catalogs: {Имя: [read,write]}, documents: {Имя: [read,write,post,unpost]}, registers: {Имя: [read]}, reports: {Имя: [run]}}.
 - HTTP-сервис (services/<Имя>.yaml): name, root_url, auth: none|basic|session, templates: [{template: /путь, methods: {GET: ИмяПроцедуры}}] + обработчики в src/<Сервис>.service.os.
 - Регламентное задание (scheduled/<Имя>.yaml): name, schedule: "*/5 * * * *" (cron), processor: <ИмяОбработки>, params: {...}, enabled: true, on_error: continue|stop, timeout: 60.
-- Страница (pages/<Имя>.yaml): name, title, icon; обработчик в src/<Страница>.page.os (Процедура ПриФормировании(Страница, Параметры) Экспорт).`
+- Страница (pages/<Имя>.yaml): name, title, icon; обработчик в src/<Страница>.page.os (Процедура ПриФормировании(Страница, Параметры) Экспорт).
+- Обработка (processors/<Имя>.yaml): name, title; код — src/<имя>.proc.os (нижний регистр, пробелы → «_»), точка входа Процедура Выполнить().
+- Константы (constants/<файл>.yaml): constants: [{name, type: string|number|date|bool|enum:<Имя>|reference:<Справочник>, label, default, required}] — список в одном файле (обычно constants/константы.yaml).
+- Печатная форма (printforms/<Имя>.layout.yaml): name, document: <Документ>, columns, areas (rows/cells: text «{{Поле}}»/«{{Поле | date}}» или parameter), binding: {sequence: [...], repeat: [{area, source: <ТабЧасть>, parameters: {...}}]}. Точный формат — «пример_объекта» тип «печатная форма».`
 
 // pathConventionsGuide — куда класть файлы: генератор жжёт раунды на неверных
 // путях (forms в корне, вложенный src и т.п.).
 const pathConventionsGuide = `Пути файлов для «создать_файл» (частые ошибки):
-  метаданные — плоско в своём каталоге: <catalogs|documents|registers|inforegs|enums|accounts|accountregs|reports|widgets|journals|processors|subsystems|roles|services|scheduled>/<Имя>.yaml
-  модули .os — ПЛОСКО в src/, без подпапок: проведение src/<Документ>.posting.os, модуль объекта src/<Имя>.module.os, отчёт src/<Отчёт>.rep.os, страница src/<Страница>.page.os, сервис src/<Сервис>.service.os
+  метаданные — плоско в своём каталоге: <catalogs|documents|registers|inforegs|enums|accounts|accountregs|reports|widgets|journals|processors|subsystems|roles|services|scheduled|constants>/<Имя>.yaml
+  модули .os — ПЛОСКО в src/, без подпапок: проведение src/<Документ>.posting.os, обработка src/<имя>.proc.os, модуль объекта src/<Имя>.module.os, отчёт src/<Отчёт>.rep.os, страница src/<Страница>.page.os, сервис src/<Сервис>.service.os
+  печатные формы — printforms/<имя>.layout.yaml (суффикс .layout.yaml обязателен)
   формы — forms/<сущность-в-нижнем-регистре>/<Форма>.form.yaml (+ одноимённый .form.os)`
 
 // aiGenerateSystem — роль генератора каркаса конфигурации.
 var aiGenerateSystem = "Ты — генератор каркаса конфигурации OneBase (платформа учёта, похожая на 1С). " +
 	"По описанию задачи на русском создавай рабочий feature slice: YAML-метаданные через «создать_объект» " +
-	"или «создать_файл», при необходимости .os-модули, формы, отчёты, виджеты, журналы, страницы, подсистемы, роли и сервисы. " +
+	"или «создать_файл», при необходимости .os-модули, формы, отчёты, виджеты, журналы, страницы, подсистемы, роли, сервисы, обработки, печатные формы и константы. " +
 	"После создания набора файлов обязательно вызывай «проверить_конфигурацию» с full=true и исправляй ошибки. " +
 	"Перед финальным ответом вызывай «форматировать»; для отчётов и виджетов проверяй запросы через «прогнать_запрос». " +
 	"Используй существующие объекты (через «список_объектов», «показать_объект», «прочитать_файл») вместо дублирования. " +

--- a/internal/launcher/ai_generate.go
+++ b/internal/launcher/ai_generate.go
@@ -567,7 +567,7 @@ func (g *genSession) tools() ([]llm.Tool, llm.ToolExecutor) {
 	tools := []llm.Tool{
 		{
 			Name:        "создать_объект",
-			Description: "Создать черновик объекта метаданных в конфигурации. тип: справочник|документ|регистр накопления|регистр сведений|перечисление|план счетов|регистр бухгалтерии|журнал. имя — на русском. yaml — содержимое файла объекта (без модулей .os).",
+			Description: "Создать черновик объекта метаданных в конфигурации. тип: справочник|документ|регистр накопления|регистр сведений|перечисление|план счетов|регистр бухгалтерии|отчёт|виджет|журнал|обработка|страница|подсистема|роль|сервис|задание|константы|печатная форма. имя — на русском. yaml — содержимое файла объекта (без модулей .os).",
 			Schema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -580,7 +580,7 @@ func (g *genSession) tools() ([]llm.Tool, llm.ToolExecutor) {
 		},
 		{
 			Name:        "создать_файл",
-			Description: "Создать или заменить whitelist-файл в staging. Разрешены YAML в каталогах метаданных/forms/roles/services/widgets/reports/pages/journals/processors/subsystems/scheduled и .os в src или forms/<объект>/.",
+			Description: "Создать или заменить whitelist-файл в staging. Разрешены YAML в каталогах метаданных/forms/roles/services/widgets/reports/pages/journals/processors/subsystems/scheduled/constants/printforms и .os в src или forms/<объект>/.",
 			Schema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/internal/launcher/ai_generate_guides_test.go
+++ b/internal/launcher/ai_generate_guides_test.go
@@ -14,8 +14,8 @@ func TestFormatGuides_InSystemPrompt(t *testing.T) {
 	cases := map[string][]string{
 		"управляемая форма": {"forms/<сущность-в-нижнем-регистре>/<Форма>.form.yaml", "ПОД ключом form:", "data_path", "АВТОГЕНЕРИРУЕТСЯ"},
 		"проведение":        {"src/<Документ>.posting.os", "Движения.<Регистр>.Добавить()", "РегистрыНакопления.X.СоздатьДвижение() (такого API нет)", "this.<Имя>"},
-		"прочие объекты":    {"reports/<Имя>.yaml", "type: kpi|list|chart|actions|recent", "accounts/<Имя>.yaml", "subconto", "permissions:", "root_url", "schedule:"},
-		"пути файлов":       {"Пути файлов", "ПЛОСКО в src/", "forms/<сущность-в-нижнем-регистре>/<Форма>.form.yaml"},
+		"прочие объекты":    {"reports/<Имя>.yaml", "type: kpi|list|chart|actions|recent", "accounts/<Имя>.yaml", "subconto", "permissions:", "root_url", "schedule:", "processors/<Имя>.yaml", "constants:", "printforms/<Имя>.layout.yaml"},
+		"пути файлов":       {"Пути файлов", "ПЛОСКО в src/", "forms/<сущность-в-нижнем-регистре>/<Форма>.form.yaml", ".proc.os", "printforms/<имя>.layout.yaml"},
 	}
 	for name, needles := range cases {
 		for _, n := range needles {
@@ -68,6 +68,9 @@ func TestExampleForType(t *testing.T) {
 		"виджет":     "type: kpi",                                 // виджет с обязательным type
 		"план счетов": "kind: active",                             // счета
 		"журнал":     "documents: [РеализацияТоваров",             // journals
+		"обработка":  ".proc.os",                                  // код отдельным модулем
+		"константы":  "constants:",                                // список, не по-объектно
+		"печатная форма": "binding:",                              // areas + binding/repeat
 	}
 	for kind, needle := range cases {
 		ex, ok := exampleForType(kind)

--- a/internal/launcher/ai_generate_test.go
+++ b/internal/launcher/ai_generate_test.go
@@ -55,6 +55,46 @@ func TestGenCreateObject_WritesToOverlay(t *testing.T) {
 	}
 }
 
+func TestGenCreateObject_ConstantsAndPrintForm(t *testing.T) {
+	g := newTestGenSession(t)
+	cases := []struct {
+		kind    string
+		name    string
+		content string
+		want    string
+	}{
+		{
+			kind:    "константы",
+			name:    "Общие",
+			content: "constants:\n  - {name: Организация, type: string}\n",
+			want:    "constants/общие.yaml",
+		},
+		{
+			kind:    "печатная форма",
+			name:    "Счёт",
+			content: "name: Счёт\ndocument: Реализация\n",
+			want:    "printforms/счёт.layout.yaml",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			if err := g.createObject(tc.kind, tc.name, tc.content); err != nil {
+				t.Fatalf("createObject(%q): %v", tc.kind, err)
+			}
+			got, err := os.ReadFile(filepath.Join(g.overlay, filepath.FromSlash(tc.want)))
+			if err != nil {
+				t.Fatalf("%s не создан: %v", tc.want, err)
+			}
+			if string(got) != tc.content {
+				t.Errorf("%s: содержимое не совпало: %q", tc.want, got)
+			}
+			if err := safeConfigPath(tc.want); err != nil {
+				t.Errorf("%s нельзя применить: %v", tc.want, err)
+			}
+		})
+	}
+}
+
 func TestGenCreateObject_UnknownKind(t *testing.T) {
 	g := newTestGenSession(t)
 	if err := g.createObject("ракета", "X", "name: X\n"); err == nil {

--- a/internal/ui/static_test.go
+++ b/internal/ui/static_test.go
@@ -135,7 +135,10 @@ func TestToggleNextSingleHandler(t *testing.T) {
 // При этом документированный контракт onebase:<имя> сохраняется: оболочка
 // ретранслирует событие во фреймы, а те проверяют source и origin отправителя.
 func TestTabShellSingleSSEAndEventForwarding(t *testing.T) {
-	src := string(uiJS)
+	// go:embed вкомпилирует worktree-содержимое: в клоне без свежего чекаута
+	// (до .gitattributes eol=lf) ui.js может лежать с CRLF — нормализуем, чтобы
+	// проверки точных "\n"-строк не зависели от EOL чекаута.
+	src := strings.ReplaceAll(string(uiJS), "\r\n", "\n")
 	// SSE /ui/events подключается только в верхнем окне, не во фрейме оболочки.
 	if !strings.Contains(src, "if (!window.__obEmbedded) {") {
 		t.Error("ui.js должен подключать SSE /ui/events только вне вкладочного фрейма (гейт window.__obEmbedded)")


### PR DESCRIPTION
По итогам ревью изменений недели (07-09…07-17). Три независимых фикса одной темы: «go test ./... зелёный на Windows» + закрытие слепых зон ИИ-генератора.

## 1. fix(build): LF для go:embed-ассетов
`go:embed` вкомпилирует worktree-содержимое: с `autocrlf=true` Windows-чекаут давал CRLF в `ui.js`/`configurator.js`/`sw.js` — **другой бинарь**, другие content-хэши immutable-кэша `/static` и красный `TestTabShellSingleSSEAndEventForwarding` (проверка точной `"{\n    …"`-строки). В `.gitattributes` — `eol=lf` для первопартийных embed-ассетов (вендоренные monaco/quill/slickgrid не тронуты), в тесте — нормализация CRLF для клонов без свежего чекаута.

## 2. feat(configurator): обработка/константы/печатная форма в ИИ-генераторе
- «создать_объект» понимает **константы** (`constants/`) и **печатные формы** (`printforms/<имя>.layout.yaml`, суффикс подставляется автоматически); синоним «задание» принимается и созданием, а не только «пример_объекта» (раньше модель получала эталон, а создать объект тем же словом не могла);
- эталоны `exProcessor`/`exConstants`/`exPrintform` (binding/repeat сверен с examples/trade) + памятки в промпте (`.proc.os` + `Процедура Выполнить()`, constants, layout);
- **TestExamples_PassCheck**: все эталоны собираются в связный проект и проходят `configcheck.RunFull` — ту же линейку, которой генератор меряет свой результат. Мутационная проверка: битая ссылка в эталоне ловится (`references unknown entity`). Устаревший эталон больше не сможет молча учить модель ошибкам;
- **TestKindAndExampleSynonymsAligned**: каждый создаваемый тип обязан отдавать эталон под тем же синонимом.

## 3. fix(backup): file-URI восстановления SQLite на Windows
`validateSQLiteBackup` собирал DSN через `url.URL{Scheme: "file", Path: "C:/…"}` — путь без ведущего `/` печатается как `file://C:/…`, диск попадает в authority, SQLite отвергает URI (`invalid uri authority: C:`). Восстановление бэкапа и `TestDumpRestoreSQLite` падали на Windows. Теперь `file:///C:/…`; на POSIX поведение не меняется.

## Тесты
- `go test ./...` — полностью зелёный на Windows (до PR: 2 красных пакета — ui, backup);
- мутационные проверки нового validity-теста руками: битая ссылка и отсутствующий модуль сервиса ловятся.

Остаётся открытым (не в этом PR): движения, добавленные хуком `ОбработкаУдаленияПроведения`, молча теряются (`entityservice.Unpost` собирает коллектор, но не пишет его) — нужно решение: писать как в `Save` или явно запрещать.

🤖 Generated with [Claude Code](https://claude.com/claude-code)