### PR TITLE
fix(ui): таблицы в ответах ИИ-помощника — перенос по словам и скролл

### DIFF
--- a/internal/ui/ai_chat_markdown_test.go
+++ b/internal/ui/ai_chat_markdown_test.go
@@ -37,4 +37,18 @@ func TestAIChat_RendersMarkdown(t *testing.T) {
 			t.Errorf("в стилях нет %q — оформление ответа ассистента не подключено", want)
 		}
 	}
+
+	// Регресс: ячейки таблицы наследовали word-break:break-word от .m — в узкой
+	// панели колонки сжимались до посимвольного переноса («Шка/ф/«Сек/рет»).
+	// Ячейкам возвращён word-break:normal, а широкая таблица целиком скроллится
+	// в собственной обёртке .tw, не растягивая остальной текст сообщения.
+	for _, want := range []string{
+		"#ob-ai-log .m.a .tw{overflow-x:auto",
+		"word-break:normal",
+		`out.push('<div class="tw"><table>`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("в ui.js нет %q — таблицы ассистента снова будут жаться посимвольно вместо скролла", want)
+		}
+	}
 }

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -997,8 +997,12 @@ obReady(function () {
     '#ob-ai-log .m.a code{background:#f1f5f9;border-radius:3px;padding:1px 4px;font-family:ui-monospace,Consolas,monospace;font-size:12px}' +
     '#ob-ai-log .m.a pre{background:#f1f5f9;border-radius:6px;padding:8px;overflow-x:auto;margin:6px 0}' +
     '#ob-ai-log .m.a pre code{background:none;padding:0}' +
-    '#ob-ai-log .m.a table{border-collapse:collapse;margin:6px 0;font-size:12px}' +
-    '#ob-ai-log .m.a th,#ob-ai-log .m.a td{border:1px solid #e2e8f0;padding:4px 7px;text-align:left;vertical-align:top}' +
+    // Таблица живёт в собственной скролл-обёртке .tw и держит естественную
+    // ширину; ячейкам возвращаем word-break:normal — иначе наследованный от .m
+    // break-word даёт min-width колонки в один символ и текст жмётся посимвольно.
+    '#ob-ai-log .m.a .tw{overflow-x:auto;margin:6px 0}' +
+    '#ob-ai-log .m.a table{border-collapse:collapse;margin:0;font-size:12px;width:max-content}' +
+    '#ob-ai-log .m.a th,#ob-ai-log .m.a td{border:1px solid #e2e8f0;padding:4px 7px;text-align:left;vertical-align:top;word-break:normal;max-width:240px}' +
     '#ob-ai-log .m.a th{background:#f1f5f9;font-weight:600;white-space:nowrap}' +
     '#ob-ai-log .m.a tbody tr:nth-child(even){background:#f8fafc}' +
     '#ob-ai-log .m.err{align-self:stretch;background:#fef2f2;border:1px solid #fecaca;color:#b91c1c}' +
@@ -1088,6 +1092,7 @@ obReady(function () {
       }
       function cells(l) { return l.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map(function (c) { return c.trim(); }); }
       function isSep(l) { return /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?\s*$/.test(l || ''); }
+      function tcell(tag, align, html) { return '<' + tag + (align ? ' style="text-align:' + align + '"' : '') + '>' + html + '</' + tag + '>'; }
       var lines = esc(src).replace(/\r\n?/g, '\n').split('\n');
       var out = [], i = 0;
       while (i < lines.length) {
@@ -1100,14 +1105,20 @@ obReady(function () {
           continue;
         }
         if (line.indexOf('|') >= 0 && isSep(lines[i + 1])) {
-          var head = cells(line); i += 2; var body = '';
+          var head = cells(line);
+          // Выравнивание из GFM-разделителя: `---:` → вправо, `:---:` → по центру.
+          var aligns = cells(lines[i + 1]).map(function (c) {
+            var a = /^(:)?-+(:)?$/.exec(c);
+            return a && a[2] ? (a[1] ? 'center' : 'right') : '';
+          });
+          i += 2; var body = '';
           while (i < lines.length && lines[i].indexOf('|') >= 0 && lines[i].trim() !== '') {
             var r = cells(lines[i]), tds = '';
-            for (var k = 0; k < head.length; k++) tds += '<td>' + inline(r[k] || '') + '</td>';
+            for (var k = 0; k < head.length; k++) tds += tcell('td', aligns[k], inline(r[k] || ''));
             body += '<tr>' + tds + '</tr>'; i++;
           }
-          var ths = ''; for (var h = 0; h < head.length; h++) ths += '<th>' + inline(head[h]) + '</th>';
-          out.push('<table><thead><tr>' + ths + '</tr></thead><tbody>' + body + '</tbody></table>');
+          var ths = ''; for (var h = 0; h < head.length; h++) ths += tcell('th', aligns[h], inline(head[h]));
+          out.push('<div class="tw"><table><thead><tr>' + ths + '</tr></thead><tbody>' + body + '</tbody></table></div>');
           continue;
         }
         var hm = /^(#{1,6})\s+(.*)$/.exec(line);


### PR DESCRIPTION
## Проблема

Markdown-таблица в чате ИИ-помощника рендерилась нечитаемо: текстовые колонки сжимались до нескольких символов с посимвольным переносом («Шка / ф / «Сек / рет / деду / шки»»), строки вырастали на пол-экрана, и при этом таблица всё равно уходила в горизонтальный скролл.

Причина: пузырь сообщения `#ob-ai-log .m` задаёт `word-break:break-word`, ячейки таблицы его наследовали → минимальная ширина текстовой колонки в auto-layout становится «один символ», и браузер давит колонки до предела.

## Что сделано (`internal/ui/static/ui.js`)

- Ячейкам возвращён `word-break:normal` — перенос только по границам слов; `max-width:240px`, чтобы длинный текст переносился, а не раздувал колонку.
- Таблица оборачивается в собственный скролл-контейнер `<div class=tw>` (`overflow-x:auto`) и держит естественную ширину (`width:max-content`) — горизонтально скроллится только таблица, остальной текст сообщения не растягивается.
- `mdToHtml` понимает выравнивание из GFM-разделителя: `---:` → вправо, `:---:` → по центру (числовые колонки прижимаются вправо, если модель их так пометила).

## Было / стало

Проверено на ответе из скриншота бага (8 колонок в панели 440px, headless-Chromium — тот же движок, что WebView2): было — строки-«лапша» высотой в 4–6 строк текста и обрезанные колонки; стало — «Шкаф «Секрет дедушки»» в одну строку, компактные ряды, числовые колонки вправо, горизонтальный скролл под самой таблицей (скриншот сравнения приложу комментарием).

## Тесты

- `ai_chat_markdown_test.go` расширен регрессионными проверками: скролл-обёртка `.tw`, `word-break:normal`, таблица эмитится внутрь обёртки.
- `mdToHtml` прогнан отдельно (Node): обёртка, выравнивание по разделителю, ряды короче шапки, экранирование HTML в ячейках — без изменений поведения, кроме заявленных.
- `go test ./internal/ui/` — зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)