### PR TITLE
feat(configurator): регулируемая высота панели свойств ячейки в редакторе макетов

### DIFF
--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -527,6 +527,7 @@
   "Тонкая": "Dünn",
   "Толстая": "Dick",
   "Цвет границы": "Rahmenfarbe",
+  "Потяните, чтобы изменить высоту; двойной клик — сброс": "Ziehen, um die Höhe zu ändern; Doppelklick zum Zurücksetzen",
   "Подсистема": "Subsystem",
   "Название подсистемы": "Subsystemname",
   "Иконка": "Symbol",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -950,6 +950,7 @@
   "Номер": "Number",
   "Откроется во внешнем приложении (системный просмотрщик PDF)": "Will open in an external application (system PDF viewer)",
   "Поля, мм": "Margins, mm",
+  "Потяните, чтобы изменить высоту; двойной клик — сброс": "Drag to change height; double-click to reset",
   "Правое": "Right",
   "Свернуть/развернуть YAML": "Collapse/expand YAML",
   "альбомная": "landscape",

--- a/internal/launcher/configurator_tmpl_tree.go
+++ b/internal/launcher/configurator_tmpl_tree.go
@@ -992,8 +992,11 @@ const cfgTabTree = `{{define "tab-tree"}}
       </div>
 
       {{/* Cell properties panel — закреплённый док снизу (не проматывает страницу
-           при выборе ячейки). На неактивной cfg-panel скрыт через display:none. */}}
-      <div id="vprops-{{.Name}}" style="display:none;position:fixed;left:0;right:0;bottom:0;z-index:50;max-height:44vh;overflow:auto;background:#f0f8ff;border-top:2px solid #b0d0f0;box-shadow:0 -4px 16px rgba(15,23,42,.18);padding:10px 14px">
+           при выборе ячейки). На неактивной cfg-panel скрыт через display:none.
+           Высота регулируется ручкой сверху (--cfg-vprops-h + localStorage). */}}
+      <div id="vprops-{{.Name}}" style="display:none;position:fixed;left:0;right:0;bottom:0;z-index:50;background:#f0f8ff;border-top:2px solid #b0d0f0;box-shadow:0 -4px 16px rgba(15,23,42,.18)">
+        <div class="vprops-grip" title="{{t $.Lang "Потяните, чтобы изменить высоту; двойной клик — сброс"}}" onpointerdown="ldPropsResizeStart(event)" ondblclick="ldPropsResizeReset()"></div>
+        <div style="max-height:calc(var(--cfg-vprops-h,44vh) - 10px);overflow:auto;padding:2px 14px 10px">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
           <span style="font-weight:bold;font-size:12px">{{t $.Lang "Свойства ячейки"}}</span>
           <span>
@@ -1073,6 +1076,7 @@ const cfgTabTree = `{{define "tab-tree"}}
           <div><label>{{t $.Lang "Объединить"}} (colspan)</label><br><input type="number" id="vp-colspan-{{.Name}}" min="1" max="20" style="width:100%;padding:3px" oninput="updateCellProp('{{.Name}}','colspan',parseInt(this.value)||0)"></div>
           <div><label>{{t $.Lang "Объединить"}} (rowspan)</label><br><input type="number" id="vp-rowspan-{{.Name}}" min="1" max="20" style="width:100%;padding:3px" oninput="updateCellProp('{{.Name}}','rowspan',parseInt(this.value)||0)"></div>
           <div></div>
+        </div>
         </div>
       </div>
       <div class="module-save-row">

--- a/internal/launcher/layout_editor_render_test.go
+++ b/internal/launcher/layout_editor_render_test.go
@@ -168,3 +168,31 @@ func TestLayoutEditor_UXImprovements(t *testing.T) {
 		}
 	}
 }
+
+// Регулируемая высота дока свойств ячейки: ручка сверху панели (drag по
+// вертикали), высота в --cfg-vprops-h + localStorage, сброс двойным кликом.
+func TestLayoutEditor_PropsPanelResize(t *testing.T) {
+	js := configuratorJS(t)
+	for _, sub := range []string{
+		"function ldPropsResizeStart", // drag ручки
+		"function ldPropsResizeReset", // сброс по dblclick
+		"--cfg-vprops-h",              // общая CSS-переменная высоты
+		"cfgVPropsH",                  // ключ localStorage (восстановление в initResizers)
+	} {
+		if !strings.Contains(js, sub) {
+			t.Errorf("в JS редактора нет фрагмента: %q", sub)
+		}
+	}
+
+	html := renderLayoutPanelTree(t)
+	for _, sub := range []string{
+		`class="vprops-grip"`,
+		`ldPropsResizeStart(event)`,
+		`ldPropsResizeReset()`,
+		`var(--cfg-vprops-h,44vh)`, // высота по умолчанию как раньше
+	} {
+		if !strings.Contains(html, sub) {
+			t.Errorf("в HTML панели редактора нет фрагмента: %q", sub)
+		}
+	}
+}

--- a/internal/launcher/static/configurator.css
+++ b/internal/launcher/static/configurator.css
@@ -26,6 +26,11 @@ body{font-family:'Segoe UI',Arial,sans-serif;font-size:13px;background:#f0f2f5;h
 .cfg-left.collapsed + .cfg-resizer{display:none}
 body.cfg-resizing{cursor:col-resize}
 body.cfg-resizing .cfg-left,body.cfg-resizing .dbg-panel{transition:none}
+/* Ручка высоты дока свойств ячейки (редактор макетов печатных форм) */
+.vprops-grip{height:10px;cursor:ns-resize;background:transparent;position:relative;touch-action:none;transition:background .15s}
+.vprops-grip::after{content:'';position:absolute;left:50%;top:4px;width:44px;height:3px;margin-left:-22px;border-radius:2px;background:#b0c8e4}
+.vprops-grip:hover,.vprops-grip.dragging{background:#dcebfb}
+body.cfg-vresizing{cursor:ns-resize;user-select:none}
 .cfg-group{font-size:11px;font-weight:700;color:#888;text-transform:uppercase;letter-spacing:.5px;padding:10px 12px 4px;margin-top:4px}
 .cfg-tree details summary{font-size:11px;font-weight:700;color:#888;text-transform:uppercase;letter-spacing:.5px;padding:10px 12px 4px;margin-top:4px;cursor:pointer;list-style:none;display:flex;align-items:center;gap:2px}
 .cfg-tree details summary::-webkit-details-marker{display:none}

--- a/internal/launcher/static/configurator.js
+++ b/internal/launcher/static/configurator.js
@@ -1102,9 +1102,52 @@ function cfgMakeResizer(target, opts){
 function cfgRestoreVar(cssVar,storeKey){
   try{var v=localStorage.getItem(storeKey);if(v)document.documentElement.style.setProperty(cssVar,v);}catch(_){}
 }
+// ── Высота дока свойств ячейки (редактор макетов печатных форм) ────────────
+// Панелей несколько (по одной на макет), высота общая: CSS-переменная
+// --cfg-vprops-h + localStorage — тот же приём, что у боковых панелей выше.
+// Ручка рендерится в шаблоне (.vprops-grip), обработчики — инлайновые.
+// Двойной клик ловим вручную по таймингу pointerdown: preventDefault на
+// pointerdown подавляет синтез mousedown/dblclick в Chromium, поэтому
+// ondblclick на ручке с мышью не срабатывает. Сброс — только если второе
+// нажатие отпущено без движения (иначе это обычное перетаскивание).
+var _vpropsLastDown=0;
+function ldPropsResizeStart(e){
+  e.preventDefault();
+  var grip=e.currentTarget;
+  var now=Date.now();
+  var maybeReset=(now-_vpropsLastDown<400);
+  _vpropsLastDown=now;
+  try{grip.setPointerCapture(e.pointerId);}catch(_){}
+  grip.classList.add('dragging');
+  document.body.classList.add('cfg-vresizing');
+  var startY=e.clientY;
+  function move(ev){
+    if(Math.abs(ev.clientY-startY)>4)maybeReset=false;
+    var h=window.innerHeight-ev.clientY;
+    h=Math.max(120,Math.min(Math.round(window.innerHeight*0.85),h));
+    document.documentElement.style.setProperty('--cfg-vprops-h',h+'px');
+  }
+  function up(){
+    grip.classList.remove('dragging');
+    document.body.classList.remove('cfg-vresizing');
+    grip.removeEventListener('pointermove',move);
+    grip.removeEventListener('pointerup',up);
+    if(maybeReset){_vpropsLastDown=0;ldPropsResizeReset();return;}
+    var cur=getComputedStyle(document.documentElement).getPropertyValue('--cfg-vprops-h').trim();
+    try{localStorage.setItem('cfgVPropsH',cur);}catch(_){}
+  }
+  grip.addEventListener('pointermove',move);
+  grip.addEventListener('pointerup',up);
+}
+// Двойной клик по ручке — сброс к высоте по умолчанию (44vh).
+function ldPropsResizeReset(){
+  document.documentElement.style.removeProperty('--cfg-vprops-h');
+  try{localStorage.removeItem('cfgVPropsH');}catch(_){}
+}
 function initResizers(){
   cfgRestoreVar('--cfg-left-w','cfgLeftW');
   cfgRestoreVar('--cfg-dbg-w','cfgDbgW');
+  cfgRestoreVar('--cfg-vprops-h','cfgVPropsH');
   var left=document.getElementById('cfg-sidebar');
   if(left&&!left._rsz){left._rsz=cfgMakeResizer(left,{side:'right',cssVar:'--cfg-left-w',storeKey:'cfgLeftW',min:150,max:600});}
   var dbg=document.getElementById('dbg-panel');


### PR DESCRIPTION
## Что сделано

В редакторе макетов печатных форм (конфигуратор) панель «Свойства ячейки» — закреплённый док внизу — получила **регулируемую высоту**:

- сверху панели появилась ручка (полоска-грип): перетаскивание вверх/вниз меняет высоту;
- диапазон: от 120px до 85% высоты окна;
- высота запоминается (CSS-переменная `--cfg-vprops-h` + localStorage, ключ `cfgVPropsH`) и переживает перезагрузку страницы — приём тот же, что у боковых панелей (`cfgMakeResizer`, issue #131);
- **двойной клик** по ручке — сброс к высоте по умолчанию (44vh, как раньше);
- по умолчанию поведение не меняется: без сохранённой высоты панель выглядит как прежде.

## Деталь реализации

Двойной клик детектируется вручную по таймингу `pointerdown`: `preventDefault()` на pointerdown подавляет синтез mousedown/dblclick в Chromium, поэтому `ondblclick` на ручке с мышью не срабатывает. Сброс происходит только если второе нажатие отпущено без движения (>4px = обычное перетаскивание). Замечание: у `cfgMakeResizer` (боковые панели) dblclick-сброс подвержен тому же эффекту — не трогал, вне скоупа.

## Проверка

- `go test ./internal/launcher/` — ok, добавлен рендер-тест `TestLayoutEditor_PropsPanelResize`;
- прогнано вживую (headless Edge против запущенного лаунчера, изолированная база на examples/minimal): drag растит панель (var 611px), после F5 высота восстановлена, двойной клик сбрасывает (var и localStorage очищены), «клик и сразу тянуть» не даёт ложного сброса, кламп сверху 765px (85% от 900) и снизу 120px, кнопка «✕» закрывает док.

🤖 Generated with [Claude Code](https://claude.com/claude-code)