### PR TITLE
fix(ui): убрать двойную кнопку ИИ-помощника во вкладках

### DIFF
--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -1043,6 +1043,10 @@ obReady(function () {
 (function () {
   if (window.__obAiInit) return;
   window.__obAiInit = true;
+  // Во вкладочной оболочке ui.js загружается и в верхнем окне, и внутри
+  // каждой вкладки-iframe. Помощник принадлежит оболочке: если строить его во
+  // фрейме, поверх кнопки оболочки появляется второй робот.
+  if (window.__obEmbedded) return;
   function init() {
     if (document.getElementById('ob-ai-btn')) return;
     fetch('/ui/ai/enabled').then(function (r) { return r.json(); }).then(function (d) {

--- a/internal/ui/static_test.go
+++ b/internal/ui/static_test.go
@@ -150,6 +150,14 @@ func TestTabShellSingleSSEAndEventForwarding(t *testing.T) {
 	// (до .gitattributes eol=lf) ui.js может лежать с CRLF — нормализуем, чтобы
 	// проверки точных "\n"-строк не зависели от EOL чекаута.
 	src := strings.ReplaceAll(string(uiJS), "\r\n", "\n")
+	// Глобальный ИИ-помощник принадлежит верхнему окну оболочки. Иначе каждая
+	// активная вкладка рисует поверх его кнопки собственного робота.
+	aiStart := strings.Index(src, "if (window.__obAiInit) return;")
+	aiBuild := strings.Index(src, "function buildUI()")
+	if aiStart < 0 || aiBuild <= aiStart ||
+		!strings.Contains(src[aiStart:aiBuild], "if (window.__obEmbedded) return;") {
+		t.Error("ui.js должен строить ИИ-помощника только в верхнем окне вкладочной оболочки")
+	}
 	// SSE /ui/events подключается только в верхнем окне, не во фрейме оболочки.
 	if !strings.Contains(src, "if (!window.__obEmbedded) {") {
 		t.Error("ui.js должен подключать SSE /ui/events только вне вкладочного фрейма (гейт window.__obEmbedded)")


### PR DESCRIPTION
## Что изменено

- ИИ-помощник инициализируется только в верхнем окне вкладочной оболочки
- вложенные iframe больше не создают собственную кнопку помощника
- добавлен регрессионный тест

## Проверка

- `node --check internal/ui/static/ui.js`
- `go test ./...`