### PR TITLE
fix(configurator): вкладка «Печатные формы» сущности показывает DSL-формы и макеты

### DIFF
--- a/internal/launcher/configurator_load.go
+++ b/internal/launcher/configurator_load.go
@@ -283,9 +283,18 @@ func (h *handler) loadCfgData(ctx context.Context, b *Base, tab string, lang ...
 		}
 		data.DSLPrintForms = append(data.DSLPrintForms, cpf)
 	}
+
+	// Обратный индекс «документ → DSL/декларативные формы» для вкладки
+	// «Печатные формы» сущности (там раньше были видны только legacy YAML).
+	dslByDoc := make(map[string][]cfgDSLPrintForm)
+	for _, cpf := range data.DSLPrintForms {
+		key := strings.ToLower(cpf.Document)
+		dslByDoc[key] = append(dslByDoc[key], cpf)
+	}
 	for _, e := range data.Entities {
 		data.AllEntityNames = append(data.AllEntityNames, e.Name)
 		e.LinkedPrintForms = pfByDoc[strings.ToLower(e.Name)]
+		e.LinkedDSLForms = dslByDoc[strings.ToLower(e.Name)]
 		if e.Kind == "Справочник" {
 			data.Catalogs = append(data.Catalogs, e)
 		} else {

--- a/internal/launcher/configurator_tmpl_tree.go
+++ b/internal/launcher/configurator_tmpl_tree.go
@@ -1774,12 +1774,26 @@ const cfgTabTree = `{{define "tab-tree"}}
   </div>{{/* end ot-forms */}}
 
   <div class="obj-pane" id="ot-print-{{$e.Name}}">
-    {{if $e.LinkedPrintForms}}
+    {{if or $e.LinkedPrintForms $e.LinkedDSLForms}}
     <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px">
+      {{/* Порядок как приоритет рантайма: макеты (декларативные) > DSL > legacy YAML */}}
+      {{range $e.LinkedDSLForms}}
+      {{if .LayoutOnly}}
+      <a href="#" onclick="cfgSelectPanel('mkt-{{.Name}}');return false"
+         style="display:inline-flex;align-items:center;gap:5px;padding:5px 12px;background:#f0fdf4;border:1px solid #a7d8b9;border-radius:4px;font-size:12px;color:#166534;text-decoration:none">
+        &#x1F4D0; {{.Name}} <span style="color:#64748b;font-size:10px">({{t $.Lang "макет"}})</span>
+      </a>
+      {{else}}
+      <a href="#" onclick="cfgSelectPanel('dpf-{{.Name}}');return false"
+         style="display:inline-flex;align-items:center;gap:5px;padding:5px 12px;background:#f0f4ff;border:1px solid #c8d4f0;border-radius:4px;font-size:12px;color:#1a4a80;text-decoration:none">
+        📋 {{.Name}} <span style="color:#64748b;font-size:10px">(DSL{{if .HasLayout}}+{{t $.Lang "макет"}}{{end}})</span>
+      </a>
+      {{end}}
+      {{end}}
       {{range $e.LinkedPrintForms}}
       <a href="#" onclick="cfgSelectPanel('pf-{{.Name}}');return false"
-         style="display:inline-flex;align-items:center;gap:5px;padding:5px 12px;background:#f0f4ff;border:1px solid #c8d4f0;border-radius:4px;font-size:12px;color:#1a4a80;text-decoration:none">
-        🖨 {{.Name}}
+         style="display:inline-flex;align-items:center;gap:5px;padding:5px 12px;background:#f0f4ff;border:1px solid #c8d4f0;border-radius:4px;font-size:12px;color:#1a4a80;text-decoration:none"{{if .Shadowed}} title="Эту YAML-форму перебивает одноимённая .os"{{end}}>
+        🖨 {{if .Shadowed}}⚠️ {{end}}{{.Name}} <span style="color:#64748b;font-size:10px">(YAML)</span>
       </a>
       {{end}}
     </div>

--- a/internal/launcher/configurator_types.go
+++ b/internal/launcher/configurator_types.go
@@ -277,9 +277,13 @@ type cfgEntity struct {
 	PostingSource    string // raw .posting.os content (ОбработкаПроведения)
 	ManagerSource    string // raw .manager.os content (модуль менеджера)
 	LinkedPrintForms []cfgPrintForm
-	Predefined       []cfgPredefined
-	Titles           map[string]string // переводы синонима объекта
-	Activity         *cfgActivity
+	// LinkedDSLForms — DSL-формы (.os) и декларативные макеты (LayoutOnly)
+	// этой сущности: вкладка «Печатные формы» показывает все варианты, а не
+	// только legacy YAML.
+	LinkedDSLForms []cfgDSLPrintForm
+	Predefined     []cfgPredefined
+	Titles         map[string]string // переводы синонима объекта
+	Activity       *cfgActivity
 }
 
 type cfgRegister struct {

--- a/internal/launcher/layout_editor_render_test.go
+++ b/internal/launcher/layout_editor_render_test.go
@@ -206,6 +206,39 @@ func TestLayoutEditor_StandaloneLayoutForm(t *testing.T) {
 	}
 }
 
+// Вкладка «Печатные формы» сущности показывает все виды форм: декларативные
+// макеты (mkt-*) и DSL (dpf-*) — раньше были видны только legacy YAML (pf-*).
+func TestEntityPrintTab_ShowsAllFormKinds(t *testing.T) {
+	data := &configuratorData{
+		Base: &Base{ID: "test-base", Name: "Тест", ConfigSource: "file"},
+		Lang: "ru",
+		Tab:  "tree",
+		Docs: []cfgEntity{{
+			Name: "Реализация", Kind: "Документ",
+			LinkedPrintForms: []cfgPrintForm{{Name: "накладная", Document: "Реализация"}},
+			LinkedDSLForms: []cfgDSLPrintForm{
+				{Name: "упд", Document: "Реализация", HasLayout: true},
+				{Name: "Счет2", Document: "Реализация", HasLayout: true, LayoutOnly: true},
+			},
+		}},
+	}
+	var buf bytes.Buffer
+	if err := cfgTmpl.ExecuteTemplate(&buf, "tab-tree", data); err != nil {
+		t.Fatalf("ExecuteTemplate tab-tree: %v", err)
+	}
+	html := buf.String()
+	for _, sub := range []string{
+		`cfgSelectPanel('dpf-упд')`,      // DSL-форма
+		`cfgSelectPanel('mkt-Счет2')`,    // декларативный макет
+		`cfgSelectPanel('pf-накладная')`, // legacy YAML (с пометкой)
+		`(YAML)`,
+	} {
+		if !strings.Contains(html, sub) {
+			t.Errorf("на вкладке «Печатные формы» нет фрагмента: %q", sub)
+		}
+	}
+}
+
 // Диалог «+» у группы «Печатные формы» предлагает выбор типа: макет
 // (визуальный конструктор, по умолчанию) или классический YAML; отправка
 // переключает action между new-layout и new-printform.


### PR DESCRIPTION
## Что сделано

Продолжение #347 (третий фикс из обсуждения — не успел в мердж): на вкладке «Печатные формы» у объекта (документа/справочника) были видны **только старые legacy YAML-формы** — `LinkedPrintForms` строился только из `proj.PrintForms`, DSL `.os` и декларативные макеты туда не попадали. У документа с современными формами вкладка выглядела пустой («Печатных форм нет»).

Теперь вкладка показывает чипы всех видов форм в порядке приоритета рантайма (Declarative > DSL > Legacy):

- 📐 **макеты** (зелёные) → переход в редактор макета (`mkt-*`);
- 📋 **DSL-формы** → `dpf-*`, с пометкой «+макет» при парном `.layout.yaml`;
- 🖨 **legacy YAML** → `pf-*`, с пометкой `(YAML)` и ⚠️ для перебитых одноимённой `.os`.

Реализация: `cfgEntity.LinkedDSLForms` + обратный индекс «документ → DSL/декларативные формы» в `loadCfgData` (из уже собранного `data.DSLPrintForms`, включая standalone из #347).

## Проверка

- `go test ./internal/launcher/` — ok, добавлен `TestEntityPrintTab_ShowsAllFormKinds`;
- вживую (headless Edge, база examples/minimal): у документа «Счёт» вкладка показывает все три формы — «накладная (DSL+макет)», «ТестМакет (макет)», «счёт (макет)»; клик по чипу открывает соответствующий редактор и выделяет узел в дереве.

🤖 Generated with [Claude Code](https://claude.com/claude-code)