### PR TITLE
fix(configurator): защитить bootstrap и импорт конфигурации

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -826,6 +826,8 @@
   "Открыть карточку": "Open card",
   "Показывать «+ Создать» в picker'е": "Show «+ Create» in the picker",
   "Выберите папку XML-выгрузки": "Select XML export folder",
+  "Выберите папку конфигурации": "Select configuration folder",
+  "Первый пользователь должен быть администратором": "The first user must be an administrator",
   "Добавить обработку": "Add data processor",
   "Добавить общий модуль": "Add common module",
   "Переместить вверх": "Move up",

--- a/internal/launcher/admin_handlers.go
+++ b/internal/launcher/admin_handlers.go
@@ -263,11 +263,36 @@ func (h *handler) cfgAdminUserCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	repo := auth.NewRepo(db)
-	if _, err := repo.Create(r.Context(), req.Login, req.Password, req.FullName, req.IsAdmin); err != nil {
+	hadUsers, err := repo.HasUsers(r.Context())
+	if err != nil {
 		writeJSON(w, 500, map[string]any{"error": err.Error()})
 		return
 	}
-	writeJSON(w, 200, map[string]any{"ok": true})
+	// Иначе первый обычный пользователь мгновенно включает авторизацию и
+	// навсегда закрывает конфигуратор: войти в него может только admin.
+	if !hadUsers && !req.IsAdmin {
+		writeJSON(w, 400, map[string]any{"error": tr(lang, "Первый пользователь должен быть администратором")})
+		return
+	}
+	user, err := repo.Create(r.Context(), req.Login, req.Password, req.FullName, req.IsAdmin)
+	if err != nil {
+		writeJSON(w, 500, map[string]any{"error": err.Error()})
+		return
+	}
+	// До создания первого пользователя текущая страница была открыта без
+	// cookie. Сразу начинаем configurator-сессию, чтобы cfgAdmin('users') после
+	// AJAX не получил HTML логина внутри панели (его form submit давал HTTP 405).
+	if !hadUsers {
+		token, err := repo.CreateSession(r.Context(), user.ID, auth.SessionMeta{
+			Kind: auth.SessionKindConfigurator, IP: r.RemoteAddr, UserAgent: r.UserAgent(),
+		})
+		if err != nil {
+			writeJSON(w, 500, map[string]any{"error": err.Error()})
+			return
+		}
+		setConfiguratorSessionCookie(w, token)
+	}
+	writeJSON(w, 200, map[string]any{"ok": true, "sessionStarted": !hadUsers})
 }
 
 func (h *handler) cfgAdminUserDelete(w http.ResponseWriter, r *http.Request) {

--- a/internal/launcher/cfgauth.go
+++ b/internal/launcher/cfgauth.go
@@ -190,6 +190,16 @@ func (h *handler) cfgLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	setConfiguratorSessionCookie(w, token)
+
+	http.Redirect(w, r, "/bases/"+id+"/configurator", http.StatusFound)
+}
+
+// setConfiguratorSessionCookie starts the dedicated configurator session in
+// the browser. It is shared by the normal login and by first-admin bootstrap:
+// before the first user exists the configurator is intentionally open, so the
+// create-user AJAX response must establish a session before the next request.
+func setConfiguratorSessionCookie(w http.ResponseWriter, token string) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "onebase_session",
 		Value:    token,
@@ -197,8 +207,6 @@ func (h *handler) cfgLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})
-
-	http.Redirect(w, r, "/bases/"+id+"/configurator", http.StatusFound)
 }
 
 func (h *handler) cfgLogout(w http.ResponseWriter, r *http.Request) {

--- a/internal/launcher/config_workflow_test.go
+++ b/internal/launcher/config_workflow_test.go
@@ -1,0 +1,183 @@
+package launcher
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/configdb"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func requestWithBaseID(req *http.Request, id string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// Создание первого администратора происходит в конфигураторе, который до
+// появления пользователей работает без сессии. Ответ должен сразу выдать
+// configurator-cookie, иначе следующий AJAX-запрос загрузит форму входа внутрь
+// панели, а её submit уйдёт POST-запросом на GET-only /configurator (HTTP 405).
+func TestCfgAdminUserCreate_FirstAdminStartsConfiguratorSession(t *testing.T) {
+	t.Cleanup(CloseAuthPools)
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "first-admin.db")
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	repo := auth.NewRepo(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	base := &Base{ID: "first-admin-base", Name: "First admin", ConfigSource: "database", DBType: "sqlite", DBPath: dbPath}
+	if err := store.save([]*Base{base}); err != nil {
+		t.Fatal(err)
+	}
+	h := &handler{store: store, runner: NewRunner()}
+
+	req := httptest.NewRequest(http.MethodPost, "/bases/first-admin-base/configurator/admin/users/create",
+		strings.NewReader(`{"login":"admin","password":"secret","fullName":"Admin","isAdmin":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithBaseID(req, base.ID)
+	rec := httptest.NewRecorder()
+	h.cfgAdminUserCreate(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "onebase_session" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil || sessionCookie.Value == "" {
+		t.Fatalf("first admin response did not start configurator session: %v", rec.Header())
+	}
+	user, err := repo.LookupSession(ctx, sessionCookie.Value)
+	if err != nil {
+		t.Fatalf("LookupSession: %v", err)
+	}
+	if user.Login != "admin" || !user.IsAdmin {
+		t.Fatalf("session user=%+v", user)
+	}
+}
+
+func TestCfgAdminUserCreate_FirstUserMustBeAdmin(t *testing.T) {
+	t.Cleanup(CloseAuthPools)
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "first-user.db")
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	repo := auth.NewRepo(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	base := &Base{ID: "first-user-base", ConfigSource: "database", DBType: "sqlite", DBPath: dbPath}
+	if err := store.save([]*Base{base}); err != nil {
+		t.Fatal(err)
+	}
+	h := &handler{store: store, runner: NewRunner()}
+	req := httptest.NewRequest(http.MethodPost, "/bases/first-user-base/configurator/admin/users/create",
+		strings.NewReader(`{"login":"user","password":"secret","isAdmin":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = requestWithBaseID(req, base.ID)
+	rec := httptest.NewRecorder()
+	h.cfgAdminUserCreate(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if has, err := repo.HasUsers(ctx); err != nil || has {
+		t.Fatalf("first non-admin must not be created: has=%v err=%v", has, err)
+	}
+}
+
+// Пустая/неверная папка не должна очищать _onebase_config. Раньше
+// ImportFromDir сначала делал DELETE, а пустой workspace считался успешным
+// импортом нулевой конфигурации.
+func TestConfigImport_RejectsFolderWithoutAppConfigAndPreservesDatabase(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "config.db")
+	source := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(source, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "config", "app.yaml"), []byte("name: Existing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := configdb.New(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	if err := repo.ImportFromDir(ctx, source); err != nil {
+		db.Close()
+		t.Fatal(err)
+	}
+	db.Close()
+
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	base := &Base{ID: "safe-import-base", ConfigSource: "database", DBType: "sqlite", DBPath: dbPath}
+	if err := store.save([]*Base{base}); err != nil {
+		t.Fatal(err)
+	}
+	h := &handler{store: store, runner: NewRunner()}
+	form := url.Values{"path": {t.TempDir()}}
+	req := httptest.NewRequest(http.MethodPost, "/bases/safe-import-base/config/import", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = requestWithBaseID(req, base.ID)
+	rec := httptest.NewRecorder()
+	h.configImport(rec, req)
+
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "config/app.yaml") {
+		t.Fatalf("expected invalid config folder error, status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	checkDB, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer checkDB.Close()
+	content, ok, err := configdb.New(checkDB).ReadFile(ctx, "config/app.yaml")
+	if err != nil || !ok || !bytes.Contains(content, []byte("Existing")) {
+		t.Fatalf("existing config was damaged: ok=%v content=%q err=%v", ok, content, err)
+	}
+}
+
+func TestConfigResult_UsesConfiguratorBackURL(t *testing.T) {
+	var out bytes.Buffer
+	err := tmpl.ExecuteTemplate(&out, "page-config-result", map[string]any{
+		"Title":   "Result",
+		"BackURL": "/bases/base-id/configurator?tab=files",
+		"Lang":    "ru",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `href="/bases/base-id/configurator?tab=files"`) {
+		t.Fatalf("configurator back URL missing: %s", out.String())
+	}
+}

--- a/internal/launcher/configurator_tmpl_tabs.go
+++ b/internal/launcher/configurator_tmpl_tabs.go
@@ -114,7 +114,10 @@ function cfgViewFile(el){
     <form method="POST" action="/bases/{{.Base.ID}}/config/import">
       <div class="fg">
         <label>{{t $.Lang "Путь к папке"}}</label>
-        <input type="text" name="path" placeholder="~/.onebase/workspace/{{.Base.ID}}">
+        <div class="input-browse">
+          <input type="text" id="config-import-dir" name="path" placeholder="~/.onebase/workspace/{{.Base.ID}}">
+          <button type="button" class="btn-browse" onclick="pickDir('config-import-dir','{{t $.Lang "Выберите папку конфигурации"}}')">📁</button>
+        </div>
       </div>
       <button class="btn-primary" type="submit">{{t $.Lang "Загрузить"}}</button>
     </form>

--- a/internal/launcher/files_tree_test.go
+++ b/internal/launcher/files_tree_test.go
@@ -108,7 +108,7 @@ func TestBuildConfigFileTree(t *testing.T) {
 // Вкладка «Файлы» рендерит дерево файлов с просмотрщиком (issue #132).
 func TestTabFiles_Render(t *testing.T) {
 	data := &configuratorData{
-		Base: &Base{ID: "test-base", ConfigSource: "file", Path: "/tmp/x"},
+		Base: &Base{ID: "test-base", ConfigSource: "database"},
 		Tab:  "files",
 		Lang: "ru",
 		ConfigFileTree: []fileTreeCategory{
@@ -139,6 +139,8 @@ func TestTabFiles_Render(t *testing.T) {
 		`class="ftedit"`,       // фаза 2: «открыть в редакторе»
 		`tab=tree`,             // ведёт на вкладку дерева
 		`select=`,              // с выбором узла
+		`id="config-import-dir"`,
+		`pickDir('config-import-dir'`, // выбор каталога как на вкладке импорта
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("tab-files не содержит %q", want)

--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -599,11 +599,13 @@ func (h *handler) configExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := resolveLang(r)
+	backURL := "/bases/" + b.ID + "/configurator?tab=files"
 	if b.ConfigSource != "database" {
 		render(w, r, "page-config-result", map[string]any{
 			"Title":   tr(lang, "onebase — Конфигуратор"),
 			"Message": tr(lang, "Выгрузка доступна только для баз в режиме «В базе данных»."),
 			"Error":   "",
+			"BackURL": backURL,
 		})
 		return
 	}
@@ -612,7 +614,8 @@ func (h *handler) configExport(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		render(w, r, "page-config-result", map[string]any{
 			"Title": tr(lang, "onebase — Конфигуратор"), "Message": "",
-			"Error": tr(lang, "Ошибка подключения") + ": " + err.Error(),
+			"Error":   tr(lang, "Ошибка подключения") + ": " + err.Error(),
+			"BackURL": backURL,
 		})
 		return
 	}
@@ -628,7 +631,8 @@ func (h *handler) configExport(w http.ResponseWriter, r *http.Request) {
 	if err := repo.ExportToDir(r.Context(), workDir); err != nil {
 		render(w, r, "page-config-result", map[string]any{
 			"Title": tr(lang, "onebase — Конфигуратор"), "Message": "",
-			"Error": tr(lang, "Ошибка выгрузки") + ": " + err.Error(),
+			"Error":   tr(lang, "Ошибка выгрузки") + ": " + err.Error(),
+			"BackURL": backURL,
 		})
 		return
 	}
@@ -639,7 +643,34 @@ func (h *handler) configExport(w http.ResponseWriter, r *http.Request) {
 		"Title":   tr(lang, "onebase — Конфигуратор"),
 		"Message": fmt.Sprintf(tr(lang, "Конфигурация выгружена в папку")+": %s", workDir),
 		"Error":   "",
+		"BackURL": backURL,
 	})
+}
+
+// validateConfigImportDir rejects an empty/non-project directory before
+// configdb.ImportFromDir starts its replace-all transaction. In particular,
+// an untouched ~/.onebase/workspace/<base-id> must not be accepted as a valid
+// zero-file configuration.
+func validateConfigImportDir(srcDir string) error {
+	info, err := os.Stat(srcDir)
+	if err != nil {
+		return fmt.Errorf("папка конфигурации недоступна: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("путь не является папкой: %s", srcDir)
+	}
+	appPath := filepath.Join(srcDir, "config", "app.yaml")
+	if info, err := os.Stat(appPath); err != nil || info.IsDir() {
+		return fmt.Errorf("папка не содержит config/app.yaml: %s", srcDir)
+	}
+	cfg, err := project.LoadConfig(srcDir)
+	if err != nil {
+		return fmt.Errorf("ошибка config/app.yaml: %w", err)
+	}
+	if strings.TrimSpace(cfg.Name) == "" {
+		return fmt.Errorf("в config/app.yaml не заполнено поле name")
+	}
+	return nil
 }
 
 func (h *handler) configImport(w http.ResponseWriter, r *http.Request) {
@@ -649,18 +680,34 @@ func (h *handler) configImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := resolveLang(r)
+	backURL := "/bases/" + b.ID + "/configurator?tab=files"
 
 	r.ParseForm()
-	srcDir := r.FormValue("path")
+	srcDir := strings.TrimSpace(r.FormValue("path"))
 	if srcDir == "" {
-		srcDir, _ = workspacePath(b.ID)
+		srcDir, err = workspacePath(b.ID)
+		if err != nil {
+			render(w, r, "page-config-result", map[string]any{
+				"Title": tr(lang, "onebase — Загрузка конфигурации"), "Message": "",
+				"Error": tr(lang, "Ошибка загрузки") + ": " + err.Error(), "BackURL": backURL,
+			})
+			return
+		}
+	}
+	if err := validateConfigImportDir(srcDir); err != nil {
+		render(w, r, "page-config-result", map[string]any{
+			"Title": tr(lang, "onebase — Загрузка конфигурации"), "Message": "",
+			"Error": tr(lang, "Ошибка загрузки") + ": " + err.Error(), "BackURL": backURL,
+		})
+		return
 	}
 
 	db, err := OpenDB(r.Context(), b)
 	if err != nil {
 		render(w, r, "page-config-result", map[string]any{
 			"Title": tr(lang, "onebase — Загрузка конфигурации"), "Message": "",
-			"Error": tr(lang, "Ошибка подключения") + ": " + err.Error(),
+			"Error":   tr(lang, "Ошибка подключения") + ": " + err.Error(),
+			"BackURL": backURL,
 		})
 		return
 	}
@@ -670,7 +717,8 @@ func (h *handler) configImport(w http.ResponseWriter, r *http.Request) {
 	if err := repo.ImportFromDir(r.Context(), srcDir); err != nil {
 		render(w, r, "page-config-result", map[string]any{
 			"Title": tr(lang, "onebase — Загрузка конфигурации"), "Message": "",
-			"Error": tr(lang, "Ошибка загрузки") + ": " + err.Error(),
+			"Error":   tr(lang, "Ошибка загрузки") + ": " + err.Error(),
+			"BackURL": backURL,
 		})
 		return
 	}
@@ -680,7 +728,8 @@ func (h *handler) configImport(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		render(w, r, "page-config-result", map[string]any{
 			"Title": tr(lang, "onebase — Загрузка конфигурации"), "Message": "",
-			"Error": tr(lang, "Ошибка версии конфигурации") + ": " + err.Error(),
+			"Error":   tr(lang, "Ошибка версии конфигурации") + ": " + err.Error(),
+			"BackURL": backURL,
 		})
 		return
 	}
@@ -691,6 +740,7 @@ func (h *handler) configImport(w http.ResponseWriter, r *http.Request) {
 		"Title":   tr(lang, "onebase — Загрузка конфигурации"),
 		"Message": fmt.Sprintf(tr(lang, "Конфигурация загружена из")+": %s\n\n"+tr(lang, "Миграция")+":\n%s", srcDir, out),
 		"Error":   "",
+		"BackURL": backURL,
 	})
 }
 

--- a/internal/launcher/templates.go
+++ b/internal/launcher/templates.go
@@ -476,7 +476,7 @@ const tplConfigResult = `
   <h2>{{.Title}}</h2>
   <p style="margin-bottom:12px;font-size:13px;color:#555">{{.Message}}</p>
   {{if .Error}}<div class="err">{{.Error}}</div>{{end}}
-  <div style="margin-top:14px"><a class="btn-cancel" href="/">← {{t $.Lang "Назад"}}</a></div>
+  <div style="margin-top:14px"><a class="btn-cancel" href="{{if .BackURL}}{{.BackURL}}{{else}}/{{end}}">← {{t $.Lang "Назад"}}</a></div>
 </div>
 </body></html>
 {{end}}


### PR DESCRIPTION
## Что изменено

- первый пользователь конфигуратора теперь обязан быть администратором, а после его создания сразу запускается configurator-сессия
- импорт каталога проверяет наличие корректного `config/app.yaml` до replace-all транзакции и не очищает существующую конфигурацию при неверном пути
- на вкладку файлов добавлен выбор каталога, а страницы результата возвращают обратно в конфигуратор
- добавлены регрессионные тесты bootstrap, безопасного импорта и навигации

## Проверка

- `go test ./...`