### PR TITLE
feat(launcher): «Предприятие» открывается в нативном окне без адресной строки

### DIFF
--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -353,36 +353,65 @@ func (h *handler) baseRunning(b *Base) bool {
 	return !portFree(b.Port) && h.runner.Healthy(b)
 }
 
+// ensureBaseReady запускает базу, если она ещё не запущена, и ждёт готовности
+// её сервера. Общий пролог обработчиков start / startIsolated / startNative:
+// при ошибке пишет JSON-ответ и возвращает false.
+func (h *handler) ensureBaseReady(w http.ResponseWriter, r *http.Request, b *Base, lang string) bool {
+	if !h.baseRunning(b) {
+		if b.DBType != "sqlite" {
+			if err := storage.EnsureDatabase(r.Context(), b.DB); err != nil {
+				writeJSON(w, 500, map[string]any{"error": tr(lang, "Не удалось создать БД") + ": " + err.Error()})
+				return false
+			}
+		}
+		if err := h.runner.Start(b); err != nil {
+			writeJSON(w, 500, map[string]any{"error": errText(r, err)})
+			return false
+		}
+		b.LastOpened = time.Now()
+		h.store.Update(b)
+	}
+	// Wait until the base server is ready before handing the URL to the client.
+	if err := h.runner.WaitReady(b, 15*time.Second); err != nil {
+		writeJSON(w, 500, map[string]any{"error": errText(r, err)})
+		return false
+	}
+	return true
+}
+
 func (h *handler) start(w http.ResponseWriter, r *http.Request) {
 	b, err := h.store.Get(chi.URLParam(r, "id"))
 	if err != nil {
 		writeJSON(w, 404, map[string]any{"error": "not found"})
 		return
 	}
-	lang := resolveLang(r)
-
-	if !h.baseRunning(b) {
-		if b.DBType != "sqlite" {
-			if err := storage.EnsureDatabase(r.Context(), b.DB); err != nil {
-				writeJSON(w, 500, map[string]any{"error": tr(lang, "Не удалось создать БД") + ": " + err.Error()})
-				return
-			}
-		}
-		if err := h.runner.Start(b); err != nil {
-			writeJSON(w, 500, map[string]any{"error": errText(r, err)})
-			return
-		}
-		b.LastOpened = time.Now()
-		h.store.Update(b)
+	if !h.ensureBaseReady(w, r, b, resolveLang(r)) {
+		return
 	}
+	writeJSON(w, 200, map[string]any{"url": h.runner.BaseURL(b)})
+}
 
-	// Wait until the base server is ready before handing the URL to the browser
-	if err := h.runner.WaitReady(b, 15*time.Second); err != nil {
+// startNative (кнопка «Предприятие» в GUI-сборке под Windows): запускает базу и
+// открывает её в нативном WebView2-окне на ОБЩЕМ профиле — окно без адресной
+// строки, в отличие от window.open, который в WebView2 убегает во внешний
+// браузер. Пустой профиль (не изолированный) = единый cookie-jar с лаунчером,
+// т.е. обычный сеанс Предприятия, а не свежий вход под другим пользователем
+// («Новое окно»). В не-GUI-сборках isoBrowser.Open вернёт понятную ошибку, но
+// UI туда и не ходит — при NativeOK=false кнопка открывает браузер.
+func (h *handler) startNative(w http.ResponseWriter, r *http.Request) {
+	b, err := h.store.Get(chi.URLParam(r, "id"))
+	if err != nil {
+		writeJSON(w, 404, map[string]any{"error": "not found"})
+		return
+	}
+	if !h.ensureBaseReady(w, r, b, resolveLang(r)) {
+		return
+	}
+	if err := h.isoBrowser.Open("", h.runner.BaseURL(b), isolatedModeNative); err != nil {
 		writeJSON(w, 500, map[string]any{"error": errText(r, err)})
 		return
 	}
-
-	writeJSON(w, 200, map[string]any{"url": h.runner.BaseURL(b)})
+	writeJSON(w, 200, map[string]any{"ok": true})
 }
 
 // startIsolated (план 78, фаза 3): запускает базу (если нужно) и открывает
@@ -395,24 +424,7 @@ func (h *handler) startIsolated(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 404, map[string]any{"error": "not found"})
 		return
 	}
-	lang := resolveLang(r)
-
-	if !h.baseRunning(b) {
-		if b.DBType != "sqlite" {
-			if err := storage.EnsureDatabase(r.Context(), b.DB); err != nil {
-				writeJSON(w, 500, map[string]any{"error": tr(lang, "Не удалось создать БД") + ": " + err.Error()})
-				return
-			}
-		}
-		if err := h.runner.Start(b); err != nil {
-			writeJSON(w, 500, map[string]any{"error": errText(r, err)})
-			return
-		}
-		b.LastOpened = time.Now()
-		h.store.Update(b)
-	}
-	if err := h.runner.WaitReady(b, 15*time.Second); err != nil {
-		writeJSON(w, 500, map[string]any{"error": errText(r, err)})
+	if !h.ensureBaseReady(w, r, b, resolveLang(r)) {
 		return
 	}
 

--- a/internal/launcher/isolated_browser_test.go
+++ b/internal/launcher/isolated_browser_test.go
@@ -91,10 +91,10 @@ func TestPickProfileDir_ReusesFreeSkipsBusy(t *testing.T) {
 
 func TestCleanIsolatedProfiles(t *testing.T) {
 	root := t.TempDir()
-	free, _ := pickProfileDir(root)   // profile-1 — свободный
+	free, _ := pickProfileDir(root) // profile-1 — свободный
 	release := makeProfileBusy(t, free)
 	busyDir := free
-	free2, _ := pickProfileDir(root)  // profile-2 — свободный
+	free2, _ := pickProfileDir(root) // profile-2 — свободный
 	_ = free2
 
 	removed, err := cleanIsolatedProfiles(root)
@@ -290,5 +290,58 @@ func TestStartIsolated_UnknownBase(t *testing.T) {
 	}
 	if fb.calls != 0 {
 		t.Fatal("браузер не должен запускаться для неизвестной базы")
+	}
+}
+
+func startNativeReq(t *testing.T, h *handler, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/bases/"+id+"/start-native", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.startNative(rec, req)
+	return rec
+}
+
+// «Предприятие» (startNative) открывает нативное окно на ОБЩЕМ профиле
+// (пустой каталог) в режиме native, на URL базы без суффикса /ui — единый
+// сеанс с лаунчером, а не изолированный вход как у «Нового окна».
+func TestStartNative_SharedProfile(t *testing.T) {
+	fb := &fakeBrowser{}
+	h, b := newIsolatedFixture(t, fb)
+
+	rec := startNativeReq(t, h, b.ID)
+	if rec.Code != 200 {
+		t.Fatalf("код ответа %d: %s", rec.Code, rec.Body.String())
+	}
+	if fb.calls != 1 {
+		t.Fatalf("нативное окно должно открыться один раз, вызовов: %d", fb.calls)
+	}
+	if fb.mode != isolatedModeNative {
+		t.Errorf("режим окна: %q, ожидался %q", fb.mode, isolatedModeNative)
+	}
+	if fb.dir != "" {
+		t.Errorf("общий профиль = пустой каталог, получен %q", fb.dir)
+	}
+	wantURL := fmt.Sprintf("http://localhost:%d", b.Port)
+	if fb.url != wantURL {
+		t.Errorf("URL окна: %q, ожидался %q", fb.url, wantURL)
+	}
+}
+
+// В не-GUI-сборке реальный systemBrowser вернул бы ошибку native-режима, но
+// ответ обработчика приходит из isoBrowser — проверяем, что ошибка Open
+// пробрасывается как 500 (UI на этот путь не ходит, но контракт честный).
+func TestStartNative_OpenError(t *testing.T) {
+	fb := &fakeBrowser{err: fmt.Errorf("нативные окна доступны только в GUI-сборке")}
+	h, b := newIsolatedFixture(t, fb)
+
+	rec := startNativeReq(t, h, b.ID)
+	if rec.Code != 500 {
+		t.Fatalf("ожидался код 500, получен %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "GUI") {
+		t.Errorf("ошибка Open должна пробрасываться в ответ: %s", rec.Body.String())
 	}
 }

--- a/internal/launcher/isolated_native_windows.go
+++ b/internal/launcher/isolated_native_windows.go
@@ -11,16 +11,22 @@ import (
 // Windows (план 78, п. 4.2) — на них работает сам лаунчер, runtime заведомо есть.
 func nativeIsolatedSupported() bool { return true }
 
-// nativeIsolatedCommand строит запуск второго нативного окна: сам же exe
-// (`onebase-gui window --url ...`) с переменной ONEBASE_WEBVIEW_PROFILE,
-// которую читает наш патч webview.h (third_party/webview_go) — у каждого окна
-// свой каталог профиля WebView2, а значит свой cookie-jar.
+// nativeIsolatedCommand строит запуск нативного окна: сам же exe
+// (`onebase-gui window --url ...`). Непустой profileDir задаётся через
+// ONEBASE_WEBVIEW_PROFILE (её читает наш патч webview.h в third_party/webview_go)
+// — у изолированного окна свой каталог профиля WebView2, а значит свой
+// cookie-jar. Пустой profileDir = ОБЩИЙ профиль (%APPDATA%\<exe>, как у самого
+// лаунчера): переменную не задаём, окно делит сеанс с Предприятием — это путь
+// кнопки «Предприятие».
 func nativeIsolatedCommand(profileDir, url string) (*exec.Cmd, bool) {
 	exe, err := os.Executable()
 	if err != nil {
 		return nil, false
 	}
 	cmd := exec.Command(exe, "window", "--url", url, "--title", "onebase — Предприятие")
-	cmd.Env = append(os.Environ(), "ONEBASE_WEBVIEW_PROFILE="+profileDir)
+	cmd.Env = os.Environ()
+	if profileDir != "" {
+		cmd.Env = append(cmd.Env, "ONEBASE_WEBVIEW_PROFILE="+profileDir)
+	}
 	return cmd, true
 }

--- a/internal/launcher/server.go
+++ b/internal/launcher/server.go
@@ -130,6 +130,7 @@ func (s *Server) ListenAndServe() error {
 	r.Post("/bases/{id}/delete", s.h.delete)
 	r.Post("/bases/{id}/move", s.h.move)
 	r.Post("/bases/{id}/start", s.h.start)
+	r.Post("/bases/{id}/start-native", s.h.startNative)
 	r.Post("/bases/{id}/start-isolated", s.h.startIsolated)
 	r.Post("/bases/{id}/profiles/clean", s.h.cleanProfiles)
 	r.Post("/bases/{id}/stop", s.h.stop)

--- a/internal/launcher/templates.go
+++ b/internal/launcher/templates.go
@@ -197,6 +197,10 @@ const tplIndex = `
 
 <script>
 var _sel = '{{if .Selected}}{{.Selected.ID}}{{end}}';
+// GUI-сборка под Windows умеет нативные WebView2-окна — «Предприятие»
+// открывается в таком окне (без адресной строки), а не через window.open,
+// который в WebView2 убегает во внешний браузер. В остальных сборках — браузер.
+var _nativeOK = {{if .NativeOK}}true{{else}}false{{end}};
 function selectBase(id) {
   if (_sel === id) return;
   window.location.href = '/?sel=' + id;
@@ -268,6 +272,7 @@ function showStartError(win, msg) {
   alert('Ошибка запуска:\n' + text);
 }
 function startBase(el, id) {
+  if (_nativeOK) return startBaseNative(el, id);
   el.preventDefault ? el.preventDefault() : (el.returnValue = false);
   var btn = el.target || el;
   var origText = btn.textContent || '';
@@ -295,6 +300,30 @@ function startBase(el, id) {
     .catch(function(e){
       showStartError(win, e);
       if (btn.innerHTML) btn.innerHTML = origText;
+    });
+  return false;
+}
+// startBaseNative открывает базу в нативном WebView2-окне (сервер запускает его
+// сам, без window.open — иначе WebView2 отдал бы URL внешнему браузеру с
+// адресной строкой). Окно на общем профиле = обычный сеанс Предприятия.
+function startBaseNative(el, id) {
+  el.preventDefault ? el.preventDefault() : (el.returnValue = false);
+  var btn = el.target || el;
+  var origHTML = btn.innerHTML;
+  if (btn.innerHTML) btn.innerHTML = '⏳ Запуск...';
+  fetch('/bases/' + id + '/start-native', {method:'POST'})
+    .then(function(r){ return r.json(); })
+    .then(function(d){
+      if (d && d.error) {
+        alert('Ошибка запуска:\n' + d.error);
+        if (btn.innerHTML) btn.innerHTML = origHTML;
+      } else {
+        setTimeout(function(){ window.location.href = '/?sel=' + id; }, 500);
+      }
+    })
+    .catch(function(e){
+      alert('Ошибка запуска: ' + e);
+      if (btn.innerHTML) btn.innerHTML = origHTML;
     });
   return false;
 }


### PR DESCRIPTION
## Проблема

Кнопка **«Предприятие»** открывала базу через `window.open('', '_blank')`. В
нативной GUI-сборке лаунчера (WebView2) обработчик `NewWindowRequested` не
зарегистрирован, поэтому WebView2 отдаёт такой вызов **внешнему системному
браузеру** — отсюда и адресная строка, которой не должно быть у «настольного»
окна Предприятия. Для сравнения, «Новое окно → Нативное» уже открывалось
сервером через нативное WebView2-окно и адресной строки не имело.

## Решение

В GUI-сборке под Windows «Предприятие» теперь тоже открывается **сервером** в
нативном WebView2-окне — без адресной строки. Окно запускается на **общем
профиле** (переменная `ONEBASE_WEBVIEW_PROFILE` не задаётся → дефолтный
`%APPDATA%\<exe>`, как у самого лаунчера), то есть это обычный единый сеанс
Предприятия, а не изолированный вход под другим пользователем, как у «Нового
окна».

В не-GUI-сборках (`NativeOK=false`) поведение прежнее — открытие во внешнем
браузере через `window.open`.

## Что изменилось

- Новый endpoint `POST /bases/{id}/start-native` (`handler.startNative`):
  запускает базу и открывает её нативным окном на общем профиле
  (`isoBrowser.Open("", url, native)`).
- `nativeIsolatedCommand`: пустой `profileDir` = общий профиль (переменную
  окружения не выставляем); непустой — прежняя изоляция.
- UI (`templates.go`): кнопка «Предприятие» при `NativeOK` вызывает
  `startBaseNative` (fetch endpoint), иначе — прежний `window.open`-путь.
- Рефактор: общий пролог запуска базы вынесен в `ensureBaseReady`
  (используют `start`, `startIsolated`, `startNative`).

## Проверка

- Юнит-тесты: `TestStartNative_SharedProfile` (общий профиль = пустой каталог,
  режим `native`, URL базы без `/ui`) и `TestStartNative_OpenError`
  (проброс ошибки как 500). Существующие тесты `start`/`startIsolated` зелёные
  после рефактора.
- Сборка `go build ./cmd/onebase` и `go build -tags webview ./cmd/onebase`
  проходят.
- ⚠️ Само нативное окно (отсутствие адресной строки визуально) headless не
  драйвится — нужна ручная проверка на GUI-сборке под Windows.

Generated-with: Claude Code
