### PR TITLE
fix(ui): не затирать введённый Номер автономером при создании документа

### DIFF
--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -451,11 +451,15 @@ func (s *Server) parseSubmitForm(w http.ResponseWriter, r *http.Request, entity 
 		}
 		obj.TablePartRows = tpRows
 
-		// Auto-number: fill Номер if empty for new documents
+		// Auto-number: fill Номер if empty for new documents.
+		// ВАЖНО: значение читаем через obj.Get (регистронезависимо) — obj.Set выше
+		// нормализует ключи в нижний регистр ("номер"), поэтому прямое обращение
+		// obj.Fields["Номер"] всегда возвращало nil и автономер безусловно затирал
+		// введённый пользователем номер (issue #359).
 		if entity.Kind == metadata.KindDocument {
 			for _, f := range entity.Fields {
 				if f.Name == "Номер" && f.Type == metadata.FieldTypeString {
-					if v := fmt.Sprintf("%v", obj.Fields["Номер"]); v == "" || v == "<nil>" {
+					if v := fmt.Sprintf("%v", obj.Get("Номер")); v == "" || v == "<nil>" {
 						obj.Set("Номер", s.generateNumber(r.Context(), entity, obj.Fields))
 					}
 					break

--- a/internal/ui/submit_test.go
+++ b/internal/ui/submit_test.go
@@ -245,6 +245,45 @@ func TestSubmit_NewDocument_AutoNumber(t *testing.T) {
 	}
 }
 
+// Регрессия issue #359: введённый пользователем Номер нового документа не должен
+// затираться автономером. До фикса проверка emptiness читала obj.Fields["Номер"]
+// (PascalCase), тогда как obj.Set нормализует ключ в "номер" → значение всегда
+// выглядело пустым и автономер безусловно перезаписывал пользовательский ввод.
+func TestSubmit_NewDocument_UserNumberPreserved(t *testing.T) {
+	doc := &metadata.Entity{
+		Name: "Заявка",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+		},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{doc})
+
+	form := url.Values{"Номер": {"СН-2026-42"}} // осмысленный номер, введённый пользователем
+	r := reqWithChi("POST", "/ui/document/Заявка/new", form, map[string]string{"entity": "Заявка"})
+	w := httptest.NewRecorder()
+	s.submit(w, r)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("ожидался 303, получен %d: %s", w.Code, w.Body.String())
+	}
+
+	rows, err := s.store.List(ctx, "Заявка", doc, storage.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ожидалась 1 запись, получено %d", len(rows))
+	}
+	num, _ := rows[0]["Номер"].(string)
+	if num == "" {
+		num, _ = rows[0]["номер"].(string)
+	}
+	if num != "СН-2026-42" {
+		t.Errorf("Номер = %q, ожидался «СН-2026-42» — автономер затёр пользовательский ввод (issue #359). Запись: %v", num, rows[0])
+	}
+}
+
 func TestSubmit_NewDocumentPostChecksRowPolicy(t *testing.T) {
 	doc := &metadata.Entity{
 		Name:    "Заявка",


### PR DESCRIPTION
## Проблема (#359)

При создании **нового** документа через веб-форму автонумерация молча затирала введённое пользователем значение поля `Номер` — для любого документа со строковым полем `Номер`.

Причина — рассогласование регистра ключа. Объект строится через `obj.Set(k, v)`, который нормализует ключ в нижний регистр (`"номер"`), а проверка «пусто ли поле» читала `obj.Fields["Номер"]` (PascalCase) напрямую → **всегда** `nil` → условие `v == "<nil>"` всегда истинно → `generateNumber` безусловно перезаписывал ввод.

```go
// было: всегда nil, т.к. ключ в карте — "номер"
if v := fmt.Sprintf("%v", obj.Fields["Номер"]); v == "" || v == "<nil>" {
```

Затронут только путь веб-формы; REST (`ensureDocumentNumber`) читает ключи из JSON-тела и не подвержен.

## Исправление

Читаем значение через регистронезависимый `obj.Get("Номер")`. Пустой `Номер` по-прежнему получает автономер, а осмысленный пользовательский (серийный номер прибора, номер платёжного документа) — сохраняется.

## Тест

`TestSubmit_NewDocument_UserNumberPreserved` — отправляет новый документ с `Номер=СН-2026-42` и проверяет, что в БД сохранился именно он, а не автономер. До фикса тест падает (получал `000001`).

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)