### PR TITLE
fix(ui): читаемая подпись документа без строкового реквизита в reference-пикере

### DIFF
--- a/internal/ui/firststringfield_test.go
+++ b/internal/ui/firststringfield_test.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Регрессия issue #361: reference-picker для документа без строкового реквизита
+// раньше проваливался в сырой UUID (row["id"]). Теперь подпись строится из
+// Номера, а если его нет — синтезируется из дат и чисел.
+func TestFirstStringField_DocumentFallback(t *testing.T) {
+	docFinancial := &metadata.Entity{
+		Name: "Начисление",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "ФинансовыйОбъект", Type: "reference:ФО", RefEntity: "ФО"},
+			{Name: "Период", Type: metadata.FieldTypeDate},
+			{Name: "Сумма", Type: metadata.FieldTypeNumber},
+		},
+	}
+	docWithNumber := &metadata.Entity{
+		Name: "Заявка",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Дата", Type: metadata.FieldTypeDate},
+		},
+	}
+	docWithName := &metadata.Entity{
+		Name: "Приказ",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Тема", Type: metadata.FieldTypeString},
+			{Name: "Сумма", Type: metadata.FieldTypeNumber},
+		},
+	}
+	catNoString := &metadata.Entity{
+		Name: "Счёт",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Код", Type: metadata.FieldTypeNumber},
+		},
+	}
+
+	uid := "e594c3fb-1fdc-43be-9126-03e81f3ad4ed"
+	period := time.Date(2026, 7, 1, 0, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name   string
+		row    map[string]any
+		entity *metadata.Entity
+		want   string
+	}{
+		{
+			name:   "документ без строкового реквизита — синтез из даты и числа, не UUID",
+			row:    map[string]any{"id": uid, "ФинансовыйОбъект": "abc", "Период": period, "Сумма": 1500.0},
+			entity: docFinancial,
+			want:   "01.07.2026 · 1500",
+		},
+		{
+			name:   "документ с Номером — берём Номер",
+			row:    map[string]any{"id": uid, "Номер": "СН-0007", "Дата": period},
+			entity: docWithNumber,
+			want:   "СН-0007",
+		},
+		{
+			name:   "документ со строковым реквизитом — поведение не меняется",
+			row:    map[string]any{"id": uid, "Тема": "Отпуск", "Сумма": 1500.0},
+			entity: docWithName,
+			want:   "Отпуск",
+		},
+		{
+			name:   "документ вообще без полезных полей — сырой id как последний фолбэк",
+			row:    map[string]any{"id": uid},
+			entity: docFinancial,
+			want:   uid,
+		},
+		{
+			name:   "справочник без строкового реквизита — поведение не меняется (id)",
+			row:    map[string]any{"id": uid, "Код": 42.0},
+			entity: catNoString,
+			want:   uid,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstStringField(tc.row, tc.entity); got != tc.want {
+				t.Errorf("firstStringField = %q, ожидалось %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -678,7 +678,61 @@ func firstStringField(row map[string]any, e *metadata.Entity) string {
 			}
 		}
 	}
+	// Нет строкового реквизита — для документа не проваливаемся сразу в сырой
+	// UUID (issue #361). Представление ссылки в языке запросов для документов —
+	// Номер; а документы из одних reference/date/number (типовая проводка,
+	// начисление) вообще не имеют текстового реквизита и раньше показывались в
+	// reference-пикере голыми UUID. Синтезируем читаемую подпись без доп. запросов.
+	if e != nil && e.Kind == metadata.KindDocument {
+		if lbl := documentFallbackLabel(row, e); lbl != "" {
+			return lbl
+		}
+	}
 	return fmt.Sprintf("%v", row["id"])
+}
+
+// documentFallbackLabel строит подпись документа, у которого нет строкового
+// реквизита: сначала Номер (если такое поле есть), иначе — компактный синтез из
+// значений полей-дат и чисел в порядке объявления. Ссылочные поля не включаются:
+// в строке они лежат сырыми UUID и без доп. чтения не читаемы.
+func documentFallbackLabel(row map[string]any, e *metadata.Entity) string {
+	for _, k := range []string{"Номер", "номер"} {
+		if v, ok := row[k]; ok && v != nil {
+			if s := strings.TrimSpace(fmt.Sprintf("%v", v)); s != "" {
+				return s
+			}
+		}
+	}
+	var parts []string
+	for _, f := range e.Fields {
+		if f.Type != metadata.FieldTypeDate && f.Type != metadata.FieldTypeNumber {
+			continue
+		}
+		v, ok := row[f.Name]
+		if !ok || v == nil {
+			continue
+		}
+		if s := formatLabelValue(v); s != "" {
+			parts = append(parts, s)
+		}
+		if len(parts) >= 3 { // достаточно для узнаваемости, не раздуваем подпись
+			break
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+// formatLabelValue форматирует значение поля для синтетической подписи: даты — в
+// локальном формате, всё остальное (число может прийти строкой на SQLite) — как
+// есть, без лишних пробелов.
+func formatLabelValue(v any) string {
+	if t, ok := v.(time.Time); ok {
+		if t.IsZero() {
+			return ""
+		}
+		return t.Format("02.01.2006")
+	}
+	return strings.TrimSpace(fmt.Sprintf("%v", v))
 }
 
 func formToFields(r *http.Request, entity *metadata.Entity) map[string]any {


### PR DESCRIPTION
## Проблема (#361)

`firstStringField` формирует подпись (`_label`) опций reference-пикера. Если у сущности нет ни одного поля `type: string`, единственный фолбэк — сырой `row["id"]` (UUID):

```go
func firstStringField(row map[string]any, e *metadata.Entity) string {
	for _, f := range e.Fields {
		if f.Type == metadata.FieldTypeString { ... return ... }
	}
	return fmt.Sprintf("%v", row["id"]) // ← голый UUID
}
```

Документы, состоящие только из `reference/date/number` (типичная финансовая проводка/начисление, без описательного текстового реквизита), показывались в пикере сплошными UUID — `e594c3fb-1fdc-43be-9126-03e81f3ad4ed` — и такой список физически невозможно использовать. При этом язык запросов уже представляет ссылку на документ его `Номер`ом — расхождение двух понятий «представления ссылки» в одной платформе.

## Исправление

Для документов при отсутствии строкового реквизита:
1. берём поле `Номер`, если оно есть в строке (согласуется с представлением ссылок в языке запросов);
2. иначе синтезируем компактную подпись из значений полей-дат и чисел в порядке объявления (напр. `01.07.2026 · 1500`) — **без дополнительных запросов**.

Ссылочные поля в подпись не включаются (в строке это сырые UUID, нечитаемы без доп. чтения). Справочники и документы со строковым реквизитом не затронуты; сырой `id` остаётся лишь крайним фолбэком.

## Тест

`TestFirstStringField_DocumentFallback` — таблица: документ без строкового поля → синтез из даты и числа (не UUID); документ с `Номер` → `Номер`; документ со строковым реквизитом → без изменений; пустой документ → `id`; справочник без строкового поля → `id` (поведение не меняется).

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)