### PR TITLE
fix(entityservice): писать шапку нового документа до хука проведения

### DIFF
--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -232,6 +232,19 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 
 	var msgs []string
 	if proc != nil {
+		// Для НОВОГО объекта записываем строку-шапку ДО запуска хука (issue #360).
+		// Хук может создать связанный объект со ссылкой обратно на текущий
+		// (Соб.Прибор = ЭтотОбъект.Ссылка; Соб.Записать() — reference:ЭтотЖе).
+		// Запись связанного объекта из DSL идёт своей автокоммит-транзакцией,
+		// мимо основной транзакции ниже, поэтому строка-родитель уже должна
+		// существовать в БД — иначе FOREIGN KEY constraint failed при попытке
+		// создать+провести новый документ одним действием (post_and_close/new).
+		// Для существующего объекта строка уже закоммичена — пропускаем.
+		if req.IsNew {
+			if err := s.Store.Upsert(ctx, req.Entity.Name, req.ID, obj.Fields, req.Entity); err != nil {
+				return SaveResult{}, err
+			}
+		}
 		var vars map[string]any
 		if s.BuildVars != nil {
 			vars = s.BuildVars(hookCtx, mc, &msgs)
@@ -244,6 +257,14 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 			// DSL-ошибка (бизнес-правило), а не технический сбой: отдаём текст
 			// в DSLError, БД не трогаем. И *interpreter.DSLError, и обычная
 			// ошибка форматируются одинаково через Error().
+			// Пред-запись шапки нового объекта откатываем, чтобы неудачное
+			// правило не оставляло черновик-сироту. Best-effort: если хук успел
+			// создать ссылающиеся строки, удаление шапки не пройдёт по FK — это
+			// тот же осиротевший результат, что и до фикса (см. issue #360:
+			// прерывание процедуры после ошибки builtin — отдельная задача).
+			if req.IsNew {
+				_ = s.Store.Delete(ctx, req.Entity.Name, req.ID)
+			}
 			return SaveResult{ID: req.ID, DSLError: err.Error(), DSLMessages: msgs, Movements: mc}, nil
 		}
 	}

--- a/internal/ui/posting_new_document_test.go
+++ b/internal/ui/posting_new_document_test.go
@@ -1,0 +1,176 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/entityservice"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// newSelfRefPostingServer поднимает Server с проводимым документом «Прибор», чей
+// ОбработкаПроведения создаёт связанный справочник «СобытиеПрибора» со ссылкой
+// обратно на сам документ (reference:Прибор → ЭтотОбъект.Ссылка).
+func newSelfRefPostingServer(t *testing.T) (context.Context, *storage.DB, *Server, *metadata.Entity, *metadata.Entity) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	doc := &metadata.Entity{
+		Name:    "Прибор",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	cat := &metadata.Entity{
+		Name: "СобытиеПрибора",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Прибор", Type: "reference:Прибор", RefEntity: "Прибор"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc, cat}); err != nil {
+		t.Fatal(err)
+	}
+
+	onPostSrc := `Процедура ОбработкаПроведения()
+  Соб = Справочники.СобытиеПрибора.Создать();
+  Соб.Прибор = ЭтотОбъект.Ссылка;
+  Соб.Записать();
+КонецПроцедуры`
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{doc, cat},
+		Programs: map[string]*ast.Program{"Прибор": mustParse(t, onPostSrc)},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{store: db, reg: registry, interp: interp, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	s.entitySvc = &entityservice.Service{
+		Store:        db,
+		Reg:          registry,
+		Interp:       interp,
+		PrepareHook:  s.enrichHeaderRefs,
+		EnrichTPRows: s.enrichTPRowsWithRefs,
+		BuildVars:    s.buildDSLVarsWithMessages,
+		MakeThis: func(ctx context.Context, obj *runtime.Object, e *metadata.Entity) interpreter.This {
+			return s.newFormObjectThis(ctx, obj, e, nil)
+		},
+	}
+	return ctx, db, s, doc, cat
+}
+
+// Регрессия issue #360: создание+проведение нового документа одним действием
+// (post/post_and_close на /new), чей ОбработкаПроведения создаёт связанный
+// объект со ссылкой обратно на сам документ. До фикса шапка документа
+// записывалась ПОСЛЕ хука, поэтому FK-ссылка «на себя» падала с
+// FOREIGN KEY constraint failed. Теперь шапка нового объекта пишется до хука.
+func TestSaveNewDocument_PostWithSelfReference(t *testing.T) {
+	ctx, db, s, doc, cat := newSelfRefPostingServer(t)
+
+	docID := uuid.New()
+	res, err := s.entitySvc.Save(ctx, entityservice.SaveRequest{
+		Entity: doc,
+		ID:     docID,
+		IsNew:  true,
+		Fields: map[string]any{"Номер": "П-001"},
+		Action: "post",
+	})
+	if err != nil {
+		t.Fatalf("Save вернул технический сбой: %v", err)
+	}
+	if res.DSLError != "" {
+		t.Fatalf("Save.DSLError = %q (ожидалось пусто) — FK-ссылка на себя при создании+проведении", res.DSLError)
+	}
+
+	// Документ существует и проведён.
+	row, err := db.GetByID(ctx, "Прибор", docID, doc)
+	if err != nil || row == nil {
+		t.Fatalf("документ не найден: %v", err)
+	}
+	if !asBool(row["posted"]) {
+		t.Errorf("документ не помечен проведённым: %v", row["posted"])
+	}
+
+	// Связанный объект создан и ссылается на документ.
+	events, err := db.List(ctx, "СобытиеПрибора", cat, storage.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("ожидался 1 СобытиеПрибора, создано %d", len(events))
+	}
+	if ref := refValueString(events[0]["Прибор"]); ref != docID.String() {
+		t.Errorf("СобытиеПрибора.Прибор = %q, ожидался %q", ref, docID.String())
+	}
+}
+
+// Неудачное бизнес-правило при создании+проведении не должно оставлять
+// документ-сироту: пред-запись шапки нового объекта откатывается.
+func TestSaveNewDocument_PostHookFailureLeavesNothing(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	doc := &metadata.Entity{
+		Name:    "Прибор",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+	onPostSrc := `Процедура ОбработкаПроведения()
+  ВызватьИсключение("нельзя проводить");
+КонецПроцедуры`
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{doc},
+		Programs: map[string]*ast.Program{"Прибор": mustParse(t, onPostSrc)},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{store: db, reg: registry, interp: interp, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	s.entitySvc = &entityservice.Service{
+		Store: db, Reg: registry, Interp: interp,
+		PrepareHook:  s.enrichHeaderRefs,
+		EnrichTPRows: s.enrichTPRowsWithRefs,
+		BuildVars:    s.buildDSLVarsWithMessages,
+		MakeThis: func(ctx context.Context, obj *runtime.Object, e *metadata.Entity) interpreter.This {
+			return s.newFormObjectThis(ctx, obj, e, nil)
+		},
+	}
+
+	docID := uuid.New()
+	res, err := s.entitySvc.Save(ctx, entityservice.SaveRequest{
+		Entity: doc, ID: docID, IsNew: true,
+		Fields: map[string]any{"Номер": "П-001"}, Action: "post",
+	})
+	if err != nil {
+		t.Fatalf("Save технический сбой: %v", err)
+	}
+	if res.DSLError == "" {
+		t.Fatal("ожидалась DSLError от ВызватьИсключение")
+	}
+	rows, err := db.List(ctx, "Прибор", doc, storage.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("документ-сирота не откачен: %d строк", len(rows))
+	}
+}


### PR DESCRIPTION
## Проблема (#360)

`entityservice.Service.Save` при `IsNew=true` и `Action=post`/`post_and_close` запускал хук `OnPost` (`ОбработкаПроведения`) **до** транзакции, которая пишет строку самого документа:

1. `Interp.Run(proc, …)` — исполняет `ОбработкаПроведения`;
2. только потом `WithTxIfNeeded { … Upsert(шапка) … }`.

Если хук создаёт связанный объект со ссылкой обратно на текущий документ (`reference:ЭтотДокумент` → `ЭтотОбъект.Ссылка`), его запись — идущая своей автокоммит-транзакцией мимо основной — падает с `FOREIGN KEY constraint failed`, потому что строки документа-родителя ещё нет в БД:

```
Соб = Справочники.СобытиеПрибора.Создать();
Соб.Прибор = ЭтотОбъект.Ссылка;   // reference:Прибор
Соб.Записать();                    // ← FOREIGN KEY constraint failed
```

Ломается штатный сценарий «открыл новый документ, заполнил, „Провести и закрыть“». Через «Записать», затем отдельным «Провести» — работает (строка уже закоммичена).

## Исправление

Для нового объекта (`IsNew`) строка-шапка упсертится **до** запуска хука, так что `this.Ссылка` указывает на реально существующую строку и запись связанных объектов со ссылкой на себя проходит. Для существующего объекта порядок не меняется — строка уже есть.

При ошибке бизнес-правила пред-запись откатывается (`Delete`), чтобы неудачное проведение не оставляло документ-сироту (best-effort: если хук успел создать ссылающиеся строки, удаление шапки не пройдёт по FK — тот же осиротевший результат, что и до фикса).

> Почему не «хук внутри транзакции»: хук исполняет произвольный DSL (в т.ч. HTTP/ИИ-вызовы), и держать БД-транзакцию открытой на всё его время нежелательно. Запись связанных объектов из DSL и так идёт автокоммитом — поэтому строка-родитель должна быть закоммичена до хука.

**Вторичное наблюдение** из issue (выполнение процедуры продолжается после ошибки builtin-вызова, оставляя частично применённые записи) — отдельная задача уровня интерпретатора, здесь сознательно не затрагивается.

## Тесты (`internal/ui/posting_new_document_test.go`)

- `TestSaveNewDocument_PostWithSelfReference` — создание+проведение нового документа, чей `ОбработкаПроведения` создаёт справочник со ссылкой на сам документ. **Без фикса падает** ровно с репортовой ошибкой `constraint failed: FOREIGN KEY constraint failed`; с фиксом — документ проведён, связанный объект создан и ссылается на документ.
- `TestSaveNewDocument_PostHookFailureLeavesNothing` — `ВызватьИсключение` в хуке нового документа не оставляет строку-сироту.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)