### PR TITLE
fix(ui): симметрия DSL и UI/REST при проведении документов (#366)

### DIFF
--- a/internal/ui/deletion_posting_test.go
+++ b/internal/ui/deletion_posting_test.go
@@ -299,3 +299,117 @@ func TestFormEdit_MarkedDoc_HidesPostShowsUnmark(t *testing.T) {
 		t.Errorf("карточка помеченного документа НЕ должна содержать кнопку «Провести» (value=\"post\"); тело:\n%s", body)
 	}
 }
+
+// Регрессия #366 (баг 1): DSL Документы.X.ОтменитьПроведение(Ссылка) должно
+// запускать ОбработкаУдаленияПроведения (OnUnpost) — симметрично UI-кнопке и
+// REST, которые идут через entityservice.Unpost. Ошибка хука откатывает и снятие
+// проведения, и очистку движений. До фикса DSL-отмена чистила движения и снимала
+// posted напрямую, молча пропуская хук отката (ошибки бы не было вовсе).
+func TestDocProxyUnpost_DSL_RunsOnUnpostHook(t *testing.T) {
+	ctx, db, s, dp, doc := newPostingDoc(t)
+	w := postOne(t, dp)
+
+	program := mustParse(t, `Процедура ОбработкаУдаленияПроведения()
+  ВызватьИсключение("отмена из DSL запрещена");
+КонецПроцедуры`)
+	s.reg.Load(runtime.LoadOptions{
+		Entities:  []*metadata.Entity{doc},
+		Registers: s.reg.Registers(),
+		Programs:  map[string]*ast.Program{doc.Name: program},
+	})
+
+	err := dp.unpostRef(w.obj.ID.String())
+	if err == nil || !strings.Contains(err.Error(), "отмена из DSL запрещена") {
+		t.Fatalf("ожидалась ошибка OnUnpost при DSL-отмене, получили %v", err)
+	}
+
+	// Ошибка хука откатила транзакцию: проведение и движения остались на месте.
+	row, err := db.GetByID(ctx, doc.Name, w.obj.ID, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !asBool(row["posted"]) {
+		t.Fatalf("ошибка OnUnpost не откатила posted: %#v", row)
+	}
+	var movements int
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&movements); err != nil {
+		t.Fatal(err)
+	}
+	if movements != 1 {
+		t.Fatalf("ошибка OnUnpost не откатила движения: осталось %d", movements)
+	}
+}
+
+// Регрессия #366 (баг 2): DSL Провести() должно персистить правки реквизитов
+// шапки, сделанные в ОбработкаПроведения (OnPost) — как entityservice.Save
+// (upsert после хука). До фикса post() не upsert'ил шапку после OnPost, поэтому
+// расчётные поля жили при проведении из UI/REST, но пропадали при DSL-проведении.
+func TestDocWriterPost_DSL_PersistsOnPostFieldEdits(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	doc := &metadata.Entity{
+		Name:    "РасходТоваров",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "СуммаДокумента", Type: metadata.FieldTypeNumber},
+		},
+		TableParts: []metadata.TablePart{{Name: "Товары", Fields: []metadata.Field{
+			{Name: "Номенклатура", Type: metadata.FieldTypeString},
+			{Name: "Сумма", Type: metadata.FieldTypeNumber},
+		}}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+
+	// OnPost вычисляет СуммаДокумента из строк ТЧ и пишет её в шапку this.
+	onPostSrc := `Процедура ОбработкаПроведения()
+  Итого = 0;
+  Для Каждого Стр Из ЭтотОбъект.Товары Цикл
+    Итого = Итого + Стр.Сумма;
+  КонецЦикла;
+  ЭтотОбъект.СуммаДокумента = Итого;
+КонецПроцедуры`
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{doc},
+		Programs: map[string]*ast.Program{doc.Name: mustParse(t, onPostSrc)},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{store: db, reg: registry, interp: interp, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+
+	dp := newDocsRoot(s, interpreter.NewTxState(ctx)).Get("РасходТоваров").(*docProxy)
+	w := dp.CallMethod("создать", nil).(*docWriter)
+	w.Set("Номер", "РАС-001")
+	tp := w.Get("Товары").(*tpProxy)
+	r1 := tp.CallMethod("добавить", nil).(*interpreter.MapThis)
+	r1.Set("Номенклатура", "Тумбочка")
+	r1.Set("Сумма", float64(300))
+	r2 := tp.CallMethod("добавить", nil).(*interpreter.MapThis)
+	r2.Set("Номенклатура", "Стол")
+	r2.Set("Сумма", float64(700))
+
+	w.CallMethod("провести", nil)
+
+	// СуммаДокумента, вычисленная в OnPost, должна оказаться в БД (300+700=1000).
+	var total float64
+	if err := db.QueryRow(ctx, "SELECT суммадокумента FROM расходтоваров LIMIT 1").Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if total != 1000 {
+		t.Fatalf("СуммаДокумента из OnPost не персистилась: в БД %v, ожидалось 1000", total)
+	}
+	var posted bool
+	db.QueryRow(ctx, "SELECT posted FROM расходтоваров LIMIT 1").Scan(&posted)
+	if !posted {
+		t.Error("документ должен быть проведён после Провести()")
+	}
+}

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -316,9 +316,12 @@ func (p *docProxy) DeleteRef(uuidStr string) error {
 	})
 }
 
-// unpostRef отменяет проведение документа: чистит движения по всем регистрам и
-// снимает posted (аналог UI-хендлера unpostDocument). Использует живой ctx (как
-// DeleteRef) — участвует в открытой DSL-транзакции, если она есть.
+// unpostRef отменяет проведение документа через entityservice.Unpost — тем же
+// путём, что UI-кнопка «Отменить проведение» и REST unpost: чистит движения,
+// снимает posted и запускает ОбработкаУдаленияПроведения (OnUnpost) в одной
+// транзакции (ошибка хука откатывает и движения, и признак проведения). Раньше
+// DSL чистил движения и снимал posted напрямую, молча пропуская хук отката.
+// WithTxIfNeeded внутри Unpost переиспользует открытую DSL-транзакцию, если она есть.
 func (p *docProxy) unpostRef(uuidStr string) error {
 	id, err := uuid.Parse(uuidStr)
 	if err != nil {
@@ -328,12 +331,14 @@ func (p *docProxy) unpostRef(uuidStr string) error {
 	if err := p.s.checkDSLRowAccess(ctx, p.entity, "unpost", id, nil); err != nil {
 		return err
 	}
-	if p.entity.Posting {
-		if err := p.s.clearMovements(ctx, p.entity.Name, id); err != nil {
-			return fmt.Errorf("очистка движений: %w", err)
-		}
+	result, err := p.s.entitySvc.Unpost(ctx, p.entity, id)
+	if err != nil {
+		return err
 	}
-	return p.s.store.SetPosted(ctx, p.entity.Name, id, false)
+	if result.DSLError != "" {
+		return fmt.Errorf("%s", result.DSLError)
+	}
+	return nil
 }
 
 // markRef помечает/снимает пометку на удаление (с авто-отменой проведения при
@@ -649,10 +654,20 @@ func (w *docWriter) post() error {
 	if errMsg, _ := w.s.runOnPostCtx(ctx, w.obj, mc); errMsg != "" {
 		return fmt.Errorf("%s", errMsg)
 	}
-	if err := w.s.saveMovements(ctx, w.entity.Name, w.obj.ID, mc); err != nil {
-		return err
-	}
-	return w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true)
+	// OnPost мог изменить реквизиты шапки (расчётные поля) — персистим их upsert'ом
+	// после хука, как это делает entityservice.Save при проведении. Без этого правки
+	// this в ОбработкаПроведения жили бы только в UI/REST, но пропадали при DSL
+	// Провести(). Upsert шапки + движения + признак проведения — одной транзакцией;
+	// повторную регистрацию обмена не делаем — её уже выполнил write() (иначе эхо).
+	return w.s.store.WithTxIfNeeded(ctx, func(ctx context.Context) error {
+		if err := w.s.store.Upsert(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
+			return err
+		}
+		if err := w.s.saveMovements(ctx, w.entity.Name, w.obj.ID, mc); err != nil {
+			return err
+		}
+		return w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true)
+	})
 }
 
 // ensureSelfRef устанавливает псевдо-реквизит «Ссылка» самого документа, чтобы


### PR DESCRIPTION
Закрывает #366.

Две несимметричности DSL-пути проведения документов против `entityservice` (пути UI/REST). Оба воспроизведены на v0.9.3.

## Баг 1 — `ОтменитьПроведение(Ссылка)` из DSL не запускал OnUnpost
`docProxy.unpostRef` чистил движения и снимал `posted` напрямую, минуя хук `ОбработкаУдаленияПроведения`. UI-кнопка «Отменить проведение» и `POST /api/v2/document/{name}/{id}/unpost` вызывают хук через `entityservice.Unpost`. Последствие: логика отката в OnUnpost, правящая другие объекты, молча пропускалась при отмене из обработки/теста.

**Фикс:** `unpostRef` теперь идёт через `entityservice.Unpost` — тем же путём, что UI/REST. Хук запускается в той же транзакции; его ошибка откатывает и снятие проведения, и очистку движений. `WithTxIfNeeded` внутри переиспользует открытую DSL-транзакцию.

## Баг 2 — `Провести()` из DSL терял правки шапки в OnPost
`docWriter.post` после `runOnPostCtx` не upsert'ил шапку, поэтому изменения реквизитов `this`, сделанные в `ОбработкаПроведения`, не сохранялись. `entityservice.Save` (action=post) upsert'ит шапку после хука. Последствие: расчётные поля, записанные в `this` при проведении, жили в бою (UI/REST), но пропадали в procrun-тесте через `Провести()` — расхождение теста и прода.

**Фикс:** `post()` upsert'ит шапку после OnPost (как `entityservice.Save`) — одной транзакцией с движениями и `SetPosted`. Повторной регистрации в планах обмена нет: её уже выполняет `write()` (иначе двойное эхо).

## Проверка
- Два регрессионных теста в `internal/ui/deletion_posting_test.go`: DSL-отмена запускает OnUnpost и его ошибка откатывает; поле, вычисленное в OnPost, персистится после DSL `Провести()`. Проверено, что оба **падают без фикса** и проходят с ним.
- `go test ./internal/ui/ ./internal/entityservice/` — зелёные.

Диф — 2 файла, движок не тронут; обе правки переиспользуют существующий эталон `entityservice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
