### PR TITLE
fix(security): close masking and widget cache bypasses

### DIFF
--- a/internal/access/field_access.go
+++ b/internal/access/field_access.go
@@ -135,15 +135,13 @@ func HasFieldPolicy(u *auth.User, kind, entity string, meta *metadata.Entity) bo
 	return len(FieldDecisions(u, kind, entity, meta)) > 0
 }
 
-// DeniedMaskedColumn is the fail-closed gate for reports/AI (план 88D). Until the
-// query compiler can mask projections in SQL (этап 88E), a non-admin query that
-// outputs a column masked or hidden for the user is refused: it returns the first
-// such output column, or "" if the projection is safe. Because it inspects the
-// executed result columns, unrelated reports over the same object (that do not
-// select the sensitive field) are not blocked. lookup resolves a source object's
-// metadata and may return nil.
+// DeniedMaskedColumn is the fail-closed gate for reports/AI (план 88D). cols are
+// logical source fields from query.Result.ProjectionFields, not SQL result column
+// names: aliases and expressions must not erase the protected-field provenance.
+// A wildcard is denied whenever at least one source field is masked or hidden.
+// lookup resolves a source object's metadata and may return nil.
 func DeniedMaskedColumn(u *auth.User, sources []query.SourceRef, cols []string, lookup func(kind, name string) *metadata.Entity) string {
-	if u == nil || u.IsAdmin {
+	if u == nil || (u.IsAdmin && !MaskAdmin()) {
 		return ""
 	}
 	masked := map[string]bool{}
@@ -160,6 +158,9 @@ func DeniedMaskedColumn(u *auth.User, sources []query.SourceRef, cols []string, 
 		return ""
 	}
 	for _, c := range cols {
+		if strings.TrimSpace(c) == "*" {
+			return c
+		}
 		if masked[strings.ToLower(strings.TrimSpace(c))] {
 			return c
 		}

--- a/internal/access/field_access_test.go
+++ b/internal/access/field_access_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ivantit66/onebase/internal/access"
 	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
 )
 
 func clientEntity() *metadata.Entity {
@@ -79,6 +80,35 @@ func TestFieldDecisions_NilUserAndAdmin(t *testing.T) {
 	d := access.FieldDecisions(admin, "catalog", "Клиент", meta)
 	if got, ok := d["Телефон"]; !ok || got.Strategy != access.FieldMaskTail {
 		t.Fatalf("mask_admin must subject admin to masking, got %v", d)
+	}
+}
+
+func TestDeniedMaskedColumn_ProjectionAndMaskAdmin(t *testing.T) {
+	meta := clientEntity()
+	u := &auth.User{Roles: []*auth.Role{
+		catRole([]string{"read"}, auth.FieldPolicies{"Телефон": {Read: "mask_all"}}),
+	}}
+	sources := []query.SourceRef{{Kind: "catalog", Name: "Клиент"}}
+	lookup := func(_, _ string) *metadata.Entity { return meta }
+
+	if got := access.DeniedMaskedColumn(u, sources, []string{"Телефон"}, lookup); got != "Телефон" {
+		t.Fatalf("protected projection got %q", got)
+	}
+	if got := access.DeniedMaskedColumn(u, sources, []string{"Наименование"}, lookup); got != "" {
+		t.Fatalf("safe projection denied as %q", got)
+	}
+	if got := access.DeniedMaskedColumn(u, sources, []string{"*"}, lookup); got != "*" {
+		t.Fatalf("wildcard must fail closed, got %q", got)
+	}
+
+	admin := &auth.User{IsAdmin: true, Roles: u.Roles}
+	if got := access.DeniedMaskedColumn(admin, sources, []string{"Телефон"}, lookup); got != "" {
+		t.Fatalf("unmasked admin denied as %q", got)
+	}
+	access.SetMaskAdmin(true)
+	defer access.SetMaskAdmin(false)
+	if got := access.DeniedMaskedColumn(admin, sources, []string{"Телефон"}, lookup); got != "Телефон" {
+		t.Fatalf("mask_admin projection got %q", got)
 	}
 }
 

--- a/internal/api/v2.go
+++ b/internal/api/v2.go
@@ -402,15 +402,13 @@ func (h *handler) runReportV2() http.HandlerFunc {
 			writeError(w, http.StatusForbidden, "forbidden source: "+denied, "", 0)
 			return
 		}
+		if denied := h.deniedMaskedColumn(r.Context(), compiled.Sources, compiled.ProjectionFields); denied != "" {
+			writeError(w, http.StatusForbidden, "masked field: "+denied, "", 0)
+			return
+		}
 		rows, cols, truncated, err := h.store.RunQueryLimit(r.Context(), compiled.SQL, compiled.Args, limit)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
-			return
-		}
-		// План 88D (fail-closed): отчёт non-admin с чувствительной колонкой в
-		// выводе не отдаётся, пока компилятор не маскирует проекцию (88E).
-		if denied := h.deniedMaskedColumn(r.Context(), compiled.Sources, cols); denied != "" {
-			writeError(w, http.StatusForbidden, "masked field: "+denied, "", 0)
 			return
 		}
 		if wantsReportComposition(r.URL.Query()) {

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -43,6 +43,12 @@ type Result struct {
 	// Имя — исходное имя сущности/регистра; Kind — секция прав ("catalog"|
 	// "document"|"register"|"inforeg"; "" — для неизвестных типов).
 	Sources []SourceRef
+	// ProjectionFields перечисляет логические поля, прочитанные выражениями
+	// SELECT до применения SQL-алиасов. Поле используется security-gate отчётов,
+	// AI и виджетов: сравнение с результирующими именами колонок позволяло
+	// обойти masking через `Телефон КАК Контакт` или функцию над полем.
+	// Значение "*" означает wildcard-проекцию.
+	ProjectionFields []string
 }
 
 // SourceRef — объект-источник запроса (для проверки прав доступа).
@@ -2167,10 +2173,124 @@ func preScanMainTable(tokens []tok) string {
 	return ""
 }
 
+// projectionFieldNames extracts identifiers used by SELECT expressions before
+// aliases are applied. It deliberately errs on the safe side: qualifiers and
+// otherwise harmless identifiers may be included, but an underlying field must
+// never be omitted merely because it is wrapped in an expression or renamed.
+func projectionFieldNames(tokens []tok) []string {
+	type selectFrame struct {
+		depth  int
+		active bool
+	}
+	var frames []selectFrame
+	depth := 0
+	seen := map[string]bool{}
+	var out []string
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		key := strings.ToLower(name)
+		if name == "" || seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, name)
+	}
+	projectionActive := func() bool {
+		for i := len(frames) - 1; i >= 0; i-- {
+			if frames[i].active {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i, t := range tokens {
+		switch t.kind {
+		case tLParen:
+			depth++
+			continue
+		case tRParen:
+			for len(frames) > 0 && frames[len(frames)-1].depth >= depth {
+				frames = frames[:len(frames)-1]
+			}
+			if depth > 0 {
+				depth--
+			}
+			continue
+		}
+		if t.kind == tIdent {
+			kw, isKW := sqlKW(t.val)
+			switch kw {
+			case "SELECT":
+				frames = append(frames, selectFrame{depth: depth, active: true})
+				continue
+			case "FROM":
+				for j := len(frames) - 1; j >= 0; j-- {
+					if frames[j].depth == depth && frames[j].active {
+						frames[j].active = false
+						break
+					}
+				}
+				continue
+			}
+			if !projectionActive() || isKW {
+				continue
+			}
+			if i > 0 && tokens[i-1].kind == tIdent {
+				prev := strings.ToUpper(tokens[i-1].val)
+				if prev == "КАК" || prev == "AS" {
+					continue // output alias, not a source field
+				}
+			}
+			if i+1 < len(tokens) && tokens[i+1].kind == tLParen {
+				continue // function name; its arguments are inspected separately
+			}
+			add(t.val)
+			continue
+		}
+		if t.kind == tStar && projectionActive() {
+			add("*")
+		}
+	}
+	return out
+}
+
+func expandReferenceProjection(fields []string, dims []refDimInfo) []string {
+	out := append([]string(nil), fields...)
+	contains := func(name string) bool {
+		for _, field := range fields {
+			if strings.EqualFold(field, name) {
+				return true
+			}
+		}
+		return false
+	}
+	appendUnique := func(name string) {
+		for _, field := range out {
+			if strings.EqualFold(field, name) {
+				return
+			}
+		}
+		out = append(out, name)
+	}
+	for _, dim := range dims {
+		if !contains(dim.fieldName) {
+			continue
+		}
+		if dim.refIsDoc {
+			appendUnique("Номер")
+		} else {
+			appendUnique("Наименование")
+		}
+	}
+	return out
+}
+
 func translate(tokens []tok, opts CompileOpts) (Result, error) {
 	if opts.Params == nil {
 		opts.Params = map[string]any{}
 	}
+	projectionFields := projectionFieldNames(tokens)
 	// расширяем НачалоДня/Год/Месяц/ОКР/АБС/ЦЕЛ/... в SQL-эквиваленты
 	// до основной трансляции, чтобы остальные шаги ничего не знали о них.
 	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect))
@@ -2536,7 +2656,12 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 	if err := tr.assertRowFiltersApplied(); err != nil {
 		return Result{}, err
 	}
-	return Result{SQL: tr.build(), Args: tr.args, Sources: tr.sources}, nil
+	return Result{
+		SQL:              tr.build(),
+		Args:             tr.args,
+		Sources:          tr.sources,
+		ProjectionFields: expandReferenceProjection(projectionFields, tr.refDims),
+	}, nil
 }
 
 // dialectName возвращает строковое имя диалекта SQL для opts.Dialect; nil → "pg"

--- a/internal/query/sources_test.go
+++ b/internal/query/sources_test.go
@@ -1,6 +1,7 @@
 package query_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ivantit66/onebase/internal/metadata"
@@ -123,5 +124,53 @@ func TestCompile_Sources_RefDimToDocument(t *testing.T) {
 	}
 	if !hasSource(res.Sources, "document", "Заказ") {
 		t.Fatalf("связанный документ Заказ должен попасть в Sources как document, среди %+v", res.Sources)
+	}
+}
+
+func TestCompile_ProjectionFieldsPreserveProvenance(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "Клиент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Телефон", Type: metadata.FieldTypeString},
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+		},
+	}
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{"alias", `ВЫБРАТЬ К.Телефон КАК Контакт ИЗ Справочник.Клиент КАК К`, []string{"Телефон"}},
+		{"expression", `ВЫБРАТЬ Строка(Телефон) КАК Контакт ИЗ Справочник.Клиент`, []string{"Телефон"}},
+		{"wildcard", `ВЫБРАТЬ * ИЗ Справочник.Клиент`, []string{"*"}},
+		{"where is not projection", `ВЫБРАТЬ Наименование ИЗ Справочник.Клиент ГДЕ Телефон <> ""`, []string{"Наименование"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := query.Compile(tc.text, query.CompileOpts{Entities: []*metadata.Entity{entity}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tc.want {
+				found := false
+				for _, got := range res.ProjectionFields {
+					if strings.EqualFold(got, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("projection %v does not contain %q", res.ProjectionFields, want)
+				}
+			}
+			if tc.name == "where is not projection" {
+				for _, got := range res.ProjectionFields {
+					if strings.EqualFold(got, "Телефон") {
+						t.Fatalf("WHERE-only field leaked into projection: %v", res.ProjectionFields)
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -777,6 +777,7 @@ func (s *Server) adminUserRolesUpdate(w http.ResponseWriter, r *http.Request) {
 			s.authRepo.UnassignRole(r.Context(), userID, role.ID)
 		}
 	}
+	s.InvalidateWidgetCache()
 	http.Redirect(w, r, "/ui/admin/users", http.StatusFound)
 }
 

--- a/internal/ui/ai_actions.go
+++ b/internal/ui/ai_actions.go
@@ -142,6 +142,10 @@ func (s *Server) aiRefDisplay(ctx context.Context, entity *metadata.Entity, id u
 	if err != nil || !s.rowAllowsSelected(ctx, entity, row) {
 		return "", false
 	}
+	// Подпись ссылки уходит в tool result и затем модели, поэтому к ней применимы
+	// те же field policies, что к карточке и REST. Hidden lookup исчезнет из row,
+	// masked lookup вернётся только в замаскированном виде.
+	s.maskRecord(ctx, entity, row)
 	field := aiRefLookupField(entity)
 	if field == "" {
 		return id.String(), true
@@ -235,6 +239,11 @@ func (s *Server) aiNormalizeValue(ctx context.Context, f metadata.Field, raw any
 		lookup := aiRefLookupField(refEntity)
 		if lookup == "" {
 			return nil, "", fmt.Errorf("поле %s: у %s нет строкового реквизита для поиска по имени — передай UUID", f.Name, refEntity.Name)
+		}
+		for protected := range s.fieldDecisions(ctx, refEntity) {
+			if strings.EqualFold(protected, lookup) {
+				return nil, "", fmt.Errorf("поле %s: поиск %s по защищённому полю %s запрещён — передай UUID", f.Name, refEntity.Name, lookup)
+			}
 		}
 		id, display, count, err := s.store.MatchCatalogByField(ctx, refEntity, lookup, str)
 		if err != nil {

--- a/internal/ui/ai_actions_test.go
+++ b/internal/ui/ai_actions_test.go
@@ -148,6 +148,35 @@ func TestAIActions_StageCreate_Errors(t *testing.T) {
 	}
 }
 
+func TestAIActions_ReferenceLabelsHonorFieldMasking(t *testing.T) {
+	ents := aiActionsEntities()
+	s, ctx := newSubmitTestServer(t, ents)
+	contraID := uuid.New()
+	if err := s.store.Upsert(ctx, "Контрагенты", contraID, map[string]any{"Наименование": "Ромашка"}, ents[0]); err != nil {
+		t.Fatal(err)
+	}
+	user := &auth.User{Login: "masked", Roles: []*auth.Role{{Permissions: auth.Permission{
+		Catalogs: map[string][]string{"Контрагенты": {"read"}},
+		FieldAccess: auth.FieldAccess{Catalogs: map[string]auth.FieldPolicies{
+			"Контрагенты": {"Наименование": {Read: "mask_all"}},
+		}},
+	}}}}
+	userCtx := auth.ContextWithUser(ctx, user)
+
+	display, ok := s.aiRefDisplay(userCtx, ents[0], contraID)
+	if !ok || display != "••••••" {
+		t.Fatalf("masked reference display = %q, %v", display, ok)
+	}
+	refField := ents[1].Fields[2]
+	if _, _, err := s.aiNormalizeValue(userCtx, refField, "Ромашка"); err == nil || !strings.Contains(err.Error(), "защищённому полю") {
+		t.Fatalf("name lookup over protected field must fail closed, got %v", err)
+	}
+	value, label, err := s.aiNormalizeValue(userCtx, refField, contraID.String())
+	if err != nil || fmt.Sprint(value) != contraID.String() || label != "••••••" {
+		t.Fatalf("UUID lookup must return masked label: value=%v label=%q err=%v", value, label, err)
+	}
+}
+
 func TestAIActionRun_CreatesDraft(t *testing.T) {
 	ents := aiActionsEntities()
 	s, ctx := newSubmitTestServer(t, ents)

--- a/internal/ui/ai_tools.go
+++ b/internal/ui/ai_tools.go
@@ -187,14 +187,12 @@ func (s *Server) aiRunQuery(ctx context.Context, call llm.ToolCall) llm.ToolResu
 			return llm.ToolResult{ID: call.ID, Content: "нет доступа к объекту: " + denied, IsError: true}
 		}
 	}
+	if denied := s.deniedMaskedColumn(ctx, res.Sources, res.ProjectionFields); denied != "" {
+		return llm.ToolResult{ID: call.ID, Content: "нет доступа к защищённому полю: " + denied, IsError: true}
+	}
 	rows, err := s.store.QueryAll(ctx, res.SQL, res.Args...)
 	if err != nil {
 		return llm.ToolResult{ID: call.ID, Content: "ошибка выполнения: " + err.Error(), IsError: true}
-	}
-	// План 88D (fail-closed): модель не получает чувствительное поле через запрос,
-	// пока компилятор не маскирует проекцию в SQL.
-	if denied := s.deniedMaskedColumn(ctx, res.Sources, queryColumns(rows)); denied != "" {
-		return llm.ToolResult{ID: call.ID, Content: "нет доступа к защищённому полю: " + denied, IsError: true}
 	}
 	truncated := false
 	if len(rows) > aiQueryRowLimit {

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -66,6 +66,10 @@ func (s *Server) queryConsoleExec(w http.ResponseWriter, r *http.Request) {
 		jsonResp(w, 200, map[string]any{"error": "Ошибка запроса: " + err.Error()})
 		return
 	}
+	if denied := s.deniedMaskedColumn(r.Context(), res.Sources, res.ProjectionFields); denied != "" {
+		jsonResp(w, http.StatusForbidden, map[string]any{"error": "Нет доступа к защищённому полю: " + denied})
+		return
+	}
 
 	start := time.Now()
 	rows, err := s.store.QueryAll(r.Context(), res.SQL, res.Args...)

--- a/internal/ui/field_access.go
+++ b/internal/ui/field_access.go
@@ -41,8 +41,8 @@ func (s *Server) fieldMaskRestricted(ctx context.Context, entity *metadata.Entit
 	return len(s.fieldDecisions(ctx, entity)) > 0
 }
 
-// deniedMaskedColumn is the fail-closed report/AI gate (план 88D): returns a
-// masked output column the user may not receive via a query, or "".
+// deniedMaskedColumn is the fail-closed report/AI gate (план 88D): cols are
+// logical fields from query.Result.ProjectionFields, before output aliases.
 func (s *Server) deniedMaskedColumn(ctx context.Context, sources []query.SourceRef, cols []string) string {
 	return access.DeniedMaskedColumn(auth.UserFromContext(ctx), sources, cols, s.sourceMeta)
 }
@@ -63,22 +63,6 @@ func (s *Server) sourceMeta(kind, name string) *metadata.Entity {
 		return storage.AccountRegisterPredicateEntity(ar)
 	}
 	return nil
-}
-
-// queryColumns returns the union of column names across result rows (для AI-пути,
-// где QueryAll не отдаёт список колонок отдельно).
-func queryColumns(rows []map[string]any) []string {
-	seen := map[string]bool{}
-	var cols []string
-	for _, row := range rows {
-		for k := range row {
-			if !seen[k] {
-				seen[k] = true
-				cols = append(cols, k)
-			}
-		}
-	}
-	return cols
 }
 
 // protectMaskedFieldsOnWrite restores the real stored value for any field masked

--- a/internal/ui/field_access_test.go
+++ b/internal/ui/field_access_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,34 @@ func uiMaskUser(ops []string, fields auth.FieldPolicies) *auth.User {
 				FieldAccess: auth.FieldAccess{Catalogs: map[string]auth.FieldPolicies{"Клиент": fields}},
 			},
 		}},
+	}
+}
+
+func TestUI_QueryProjectionMaskGateRejectsAliasAndExpression(t *testing.T) {
+	cat := uiClientEntity()
+	s, _ := newSubmitTestServer(t, []*metadata.Entity{cat})
+	user := uiMaskUser([]string{"read"}, auth.FieldPolicies{"Телефон": {Read: "mask_all"}})
+	ctx := auth.ContextWithUser(context.Background(), user)
+
+	for _, text := range []string{
+		`ВЫБРАТЬ Телефон КАК Контакт ИЗ Справочник.Клиент`,
+		`ВЫБРАТЬ Строка(Телефон) КАК Контакт ИЗ Справочник.Клиент`,
+		`ВЫБРАТЬ * ИЗ Справочник.Клиент`,
+	} {
+		compiled, err := s.compileQueryWithRowAccess(ctx, text, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if denied := s.deniedMaskedColumn(ctx, compiled.Sources, compiled.ProjectionFields); denied == "" {
+			t.Fatalf("masked projection was allowed: %s (%v)", text, compiled.ProjectionFields)
+		}
+	}
+	compiled, err := s.compileQueryWithRowAccess(ctx, `ВЫБРАТЬ Наименование ИЗ Справочник.Клиент ГДЕ Телефон <> ""`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if denied := s.deniedMaskedColumn(ctx, compiled.Sources, compiled.ProjectionFields); denied != "" {
+		t.Fatalf("safe output projection denied as %q", denied)
 	}
 }
 

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -178,6 +178,24 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 		s.renderForbidden(w, r)
 		return
 	}
+	// Проверяем логические поля проекции ДО выполнения SQL. Имена результирующих
+	// колонок уже могут быть заменены КАК/AS и не годятся как security provenance.
+	if denied := s.deniedMaskedColumn(opCtx, compiled.Sources, compiled.ProjectionFields); denied != "" {
+		opStatus = "error"
+		s.render(w, r, "page-report", map[string]any{
+			"Report":             rep,
+			"QueryError":         s.tr(s.resolveLang(r), "Отчёт содержит защищённое поле и не может быть построен под текущей ролью") + ": " + denied,
+			"ParamValues":        paramValues,
+			"ReportParams":       reportParams,
+			"ActiveVariant":      variant,
+			"UserSettings":       settings,
+			"ReportSettingsJSON": settingsJSON,
+			"ReportPresets":      presets,
+			"ActivePresetID":     rs.ActivePresetID,
+			"ActivePreset":       activePreset,
+		})
+		return
+	}
 	opAttrs = []slog.Attr{slog.String("sql_hash", sqlHash(compiled.SQL))}
 	rows, cols, truncated, err := s.store.RunQueryLimit(opCtx, compiled.SQL, compiled.Args, s.cfg.Limits.ReportMaxRows)
 	opTruncated = truncated
@@ -191,24 +209,6 @@ func (s *Server) runReport(w http.ResponseWriter, r *http.Request, rep *reportpk
 		s.render(w, r, "page-report", map[string]any{
 			"Report":             rep,
 			"QueryError":         err.Error(),
-			"ParamValues":        paramValues,
-			"ReportParams":       reportParams,
-			"ActiveVariant":      variant,
-			"UserSettings":       settings,
-			"ReportSettingsJSON": settingsJSON,
-			"ReportPresets":      presets,
-			"ActivePresetID":     rs.ActivePresetID,
-			"ActivePreset":       activePreset,
-		})
-		return
-	}
-	// План 88D (fail-closed): пока query-компилятор не маскирует проекцию в SQL,
-	// отчёт non-admin с чувствительной колонкой в выводе не отдаётся.
-	if denied := s.deniedMaskedColumn(opCtx, compiled.Sources, cols); denied != "" {
-		opStatus = "error"
-		s.render(w, r, "page-report", map[string]any{
-			"Report":             rep,
-			"QueryError":         s.tr(s.resolveLang(r), "Отчёт содержит защищённое поле и не может быть построен под текущей ролью") + ": " + denied,
 			"ParamValues":        paramValues,
 			"ReportParams":       reportParams,
 			"ActiveVariant":      variant,
@@ -581,6 +581,9 @@ func (s *Server) reportExportRowsWithContext(ctx context.Context, r *http.Reques
 	if denied := s.deniedQuerySource(ctx, compiled.Sources); denied != "" {
 		return nil, nil, newReportExportError(http.StatusForbidden, "source access", fmt.Errorf("нет доступа к объекту: %s", denied))
 	}
+	if denied := s.deniedMaskedColumn(ctx, compiled.Sources, compiled.ProjectionFields); denied != "" {
+		return nil, nil, newReportExportError(http.StatusForbidden, "masked field", fmt.Errorf("отчёт содержит защищённое поле: %s", denied))
+	}
 	if stats != nil {
 		stats.attrs = []slog.Attr{slog.String("sql_hash", sqlHash(compiled.SQL))}
 	}
@@ -594,10 +597,6 @@ func (s *Server) reportExportRowsWithContext(ctx context.Context, r *http.Reques
 	}
 	if truncated {
 		return nil, nil, newReportExportError(http.StatusRequestEntityTooLarge, "export limit", fmt.Errorf("результат выгрузки превышает export_max_rows"))
-	}
-	// План 88D (fail-closed): выгрузка отчёта с чувствительной колонкой запрещена.
-	if denied := s.deniedMaskedColumn(ctx, compiled.Sources, cols); denied != "" {
-		return nil, nil, newReportExportError(http.StatusForbidden, "masked field", fmt.Errorf("отчёт содержит защищённое поле: %s", denied))
 	}
 	detailLinkCol := ""
 	if comp != nil {

--- a/internal/widget/cache.go
+++ b/internal/widget/cache.go
@@ -1,8 +1,14 @@
 package widget
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"sync"
 	"time"
+
+	"github.com/ivantit66/onebase/internal/access"
+	"github.com/ivantit66/onebase/internal/auth"
 )
 
 // Cache stores widget execution results for a fixed TTL. Dashboard requests
@@ -73,6 +79,30 @@ func (c *Cache) Invalidate() {
 	c.mu.Unlock()
 }
 
-func cacheKey(widgetName, user string) string {
-	return widgetName + "\x00" + user
+func cacheKey(widgetName, user, security string) string {
+	return widgetName + "\x00" + user + "\x00" + security
+}
+
+// securityFingerprint makes cached output follow the complete authorization
+// state, not merely a login. Role/row/field-policy changes therefore produce a
+// cache miss immediately. Unsupported host attributes disable caching rather
+// than risking reuse under an incomplete fingerprint.
+func securityFingerprint(user *auth.User) (string, bool) {
+	payload := struct {
+		IsAdmin   bool
+		Attrs     map[string]any
+		Roles     []*auth.Role
+		MaskAdmin bool
+	}{MaskAdmin: access.MaskAdmin()}
+	if user != nil {
+		payload.IsAdmin = user.IsAdmin
+		payload.Attrs = user.Attrs
+		payload.Roles = user.Roles
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", false
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), true
 }

--- a/internal/widget/cache_test.go
+++ b/internal/widget/cache_test.go
@@ -3,6 +3,9 @@ package widget
 import (
 	"testing"
 	"time"
+
+	"github.com/ivantit66/onebase/internal/access"
+	"github.com/ivantit66/onebase/internal/auth"
 )
 
 func TestCache_GetPut(t *testing.T) {
@@ -49,10 +52,36 @@ func TestCache_NilSafe(t *testing.T) {
 }
 
 func TestCacheKey(t *testing.T) {
-	if cacheKey("A", "u1") == cacheKey("A", "u2") {
+	if cacheKey("A", "u1", "s") == cacheKey("A", "u2", "s") {
 		t.Fatal("different users must produce different keys")
 	}
-	if cacheKey("A", "u1") != cacheKey("A", "u1") {
+	if cacheKey("A", "u1", "s") != cacheKey("A", "u1", "s") {
 		t.Fatal("same inputs must produce same key")
+	}
+}
+
+func TestSecurityFingerprintChangesWithPermissions(t *testing.T) {
+	user := &auth.User{Login: "u", Roles: []*auth.Role{{Name: "reader", Permissions: auth.Permission{
+		Catalogs: map[string][]string{"Товар": {"read"}},
+	}}}}
+	one, ok := securityFingerprint(user)
+	if !ok {
+		t.Fatal("ordinary auth state must be cacheable")
+	}
+	user.Roles[0].Permissions.Catalogs["Товар"] = []string{"read", "write"}
+	two, ok := securityFingerprint(user)
+	if !ok || one == two {
+		t.Fatal("permission change must alter fingerprint")
+	}
+	access.SetMaskAdmin(true)
+	defer access.SetMaskAdmin(false)
+	three, ok := securityFingerprint(user)
+	if !ok || two == three {
+		t.Fatal("mask_admin change must alter fingerprint")
+	}
+
+	user.Attrs = map[string]any{"unsupported": make(chan int)}
+	if _, ok := securityFingerprint(user); ok {
+		t.Fatal("unsupported attributes must disable caching")
 	}
 }

--- a/internal/widget/runner.go
+++ b/internal/widget/runner.go
@@ -140,7 +140,7 @@ type Runner struct {
 	Store       *storage.DB
 	CurrentUser string // login of the user looking at the dashboard (for recent.scope=current_user)
 	User        *auth.User
-	Cache       *Cache // optional — when set, results are cached by widget name + user
+	Cache       *Cache // optional — key includes widget, user and authorization fingerprint
 }
 
 // New creates a Runner. The Resolve hook is optional — when non-nil it is
@@ -156,7 +156,11 @@ func New(reg *runtime.Registry, store *storage.DB) *Runner {
 // "actions" widget type is purely declarative so it skips the cache.
 func (r *Runner) Run(ctx context.Context, w *metadata.Widget) Result {
 	if r.Cache != nil && w.Type != metadata.WidgetTypeActions {
-		key := cacheKey(w.Name, r.CurrentUser)
+		security, cacheable := securityFingerprint(r.User)
+		if !cacheable {
+			return r.runOnce(ctx, w)
+		}
+		key := cacheKey(w.Name, r.CurrentUser, security)
 		if cached, ok := r.Cache.get(key); ok {
 			return cached
 		}
@@ -483,14 +487,12 @@ func (r *Runner) runQuery(ctx context.Context, w *metadata.Widget) ([]map[string
 	if denied := r.deniedQuerySource(compiled.Sources); denied != "" {
 		return nil, nil, &accessDeniedError{object: denied}
 	}
+	if denied := access.DeniedMaskedColumn(r.User, compiled.Sources, compiled.ProjectionFields, r.sourceMeta); denied != "" {
+		return nil, nil, &accessDeniedError{object: "поле «" + denied + "»"}
+	}
 	rows, cols, err := r.Store.RunQuery(ctx, compiled.SQL, compiled.Args)
 	if err != nil {
 		return rows, cols, err
-	}
-	// План 88D (fail-closed): виджет non-admin с чувствительной колонкой в выводе
-	// не строится, пока компилятор не маскирует проекцию в SQL (88E).
-	if denied := access.DeniedMaskedColumn(r.User, compiled.Sources, cols, r.sourceMeta); denied != "" {
-		return nil, nil, &accessDeniedError{object: "поле «" + denied + "»"}
 	}
 	return rows, cols, nil
 }
@@ -515,7 +517,9 @@ func (r *Runner) sourceMeta(kind, name string) *metadata.Entity {
 // setResultError переводит его в Result.AccessDenied.
 type accessDeniedError struct{ object string }
 
-func (e *accessDeniedError) Error() string { return "нет доступа к объекту: " + e.object }
+func (e *accessDeniedError) Error() string {
+	return "нет доступа к объекту: " + e.object
+}
 
 // setResultError записывает ошибку в Result, помечая отказ в доступе.
 func setResultError(res *Result, err error) {


### PR DESCRIPTION
## Что исправлено
- контроль маскирования проверяет исходные поля проекции до алиасов и выражений;
- закрыты обходы через `*`, aliases, REST/API, отчёты, AI tools и widget queries;
- отображение ссылок в AI также проходит field masking;
- cache key виджетов учитывает роли, атрибуты, admin/mask-admin и сбрасывается при изменении ролей.

## Проверка
- `go test ./...`
- `go vet ./...`
- targeted race tests выполнены перед публикацией