### PR TITLE
fix(exchange): preserve versions and validate hub peers

### DIFF
--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -655,10 +655,9 @@ func (w *docWriter) post() error {
 		return fmt.Errorf("%s", errMsg)
 	}
 	// OnPost мог изменить реквизиты шапки (расчётные поля) — персистим их upsert'ом
-	// после хука, как это делает entityservice.Save при проведении. Без этого правки
-	// this в ОбработкаПроведения жили бы только в UI/REST, но пропадали при DSL
-	// Провести(). Upsert шапки + движения + признак проведения — одной транзакцией;
-	// повторную регистрацию обмена не делаем — её уже выполнил write() (иначе эхо).
+	// после хука, как это делает entityservice.Save при проведении. Финальный Upsert
+	// повышает _version, поэтому очередь обмена обязательно перерегистрируется в
+	// этой же транзакции: RegisterExchangeChange — idempotent upsert, это не эхо.
 	return w.s.store.WithTxIfNeeded(ctx, func(ctx context.Context) error {
 		if err := w.s.store.Upsert(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
 			return err
@@ -666,7 +665,10 @@ func (w *docWriter) post() error {
 		if err := w.s.saveMovements(ctx, w.entity.Name, w.obj.ID, mc); err != nil {
 			return err
 		}
-		return w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true)
+		if err := w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true); err != nil {
+			return err
+		}
+		return exchange.RegisterOnSave(ctx, w.s.store, w.s.reg.ExchangePlans(), w.entity, w.obj.ID, false)
 	})
 }
 

--- a/internal/ui/dsl_documents_test.go
+++ b/internal/ui/dsl_documents_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
 	"github.com/ivantit66/onebase/internal/dsl/lexer"
 	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/exchange"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
@@ -56,6 +57,17 @@ func TestDocsRoot_CreateWritePost(t *testing.T) {
 	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
 		t.Fatal(err)
 	}
+	if err := db.EnsureExchangeSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	plan := &metadata.ExchangePlan{
+		Name: "Документы", Content: []string{"Документ.ПоступлениеТоваров"},
+		Nodes: []metadata.ExchangeNode{{Code: "center"}, {Code: "fil01"}},
+	}
+	plan.Normalize()
+	if err := db.SaveExchangeThisNode(ctx, plan.Name, "center"); err != nil {
+		t.Fatal(err)
+	}
 
 	// OnPost: пишем приход в регистр по строкам ТЧ.
 	onPostSrc := `Процедура ОбработкаПроведения()
@@ -74,6 +86,7 @@ func TestDocsRoot_CreateWritePost(t *testing.T) {
 		Programs:  map[string]*ast.Program{"ПоступлениеТоваров": prog},
 		Registers: []*metadata.Register{reg},
 	})
+	registry.LoadExchangePlans([]*metadata.ExchangePlan{plan})
 
 	interp := interpreter.New()
 	interp.LookupProc = registry.GetModuleProc
@@ -148,6 +161,31 @@ func TestDocsRoot_CreateWritePost(t *testing.T) {
 	db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted)
 	if !posted {
 		t.Error("документ не помечен проведённым")
+	}
+
+	// Финальный Upsert после OnPost повышает версию. Очередь должна содержать
+	// именно её, иначе BuildPackage пропустит документ как stale change.
+	version, err := db.EntityVersion(ctx, doc.Name, w.obj.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changes, err := db.PendingExchangeChanges(ctx, plan.Name, "fil01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 || changes[0].Version != version {
+		t.Fatalf("очередь=%+v, финальная версия=%d", changes, version)
+	}
+	data, err := exchange.BuildPackage(ctx, db, registry, plan, "fil01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, err := exchange.ParsePackage(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkg.Objects) != 1 || !pkg.Objects[0].Posted || pkg.Objects[0].Version != version {
+		t.Fatalf("DSL-проведение не попало в пакет: %+v", pkg.Objects)
 	}
 }
 

--- a/internal/ui/exchange_http.go
+++ b/internal/ui/exchange_http.go
@@ -69,11 +69,7 @@ func (s *Server) exchangeAuthedPlan(w http.ResponseWriter, r *http.Request) *met
 	return plan
 }
 
-func (s *Server) exchangePair(w http.ResponseWriter, r *http.Request, plan *metadata.ExchangePlan) (thisNode, peerNode string, ok bool) {
-	if len(plan.Nodes) != 2 {
-		http.Error(w, "онлайн-обмен поддерживает только планы из двух узлов", http.StatusConflict)
-		return "", "", false
-	}
+func (s *Server) exchangePair(w http.ResponseWriter, r *http.Request, plan *metadata.ExchangePlan, requestedPeer string) (thisNode, peerNode string, ok bool) {
 	thisNode, err := s.store.GetExchangeThisNode(r.Context(), plan.Name)
 	if err != nil {
 		http.Error(w, "не удалось прочитать текущий узел", http.StatusInternalServerError)
@@ -85,13 +81,27 @@ func (s *Server) exchangePair(w http.ResponseWriter, r *http.Request, plan *meta
 		return "", "", false
 	}
 	thisNode = thisDef.Code
-	for _, node := range plan.Nodes {
-		if !strings.EqualFold(node.Code, thisNode) {
-			return thisNode, node.Code, true
-		}
+	peerDef := plan.Node(strings.TrimSpace(requestedPeer))
+	if peerDef == nil || strings.EqualFold(peerDef.Code, thisNode) {
+		http.Error(w, "узел-партнёр не найден или совпадает с текущим", http.StatusForbidden)
+		return "", "", false
 	}
-	http.Error(w, "партнёр плана не найден", http.StatusConflict)
-	return "", "", false
+	// Допустимо только ребро топологии. Для пары/плоского плана это любой другой
+	// узел; для звезды — только hub↔spoke. Проверяем обе стороны, чтобы helper
+	// оставался корректным при будущей направленной топологии.
+	allowed := func(from, to string) bool {
+		for _, target := range plan.RegistrationTargets(from) {
+			if strings.EqualFold(target, to) {
+				return true
+			}
+		}
+		return false
+	}
+	if !allowed(thisNode, peerDef.Code) || !allowed(peerDef.Code, thisNode) {
+		http.Error(w, "обмен между указанными узлами запрещён топологией плана", http.StatusForbidden)
+		return "", "", false
+	}
+	return thisNode, peerDef.Code, true
 }
 
 func (s *Server) exchangePush(w http.ResponseWriter, r *http.Request) {
@@ -109,13 +119,13 @@ func (s *Server) exchangePush(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "тело пакета: "+err.Error(), status)
 		return
 	}
-	thisNode, peerNode, ok := s.exchangePair(w, r, plan)
-	if !ok {
-		return
-	}
 	pkg, err := exchange.ParsePackage(body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	thisNode, peerNode, ok := s.exchangePair(w, r, plan, pkg.FromNode)
+	if !ok {
 		return
 	}
 	if !strings.EqualFold(pkg.FromNode, peerNode) || !strings.EqualFold(pkg.ToNode, thisNode) {
@@ -136,16 +146,12 @@ func (s *Server) exchangePull(w http.ResponseWriter, r *http.Request) {
 	if plan == nil {
 		return
 	}
-	_, peerNode, ok := s.exchangePair(w, r, plan)
+	toNode := strings.TrimSpace(r.URL.Query().Get("to"))
+	_, peerNode, ok := s.exchangePair(w, r, plan, toNode)
 	if !ok {
 		return
 	}
-	toNode := strings.TrimSpace(r.URL.Query().Get("to"))
-	if toNode == "" || !strings.EqualFold(toNode, peerNode) {
-		http.Error(w, "пакет можно получить только для узла-партнёра", http.StatusForbidden)
-		return
-	}
-	data, err := exchange.BuildPackage(r.Context(), s.store, s.reg, plan, toNode)
+	data, err := exchange.BuildPackage(r.Context(), s.store, s.reg, plan, peerNode)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/ui/exchange_http_test.go
+++ b/internal/ui/exchange_http_test.go
@@ -33,6 +33,19 @@ func exchPlan() *metadata.ExchangePlan {
 	return p
 }
 
+func exchHubPlan() *metadata.ExchangePlan {
+	p := &metadata.ExchangePlan{
+		Name: "Обмен", Content: []string{"Справочник.Товар"},
+		Nodes: []metadata.ExchangeNode{
+			{Code: "center", Role: metadata.RoleHub},
+			{Code: "fil01", Role: metadata.RoleSpoke},
+			{Code: "fil02", Role: metadata.RoleSpoke},
+		},
+	}
+	p.Normalize()
+	return p
+}
+
 func newExchangeBaseDB(t *testing.T) (*storage.DB, *runtime.Registry, context.Context, *metadata.Entity) {
 	t.Helper()
 	ctx := context.Background()
@@ -128,4 +141,35 @@ func TestExchangeHTTPPushPull(t *testing.T) {
 	if _, err := exchange.PushPackage(ctx, ts.URL, "Обмен", "s3cret", forgedData); err == nil || !strings.Contains(err.Error(), "403") {
 		t.Fatalf("push с неверной парой узлов должен быть отклонён, got %v", err)
 	}
+}
+
+func TestExchangeHTTPPairHonorsHubTopology(t *testing.T) {
+	db, reg, ctx, _ := newExchangeBaseDB(t)
+	plan := exchHubPlan()
+	reg.LoadExchangePlans([]*metadata.ExchangePlan{plan})
+	s := &Server{store: db, reg: reg}
+	req := httptest.NewRequest("GET", "/api/exchange/Обмен/pull", nil)
+
+	check := func(thisNode, peer string, wantOK bool) {
+		t.Helper()
+		if err := db.SaveExchangeThisNode(ctx, plan.Name, thisNode); err != nil {
+			t.Fatal(err)
+		}
+		rr := httptest.NewRecorder()
+		gotThis, gotPeer, ok := s.exchangePair(rr, req, plan, peer)
+		if ok != wantOK {
+			t.Fatalf("%s↔%s: ok=%v status=%d body=%q", thisNode, peer, ok, rr.Code, rr.Body.String())
+		}
+		if wantOK && (!strings.EqualFold(gotThis, thisNode) || !strings.EqualFold(gotPeer, peer)) {
+			t.Fatalf("%s↔%s canonical pair = %s↔%s", thisNode, peer, gotThis, gotPeer)
+		}
+		if !wantOK && rr.Code != 403 {
+			t.Fatalf("%s↔%s: status=%d, want 403", thisNode, peer, rr.Code)
+		}
+	}
+
+	check("center", "fil01", true)
+	check("fil01", "center", true)
+	check("fil01", "fil02", false)
+	check("fil01", "unknown", false)
 }


### PR DESCRIPTION
## Что исправлено
- регистрация exchange change выполняется после финальной записи документа в той же транзакции, поэтому queue version совпадает с entity version;
- push/pull привязываются к заявленному узлу пакета;
- hub принимает только симметрично разрешённые связи center↔spoke, отклоняя unknown и spoke↔spoke.

## Проверка
- тест очереди и версии после create/write/post;
- тесты разрешённых и запрещённых topology pairs;
- `go test ./...`, `go vet ./...`.