### PR TITLE
fix(posting): reuse hook transaction for referenced writes (#381)

### DIFF
--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -61,10 +61,10 @@ func (f *formObjectThis) Get(name string) any {
 	v := f.obj.Get(name)
 	if ref, ok := v.(*interpreter.Ref); ok && f.refResolver != nil {
 		if fd := entityField(f.entity, name); fd != nil && fd.RefEntity != "" {
-			return f.refResolver.attachRef(ref, fd.RefEntity)
+			return f.refResolver.bindRefToContext(ref, fd.RefEntity)
 		}
 		if f.entity != nil && (strings.EqualFold(name, "Ссылка") || strings.EqualFold(name, "Reference")) {
-			return f.refResolver.attachRef(ref, f.entity.Name)
+			return f.refResolver.bindRefToContext(ref, f.entity.Name)
 		}
 	}
 	// Дефолты по типу: пустой numeric → 0, иначе `Объект.Сумма + 100` в DSL

--- a/internal/ui/dsl_ref_attr.go
+++ b/internal/ui/dsl_ref_attr.go
@@ -129,6 +129,27 @@ func (r *dslRefAttrResolver) attachRef(ref *interpreter.Ref, entityName string) 
 	return ref
 }
 
+// bindRefToContext returns a hook-local copy whose manager uses the resolver's
+// context. References stored in runtime.Object may have been enriched before
+// entityservice opened its transaction, so reusing their manager from OnPost
+// would make ПолучитьОбъект()/Записать() use a second connection and deadlock
+// against the transaction currently running the hook. A copy keeps the object
+// value reusable after the hook instead of leaving it bound to a completed tx.
+func (r *dslRefAttrResolver) bindRefToContext(ref *interpreter.Ref, entityName string) *interpreter.Ref {
+	if r == nil || ref == nil {
+		return ref
+	}
+	bound := *ref
+	if bound.Type == "" {
+		bound.Type = entityName
+	}
+	if r.s != nil {
+		bound.Manager = r.s.refManagerFor(r.s.reg.GetEntity(bound.Type), r.ctx)
+	}
+	bound.AttrResolver = r
+	return &bound
+}
+
 func (r *dslRefAttrResolver) preloadBatch(batch map[string]map[string]uuid.UUID) {
 	for entityName, idsByString := range batch {
 		entity := r.s.reg.GetEntity(entityName)
@@ -254,7 +275,7 @@ func (m *refAwareMapThis) wrapValue(name string, v any) any {
 		return v
 	}
 	if ref, ok := v.(*interpreter.Ref); ok {
-		return m.resolver.attachRef(ref, fd.RefEntity)
+		return m.resolver.bindRefToContext(ref, fd.RefEntity)
 	}
 	idStr, _, ok := uuidFromValue(v)
 	if !ok {

--- a/internal/ui/posting_new_document_test.go
+++ b/internal/ui/posting_new_document_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/dsl/ast"
@@ -152,6 +153,87 @@ func TestSaveNewDocument_HookChildAndFailureRollBackTogether(t *testing.T) {
 	}
 	if len(parents) != 0 || len(children) != 0 {
 		t.Fatalf("atomic rollback left parent=%d child=%d", len(parents), len(children))
+	}
+}
+
+// Регрессия issue #381: ссылка в шапке обогащалась до открытия транзакции
+// проведения и сохраняла нетранзакционный context. Поэтому
+// this.Счётчик.ПолучитьОбъект().Записать() из OnPost пытался открыть вторую
+// транзакцию и навсегда ждал первую (на SQLite — единственное соединение).
+func TestSaveNewDocument_OnPostUpdatesExistingReferencedCatalog(t *testing.T) {
+	baseCtx := context.Background()
+	db, err := storage.ConnectSQLite(baseCtx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	counter := &metadata.Entity{
+		Name: "Счётчик",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Статус", Type: metadata.FieldTypeString},
+		},
+	}
+	dismantling := &metadata.Entity{
+		Name:    "ДемонтажСчётчика",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Счётчик", Type: "reference:Счётчик", RefEntity: counter.Name},
+		},
+	}
+	if err := db.Migrate(baseCtx, []*metadata.Entity{counter, dismantling}); err != nil {
+		t.Fatal(err)
+	}
+
+	counterID := uuid.New()
+	if err := db.Upsert(baseCtx, counter.Name, counterID, map[string]any{
+		"Наименование": "Счётчик №1",
+		"Статус":       "Установлен",
+	}, counter); err != nil {
+		t.Fatal(err)
+	}
+
+	onPostSrc := `Процедура ОбработкаПроведения()
+  СчётчикОбъект = this.Счётчик.ПолучитьОбъект();
+  СчётчикОбъект.Статус = "Демонтирован";
+  СчётчикОбъект.Записать();
+КонецПроцедуры`
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{counter, dismantling},
+		Programs: map[string]*ast.Program{dismantling.Name: mustParse(t, onPostSrc)},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{store: db, reg: registry, interp: interp, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	s.entitySvc = s.newEntityService(nil)
+
+	ctx, cancel := context.WithTimeout(baseCtx, 2*time.Second)
+	defer cancel()
+	result, err := s.entitySvc.Save(ctx, entityservice.SaveRequest{
+		Entity: dismantling,
+		ID:     uuid.New(),
+		IsNew:  true,
+		Fields: map[string]any{"Номер": "ДС-001", "Счётчик": counterID.String()},
+		Action: "post",
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if result.DSLError != "" {
+		t.Fatalf("OnPost: %s", result.DSLError)
+	}
+
+	row, err := db.GetByID(baseCtx, counter.Name, counterID, counter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprint(row["Статус"]); got != "Демонтирован" {
+		t.Fatalf("Счётчик.Статус = %q, ожидался %q", got, "Демонтирован")
 	}
 }
 


### PR DESCRIPTION
## Что исправлено

- ссылки из шапки и табличных частей внутри `OnPost` получают менеджер с контекстом активной транзакции;
- `ПолучитьОбъект().Записать()` обновляет существующий объект атомарно с проведением и больше не открывает конкурирующую транзакцию;
- исходная ссылка не остаётся привязанной к завершённой транзакции;
- добавлен регрессионный тест точного сценария из issue.

## Проверка

- `go test ./... -count=1 -timeout=300s`
- профильные тесты `go test -race`
- `go vet ./...`
- `git diff --check`

Closes #381