### PR TITLE
fix(posting): сохранить идентичность объекта формы

### DIFF
--- a/internal/dsl/interpreter/query_proxy.go
+++ b/internal/dsl/interpreter/query_proxy.go
@@ -93,7 +93,7 @@ func (q *queryProxy) CallMethod(name string, args []any) any {
 
 // unwrapArrayParams converts DSL params for query compilation:
 // - *Array → []any (each item unwrapped)
-// - *Ref → UUID string
+// - any reference-like value implementing GetRefUUID → UUID string
 // This ensures pgx receives plain Go types, not interpreter-specific wrappers.
 func unwrapArrayParams(params map[string]any) map[string]any {
 	result := make(map[string]any, len(params))
@@ -105,18 +105,16 @@ func unwrapArrayParams(params map[string]any) map[string]any {
 				items[i] = unwrapRef(item)
 			}
 			result[k] = items
-		case *Ref:
-			result[k] = val.UUID
 		default:
-			result[k] = v
+			result[k] = unwrapRef(v)
 		}
 	}
 	return result
 }
 
 func unwrapRef(v any) any {
-	if ref, ok := v.(*Ref); ok {
-		return ref.UUID
+	if ref, ok := v.(interface{ GetRefUUID() string }); ok {
+		return ref.GetRefUUID()
 	}
 	return v
 }

--- a/internal/dsl/interpreter/query_test.go
+++ b/internal/dsl/interpreter/query_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -111,6 +112,29 @@ func TestQuery_SetParameter(t *testing.T) {
 	evalQuery(t, src, db, &stubReg{})
 	assert.NotEmpty(t, capturedSQL)
 	assert.Contains(t, capturedArgs, "Кабель")
+}
+
+// Объект документа и оборачивающий его UI this реализуют GetRefUUID. Параметр
+// запроса должен получить обычную UUID-строку, а не внутренний Go-объект,
+// который PostgreSQL-драйвер не умеет кодировать.
+func TestQuery_ReferenceLikeParameter_UnwrapsUUID(t *testing.T) {
+	var capturedArgs []any
+	db := &captureDB{onQuery: func(_ string, args []any) {
+		capturedArgs = args
+	}}
+	src := `Процедура Тест()
+		Запрос = Новый Запрос;
+		Запрос.Текст = "ВЫБРАТЬ Номер ИЗ Документ.Заказ ГДЕ Ссылка <> &ЭтотДокумент";
+		Запрос.УстановитьПараметр("ЭтотДокумент", ЭтотОбъект);
+		Запрос.Выполнить();
+	КонецПроцедуры`
+	evalQuery(t, src, db, &stubReg{})
+
+	require.Len(t, capturedArgs, 1)
+	id, ok := capturedArgs[0].(string)
+	require.Truef(t, ok, "параметр имеет тип %T, ожидалась UUID-строка", capturedArgs[0])
+	_, err := uuid.Parse(id)
+	require.NoError(t, err)
 }
 
 func TestQuery_EmptyText_Panics(t *testing.T) {

--- a/internal/runtime/object.go
+++ b/internal/runtime/object.go
@@ -137,7 +137,9 @@ func (o *Object) String() string {
 		return ""
 	}
 	for _, k := range []string{"наименование", "name", "номер", "number"} {
-		if v, ok := o.Fields[k]; ok && v != nil {
+		// Fields приходят как в lowercase после Object.Set, так и в PascalCase
+		// из БД/формы существующего объекта. Get ищет регистронезависимо.
+		if v := o.Get(k); v != nil {
 			s := strings.TrimSpace(fmt.Sprint(v))
 			if s != "" {
 				return s

--- a/internal/runtime/object_test.go
+++ b/internal/runtime/object_test.go
@@ -51,6 +51,20 @@ func TestObject_String_Number(t *testing.T) {
 	}
 }
 
+// Существующий объект формы получает Fields с именами из метаданных
+// (PascalCase), тогда как новый объект после Set хранит lowercase.
+func TestObject_String_PascalCaseNumber(t *testing.T) {
+	o := &Object{
+		Type:   "ПриходныйКассовыйОрдер",
+		Kind:   metadata.KindDocument,
+		ID:     uuid.New(),
+		Fields: map[string]any{"Номер": "ПКО-00001"},
+	}
+	if got := o.String(); got != "ПКО-00001" {
+		t.Errorf("String() = %q, ожидалось значение PascalCase-поля Номер", got)
+	}
+}
+
 // Без конвенционных полей — fallback на Type:short-uuid.
 func TestObject_String_Fallback(t *testing.T) {
 	o := &Object{

--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -33,6 +33,36 @@ type formObjectThis struct {
 	refResolver *dslRefAttrResolver
 }
 
+// GetRefUUID сохраняет ссылочную идентичность runtime.Object у формовой
+// обёртки. Storage использует этот контракт при записи this/ЭтотОбъект в
+// reference-поля сущностей и регистров.
+func (f *formObjectThis) GetRefUUID() string {
+	if f == nil || f.obj == nil {
+		return ""
+	}
+	return f.obj.GetRefUUID()
+}
+
+// String сохраняет строковое представление runtime.Object. В частности, это
+// позволяет писать this/ЭтотОбъект в строковые атрибуты регистра так же, как
+// до оборачивания объекта для управляемой формы.
+func (f *formObjectThis) String() string {
+	if f == nil || f.obj == nil {
+		return ""
+	}
+	return f.obj.String()
+}
+
+// CallMethod делегирует объектные методы (например, МоментВремени) исходному
+// runtime.Object. Специальное поведение формовой обёртки относится к Get/Set и
+// табличным частям, остальные возможности объекта должны оставаться доступны.
+func (f *formObjectThis) CallMethod(method string, args []any) any {
+	if f == nil || f.obj == nil {
+		return nil
+	}
+	return f.obj.CallMethod(method, args)
+}
+
 func (f *formObjectThis) Get(name string) any {
 	if f == nil || f.obj == nil {
 		return nil

--- a/internal/ui/dsl_form_object_test.go
+++ b/internal/ui/dsl_form_object_test.go
@@ -2,12 +2,16 @@ package ui
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/entityservice"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
 )
 
 // План 37, этап 8: formObjectThis должен возвращать formTpProxy при Get
@@ -37,6 +41,114 @@ func TestFormObjectThis_GetReturnsTpProxy(t *testing.T) {
 	}
 	if tp.tpName != "Товары" {
 		t.Errorf("tpName = %q, ожидалось \"Товары\"", tp.tpName)
+	}
+}
+
+// formObjectThis должен сохранять контракты идентичности и строкового
+// представления runtime.Object. Иначе запись `Дв.Документ = this` передаёт в
+// драйвер БД внутренний *formObjectThis вместо UUID/display-строки.
+func TestFormObjectThis_DelegatesIdentityAndString(t *testing.T) {
+	id := uuid.New()
+	obj := &runtime.Object{
+		ID:     id,
+		Type:   "ПриходныйКассовыйОрдер",
+		Fields: map[string]any{"номер": "ПКО-00001"},
+	}
+	this := &formObjectThis{obj: obj}
+
+	if got := this.GetRefUUID(); got != id.String() {
+		t.Errorf("GetRefUUID() = %q, ожидался %q", got, id.String())
+	}
+	if got := this.String(); got != "ПКО-00001" {
+		t.Errorf("String() = %q, ожидался номер документа", got)
+	}
+}
+
+// Оборачивание объекта для формы не должно скрывать его методы. В частности,
+// posting-модули используют this.МоментВремени() для корректных срезов остатков.
+func TestFormObjectThis_DelegatesObjectMethods(t *testing.T) {
+	id := uuid.New()
+	period := time.Date(2026, time.July, 22, 12, 30, 0, 0, time.UTC)
+	obj := &runtime.Object{
+		ID:     id,
+		Type:   "РеализацияТоваров",
+		Fields: map[string]any{"дата": period},
+	}
+	this := &formObjectThis{obj: obj}
+
+	got, ok := this.CallMethod("моментвремени", nil).(*runtime.MomentTime)
+	if !ok {
+		t.Fatalf("МоментВремени() = %T, ожидался *runtime.MomentTime", got)
+	}
+	if got.DocID != id || got.DocType != obj.Type || !got.Period.Equal(period) {
+		t.Errorf("МоментВремени() = %+v, ожидались ID=%s, Type=%s, Period=%s", got, id, obj.Type, period)
+	}
+}
+
+// Сквозная регрессия: UI проводит документ через formObjectThis, а posting-код
+// кладёт сам this одновременно в строковый и ссылочный атрибуты регистра.
+// PostgreSQL раньше падал на string-поле с "cannot find encode plan"; SQLite
+// также не должен получать внутренний тип UI на границе storage.
+func TestFormObjectThis_DirectValueWritesToRegister(t *testing.T) {
+	doc := &metadata.Entity{
+		Name:    "ПриходныйКассовыйОрдер",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	reg := &metadata.Register{
+		Name:       "ДенежныеСредства",
+		Dimensions: []metadata.Field{{Name: "Касса", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Сумма", Type: metadata.FieldTypeNumber}},
+		Attributes: []metadata.Field{
+			{Name: "Документ", Type: metadata.FieldTypeString},
+			{Name: "ДокументСсылка", Type: "reference:ПриходныйКассовыйОрдер", RefEntity: "ПриходныйКассовыйОрдер"},
+		},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{doc})
+	if err := s.store.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatal(err)
+	}
+	posting := mustParse(t, `Процедура ОбработкаПроведения()
+	Дв = Движения.ДенежныеСредства.Добавить();
+	Дв.Касса = "Основная";
+	Дв.Сумма = 100;
+	Дв.Документ = this;
+	Дв.ДокументСсылка = this;
+КонецПроцедуры`)
+	s.reg.Load(runtime.LoadOptions{
+		Entities:  []*metadata.Entity{doc},
+		Programs:  map[string]*ast.Program{doc.Name: posting},
+		Registers: []*metadata.Register{reg},
+	})
+
+	id := uuid.New()
+	res, err := s.entitySvc.Save(ctx, entityservice.SaveRequest{
+		Entity: doc,
+		ID:     id,
+		IsNew:  true,
+		Fields: map[string]any{"Номер": "ПКО-00001"},
+		Action: "post",
+	})
+	if err != nil {
+		t.Fatalf("проведение вернуло техническую ошибку: %v", err)
+	}
+	if res.DSLError != "" {
+		t.Fatalf("проведение вернуло DSL-ошибку: %s", res.DSLError)
+	}
+
+	rows, err := s.store.GetMovements(ctx, reg.Name, reg, storage.RegFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ожидалось одно движение, получено %d", len(rows))
+	}
+	if got := rows[0]["Документ"]; got != "ПКО-00001" {
+		t.Errorf("Документ = %v, ожидалось ПКО-00001", got)
+	}
+	if got := rows[0]["ДокументСсылка"]; got != id.String() {
+		t.Errorf("ДокументСсылка = %v, ожидалось %s", got, id)
 	}
 }
 


### PR DESCRIPTION
## Что исправлено

- `formObjectThis` сохраняет `GetRefUUID`, `String` и объектные методы исходного `runtime.Object`
- ссылкоподобные параметры DSL-запросов разворачиваются в UUID
- строковое представление объекта регистронезависимо читает `Наименование`/`Номер`
- добавлен сквозной тест записи `this` в строковое и ссылочное поля регистра

## Проверка

- `go test ./...`
- `go vet ./...`
- `onebase check --project /home/admo/git/PuT` (ошибок нет; только существующие предупреждения legacy printform)