### PR TITLE
fix(ui): учитывать поля формы списка

### DIFF
--- a/internal/ui/tile_view.go
+++ b/internal/ui/tile_view.go
@@ -1,6 +1,10 @@
 package ui
 
-import "github.com/ivantit66/onebase/internal/metadata"
+import (
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
 
 type tileViewRender struct {
 	ImageFields   []metadata.Field
@@ -67,14 +71,21 @@ func resolveTileView(entity *metadata.Entity) tileViewRender {
 }
 
 // resolveListColumns возвращает набор колонок для табличных режимов списка
-// (страницы/лента/дерево). Если в плитке явно задан набор реквизитов
-// (tile_view.fields), тот же набор применяется и к таблице: Заголовок,
-// Подзаголовок и выбранные поля. Иначе показываем все поля сущности — как
-// раньше. Это устраняет расхождение, когда выбор реквизитов влиял только на
-// плитку, а таблица/лента/дерево печатали всё (#216).
+// (страницы/лента/дерево) и экспорта. Источники настройки применяются от более
+// специализированного к общему: управляемая ФормаСписка, list_form сущности,
+// tile_view.fields, затем все поля. Так обычный конфигуратор и редактор
+// управляемой формы задают один и тот же состав и порядок колонок (#386).
 func resolveListColumns(entity *metadata.Entity) []metadata.Field {
 	if entity == nil {
 		return nil
+	}
+	if form := pickManagedForm(entity, "list"); form != nil {
+		if cols := managedListColumns(entity, form); len(cols) > 0 {
+			return cols
+		}
+	}
+	if len(entity.ListForm) > 0 {
+		return namedListColumns(entity, entity.ListForm)
 	}
 	tv := entity.TileView
 	// Тот же критерий «набор задан», что и в resolveTileView: явный fields: []
@@ -100,6 +111,75 @@ func resolveListColumns(entity *metadata.Entity) []metadata.Field {
 	return cols
 }
 
+// namedListColumns сохраняет заданный пользователем порядок и отбрасывает
+// дубликаты. Неизвестные имена не превращают настройку обратно в «все поля»:
+// валидатор конфигурации отдельно сообщит о такой ссылке.
+func namedListColumns(entity *metadata.Entity, names []string) []metadata.Field {
+	cols := make([]metadata.Field, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		field := uiFieldByNameFold(entity, strings.TrimSpace(name))
+		if field == nil {
+			continue
+		}
+		key := strings.ToLower(field.Name)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		cols = append(cols, *field)
+	}
+	return cols
+}
+
+// managedListColumns извлекает колонки из дерева элементов управляемой формы.
+// Для импортированных форм это обычно Колонка с data_path "Список.Поле";
+// нативный редактор также может хранить ПолеВвода/ПолеФормы с путём
+// "Объект.Поле". Контейнеры обходятся рекурсивно, поэтому порядок на форме
+// становится порядком колонок списка.
+func managedListColumns(entity *metadata.Entity, form *metadata.FormModule) []metadata.Field {
+	if entity == nil || form == nil {
+		return nil
+	}
+	var names []string
+	var walk func([]*metadata.FormElement)
+	walk = func(elements []*metadata.FormElement) {
+		for _, element := range elements {
+			if element == nil {
+				continue
+			}
+			if isManagedListColumnElement(element.Kind) {
+				name := formDataPathFieldName(element.DataPath)
+				if name == "" {
+					name = strings.TrimSpace(element.FieldName)
+				}
+				if name != "" {
+					names = append(names, name)
+				}
+			}
+			walk(element.Children)
+		}
+	}
+	walk(form.Elements)
+	return namedListColumns(entity, names)
+}
+
+func isManagedListColumnElement(kind metadata.FormElementType) bool {
+	switch kind {
+	case metadata.FormElementColumn,
+		metadata.FormElementField,
+		metadata.FormElementFormField,
+		metadata.FormElementCheckbox,
+		metadata.FormElementSwitch,
+		metadata.FormElementInputList,
+		metadata.FormElementDatePicker,
+		metadata.FormElementPicture:
+		return true
+	default:
+		return false
+	}
+}
+
 func isTreeListColumn(cols []metadata.Field, idx int) bool {
 	if idx < 0 || idx >= len(cols) {
 		return false
@@ -120,6 +200,18 @@ func fieldPtr(f metadata.Field) *metadata.Field {
 func uiFieldByName(entity *metadata.Entity, name string) *metadata.Field {
 	for i := range entity.Fields {
 		if entity.Fields[i].Name == name {
+			return &entity.Fields[i]
+		}
+	}
+	return nil
+}
+
+func uiFieldByNameFold(entity *metadata.Entity, name string) *metadata.Field {
+	if field := uiFieldByName(entity, name); field != nil {
+		return field
+	}
+	for i := range entity.Fields {
+		if strings.EqualFold(entity.Fields[i].Name, name) {
 			return &entity.Fields[i]
 		}
 	}

--- a/internal/ui/tile_view_test.go
+++ b/internal/ui/tile_view_test.go
@@ -114,6 +114,100 @@ func TestResolveListColumns(t *testing.T) {
 	}
 }
 
+func TestResolveListColumnsEntityListForm(t *testing.T) {
+	ent := &metadata.Entity{
+		Name: "Показания",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "ДатаНачала", Type: metadata.FieldTypeDate},
+			{Name: "ДатаОкончания", Type: metadata.FieldTypeDate},
+			{Name: "ПоказанияНачала", Type: metadata.FieldTypeNumber},
+		},
+		ListForm: []string{"ДатаНачала", "Наименование"},
+		TileView: &metadata.TileView{Title: "ПоказанияНачала"},
+	}
+
+	var names []string
+	for _, field := range resolveListColumns(ent) {
+		names = append(names, field.Name)
+	}
+	if got, want := strings.Join(names, ","), "ДатаНачала,Наименование"; got != want {
+		t.Fatalf("колонки list_form = %q, ожидалось %q", got, want)
+	}
+}
+
+func TestResolveListColumnsManagedListForm(t *testing.T) {
+	form := &metadata.FormModule{
+		Name:       "ФормаСписка",
+		Kind:       "list",
+		LayoutKind: metadata.FormLayoutManaged,
+		Elements: []*metadata.FormElement{
+			{
+				Kind:     metadata.FormElementTable,
+				Name:     "Список",
+				DataPath: "Список",
+				Children: []*metadata.FormElement{
+					{Kind: metadata.FormElementColumn, Name: "КолПоказания", DataPath: "Список.ПоказанияНачала"},
+					{Kind: metadata.FormElementColumn, Name: "КолНаименование", DataPath: "Список.Наименование"},
+				},
+			},
+		},
+	}
+	ent := &metadata.Entity{
+		Name: "Показания",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "ДатаНачала", Type: metadata.FieldTypeDate},
+			{Name: "ПоказанияНачала", Type: metadata.FieldTypeNumber},
+		},
+		ListForm: []string{"ДатаНачала"},
+		Forms:    []*metadata.FormModule{form},
+	}
+
+	var names []string
+	for _, field := range resolveListColumns(ent) {
+		names = append(names, field.Name)
+	}
+	if got, want := strings.Join(names, ","), "ПоказанияНачала,Наименование"; got != want {
+		t.Fatalf("колонки управляемой формы списка = %q, ожидалось %q", got, want)
+	}
+}
+
+func TestPageList_HonorsEntityListForm(t *testing.T) {
+	ent := &metadata.Entity{
+		Name: "Показания",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "ДатаНачала", Type: metadata.FieldTypeDate},
+			{Name: "ДатаОкончания", Type: metadata.FieldTypeDate},
+			{Name: "ПоказанияНачала", Type: metadata.FieldTypeNumber},
+		},
+		ListForm: []string{"Наименование", "ДатаНачала"},
+	}
+	html := renderPageList(t, map[string]any{
+		"Entity": ent,
+		"Rows": []map[string]any{{
+			"id": "1", "Наименование": "Счётчик 1", "ДатаНачала": "2026-07-01T00:00:00Z",
+			"ДатаОкончания": "2099-12-31T00:00:00Z", "ПоказанияНачала": "987654.321",
+		}},
+		"Params": storage.ListParams{}, "RefFilterOptions": map[string]any{},
+		"Lang": "ru", "Total": 1, "Page": 1, "TotalPages": 1,
+	})
+	for _, want := range []string{"Счётчик 1", "01.07.2026"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("список не содержит выбранное значение %q", want)
+		}
+	}
+	for _, unwanted := range []string{"2099", "987654.321"} {
+		if strings.Contains(html, unwanted) {
+			t.Errorf("список показал значение невыбранной колонки %q", unwanted)
+		}
+	}
+}
+
 // Табличный режим списка (страницы/лента) теперь уважает tile_view.fields:
 // выбранные колонки показываются, невыбранные — нет (#216).
 func TestPageList_ListViewHonorsTileFields(t *testing.T) {


### PR DESCRIPTION
## Что изменено

- форма списка учитывает `list_form` из метаданных сущности и сохраняет выбранный порядок колонок
- управляемая `ФормаСписка` определяет колонки по вложенным элементам и `data_path`
- единая настройка применяется к таблице, ленте, дереву и Excel-экспорту
- добавлены тесты для обычной и управляемой форм списка

## Проверка

- `go test ./...`
- `go vet ./...`

Fixes #386