### PR TITLE
fix(query): учитывать тип источника системных колонок

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -481,6 +481,20 @@ type translator struct {
 	rowsScoped  bool                          // true после внедрения rowFilters в outer WHERE
 	rowApplied  []SourceRef                   // источники, к которым RLS-предикат реально внедрён (для финальной сверки)
 	parenDepth  int                           // глубина незакрытых '(' в основном потоке (VT-аргументы считает parseVTArgs)
+	sourceCtx   sourceContext                 // тип основного источника и квалификаторов для системных колонок регистра
+}
+
+type sourceClass uint8
+
+const (
+	sourceClassUnknown sourceClass = iota
+	sourceClassEntity
+	sourceClassRegister
+)
+
+type sourceContext struct {
+	main       sourceClass
+	qualifiers map[string]sourceClass
 }
 
 type pendingRowFilter struct {
@@ -2173,6 +2187,94 @@ func preScanMainTable(tokens []tok) string {
 	return ""
 }
 
+// preScanSourceContext определяет, какие квалификаторы относятся к регистрам,
+// а какие — к документам/справочникам. Это нужно до основного прохода, потому
+// что SELECT транслируется раньше FROM, а русские имена системных колонок
+// регистра (Период, Регистратор, ...) совпадают с допустимыми прикладными
+// полями сущностей.
+func preScanSourceContext(tokens []tok) sourceContext {
+	ctx := sourceContext{qualifiers: map[string]sourceClass{}}
+	for i := 0; i+2 < len(tokens); i++ {
+		if tokens[i].kind != tIdent {
+			continue
+		}
+		typeUpper := strings.ToUpper(tokens[i].val)
+		if !isSourceType(typeUpper) || tokens[i+1].kind != tDot || tokens[i+2].kind != tIdent {
+			continue
+		}
+
+		class := sourceClassEntity
+		if isAccumRegType(typeUpper) || isInfoRegType(typeUpper) || isAccountRegType(typeUpper) {
+			class = sourceClassRegister
+		}
+		if ctx.main == sourceClassUnknown {
+			ctx.main = class
+		}
+
+		entityName := strings.ToLower(tokens[i+2].val)
+		ctx.qualifiers[entityName] = class
+		ctx.qualifiers[sourceToTable(typeUpper, tokens[i+2].val)] = class
+
+		// У обычного источника КАК/AS следует сразу за именем сущности.
+		aliasPos := i + 3
+		if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
+			aliasUpper := strings.ToUpper(tokens[aliasPos].val)
+			if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
+				ctx.qualifiers[strings.ToLower(tokens[aliasPos+1].val)] = class
+				continue
+			}
+		}
+
+		// У виртуальной таблицы пользовательский алиас находится после списка
+		// аргументов: Регистр.X.Остатки(...) КАК Р.
+		if i+5 >= len(tokens) || tokens[i+3].kind != tDot || tokens[i+5].kind != tLParen {
+			continue
+		}
+		depth := 0
+		for j := i + 5; j < len(tokens); j++ {
+			switch tokens[j].kind {
+			case tLParen:
+				depth++
+			case tRParen:
+				depth--
+				if depth == 0 {
+					aliasPos = j + 1
+					if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
+						aliasUpper := strings.ToUpper(tokens[aliasPos].val)
+						if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
+							ctx.qualifiers[strings.ToLower(tokens[aliasPos+1].val)] = class
+						}
+					}
+					j = len(tokens)
+				}
+			}
+		}
+	}
+	return ctx
+}
+
+// systemColumnAlias разрешает русское имя системной колонки только в контексте
+// регистра. Для документов и справочников такое имя является обычным
+// прикладным полем и должно остаться кириллическим.
+func (tr *translator) systemColumnAlias(name string, prevDot bool) (string, bool) {
+	col, ok := systemColAlias(name)
+	if !ok {
+		return "", false
+	}
+	if prevDot && tr.pos >= 3 {
+		qualifier := strings.ToLower(tr.tokens[tr.pos-3].val)
+		// Обращение через ссылочное поле регистра ведёт к документу или
+		// справочнику, поэтому Регистр.Документ.Период — не системный period.
+		if tr.findRefDim(qualifier) != nil {
+			return "", false
+		}
+		if class, known := tr.sourceCtx.qualifiers[qualifier]; known {
+			return col, class == sourceClassRegister
+		}
+	}
+	return col, tr.sourceCtx.main == sourceClassRegister
+}
+
 // projectionFieldNames extracts identifiers used by SELECT expressions before
 // aliases are applied. It deliberately errs on the safe side: qualifiers and
 // otherwise harmless identifiers may be included, but an underlying field must
@@ -2304,6 +2406,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		colTypes:    buildColTypes(tokens, opts),
 		mainTable:   preScanMainTable(tokens),
 		refDims:     preScanRefDims(tokens, opts),
+		sourceCtx:   preScanSourceContext(tokens),
 		aliases:     map[string]struct{}{},
 		section:     sectionOther,
 	}
@@ -2556,8 +2659,9 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 				continue
 			}
 			// Системные колонки регистра — PascalCase русские алиасы
-			// (см. Работает и с префиксом (Х.Период), и без.
-			if col, ok := systemColAlias(t.val); ok {
+			// (см. systemColAlias). Работает и с префиксом (Х.Период), и без,
+			// но только если соответствующий источник действительно регистр.
+			if col, ok := tr.systemColumnAlias(t.val, prevDot); ok {
 				tr.emit(col)
 				continue
 			}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -254,6 +254,102 @@ func TestCompile_SystemCols_BareAndDotted(t *testing.T) {
 	}
 }
 
+// Имена системных колонок регистра не являются зарезервированными для
+// документов и справочников: там это обычные прикладные поля с кириллическими
+// физическими именами.
+func TestCompile_SystemColNamesRemainEntityFields(t *testing.T) {
+	for _, source := range []string{"Документ.НачислениеВзноса", "Справочник.Периоды"} {
+		src := `ВЫБРАТЬ Д.Период, Д.ВидДвижения, Д.Регистратор, Д.НомерСтроки, Период
+ИЗ ` + source + ` КАК Д
+ГДЕ Д.Период >= &Дата`
+
+		r, err := query.Compile(src, query.CompileOpts{
+			Params: map[string]any{"Дата": "2026-01-01"},
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", source, err)
+		}
+		for _, want := range []string{
+			"д.период",
+			"д.виддвижения",
+			"д.регистратор",
+			"д.номерстроки",
+			"период",
+		} {
+			if !strings.Contains(r.SQL, want) {
+				t.Errorf("%s: ожидалось %q, получили: %s", source, want, r.SQL)
+			}
+		}
+		for _, unwanted := range []string{
+			"д.period",
+			"д.вид_движения",
+			"д.recorder",
+			"д.line_number",
+		} {
+			if strings.Contains(r.SQL, unwanted) {
+				t.Errorf("%s: системная колонка %q не должна применяться к сущности: %s", source, unwanted, r.SQL)
+			}
+		}
+	}
+}
+
+// В смешанном запросе тип определяется по квалификатору: одно и то же имя
+// «Период» у документа и регистра должно вести к разным физическим колонкам.
+func TestCompile_SystemColsUseQualifiedSourceType(t *testing.T) {
+	src := `ВЫБРАТЬ Д.Период, Р.Период
+ИЗ Документ.НачислениеВзноса КАК Д
+ЛЕВОЕ СОЕДИНЕНИЕ РегистрНакопления.Взносы КАК Р
+ПО Р.Регистратор = Д.Ссылка`
+
+	r, err := query.Compile(src, query.CompileOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.SQL, "д.период") {
+		t.Errorf("поле документа должно остаться кириллическим: %s", r.SQL)
+	}
+	if !strings.Contains(r.SQL, "р.period") {
+		t.Errorf("поле регистра должно разрешиться в period: %s", r.SQL)
+	}
+	if !strings.Contains(r.SQL, "р.recorder") {
+		t.Errorf("Регистратор регистра должен разрешиться в recorder: %s", r.SQL)
+	}
+}
+
+// Поле сущности, прочитанное через ссылочное измерение регистра, также не
+// должно ошибочно считаться системной колонкой самого регистра.
+func TestCompile_SystemColNameThroughReferenceRemainsEntityField(t *testing.T) {
+	src := `ВЫБРАТЬ ДокументНачисления.Период
+ИЗ РегистрНакопления.Взносы КАК Р`
+	reg := &metadata.Register{
+		Name: "Взносы",
+		Dimensions: []metadata.Field{
+			{Name: "ДокументНачисления", RefEntity: "НачислениеВзноса"},
+		},
+	}
+	doc := &metadata.Entity{
+		Name: "НачислениеВзноса",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Период", Type: metadata.FieldTypeDate},
+		},
+	}
+
+	r, err := query.Compile(src, query.CompileOpts{
+		Registers: []*metadata.Register{reg},
+		Entities:  []*metadata.Entity{doc},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.SQL, "ref_документначисления.период") {
+		t.Errorf("поле документа через ссылку должно остаться кириллическим: %s", r.SQL)
+	}
+	if strings.Contains(r.SQL, "ref_документначисления.period") {
+		t.Errorf("поле документа через ссылку ошибочно разрешилось как системное: %s", r.SQL)
+	}
+}
+
 // функции даты в DSL должны транслироваться в SQL-эквиваленты
 // под нужный диалект. SQL case-insensitive — сравниваем в lowercase, поскольку
 // транслятор лоуэркейсит идентификаторы.


### PR DESCRIPTION
## Что изменено

- системные алиасы регистров разрешаются только в контексте регистра
- поля документов и справочников с именами `Период`, `Регистратор`, `ВидДвижения`, `НомерСтроки` остаются прикладными
- учтены смешанные JOIN и обращения через ссылочные измерения
- добавлены регрессионные тесты

## Проверки

- `go test ./...`
- `go vet ./...`

Closes #390