### PR TITLE
fix(ui): закрывать вкладку крестиком формы (#392)

### DIFF
--- a/internal/ui/form_delegates_test.go
+++ b/internal/ui/form_delegates_test.go
@@ -16,6 +16,7 @@ func TestPageForm_DelegatedHandlers(t *testing.T) {
 	}
 	for _, want := range []string{
 		"data-ob-popup-cancel",
+		"data-ob-close-tab",
 		"data-ob-toggle-next",
 		"data-ob-confirm",
 		"data-ob-ref-current",
@@ -92,6 +93,7 @@ func TestPageForm_DelegatedHandlers(t *testing.T) {
 	}
 	html := buf.String()
 	for _, want := range []string{
+		`data-ob-close-tab`,
 		`data-ob-toggle-next`,
 		`data-ob-confirm=`,
 		`data-ob-ref-picker="ref-Контрагент"`,

--- a/internal/ui/managed_form_test.go
+++ b/internal/ui/managed_form_test.go
@@ -136,6 +136,7 @@ func TestPageManagedForm_Renders(t *testing.T) {
 		`accesskey="7"`,
 		`data-ob-hotkey="F7"`,
 		`aria-keyshortcuts="F7"`,
+		`data-ob-close-tab`,
 		`id="ob-managed-config"`,
 		`id="ob-managed-tp-ref-opts"`,
 		`src="/static/managed.js"`,

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -26,10 +26,27 @@ if (window.__obEmbedded) {
     } catch (_) {}
     return true;
   };
+  window.obCloseInShell = function () {
+    var shell = null;
+    try {
+      if (window.parent && window.parent.obOpenTab) shell = window.parent;
+    } catch (_) {}
+    if (!shell) return false;
+    try {
+      shell.postMessage({ source: 'obCloseTab' }, window.location.origin);
+    } catch (_) {
+      return false;
+    }
+    return true;
+  };
   document.addEventListener('click', function (e) {
     if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     var a = e.target.closest ? e.target.closest('a[href]') : null;
     if (!a || a.target === '_blank') return;
+    if (a.hasAttribute('data-ob-close-tab') && window.obCloseInShell()) {
+      e.preventDefault();
+      return;
+    }
     var href = a.getAttribute('href') || '';
     var title = (a.getAttribute('title') || a.textContent || '').replace(/\s+/g, ' ').trim() || 'Форма';
     if (!window.obOpenInShell(href, title)) return;

--- a/internal/ui/static_test.go
+++ b/internal/ui/static_test.go
@@ -26,6 +26,7 @@ func TestStaticUIJS(t *testing.T) {
 	body := rr.Body.String()
 	for _, want := range []string{
 		"window.obOpenInShell",
+		"window.obCloseInShell",
 		"openRefPicker",
 		"function obImageUpload",
 		"function addTpRow",

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -132,6 +132,7 @@ const tplAppShell = `{{define "page-app-shell"}}
     if(ev.origin!==location.origin)return;
     var d=ev.data; if(!d||typeof d!=='object')return;
     if(d.source==='obOpenTab' && d.url){ var ou=String(d.url); if(!openable(ou))return; openTab(ou, d.title?String(d.title):'Форма', {allowDup:!!d.allowDup}); }
+    else if(d.source==='obCloseTab'){ var ct=tabByWindow(ev.source); if(ct)closeTab(ct); }
     else if(d.source==='obSetTitle' && active && d.title){ active.title=String(d.title); active.label.textContent=active.title; active.btn.title=active.title; persist(); }
     else if(d.source==='obDirty'){ var dt=tabByWindow(ev.source); if(dt){ dt.dirty=!!d.dirty; dt.btn.classList.toggle('dirty',dt.dirty); } } // фаза 3
   });

--- a/internal/ui/tabs_test.go
+++ b/internal/ui/tabs_test.go
@@ -34,6 +34,7 @@ func TestAppShell_Render(t *testing.T) {
 		`window.obOpenTab=openTab`, // движок вкладок
 		`'obTabs'`,                 // ключ sessionStorage для restore
 		`source==='obOpenTab'`,     // приём запросов из iframe
+		`source==='obCloseTab'`,    // закрытие вкладки по крестику внутри формы
 		`<header class="topbar">`,  // переиспользован nav (хром оболочки)
 		`ob-tab-dup`,               // кнопка «новый экземпляр» (#130)
 		`{allowDup:true}`,          // дубликат = новый экземпляр
@@ -113,7 +114,9 @@ func TestHead_EmbeddedChromeHidden(t *testing.T) {
 		`window.__obEmbedded = window.self !== window.top`,
 		`obOpenableForm`,                           // фаза 2: перехват открытия форм во вкладку
 		`window.obOpenInShell`,                     // общий helper для ссылок и JS-открытий списков
+		`window.obCloseInShell`,                    // крестик формы закрывает вкладку оболочки
 		`source: 'obOpenTab'`,                      // постит запрос родителю-оболочке
+		`source: 'obCloseTab'`,                     // просит оболочку закрыть текущую вкладку
 		`window.parent && window.parent.obOpenTab`, // guard: только если родитель — оболочка
 		`source: 'obDirty'`,                        // фаза 3: трекер несохранённых правок
 	} {

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1320,7 +1320,7 @@ const tplForm = `
   {{if .IsPopup}}
   <a href="#" data-ob-popup-cancel title="{{t $.Lang "Закрыть"}}" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{else}}
-  <a href="/ui/{{lower (str .Entity.Kind)}}/{{lower .Entity.Name}}" title="{{t $.Lang "Закрыть"}}" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
+  <a href="/ui/{{lower (str .Entity.Kind)}}/{{lower .Entity.Name}}" data-ob-close-tab title="{{t $.Lang "Закрыть"}}" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{end}}
 </div>
 {{if .Error}}<div class="error">{{.Error}}</div>{{end}}

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -395,7 +395,7 @@ const tplManagedForm = `
   {{if .IsPopup}}
   <a href="#" data-ob-ref-cancel title="Закрыть" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{else}}
-  <a href="{{if .IsProcessor}}/ui/{{else}}/ui/{{lower (str .Entity.Kind)}}/{{lower .Entity.Name}}{{end}}" title="Закрыть" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
+  <a href="{{if .IsProcessor}}/ui/{{else}}/ui/{{lower (str .Entity.Kind)}}/{{lower .Entity.Name}}{{end}}" data-ob-close-tab title="Закрыть" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{end}}
 </div>
 {{if .Error}}<div class="error">{{.Error}}</div>{{end}}


### PR DESCRIPTION
## Что изменено

- крестик обычной и управляемой формы закрывает соответствующую внутреннюю вкладку;
- оболочка определяет вкладку по окну-источнику, поэтому корректно работает с дубликатами;
- предупреждение о несохранённых изменениях сохранено;
- добавлены регрессионные проверки шаблонов и JS-моста.

## Проверки

- `go test ./... -count=1`
- `node --check internal/ui/static/ui.js`
- `git diff --check`

Closes #392