### PR TITLE
fix: make document lifecycle writes transactional (#407)

### DIFF
--- a/internal/entityservice/audit_test.go
+++ b/internal/entityservice/audit_test.go
@@ -1,0 +1,77 @@
+package entityservice
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func TestSaveNewObjectWithHookWritesSingleCreateAudit(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "audit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.EnsureAuditSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	entity := &metadata.Entity{
+		Name: "Клиент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Нормализовано", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{entity}); err != nil {
+		t.Fatal(err)
+	}
+
+	program := mustParseProgramT(t, `
+Процедура ПриЗаписи()
+  ЭтотОбъект.Нормализовано = "готово";
+КонецПроцедуры`)
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{entity},
+		Programs: map[string]*ast.Program{entity.Name: program},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	svc := &Service{Store: db, Reg: registry, Interp: interp}
+
+	id := uuid.New()
+	result, err := svc.Save(ctx, SaveRequest{
+		Entity: entity,
+		ID:     id,
+		IsNew:  true,
+		Fields: map[string]any{"Наименование": "Тест"},
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if result.DSLError != "" {
+		t.Fatalf("DSLError: %s", result.DSLError)
+	}
+
+	var creates, updates int
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM _audit WHERE record_id = ? AND action = 'create'`, id.String()).Scan(&creates); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM _audit WHERE record_id = ? AND action = 'update'`, id.String()).Scan(&updates); err != nil {
+		t.Fatal(err)
+	}
+	if creates != 1 || updates != 0 {
+		t.Fatalf("аудит нового объекта: create=%d update=%d, ожидалось 1/0", creates, updates)
+	}
+}

--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -237,7 +237,7 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 	err := s.Store.WithTxIfNeeded(ctx, func(txCtx context.Context) error {
 		if proc != nil {
 			if req.IsNew {
-				if err := s.Store.Upsert(txCtx, req.Entity.Name, req.ID, obj.Fields, req.Entity); err != nil {
+				if err := s.Store.UpsertProvisional(txCtx, req.Entity.Name, req.ID, obj.Fields, req.Entity); err != nil {
 					return err
 				}
 			}
@@ -311,28 +311,14 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 			if isPosting {
 				return s.Store.SetPosted(txCtx, req.Entity.Name, req.ID, true)
 			}
-			// «Записать» для уже проведённого документа (только при редактировании,
-			// при IsNew проведения нет в принципе) — сбрасываем движения по ВСЕМ
-			// типам регистров (накопления, бухгалтерии, сведений) и снимаем флаг
-			// проведения. Раньше чистились только регистры накопления, из-за чего
-			// движения бухгалтерии/сведений оставались осиротевшими.
+			// Обычная запись существующего проводимого документа сохраняет
+			// прежнюю семантику: это полноценная отмена проведения. Поэтому
+			// недостаточно снять флаг и очистить движения — должен выполниться
+			// OnUnpost в той же транзакции.
 			if !req.IsNew {
-				for _, reg := range s.Reg.Registers() {
-					if err := s.Store.WriteMovements(txCtx, reg.Name, req.Entity.Name, req.ID, nil, reg, nil); err != nil {
-						return err
-					}
-				}
-				for _, ar := range s.Reg.AccountRegisters() {
-					if err := s.Store.WriteAccountMovements(txCtx, ar.Name, req.Entity.Name, req.ID, nil, ar, nil); err != nil {
-						return err
-					}
-				}
-				for _, ir := range s.Reg.InfoRegisters() {
-					if err := s.Store.WriteInfoMovements(txCtx, ir.Name, req.Entity.Name, req.ID, nil, ir, nil); err != nil {
-						return err
-					}
-				}
-				return s.Store.SetPosted(txCtx, req.Entity.Name, req.ID, false)
+				unpostMovements := runtime.NewMovementsCollector(req.Entity.Name, req.ID)
+				SetPeriodFromFields(unpostMovements, req.Entity, obj.Fields)
+				return s.unpostInTx(txCtx, req.Entity, req.ID, unpostMovements, &msgs, lockCollector)
 			}
 		}
 		return nil
@@ -358,6 +344,79 @@ type hookRunError struct{ err error }
 func (e *hookRunError) Error() string { return e.err.Error() }
 func (e *hookRunError) Unwrap() error { return e.err }
 
+func (s *Service) unpostInTx(
+	txCtx context.Context,
+	entity *metadata.Entity,
+	id uuid.UUID,
+	movements *runtime.MovementsCollector,
+	messages *[]string,
+	lockCollector *runtime.LockCollector,
+) error {
+	if err := s.clearMovements(txCtx, entity.Name, id); err != nil {
+		return err
+	}
+	if err := s.Store.SetPosted(txCtx, entity.Name, id, false); err != nil {
+		return err
+	}
+	proc := s.Reg.GetProcedure(entity.Name, "OnUnpost")
+	if proc == nil {
+		return nil
+	}
+
+	fields, err := s.Store.GetByID(txCtx, entity.Name, id, entity)
+	if err != nil {
+		return fmt.Errorf("отмена проведения %s: чтение документа: %w", entity.Name, err)
+	}
+	tpRows := make(map[string][]map[string]any, len(entity.TableParts))
+	for _, tp := range entity.TableParts {
+		rows, err := s.Store.GetTablePartRows(txCtx, entity.Name, tp.Name, id, tp)
+		if err != nil {
+			return fmt.Errorf("отмена проведения %s: чтение ТЧ %s: %w", entity.Name, tp.Name, err)
+		}
+		tpRows[tp.Name] = rows
+	}
+
+	obj := &runtime.Object{
+		Type:          entity.Name,
+		Kind:          entity.Kind,
+		ID:            id,
+		Fields:        fields,
+		TablePartRows: tpRows,
+	}
+	if obj.Fields == nil {
+		obj.Fields = map[string]any{}
+	}
+	selfRef := &interpreter.Ref{UUID: id.String(), Type: entity.Name}
+	obj.Fields["ссылка"] = selfRef
+	obj.Fields["reference"] = selfRef
+
+	hookCtx := runtime.ContextWithLockCollector(txCtx, lockCollector)
+	if s.PrepareHook != nil {
+		s.PrepareHook(hookCtx, entity, obj)
+	}
+	if s.EnrichTPRows != nil {
+		for _, tp := range entity.TableParts {
+			if rows, ok := obj.TablePartRows[tp.Name]; ok {
+				s.EnrichTPRows(hookCtx, tp, rows)
+			}
+		}
+	}
+	SetPeriodFromFields(movements, entity, obj.Fields)
+
+	var vars map[string]any
+	if s.BuildVars != nil {
+		vars = s.BuildVars(hookCtx, movements, messages)
+	}
+	var thisVal interpreter.This = obj
+	if s.MakeThis != nil {
+		thisVal = s.MakeThis(hookCtx, obj, entity)
+	}
+	if err := s.Interp.Run(proc, thisVal, vars); err != nil {
+		return &hookRunError{err: err}
+	}
+	return s.Store.AdvisoryXactLock(txCtx, lockCollector.Keys())
+}
+
 // Unpost cancels document posting atomically: removes every movement, sets
 // posted=false and then runs OnUnpost/ОбработкаУдаленияПроведения. The hook is
 // deliberately executed after the storage changes but inside the same
@@ -368,73 +427,11 @@ func (s *Service) Unpost(ctx context.Context, entity *metadata.Entity, id uuid.U
 		ID:        id,
 		Movements: runtime.NewMovementsCollector(entity.Name, id),
 	}
-	proc := s.Reg.GetProcedure(entity.Name, "OnUnpost")
 	lockCollector := runtime.NewLockCollector()
 	defer lockCollector.ReleaseAll()
 
 	err := s.Store.WithTxIfNeeded(ctx, func(txCtx context.Context) error {
-		if err := s.clearMovements(txCtx, entity.Name, id); err != nil {
-			return err
-		}
-		if err := s.Store.SetPosted(txCtx, entity.Name, id, false); err != nil {
-			return err
-		}
-		if proc == nil {
-			return nil
-		}
-
-		fields, err := s.Store.GetByID(txCtx, entity.Name, id, entity)
-		if err != nil {
-			return fmt.Errorf("отмена проведения %s: чтение документа: %w", entity.Name, err)
-		}
-		tpRows := make(map[string][]map[string]any, len(entity.TableParts))
-		for _, tp := range entity.TableParts {
-			rows, err := s.Store.GetTablePartRows(txCtx, entity.Name, tp.Name, id, tp)
-			if err != nil {
-				return fmt.Errorf("отмена проведения %s: чтение ТЧ %s: %w", entity.Name, tp.Name, err)
-			}
-			tpRows[tp.Name] = rows
-		}
-
-		obj := &runtime.Object{
-			Type:          entity.Name,
-			Kind:          entity.Kind,
-			ID:            id,
-			Fields:        fields,
-			TablePartRows: tpRows,
-		}
-		if obj.Fields == nil {
-			obj.Fields = map[string]any{}
-		}
-		selfRef := &interpreter.Ref{UUID: id.String(), Type: entity.Name}
-		obj.Fields["ссылка"] = selfRef
-		obj.Fields["reference"] = selfRef
-
-		hookCtx := runtime.ContextWithLockCollector(txCtx, lockCollector)
-		if s.PrepareHook != nil {
-			s.PrepareHook(hookCtx, entity, obj)
-		}
-		if s.EnrichTPRows != nil {
-			for _, tp := range entity.TableParts {
-				if rows, ok := obj.TablePartRows[tp.Name]; ok {
-					s.EnrichTPRows(hookCtx, tp, rows)
-				}
-			}
-		}
-		SetPeriodFromFields(result.Movements, entity, obj.Fields)
-
-		var vars map[string]any
-		if s.BuildVars != nil {
-			vars = s.BuildVars(hookCtx, result.Movements, &result.DSLMessages)
-		}
-		var thisVal interpreter.This = obj
-		if s.MakeThis != nil {
-			thisVal = s.MakeThis(hookCtx, obj, entity)
-		}
-		if err := s.Interp.Run(proc, thisVal, vars); err != nil {
-			return &hookRunError{err: err}
-		}
-		return s.Store.AdvisoryXactLock(txCtx, lockCollector.Keys())
+		return s.unpostInTx(txCtx, entity, id, result.Movements, &result.DSLMessages, lockCollector)
 	})
 	if err != nil {
 		var hookErr *hookRunError

--- a/internal/entityservice/unpost_test.go
+++ b/internal/entityservice/unpost_test.go
@@ -55,6 +55,34 @@ func TestUnpostHookErrorRollsBackFlagAndMovements(t *testing.T) {
 	assertUnpostState(t, db, ctx, doc, reg, id, true, 1)
 }
 
+func TestSaveExistingPostedDocumentRunsUnpostHook(t *testing.T) {
+	svc, db, ctx, doc, reg, id := newUnpostFixture(t, `
+Процедура ОбработкаУдаленияПроведения()
+  Если ЭтотОбъект.Posted Тогда
+    ВызватьИсключение("хук увидел проведённый документ");
+  КонецЕсли;
+  Сообщить("обычная запись вызвала отмену");
+КонецПроцедуры`)
+
+	result, err := svc.Save(ctx, SaveRequest{
+		Entity: doc,
+		ID:     id,
+		IsNew:  false,
+		Fields: map[string]any{"Номер": "2"},
+		Action: "",
+	})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if result.DSLError != "" {
+		t.Fatalf("неожиданная DSL-ошибка: %s", result.DSLError)
+	}
+	if len(result.DSLMessages) != 1 || result.DSLMessages[0] != "обычная запись вызвала отмену" {
+		t.Fatalf("сообщения хука = %v", result.DSLMessages)
+	}
+	assertUnpostState(t, db, ctx, doc, reg, id, false, 0)
+}
+
 func newUnpostFixture(t *testing.T, hookSource string) (*Service, *storage.DB, context.Context, *metadata.Entity, *metadata.Register, uuid.UUID) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -416,7 +416,8 @@ func parseTimeStr(s string) time.Time {
 	return time.Time{}
 }
 
-// execAudit runs a statement on the pool directly (audit inserts bypass tx).
+// execAudit follows the transaction in ctx, so rolled-back business changes do
+// not leave committed audit records.
 func (db *DB) execAudit(ctx context.Context, sql string, args ...any) error {
 	_, err := db.Exec(ctx, sql, args...)
 	return err
@@ -424,8 +425,8 @@ func (db *DB) execAudit(ctx context.Context, sql string, args ...any) error {
 
 // ActiveUserInfo represents a user seen recently in the audit log.
 type ActiveUserInfo struct {
-	Login     string
-	LastSeen  time.Time
+	Login    string
+	LastSeen time.Time
 }
 
 // ActiveUsersFromAudit returns distinct user_logins from _audit in the

--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -38,19 +38,36 @@ type FilterValue struct {
 
 // Upsert inserts or updates the object fields.
 func (db *DB) Upsert(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity) error {
-	return db.upsert(ctx, entityName, id, fields, entity, true)
+	return db.upsert(ctx, entityName, id, fields, entity, true, upsertAuditAuto)
+}
+
+// UpsertProvisional inserts a transaction-local parent row without writing an
+// audit event. entityservice uses it before a new-object hook so FK children can
+// refer to the parent. The final UpsertPreserveVersion writes the single
+// externally visible create event after the hook and all final fields succeed.
+func (db *DB) UpsertProvisional(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity) error {
+	return db.upsert(ctx, entityName, id, fields, entity, true, upsertAuditSkip)
 }
 
 // UpsertPreserveVersion updates fields without advancing _version on conflict.
 // It is intentionally narrow: entityservice uses it only for the final write of
 // a new row provisionally inserted earlier in the SAME transaction so a hook can
-// create FK children. The externally visible committed object still starts at
-// version 1. Ordinary callers must use Upsert.
+// create FK children. It records one create event for the final object state;
+// the provisional insert deliberately does not audit. The externally visible
+// committed object still starts at version 1. Ordinary callers must use Upsert.
 func (db *DB) UpsertPreserveVersion(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity) error {
-	return db.upsert(ctx, entityName, id, fields, entity, false)
+	return db.upsert(ctx, entityName, id, fields, entity, false, upsertAuditCreate)
 }
 
-func (db *DB) upsert(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity, bumpVersion bool) error {
+type upsertAuditMode uint8
+
+const (
+	upsertAuditAuto upsertAuditMode = iota
+	upsertAuditSkip
+	upsertAuditCreate
+)
+
+func (db *DB) upsert(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity, bumpVersion bool, auditMode upsertAuditMode) error {
 	d := db.dialect
 	// Read old value for audit diff (best-effort, ignore errors)
 	var oldRow map[string]any
@@ -141,9 +158,15 @@ func (db *DB) upsert(ctx context.Context, entityName string, id uuid.UUID, field
 
 	// Audit (best-effort, non-blocking)
 	kind := string(entity.Kind)
-	if isNew {
+	switch {
+	case auditMode == upsertAuditSkip:
+		// A provisional row is not externally visible and is followed by the
+		// final create audit in the same transaction.
+	case auditMode == upsertAuditCreate:
 		db.logCreate(ctx, kind, entityName, id)
-	} else if oldRow != nil {
+	case isNew:
+		db.logCreate(ctx, kind, entityName, id)
+	case oldRow != nil:
 		changes := AuditDiff(oldRow, fields, entity)
 		if len(changes) > 0 {
 			db.logUpdate(ctx, kind, entityName, id, changes)

--- a/internal/ui/dsl_catalogs.go
+++ b/internal/ui/dsl_catalogs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ivantit66/onebase/internal/entityservice"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/webhook"
 )
 
@@ -186,7 +187,11 @@ func (w *catWriter) write() error {
 	if result.DSLError != "" {
 		return fmt.Errorf("%s", result.DSLError)
 	}
+	wasSaved := w.saved
 	w.saved = true
+	if !wasSaved {
+		storage.DeferUntilTxRollback(ctx, func() { w.saved = false })
+	}
 	return nil
 }
 

--- a/internal/ui/dsl_catalogs_test.go
+++ b/internal/ui/dsl_catalogs_test.go
@@ -183,6 +183,22 @@ func TestCatWriter_ExplicitTransactionCommitAndRollback(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("rollback left %d catalog rows", count)
 	}
+	if got := rolledBack.CallMethod("ЭтоНовый", nil); got != true {
+		t.Fatalf("после rollback ЭтоНовый = %v, ожидалось true", got)
+	}
+
+	// Тот же writer должен снова пройти путь создания. Иначе ПриЗаписи видит
+	// ЭтоНовый=false, а созданные им FK-строки не находят provisional parent.
+	rolledBack.Set("Наименование", "Повтор после отката")
+	callTx("НачатьТранзакцию")
+	rolledBack.CallMethod("записать", nil)
+	callTx("ЗафиксироватьТранзакцию")
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("повторная запись после rollback оставила %d строк, ожидалась 1", count)
+	}
 
 	callTx("НачатьТранзакцию")
 	committed := proxy.CallMethod("создать", nil).(*catWriter)
@@ -192,8 +208,8 @@ func TestCatWriter_ExplicitTransactionCommitAndRollback(t *testing.T) {
 	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты").Scan(&count); err != nil {
 		t.Fatal(err)
 	}
-	if count != 1 {
-		t.Fatalf("commit left %d catalog rows, want 1", count)
+	if count != 2 {
+		t.Fatalf("commit left %d catalog rows, want 2", count)
 	}
 }
 

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -618,7 +618,11 @@ func (w *docWriter) writeInContext(ctx context.Context) error {
 			return err
 		}
 	}
+	wasSaved := w.saved
 	w.saved = true
+	if !wasSaved {
+		storage.DeferUntilTxRollback(ctx, func() { w.saved = false })
+	}
 	return nil
 }
 

--- a/internal/ui/dsl_documents_test.go
+++ b/internal/ui/dsl_documents_test.go
@@ -391,6 +391,57 @@ func TestDocWriter_IsNewAndRead(t *testing.T) {
 	}
 }
 
+func TestDocWriter_RollbackRestoresIsNew(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	doc := &metadata.Entity{
+		Name:   "Заметка",
+		Kind:   metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{doc}})
+	s := &Server{store: db, reg: registry, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	txState := interpreter.NewTxState(ctx)
+	root := newDocsRoot(s, txState)
+	dp := root.Get("Заметка").(*docProxy)
+	txFns := interpreter.NewTxFunctions(txState, db)
+	callTx := func(name string) {
+		t.Helper()
+		if _, err := txFns[name].(interpreter.BuiltinFunc)(nil, "", 0); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+
+	w := dp.CallMethod("создать", nil).(*docWriter)
+	w.Set("Номер", "ОТКАТ")
+	callTx("НачатьТранзакцию")
+	w.CallMethod("записать", nil)
+	callTx("ОтменитьТранзакцию")
+	if got := w.CallMethod("этоновый", nil); got != true {
+		t.Fatalf("после rollback ЭтоНовый = %v, ожидалось true", got)
+	}
+
+	callTx("НачатьТранзакцию")
+	w.CallMethod("записать", nil)
+	callTx("ЗафиксироватьТранзакцию")
+	var count int
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM заметка").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("повторная запись после rollback оставила %d строк, ожидалась 1", count)
+	}
+}
+
 // Ссылка.ПолучитьОбъект() для существующего документа возвращает docWriter
 // с загруженной шапкой и табличными частями: можно прочитать значения,
 // изменить и Записать() — обновится та же запись по UUID, ТЧ перезапишется.


### PR DESCRIPTION
Part of #407.

- runs OnUnpost when an existing posted document is saved as a draft
- keeps movement cleanup, posted flag, and hook effects in one transaction
- emits one create audit event for provisional new-object writes
- restores catalog/document writer IsNew state after transaction rollback
- adds regression coverage for all affected paths

Validation: `go test -count=1 ./...`