### PR TITLE
test: cover multi-field mask provenance (#407)

### DIFF
--- a/internal/ui/field_access_test.go
+++ b/internal/ui/field_access_test.go
@@ -22,6 +22,7 @@ func uiClientEntity() *metadata.Entity {
 		Fields: []metadata.Field{
 			{Name: "Наименование", Type: metadata.FieldTypeString},
 			{Name: "Телефон", Type: metadata.FieldTypeString},
+			{Name: "Адрес", Type: metadata.FieldTypeString},
 		},
 	}
 }
@@ -43,13 +44,16 @@ func uiMaskUser(ops []string, fields auth.FieldPolicies) *auth.User {
 func TestUI_QueryProjectionMaskGateRejectsAliasAndExpression(t *testing.T) {
 	cat := uiClientEntity()
 	s, _ := newSubmitTestServer(t, []*metadata.Entity{cat})
-	user := uiMaskUser([]string{"read"}, auth.FieldPolicies{"Телефон": {Read: "mask_all"}})
+	user := uiMaskUser([]string{"read"}, auth.FieldPolicies{
+		"Телефон": {Read: "mask_all"},
+		"Адрес":   {Read: "mask_all"},
+	})
 	ctx := auth.ContextWithUser(context.Background(), user)
 
 	for _, text := range []string{
 		`ВЫБРАТЬ Телефон КАК Контакт ИЗ Справочник.Клиент`,
 		`ВЫБРАТЬ Строка(Телефон) КАК Контакт ИЗ Справочник.Клиент`,
-		`ВЫБРАТЬ Телефон + " " + Наименование КАК Контакт ИЗ Справочник.Клиент`,
+		`ВЫБРАТЬ Телефон + " " + Адрес КАК Контакт ИЗ Справочник.Клиент`,
 		`ВЫБРАТЬ * ИЗ Справочник.Клиент`,
 	} {
 		compiled, err := s.compileQueryWithRowAccess(ctx, text, nil)


### PR DESCRIPTION
Completes the binary-expression provenance regression requested in #407. Both `Телефон` and `Адрес` are protected fields in `Телефон + " " + Адрес`, so the fail-closed projection gate must reject the result.

Validation: `go test -count=1 ./internal/ui -run TestUI_QueryProjectionMaskGateRejectsAliasAndExpression`