### PR TITLE
fix(security): mask UUID-derived record labels (#396)

### DIFF
--- a/internal/ui/dsl_object_attr.go
+++ b/internal/ui/dsl_object_attr.go
@@ -119,7 +119,7 @@ func (s *Server) objectAttributeValues(ctx context.Context, args []any) (any, er
 			continue
 		}
 		if ref.key.Name == "" || ref.key.Name == ref.key.UUID {
-			ref.key.Name = firstStringField(row, entity)
+			ref.key.Name = s.maskedRecordLabel(ctx, entity, row)
 		}
 		vals := make(map[string]any, len(fields))
 		for _, f := range fields {
@@ -330,7 +330,7 @@ func (s *Server) bulkReferenceNames(ctx context.Context, rows map[string]map[str
 		}
 		names[entityName] = make(map[string]string, len(refRows))
 		for idStr, row := range refRows {
-			names[entityName][idStr] = firstStringField(row, refEntity)
+			names[entityName][idStr] = s.maskedRecordLabel(ctx, refEntity, row)
 		}
 	}
 	return names
@@ -392,7 +392,7 @@ func (s *Server) refFromValue(ctx context.Context, refEntityName string, raw any
 		if id, err := uuid.Parse(idStr); err == nil {
 			if err := s.checkDSLRowAccess(ctx, refEntity, "read", id, nil); err == nil {
 				if rr, err := s.store.GetByID(ctx, refEntity.Name, id, refEntity); err == nil && rr != nil {
-					name = firstStringField(rr, refEntity)
+					name = s.maskedRecordLabel(ctx, refEntity, rr)
 				}
 			}
 		}

--- a/internal/ui/field_access.go
+++ b/internal/ui/field_access.go
@@ -35,6 +35,15 @@ func (s *Server) maskRecords(ctx context.Context, entity *metadata.Entity, rows 
 	access.MaskRecords(s.fieldDecisions(ctx, entity), rows)
 }
 
+// maskedRecordLabel is the only safe way to derive a user-visible label from
+// a freshly loaded record. Reference resolvers often read a row vertically
+// (UUID → label), bypassing the list/form masking chokepoints; mask first so a
+// sensitive first string field cannot leak through reports, widgets or audit.
+func (s *Server) maskedRecordLabel(ctx context.Context, entity *metadata.Entity, row map[string]any) string {
+	s.maskRecord(ctx, entity, row)
+	return firstStringField(row, entity)
+}
+
 // deniedMaskedColumn is the fail-closed report/AI gate (план 88D): cols are
 // logical fields from query.Result.ProjectionFields, before output aliases.
 func (s *Server) deniedMaskedColumn(ctx context.Context, sources []query.SourceRef, cols []string) string {

--- a/internal/ui/field_access_test.go
+++ b/internal/ui/field_access_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -193,6 +194,46 @@ func TestUI_AppendSelectedRefOptions_MasksPII(t *testing.T) {
 	}
 	if rows[0]["_label"] != "Иванов" {
 		t.Fatalf("подпись опции должна остаться видимой, получено %v", rows[0]["_label"])
+	}
+}
+
+// Vertical UUID→label resolvers must mask the referenced row before choosing
+// its first string field. Otherwise a report/export that projects only a UUID
+// can disclose a protected value that was never present in the projection.
+func TestUI_ReferenceLabelsMaskFirstStringField(t *testing.T) {
+	client := &metadata.Entity{
+		Name: "Клиент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Телефон", Type: metadata.FieldTypeString},
+		},
+	}
+	call := &metadata.Entity{
+		Name: "Звонок",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Клиент", Type: "reference:Клиент", RefEntity: client.Name},
+		},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{client, call})
+	id := uuid.New()
+	const secret = "+79161234455"
+	if err := s.store.Upsert(ctx, client.Name, id, map[string]any{"Телефон": secret}, client); err != nil {
+		t.Fatal(err)
+	}
+	user := uiMaskUser([]string{"read"}, auth.FieldPolicies{"Телефон": {Read: "mask_all"}})
+	uctx := auth.ContextWithUser(ctx, user)
+
+	reportRows := []map[string]any{{"Клиент": id.String()}}
+	s.resolveUUIDsInReport(uctx, reportRows, "")
+	if got := fmt.Sprint(reportRows[0]["Клиент"]); got == secret || got != "••••••" {
+		t.Fatalf("report UUID label = %q, want fixed mask", got)
+	}
+
+	refRows := []map[string]any{{"Клиент": id.String()}}
+	s.resolveRefs(uctx, call, refRows)
+	if got := fmt.Sprint(refRows[0]["Клиент"]); got == secret || got != "••••••" {
+		t.Fatalf("reference field label = %q, want fixed mask", got)
 	}
 }
 

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -444,7 +444,7 @@ func (s *Server) resolveRefColumns(ctx context.Context, rows []map[string]any, c
 			for _, entity := range entities {
 				refRow, err := s.store.GetByID(ctx, entity.Name, id, entity)
 				if err == nil {
-					uuidToLabel[idStr] = firstStringField(refRow, entity)
+					uuidToLabel[idStr] = s.maskedRecordLabel(ctx, entity, refRow)
 					break
 				}
 			}
@@ -880,7 +880,7 @@ func (s *Server) resolveRefs(ctx context.Context, entity *metadata.Entity, rows 
 			if err != nil {
 				continue
 			}
-			labels[idStr] = firstStringField(refRow, refEntity)
+			labels[idStr] = s.maskedRecordLabel(ctx, refEntity, refRow)
 		}
 		// replace UUIDs with labels in all rows
 		for _, row := range rows {
@@ -927,7 +927,7 @@ func (s *Server) enrichTPRowsWithRefs(ctx context.Context, tp metadata.TablePart
 		}
 		labels := make(map[string]string, len(refRows))
 		for idStr, refRow := range refRows {
-			labels[idStr] = firstStringField(refRow, refEntity)
+			labels[idStr] = s.maskedRecordLabel(ctx, refEntity, refRow)
 		}
 		// replace plain UUID strings with *interpreter.Ref{UUID, Name, Manager}
 		mgr := s.refManagerFor(refEntity, ctx)
@@ -999,7 +999,7 @@ func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, 
 		}
 		obj.Fields[matchKey] = &interpreter.Ref{
 			UUID:    idStr,
-			Name:    firstStringField(refRow, refEntity),
+			Name:    s.maskedRecordLabel(ctx, refEntity, refRow),
 			Type:    refEntity.Name,
 			Manager: s.refManagerFor(refEntity, ctx),
 		}
@@ -1024,7 +1024,7 @@ func (s *Server) buildHierarchyBreadcrumbs(ctx context.Context, entity *metadata
 		}
 		crumbs = append(crumbs, map[string]string{
 			"ID":    ancestorID.String(),
-			"Label": firstStringField(row, entity),
+			"Label": s.maskedRecordLabel(ctx, entity, row),
 		})
 	}
 	return crumbs
@@ -1046,7 +1046,7 @@ func (s *Server) loadFolderOptions(ctx context.Context, entity *metadata.Entity,
 	var folders []map[string]any
 	for _, row := range rows {
 		if asBool(row["is_folder"]) {
-			row["_label"] = firstStringField(row, entity)
+			row["_label"] = s.maskedRecordLabel(ctx, entity, row)
 			folders = append(folders, row)
 		}
 	}
@@ -1076,7 +1076,7 @@ func (s *Server) appendSelectedFolderOptions(ctx context.Context, rows []map[str
 		if !s.rowAllowsSelected(ctx, entity, row) {
 			continue
 		}
-		row["_label"] = firstStringField(row, entity)
+		row["_label"] = s.maskedRecordLabel(ctx, entity, row)
 		rows = append(rows, row)
 		seen[idStr] = true
 	}

--- a/internal/ui/handlers_audit_enrich.go
+++ b/internal/ui/handlers_audit_enrich.go
@@ -58,7 +58,7 @@ func (s *Server) enrichAuditEntries(ctx context.Context, entity *metadata.Entity
 			if err != nil {
 				continue
 			}
-			refLabels[key] = firstStringField(refRow, refEntity)
+			refLabels[key] = s.maskedRecordLabel(ctx, refEntity, refRow)
 		}
 	}
 	for _, e := range entries {
@@ -152,7 +152,7 @@ func (s *Server) enrichAuditEntriesGlobal(ctx context.Context, entries []*storag
 			if err != nil {
 				continue
 			}
-			refLabels[key] = firstStringField(refRow, refEntity)
+			refLabels[key] = s.maskedRecordLabel(ctx, refEntity, refRow)
 		}
 		if e.OldValue != nil {
 			if idStr := extractUUIDFromAuditVal(e.OldValue); idStr != "" {

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -1617,7 +1617,7 @@ func (s *Server) deleteMarkedAll(w http.ResponseWriter, r *http.Request) {
 				EntityName: entity.Name,
 				Kind:       string(entity.Kind),
 				ID:         idStr,
-				Label:      firstStringField(row, entity),
+				Label:      s.maskedRecordLabel(r.Context(), entity, row),
 				HasRefs:    len(refs) > 0,
 			})
 		}

--- a/internal/ui/handlers_journals.go
+++ b/internal/ui/handlers_journals.go
@@ -218,7 +218,7 @@ func (s *Server) resolveJournalRefs(ctx context.Context, j *metadata.Journal, co
 			if err != nil {
 				continue
 			}
-			labels[idStr] = firstStringField(refRow, refEntity)
+			labels[idStr] = s.maskedRecordLabel(ctx, refEntity, refRow)
 		}
 		// Replace in rows
 		for _, row := range rows {

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -390,7 +390,7 @@ func (s *Server) resolveUUIDsInReport(ctx context.Context, rows []map[string]any
 			}
 			id, _ := uuid.Parse(idStr)
 			if refRow, err := s.store.GetByID(ctx, entity.Name, id, entity); err == nil {
-				uuidToLabel[idStr] = firstStringField(refRow, entity)
+				uuidToLabel[idStr] = s.maskedRecordLabel(ctx, entity, refRow)
 			}
 		}
 	}

--- a/internal/widget/reference_mask_test.go
+++ b/internal/widget/reference_mask_test.go
@@ -1,0 +1,61 @@
+package widget
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func TestReferencePresentationsMaskFirstStringField(t *testing.T) {
+	ctx := context.Background()
+	entity := &metadata.Entity{
+		Name: "Клиент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Телефон", Type: metadata.FieldTypeString},
+		},
+	}
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "widget-mask.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.Migrate(ctx, []*metadata.Entity{entity}); err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.New()
+	const secret = "+79161234455"
+	if err := db.Upsert(ctx, entity.Name, id, map[string]any{"Телефон": secret}, entity); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := runtime.NewRegistry()
+	reg.Load(runtime.LoadOptions{Entities: []*metadata.Entity{entity}})
+	runner := &Runner{
+		Reg:   reg,
+		Store: db,
+		User: &auth.User{Login: "operator", Roles: []*auth.Role{{
+			Permissions: auth.Permission{
+				Catalogs: map[string][]string{entity.Name: {"read"}},
+				FieldAccess: auth.FieldAccess{Catalogs: map[string]auth.FieldPolicies{
+					entity.Name: {"Телефон": {Read: "mask_all"}},
+				}},
+			},
+		}}},
+	}
+
+	rows := []map[string]any{{"Клиент": id.String()}}
+	runner.resolveUUIDs(ctx, rows)
+	if got := rows[0]["Клиент"]; got == secret || got != "••••••" {
+		t.Fatalf("widget UUID label = %q, want fixed mask", got)
+	}
+	if got := recordPresentation(ctx, runner, entity.Name, id.String()); got == secret || got != "••••••" {
+		t.Fatalf("recent presentation = %q, want fixed mask", got)
+	}
+}

--- a/internal/widget/runner.go
+++ b/internal/widget/runner.go
@@ -437,6 +437,7 @@ func (r *Runner) resolveUUIDs(ctx context.Context, rows []map[string]any) {
 				continue
 			}
 			if refRow, err := r.Store.GetByID(ctx, entity.Name, id, entity); err == nil {
+				r.maskRecord(entity, refRow)
 				for _, f := range entity.Fields {
 					if s, ok := refRow[f.Name].(string); ok && strings.TrimSpace(s) != "" {
 						uuidToLabel[idStr] = s
@@ -707,6 +708,7 @@ func recordPresentation(ctx context.Context, r *Runner, entityName, idStr string
 	if err != nil || row == nil {
 		return shortID(idStr)
 	}
+	r.maskRecord(ent, row)
 	if ent.Kind == metadata.KindDocument {
 		num := fmt.Sprintf("%v", firstNonEmpty(row, "Номер", "Number"))
 		dateRaw := firstNonEmpty(row, "Дата", "Date")
@@ -728,6 +730,15 @@ func recordPresentation(ctx context.Context, r *Runner, entityName, idStr string
 		}
 	}
 	return shortID(idStr)
+}
+
+// maskRecord applies the same field-level policy as UI read paths before a
+// UUID-derived label enters a widget result (and potentially its cache).
+func (r *Runner) maskRecord(entity *metadata.Entity, row map[string]any) {
+	if entity == nil {
+		return
+	}
+	access.MaskRecord(access.FieldDecisions(r.User, string(entity.Kind), entity.Name, entity), row)
 }
 
 func firstNonEmpty(row map[string]any, keys ...string) any {


### PR DESCRIPTION
## Что исправлено
- все пользовательские UUID→label резолверы маскируют загруженную запись до выбора первого строкового поля
- закрыты отчёты/Excel, журналы, аудит, общие ссылочные резолверы и DSL-представления
- list/chart/recent widgets применяют field_access до подписи и до кэширования
- добавлены регресс-тесты для report/reference и widget/recent путей

## Проверки
- `go test -count=1 ./internal/ui ./internal/widget`
- `git diff --check`

Closes #396