### PR TITLE
fix: make nested DSL writes atomic and versioned (#397-#400)

### DIFF
--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -235,7 +235,7 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 	// шапка, ТЧ, движения и проведение. Для нового объекта сначала вставляется
 	// полноценная шапка: FK-ссылки из создаваемых хуком объектов уже валидны, но
 	// при любой последующей ошибке откатываются вместе с родителем.
-	err := s.Store.WithTxIfNeeded(ctx, func(txCtx context.Context) error {
+	err := s.Store.WithTxScope(ctx, func(txCtx context.Context) error {
 		if req.Entity.Posting && !req.IsNew && !isPosting {
 			stored, err := s.Store.GetByID(txCtx, req.Entity.Name, req.ID, req.Entity)
 			if err != nil {
@@ -438,7 +438,7 @@ func (s *Service) Unpost(ctx context.Context, entity *metadata.Entity, id uuid.U
 	lockCollector := runtime.NewLockCollector()
 	defer lockCollector.ReleaseAll()
 
-	err := s.Store.WithTxIfNeeded(ctx, func(txCtx context.Context) error {
+	err := s.Store.WithTxScope(ctx, func(txCtx context.Context) error {
 		return s.unpostInTx(txCtx, entity, id, result.Movements, &result.DSLMessages, lockCollector)
 	})
 	if err != nil {

--- a/internal/storage/tx.go
+++ b/internal/storage/tx.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"sync/atomic"
 
 	"github.com/jackc/pgx/v5"
 )
 
 type txKey struct{}
+
+var txScopeSequence atomic.Uint64
 
 // IsNotFound reports the portable no-row condition for both storage drivers.
 func IsNotFound(err error) bool {
@@ -28,6 +32,48 @@ func (db *DB) WithTxIfNeeded(ctx context.Context, fn func(context.Context) error
 		return fn(ctx)
 	}
 	return db.WithTx(ctx, fn)
+}
+
+// WithTxScope makes fn atomic even when ctx already carries a transaction.
+// A top-level call owns a regular transaction; a nested/borrowed call owns a
+// savepoint, so returning an error cannot leave provisional rows or hook side
+// effects in the caller's transaction.
+func (db *DB) WithTxScope(ctx context.Context, fn func(context.Context) error) (err error) {
+	if !HasTx(ctx) {
+		return db.WithTx(ctx, fn)
+	}
+
+	savepoint := fmt.Sprintf("onebase_scope_%d", txScopeSequence.Add(1))
+	if _, err := db.Exec(ctx, "SAVEPOINT "+savepoint); err != nil {
+		return fmt.Errorf("create savepoint %s: %w", savepoint, err)
+	}
+	PushTxHookScope(ctx)
+
+	rollback := func() error {
+		_, rollbackErr := db.Exec(ctx, "ROLLBACK TO SAVEPOINT "+savepoint)
+		_, releaseErr := db.Exec(ctx, "RELEASE SAVEPOINT "+savepoint)
+		RollbackTxHookScope(ctx)
+		return errors.Join(rollbackErr, releaseErr)
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			_ = rollback()
+			panic(p)
+		}
+	}()
+
+	if err = fn(ctx); err != nil {
+		if rollbackErr := rollback(); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("rollback savepoint %s: %w", savepoint, rollbackErr))
+		}
+		return err
+	}
+	if _, err = db.Exec(ctx, "RELEASE SAVEPOINT "+savepoint); err != nil {
+		RollbackTxHookScope(ctx)
+		return fmt.Errorf("release savepoint %s: %w", savepoint, err)
+	}
+	CommitTxHookScope(ctx)
+	return nil
 }
 
 // WithTx runs fn inside a transaction. On fn error the transaction is rolled

--- a/internal/storage/tx_scope_test.go
+++ b/internal/storage/tx_scope_test.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestWithTxScopeRollsBackOnlyBorrowedScope(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "scope.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(ctx, `CREATE TABLE scoped_writes (value TEXT NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+
+	var hooks []string
+	err = db.WithTx(ctx, func(outerCtx context.Context) error {
+		if _, err := db.Exec(outerCtx, `INSERT INTO scoped_writes(value) VALUES (?)`, "outer"); err != nil {
+			return err
+		}
+		innerErr := db.WithTxScope(outerCtx, func(innerCtx context.Context) error {
+			if _, err := db.Exec(innerCtx, `INSERT INTO scoped_writes(value) VALUES (?)`, "inner"); err != nil {
+				return err
+			}
+			DeferUntilTxCommit(innerCtx, func() { hooks = append(hooks, "inner commit") })
+			DeferUntilTxRollback(innerCtx, func() { hooks = append(hooks, "inner rollback") })
+			return errors.New("reject inner write")
+		})
+		if innerErr == nil {
+			return errors.New("inner scope unexpectedly succeeded")
+		}
+
+		var count int
+		if err := db.QueryRow(outerCtx, `SELECT COUNT(*) FROM scoped_writes`).Scan(&count); err != nil {
+			return err
+		}
+		if count != 1 {
+			return errors.New("inner row survived savepoint rollback")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var values []string
+	rows, err := db.Query(ctx, `SELECT value FROM scoped_writes`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			t.Fatal(err)
+		}
+		values = append(values, value)
+	}
+	if len(values) != 1 || values[0] != "outer" {
+		t.Fatalf("committed rows = %v, want [outer]", values)
+	}
+	if len(hooks) != 1 || hooks[0] != "inner rollback" {
+		t.Fatalf("savepoint hooks = %v, want [inner rollback]", hooks)
+	}
+}

--- a/internal/ui/dsl_catalogs.go
+++ b/internal/ui/dsl_catalogs.go
@@ -78,7 +78,14 @@ func (f *catFactory) LoadCatalogObject(entity *metadata.Entity, uuidStr string) 
 	if err != nil {
 		return nil, err
 	}
-	return &catWriter{s: f.s, ctxSrc: f.ctxSrc, entity: entity, obj: obj, loaded: true}, nil
+	version, err := f.s.store.EntityVersion(ctx, entity.Name, id)
+	if err != nil {
+		return nil, err
+	}
+	return &catWriter{
+		s: f.s, ctxSrc: f.ctxSrc, entity: entity, obj: obj, loaded: true,
+		expectedVersion: &version,
+	}, nil
 }
 
 func (f *catFactory) ctx() context.Context {
@@ -102,8 +109,9 @@ type catWriter struct {
 	obj    *runtime.Object
 	// loaded — объект получен из БД (Ссылка.ПолучитьОбъект), а не создан.
 	// saved — объект уже записан в этой сессии. Оба используются ЭтоНовый().
-	loaded bool
-	saved  bool
+	loaded          bool
+	saved           bool
+	expectedVersion *int64
 }
 
 func (w *catWriter) ctx() context.Context {
@@ -175,11 +183,12 @@ func (w *catWriter) write() error {
 		return err
 	}
 	result, err := w.s.entitySvc.Save(ctx, entityservice.SaveRequest{
-		Entity:        w.entity,
-		ID:            w.obj.ID,
-		IsNew:         isNew,
-		Fields:        w.obj.Fields,
-		TablePartRows: w.obj.TablePartRows,
+		Entity:          w.entity,
+		ID:              w.obj.ID,
+		IsNew:           isNew,
+		Fields:          w.obj.Fields,
+		TablePartRows:   w.obj.TablePartRows,
+		ExpectedVersion: w.expectedVersion,
 	})
 	if err != nil {
 		return err
@@ -187,11 +196,17 @@ func (w *catWriter) write() error {
 	if result.DSLError != "" {
 		return fmt.Errorf("%s", result.DSLError)
 	}
-	wasSaved := w.saved
-	w.saved = true
-	if !wasSaved {
-		storage.DeferUntilTxRollback(ctx, func() { w.saved = false })
+	version, err := w.s.store.EntityVersion(ctx, w.entity.Name, w.obj.ID)
+	if err != nil {
+		return err
 	}
+	wasSaved, previousVersion := w.saved, w.expectedVersion
+	w.saved = true
+	w.expectedVersion = &version
+	storage.DeferUntilTxRollback(ctx, func() {
+		w.saved = wasSaved
+		w.expectedVersion = previousVersion
+	})
 	return nil
 }
 
@@ -215,6 +230,11 @@ func (w *catWriter) read() error {
 		return err
 	}
 	w.obj = obj
+	version, err := w.s.store.EntityVersion(w.ctx(), w.entity.Name, w.obj.ID)
+	if err != nil {
+		return err
+	}
+	w.expectedVersion = &version
 	w.loaded = true
 	return nil
 }

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -371,12 +371,17 @@ func (p *docProxy) LoadObject(uuidStr string) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	version, err := p.s.store.EntityVersion(p.ctx(), p.entity.Name, id)
+	if err != nil {
+		return nil, err
+	}
 	return &docWriter{
-		s:      p.s,
-		ctxSrc: p.ctxSrc,
-		entity: p.entity,
-		obj:    obj,
-		loaded: true,
+		s:               p.s,
+		ctxSrc:          p.ctxSrc,
+		entity:          p.entity,
+		obj:             obj,
+		loaded:          true,
+		expectedVersion: &version,
 	}, nil
 }
 
@@ -395,8 +400,9 @@ type docWriter struct {
 	obj    *runtime.Object
 	// loaded — объект получен из БД (Ссылка.ПолучитьОбъект), а не создан.
 	// saved — объект уже записан в этой сессии. Оба используются ЭтоНовый().
-	loaded bool
-	saved  bool
+	loaded          bool
+	saved           bool
+	expectedVersion *int64
 }
 
 func (w *docWriter) ctx() context.Context {
@@ -439,10 +445,7 @@ func (w *docWriter) CallMethod(method string, args []any) any {
 		if err := w.s.checkDSLRowAccess(w.ctx(), w.entity, "post", w.accessID(), w.obj.Fields); err != nil {
 			interpreter.RaiseUserError("Провести(" + w.entity.Name + "): " + err.Error())
 		}
-		if err := w.write(); err != nil {
-			interpreter.RaiseUserError("Провести/Записать(" + w.entity.Name + "): " + err.Error())
-		}
-		if err := w.post(); err != nil {
+		if err := w.conduct(); err != nil {
 			interpreter.RaiseUserError("Провести(" + w.entity.Name + "): " + err.Error())
 		}
 		return w.ref()
@@ -502,6 +505,11 @@ func (w *docWriter) read() error {
 	for _, tp := range w.entity.TableParts {
 		w.s.enrichTPRowsWithRefs(w.ctx(), tp, tpRows[tp.Name])
 	}
+	version, err := w.s.store.EntityVersion(w.ctx(), w.entity.Name, w.obj.ID)
+	if err != nil {
+		return err
+	}
+	w.expectedVersion = &version
 	w.loaded = true
 	return nil
 }
@@ -582,7 +590,7 @@ func (w *docWriter) autoNumber(ctx context.Context) {
 // Использует живой ctx, поэтому при открытой DSL-транзакции запись
 // участвует в ней; иначе автокоммит.
 func (w *docWriter) write() error {
-	return w.s.store.WithTxIfNeeded(w.ctx(), w.writeInContext)
+	return w.s.store.WithTxScope(w.ctx(), w.writeInContext)
 }
 
 func (w *docWriter) writeInContext(ctx context.Context) error {
@@ -600,8 +608,14 @@ func (w *docWriter) writeInContext(ctx context.Context) error {
 	if errMsg, _ := w.s.runOnWriteCtx(ctx, w.obj, mc); errMsg != "" {
 		return fmt.Errorf("%s", errMsg)
 	}
-	if err := w.s.store.Upsert(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
-		return err
+	if w.expectedVersion == nil {
+		if err := w.s.store.Upsert(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
+			return err
+		}
+	} else {
+		if err := w.s.store.UpsertVersioned(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity, w.expectedVersion); err != nil {
+			return err
+		}
 	}
 	if err := w.s.saveTablePartsDirect(ctx, w.entity, w.obj.ID, w.obj.TablePartRows); err != nil {
 		return err
@@ -618,11 +632,17 @@ func (w *docWriter) writeInContext(ctx context.Context) error {
 			return err
 		}
 	}
-	wasSaved := w.saved
-	w.saved = true
-	if !wasSaved {
-		storage.DeferUntilTxRollback(ctx, func() { w.saved = false })
+	version, err := w.s.store.EntityVersion(ctx, w.entity.Name, w.obj.ID)
+	if err != nil {
+		return err
 	}
+	wasSaved, previousVersion := w.saved, w.expectedVersion
+	w.saved = true
+	w.expectedVersion = &version
+	storage.DeferUntilTxRollback(ctx, func() {
+		w.saved = wasSaved
+		w.expectedVersion = previousVersion
+	})
 	return nil
 }
 
@@ -633,10 +653,24 @@ func (w *docWriter) accessID() uuid.UUID {
 	return uuid.Nil
 }
 
-// post запускает OnPost, собирает движения и фиксирует проведение —
-// та же логика, что в postDocument (UI-проведение).
+// conduct performs the implicit write and posting as one atomic operation.
+// OnWrite, OnPost and all nested DSL writes share the same transaction/scope.
+func (w *docWriter) conduct() error {
+	return w.s.store.WithTxScope(w.ctx(), func(ctx context.Context) error {
+		if err := w.writeInContext(ctx); err != nil {
+			return err
+		}
+		return w.postInContext(ctx)
+	})
+}
+
 func (w *docWriter) post() error {
-	ctx := w.ctx()
+	return w.s.store.WithTxScope(w.ctx(), w.postInContext)
+}
+
+// postInContext запускает OnPost, собирает движения и фиксирует проведение —
+// та же логика, что в postDocument (UI-проведение).
+func (w *docWriter) postInContext(ctx context.Context) error {
 	if err := w.s.checkDSLRowAccess(ctx, w.entity, "post", w.obj.ID, w.obj.Fields); err != nil {
 		return err
 	}
@@ -659,21 +693,19 @@ func (w *docWriter) post() error {
 		return fmt.Errorf("%s", errMsg)
 	}
 	// OnPost мог изменить реквизиты шапки (расчётные поля) — персистим их upsert'ом
-	// после хука, как это делает entityservice.Save при проведении. Финальный Upsert
-	// повышает _version, поэтому очередь обмена обязательно перерегистрируется в
-	// этой же транзакции: RegisterExchangeChange — idempotent upsert, это не эхо.
-	return w.s.store.WithTxIfNeeded(ctx, func(ctx context.Context) error {
-		if err := w.s.store.Upsert(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
-			return err
-		}
-		if err := w.s.saveMovements(ctx, w.entity.Name, w.obj.ID, mc); err != nil {
-			return err
-		}
-		if err := w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true); err != nil {
-			return err
-		}
-		return exchange.RegisterOnSave(ctx, w.s.store, w.s.reg.ExchangePlans(), w.entity, w.obj.ID, false)
-	})
+	// после хука, как это делает entityservice.Save при проведении. writeInContext
+	// уже создал ровно одну логическую версию этой операции, поэтому сохраняем
+	// hook-поля без второго инкремента _version.
+	if err := w.s.store.UpsertPreserveVersion(ctx, w.entity.Name, w.obj.ID, w.obj.Fields, w.entity); err != nil {
+		return err
+	}
+	if err := w.s.saveMovements(ctx, w.entity.Name, w.obj.ID, mc); err != nil {
+		return err
+	}
+	if err := w.s.store.SetPosted(ctx, w.entity.Name, w.obj.ID, true); err != nil {
+		return err
+	}
+	return exchange.RegisterOnSave(ctx, w.s.store, w.s.reg.ExchangePlans(), w.entity, w.obj.ID, false)
 }
 
 // ensureSelfRef устанавливает псевдо-реквизит «Ссылка» самого документа, чтобы

--- a/internal/ui/dsl_documents_test.go
+++ b/internal/ui/dsl_documents_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -186,6 +187,159 @@ func TestDocsRoot_CreateWritePost(t *testing.T) {
 	}
 	if len(pkg.Objects) != 1 || !pkg.Objects[0].Posted || pkg.Objects[0].Version != version {
 		t.Fatalf("DSL-проведение не попало в пакет: %+v", pkg.Objects)
+	}
+}
+
+func TestDocsRoot_DirectPostCreatesSingleVersion(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "version.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	doc := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument, Posting: true,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{doc}})
+	s := &Server{store: db, reg: registry, interp: interpreter.New(), lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+
+	writer := newDocsRoot(s, interpreter.NewTxState(ctx)).Get(doc.Name).(*docProxy).
+		CallMethod("создать", nil).(*docWriter)
+	writer.Set("Номер", "З-1")
+	if err := writer.conduct(); err != nil {
+		t.Fatal(err)
+	}
+	if version, err := db.EntityVersion(ctx, doc.Name, writer.obj.ID); err != nil || version != 1 {
+		t.Fatalf("new direct post version = %d, err=%v, want 1", version, err)
+	}
+
+	writer.Set("Номер", "З-2")
+	if err := writer.conduct(); err != nil {
+		t.Fatal(err)
+	}
+	if version, err := db.EntityVersion(ctx, doc.Name, writer.obj.ID); err != nil || version != 2 {
+		t.Fatalf("second logical post version = %d, err=%v, want 2", version, err)
+	}
+}
+
+func TestDocsRoot_PostRollsBackOnPostSideEffectsWhenFinalWriteFails(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "post-atomic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	doc := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument, Posting: true,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	child := &metadata.Entity{
+		Name: "Событие", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	missingRegister := &metadata.Register{
+		Name:      "НеСозданныйРегистр",
+		Resources: []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+	// Deliberately do not migrate the register: saving its movement fails after
+	// OnPost has already created a child catalog record.
+	if err := db.Migrate(ctx, []*metadata.Entity{doc, child}); err != nil {
+		t.Fatal(err)
+	}
+	onPost := `Процедура ОбработкаПроведения()
+  Соб = Справочники.Событие.Создать();
+  Соб.Наименование = "побочная запись";
+  Соб.Записать();
+  Дв = Движения.НеСозданныйРегистр.Добавить();
+  Дв.Количество = 1;
+КонецПроцедуры`
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities:  []*metadata.Entity{doc, child},
+		Programs:  map[string]*ast.Program{doc.Name: mustParse(t, onPost)},
+		Registers: []*metadata.Register{missingRegister},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{store: db, reg: registry, interp: interp, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	s.entitySvc = s.newEntityService(nil)
+
+	writer := newDocsRoot(s, interpreter.NewTxState(ctx)).Get(doc.Name).(*docProxy).
+		CallMethod("создать", nil).(*docWriter)
+	writer.Set("Номер", "З-FAIL")
+	if err := writer.conduct(); err == nil {
+		t.Fatal("post unexpectedly succeeded without register table")
+	}
+	parents, err := db.List(ctx, doc.Name, doc, storage.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	children, err := db.List(ctx, child.Name, child, storage.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parents) != 0 || len(children) != 0 {
+		t.Fatalf("failed post left parent=%d child=%d", len(parents), len(children))
+	}
+	if writer.saved || writer.expectedVersion != nil {
+		t.Fatalf("rolled-back writer state: saved=%v version=%v", writer.saved, writer.expectedVersion)
+	}
+}
+
+func TestDocsRoot_LoadedWritersUseOptimisticLock(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "dsl-lock.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	task := &metadata.Entity{
+		Name: "Задача", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Состояние", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{task}); err != nil {
+		t.Fatal(err)
+	}
+	id := uuid.New()
+	if err := db.Upsert(ctx, task.Name, id, map[string]any{"Номер": "ЗД-1", "Состояние": "Открыта"}, task); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{task}})
+	s := &Server{store: db, reg: registry, interp: interpreter.New(), lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	proxy := newDocsRoot(s, interpreter.NewTxState(ctx)).Get(task.Name).(*docProxy)
+
+	firstAny, err := proxy.LoadObject(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondAny, err := proxy.LoadObject(id.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, second := firstAny.(*docWriter), secondAny.(*docWriter)
+	first.Set("Состояние", "Выполнена")
+	if err := first.write(); err != nil {
+		t.Fatal(err)
+	}
+	second.Set("Состояние", "Отклонена")
+	if err := second.write(); !errors.Is(err, storage.ErrVersionConflict) {
+		t.Fatalf("stale DSL writer error = %v, want ErrVersionConflict", err)
+	}
+	row, err := db.GetByID(ctx, task.Name, id, task)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row["Состояние"] != "Выполнена" {
+		t.Fatalf("stale writer overwrote task: %#v", row)
 	}
 }
 

--- a/internal/ui/posting_new_document_test.go
+++ b/internal/ui/posting_new_document_test.go
@@ -156,6 +156,62 @@ func TestSaveNewDocument_HookChildAndFailureRollBackTogether(t *testing.T) {
 	}
 }
 
+// A Save called from an already open DSL transaction owns a savepoint. A hook
+// failure must roll back its provisional parent and child writes without
+// poisoning or rolling back unrelated work in the caller's transaction.
+func TestSaveNewDocument_BorrowedTransactionHookFailureUsesSavepoint(t *testing.T) {
+	ctx, db, s, doc, cat := newSelfRefPostingServer(t)
+	failing := `Процедура ОбработкаПроведения()
+  Соб = Справочники.СобытиеПрибора.Создать();
+  Соб.Прибор = ЭтотОбъект.Ссылка;
+  Соб.Записать();
+  ВызватьИсключение("откатить внутреннюю запись");
+КонецПроцедуры`
+	s.reg.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{doc, cat},
+		Programs: map[string]*ast.Program{"Прибор": mustParse(t, failing)},
+	})
+
+	outerChildID := uuid.New()
+	if err := db.WithTx(ctx, func(outerCtx context.Context) error {
+		if err := db.Upsert(outerCtx, cat.Name, outerChildID, map[string]any{}, cat); err != nil {
+			return err
+		}
+		result, err := s.entitySvc.Save(outerCtx, entityservice.SaveRequest{
+			Entity: doc, ID: uuid.New(), IsNew: true,
+			Fields: map[string]any{"Номер": "П-SAVEPOINT"}, Action: "post",
+		})
+		if err != nil {
+			return err
+		}
+		if result.DSLError == "" {
+			return fmt.Errorf("expected hook DSLError")
+		}
+		parents, err := db.List(outerCtx, doc.Name, doc, storage.ListParams{})
+		if err != nil {
+			return err
+		}
+		children, err := db.List(outerCtx, cat.Name, cat, storage.ListParams{})
+		if err != nil {
+			return err
+		}
+		if len(parents) != 0 || len(children) != 1 {
+			return fmt.Errorf("savepoint rollback left parent=%d children=%d", len(parents), len(children))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	children, err := db.List(ctx, cat.Name, cat, storage.ListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != 1 || refValueString(children[0]["id"]) != outerChildID.String() {
+		t.Fatalf("outer transaction result = %#v, want only unrelated child", children)
+	}
+}
+
 // Регрессия issue #381: ссылка в шапке обогащалась до открытия транзакции
 // проведения и сохраняла нетранзакционный context. Поэтому
 // this.Счётчик.ПолучитьОбъект().Записать() из OnPost пытался открыть вторую


### PR DESCRIPTION
## Что исправлено
- вложенный `entityservice.Save` использует SAVEPOINT и откатывает только свою область при ошибке хука
- DSL `Провести()` выполняет `OnWrite`, `OnPost`, вложенные записи, движения и флаг проведения в одной атомарной области
- hook-поля сохраняются без второго инкремента `_version`: новая прямая публикация получает version=1
- загруженные DSL-документы и справочники сохраняются через optimistic CAS; stale writer получает `ErrVersionConflict`
- состояние writer (`saved`/expected version) также восстанавливается при rollback

Описание #397 частично устарело: `OnWrite` уже находился в собственной транзакции, но `OnPost` был снаружи. PR закрывает подтверждённую часть и общий borrowed-tx пробел.

## Проверки
- `go test -count=1 ./...`
- `git diff --check`

Closes #397
Closes #398
Closes #399
Closes #400