### PR TITLE
fix: harden portability and DSL type guards (#403-#406)

### DIFF
--- a/internal/dsl/interpreter/catalogs_proxy.go
+++ b/internal/dsl/interpreter/catalogs_proxy.go
@@ -192,7 +192,7 @@ func (r *CatalogsRoot) WithObjectFactory(f CatalogObjectFactory) *CatalogsRoot {
 
 func (r *CatalogsRoot) Get(entityName string) any {
 	entity := r.lookup.GetEntity(entityName)
-	if entity == nil {
+	if entity == nil || entity.Kind != metadata.KindCatalog {
 		return nil
 	}
 	return &CatalogProxy{entity: entity, db: r.db, ctxSrc: r.ctxSrc, caller: r.caller, access: r.access, registrar: r.registrar, objFactory: r.objFactory}

--- a/internal/dsl/interpreter/catalogs_proxy_test.go
+++ b/internal/dsl/interpreter/catalogs_proxy_test.go
@@ -176,6 +176,14 @@ func TestCatalogProxy_CreateUnknownEntity(t *testing.T) {
 	}
 }
 
+func TestCatalogsRoot_RejectsNonCatalogEntity(t *testing.T) {
+	root, _, lookup := newCatalogsTestEnv()
+	lookup.m["Заказ"] = &metadata.Entity{Name: "Заказ", Kind: metadata.KindDocument}
+	if v := root.Get("Заказ"); v != nil {
+		t.Fatalf("Справочники.Заказ → %T, want nil for document entity", v)
+	}
+}
+
 // Справочники.X.ИмяПредопределённой должно возвращать Ref.
 func TestCatalogProxy_PredefinedAccess(t *testing.T) {
 	root, _, _ := newCatalogsTestEnv()

--- a/internal/dsl/interpreter/numerator_builtins.go
+++ b/internal/dsl/interpreter/numerator_builtins.go
@@ -96,6 +96,12 @@ func (r *NumeratorsRoot) nextNumber(args []any) any {
 					fields[k] = unwrapRef(value)
 				}
 			}
+		case *Struct:
+			if v != nil {
+				for _, k := range v.Fields() {
+					fields[k] = unwrapRef(v.Get(k))
+				}
+			}
 		default:
 			explicitScope = unwrapRef(v)
 		}

--- a/internal/dsl/interpreter/numerator_builtins_test.go
+++ b/internal/dsl/interpreter/numerator_builtins_test.go
@@ -96,6 +96,21 @@ func TestNumeratorsRoot_ScopeRequiredAndSeparated(t *testing.T) {
 	if got := root.CallMethod("СледующийНомер", []any{"Заявка", &MapThis{M: map[string]any{"Дата": y2026, "организация": "org-b"}}}); got != "0001" {
 		t.Fatalf("org-b first = %v", got)
 	}
+	if got := root.CallMethod("СледующийНомер", []any{"Заявка", NewStructFromMap(map[string]any{"Дата": y2026, "Организация": "org-c"})}); got != "0001" {
+		t.Fatalf("Struct org-c first = %v", got)
+	}
+	orgRef := &Ref{UUID: "11111111-1111-1111-1111-111111111111", Name: "org-ref"}
+	if got := root.CallMethod("СледующийНомер", []any{"Заявка", y2026, orgRef}); got != "0001" {
+		t.Fatalf("explicit Ref scope first = %v", got)
+	}
+	if got := root.CallMethod("СледующийНомер", []any{"Заявка", y2026, orgRef}); got != "0002" {
+		t.Fatalf("explicit Ref scope second = %v", got)
+	}
+	assertPanics(t, "empty Ref scope in Struct", func() {
+		root.CallMethod("СледующийНомер", []any{"Заявка", NewStructFromMap(map[string]any{
+			"Дата": y2026, "Организация": &Ref{},
+		})})
+	})
 	if got := root.CallMethod("СледующийНомер", []any{"Заявка", y2026, "org-a"}); got != "0002" {
 		t.Fatalf("org-a second = %v", got)
 	}

--- a/internal/launcher/config_workflow_test.go
+++ b/internal/launcher/config_workflow_test.go
@@ -28,9 +28,9 @@ func requestWithBaseID(req *http.Request, id string) *http.Request {
 // configurator-cookie, иначе следующий AJAX-запрос загрузит форму входа внутрь
 // панели, а её submit уйдёт POST-запросом на GET-only /configurator (HTTP 405).
 func TestCfgAdminUserCreate_FirstAdminStartsConfiguratorSession(t *testing.T) {
-	t.Cleanup(CloseAuthPools)
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "first-admin.db")
+	t.Cleanup(CloseAuthPools)
 	db, err := storage.ConnectSQLite(ctx, dbPath)
 	if err != nil {
 		t.Fatal(err)
@@ -78,9 +78,9 @@ func TestCfgAdminUserCreate_FirstAdminStartsConfiguratorSession(t *testing.T) {
 }
 
 func TestCfgAdminUserCreate_FirstUserMustBeAdmin(t *testing.T) {
-	t.Cleanup(CloseAuthPools)
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "first-user.db")
+	t.Cleanup(CloseAuthPools)
 	db, err := storage.ConnectSQLite(ctx, dbPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/storage/attachments.go
+++ b/internal/storage/attachments.go
@@ -125,7 +125,7 @@ func (db *DB) ListAttachments(ctx context.Context, ownerKind, ownerName string, 
 		WHERE owner_kind=%s AND owner_name=%s AND owner_id=%s
 		ORDER BY uploaded_at DESC
 	`, d.Placeholder(1), d.Placeholder(2), d.Placeholder(3))
-	rows, err := db.Query(ctx, q, ownerKind, ownerName, ownerID.String())
+	rows, err := db.Query(ctx, q, ownerKind, ownerName, idArg(d, ownerID))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (db *DB) UploadAttachment(ctx context.Context, ownerKind, ownerName string,
 		`, d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4),
 		d.Placeholder(5), d.Placeholder(6), d.Placeholder(7), d.Placeholder(8))
 	if _, err := db.Exec(ctx, q,
-		id.String(), ownerKind, ownerName, ownerID.String(), filename, mimeType, n, uploadedBy,
+		idArg(d, id), ownerKind, ownerName, idArg(d, ownerID), filename, mimeType, n, uploadedBy,
 	); err != nil {
 		os.Remove(filePath)
 		return Attachment{}, err
@@ -208,7 +208,7 @@ func (db *DB) GetAttachment(ctx context.Context, id uuid.UUID) (*Attachment, err
 		SELECT id, owner_kind, owner_name, owner_id, filename, mime_type, size_bytes, uploaded_at, uploaded_by
 		FROM _attachments WHERE id=%s
 	`, d.Placeholder(1))
-	row := db.QueryRow(ctx, q, id.String())
+	row := db.QueryRow(ctx, q, idArg(d, id))
 	return scanAttachment(row)
 }
 
@@ -237,7 +237,7 @@ func (db *DB) DeleteAttachment(ctx context.Context, id uuid.UUID) error {
 	}
 	filePath := filepath.Join(db.filesDir, a.OwnerName, id.String())
 	q := fmt.Sprintf(`DELETE FROM _attachments WHERE id=%s`, d.Placeholder(1))
-	if _, err = db.Exec(ctx, q, id.String()); err != nil {
+	if _, err = db.Exec(ctx, q, idArg(d, id)); err != nil {
 		return err
 	}
 	removeFile := func() { _ = os.Remove(filePath) }

--- a/internal/storage/attachments_pg_test.go
+++ b/internal/storage/attachments_pg_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+package storage
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestAttachments_PostgresUUIDLifecycle(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	db, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+	db.SetFilesDir(filepath.Join(t.TempDir(), "files"))
+	if err := db.EnsureAttachmentTable(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	ownerID := uuid.New()
+	ownerName := "AttachmentPG" + uuid.NewString()
+	attachment, err := db.UploadAttachment(ctx, "catalog", ownerName, ownerID,
+		"uuid.txt", "text/plain", "integration", bytes.NewBufferString("postgres"), 1<<20)
+	if err != nil {
+		t.Fatalf("UploadAttachment: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.DeleteAttachment(context.Background(), attachment.ID)
+	})
+
+	list, err := db.ListAttachments(ctx, "catalog", ownerName, ownerID)
+	if err != nil {
+		t.Fatalf("ListAttachments: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != attachment.ID || list[0].OwnerID != ownerID {
+		t.Fatalf("ListAttachments = %+v", list)
+	}
+	got, err := db.GetAttachment(ctx, attachment.ID)
+	if err != nil {
+		t.Fatalf("GetAttachment: %v", err)
+	}
+	if got.OwnerID != ownerID || got.Filename != "uuid.txt" {
+		t.Fatalf("GetAttachment = %+v", got)
+	}
+	if err := db.DeleteAttachment(ctx, attachment.ID); err != nil {
+		t.Fatalf("DeleteAttachment: %v", err)
+	}
+	if _, err := db.GetAttachment(ctx, attachment.ID); !IsNotFound(err) {
+		t.Fatalf("deleted attachment lookup = %v, want not found", err)
+	}
+}


### PR DESCRIPTION
## Что исправлено
- attachment CRUD передаёт UUID через dialect-aware `idArg`; добавлен PostgreSQL lifecycle integration test
- Windows cleanup закрывает auth pools до удаления `TempDir`
- `Справочники.X` возвращает proxy только для `KindCatalog`
- `Нумераторы.СледующийНомер` извлекает date/scope из `*Struct`, корректно unwrap-ит `*Ref` и отвергает пустой scope

По #403 исходная формулировка описывала потенциальный `42P08`; локально без `TEST_DATABASE_URL` воспроизвести PG-ошибку нельзя, но несоответствие общему UUID-контракту подтверждено и устранено. CI integration job выполняет добавленный тест на PostgreSQL.

## Проверки
- `go test -count=1 ./...`
- `go test -count=1 -tags=integration ./internal/storage` (локально PG cases skipped: `TEST_DATABASE_URL` unset)
- `git diff --check`

Closes #403
Closes #404
Closes #405
Closes #406