### PR TITLE
fix(security): fail closed on auth errors

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -480,7 +480,7 @@ func requireRESTPerm(w http.ResponseWriter, r *http.Request, kind metadata.Kind,
 func canREST(ctx context.Context, kind, entity, op string) bool {
 	u := auth.UserFromContext(ctx)
 	if u == nil {
-		return true
+		return auth.OpenAccessFromContext(ctx)
 	}
 	return u.Has(kind, entity, op)
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -115,7 +115,8 @@ func reqWithEntity(method, target string, body []byte, params map[string]string,
 	for k, v := range params {
 		rctx.URLParams.Add(k, v)
 	}
-	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	ctx := auth.ContextWithOpenAccess(r.Context())
+	return r.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
 }
 
 func withUser(r *http.Request, u *auth.User) *http.Request {
@@ -130,6 +131,16 @@ func apiUser(login string, permissions auth.Permission) *auth.User {
 			Name:        "role-" + login,
 			Permissions: permissions,
 		}},
+	}
+}
+
+func TestRESTAnonymousAccessRequiresExplicitBootstrapContext(t *testing.T) {
+	if canREST(context.Background(), string(metadata.KindCatalog), "Товар", "read") {
+		t.Fatal("missing auth context must not imply unrestricted REST access")
+	}
+	ctx := auth.ContextWithOpenAccess(context.Background())
+	if !canREST(ctx, string(metadata.KindCatalog), "Товар", "read") {
+		t.Fatal("confirmed first-run context must retain open access")
 	}
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -11,62 +11,78 @@ import (
 
 type contextKey string
 
-const userKey contextKey = "auth_user"
+const (
+	userKey       contextKey = "auth_user"
+	openAccessKey contextKey = "auth_open_access"
+)
 
 func (r *Repo) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
 		hasUsers, err := r.HasUsers(ctx)
-		if err != nil || !hasUsers {
-			next.ServeHTTP(w, req)
-			return
-		}
-
-		// Сессия принимается только из cookie. Токен в query (?_tk=) больше
-		// не поддерживается: он утекал в stdout-лог (middleware.Logger пишет
-		// полный RequestURI), Referer и историю браузера — план 53, этап 1.
-		// Конфигуратор передаёт сессию через /auth/bootstrap?code=<одноразовый>.
-		var token string
-		if cookie, err := req.Cookie("onebase_session"); err == nil {
-			token = cookie.Value
-		}
-
-		if token == "" {
-			redirectToLogin(w, req)
-			return
-		}
-
-		user, err := r.LookupSession(ctx, token)
 		if err != nil {
-			redirectToLogin(w, req)
+			writeAuthUnavailable(w, false)
+			return
+		}
+		if !hasUsers {
+			next.ServeHTTP(w, req.WithContext(ContextWithOpenAccess(ctx)))
 			return
 		}
 
-		// last_seen_at для админки сессий (план 78); троттлится внутри,
-		// ошибка не критична.
-		r.TouchSession(ctx, token, time.Now())
-
-		next.ServeHTTP(w, req.WithContext(r.contextWithUser(ctx, user)))
+		r.serveWithSession(next, w, req)
 	})
+}
+
+func (r *Repo) serveWithSession(next http.Handler, w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	// Сессия принимается только из cookie. Токен в query (?_tk=) больше
+	// не поддерживается: он утекал в stdout-лог (middleware.Logger пишет
+	// полный RequestURI), Referer и историю браузера — план 53, этап 1.
+	// Конфигуратор передаёт сессию через /auth/bootstrap?code=<одноразовый>.
+	var token string
+	if cookie, err := req.Cookie("onebase_session"); err == nil {
+		token = cookie.Value
+	}
+
+	if token == "" {
+		redirectToLogin(w, req)
+		return
+	}
+
+	user, err := r.LookupSession(ctx, token)
+	if err != nil {
+		redirectToLogin(w, req)
+		return
+	}
+
+	// last_seen_at для админки сессий (план 78); троттлится внутри,
+	// ошибка не критична.
+	r.TouchSession(ctx, token, time.Now())
+
+	next.ServeHTTP(w, req.WithContext(r.contextWithUser(ctx, user)))
 }
 
 // APITokenOrSessionMiddleware accepts REST API Bearer tokens first and falls
 // back to the regular session cookie middleware. It is intentionally separate
 // from Middleware so UI routes keep their cookie-only authentication behavior.
 func (r *Repo) APITokenOrSessionMiddleware(next http.Handler) http.Handler {
-	session := r.Middleware(next)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		hasUsers, err := r.HasUsers(ctx)
-		if err != nil || !hasUsers {
-			next.ServeHTTP(w, req)
+		if err != nil {
+			writeAuthUnavailable(w, true)
+			return
+		}
+		if !hasUsers {
+			next.ServeHTTP(w, req.WithContext(ContextWithOpenAccess(ctx)))
 			return
 		}
 
 		token, present := bearerToken(req)
 		if !present {
-			session.ServeHTTP(w, req)
+			r.serveWithSession(next, w, req)
 			return
 		}
 		if token == "" {
@@ -119,6 +135,15 @@ func writeUnauthorizedJSON(w http.ResponseWriter) {
 	http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 }
 
+func writeAuthUnavailable(w http.ResponseWriter, jsonResponse bool) {
+	if jsonResponse {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"authentication service unavailable"}`, http.StatusServiceUnavailable)
+		return
+	}
+	http.Error(w, "authentication service unavailable", http.StatusServiceUnavailable)
+}
+
 func UserFromContext(ctx context.Context) *User {
 	if u, ok := ctx.Value(userKey).(*User); ok {
 		return u
@@ -132,4 +157,18 @@ func UserFromContext(ctx context.Context) *User {
 // с Basic-аутом — чтобы ТекущийПользователь()/аудит видели вызывающего).
 func ContextWithUser(ctx context.Context, u *User) context.Context {
 	return context.WithValue(ctx, userKey, u)
+}
+
+// ContextWithOpenAccess marks the explicit bootstrap mode where the repository
+// was reachable and confirmed to contain no users. A missing user alone must
+// never imply unrestricted access: it may also mean middleware was bypassed or
+// the authentication database failed.
+func ContextWithOpenAccess(ctx context.Context) context.Context {
+	return context.WithValue(ctx, openAccessKey, true)
+}
+
+// OpenAccessFromContext reports the bootstrap decision made by auth middleware.
+func OpenAccessFromContext(ctx context.Context) bool {
+	open, _ := ctx.Value(openAccessKey).(bool)
+	return open
 }

--- a/internal/auth/repo_sqlite_test.go
+++ b/internal/auth/repo_sqlite_test.go
@@ -8,6 +8,7 @@ package auth_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -683,6 +684,9 @@ func TestMiddlewareRequiresSessionWhenUsersExist(t *testing.T) {
 	repo, ctx := newTestRepo(t)
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth.UserFromContext(r.Context()) == nil && !auth.OpenAccessFromContext(r.Context()) {
+			t.Fatal("anonymous pass-through must be explicitly marked as open access")
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	handler := repo.Middleware(next)
@@ -713,6 +717,71 @@ func TestMiddlewareRequiresSessionWhenUsersExist(t *testing.T) {
 	handler.ServeHTTP(rr2, req)
 	if rr2.Code != http.StatusOK {
 		t.Fatalf("с валидной сессией ожидался 200, получено %d", rr2.Code)
+	}
+}
+
+func TestMiddlewareFailsClosedWhenAuthDatabaseErrors(t *testing.T) {
+	repo, db, _ := newTestRepoDB(t)
+	db.Close()
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	for name, handler := range map[string]http.Handler{
+		"session": repo.Middleware(next),
+		"api":     repo.APITokenOrSessionMiddleware(next),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/protected", nil))
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+			if called {
+				t.Fatal("protected handler was called after auth database error")
+			}
+		})
+	}
+}
+
+func TestManagedUserInvariants(t *testing.T) {
+	repo, ctx := newTestRepo(t)
+
+	if _, err := repo.CreateManaged(ctx, "user", "pass", "", false); !errors.Is(err, auth.ErrFirstUserMustBeAdmin) {
+		t.Fatalf("first non-admin error=%v, want ErrFirstUserMustBeAdmin", err)
+	}
+	admin1, err := repo.CreateManaged(ctx, "admin1", "pass", "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user, err := repo.CreateManaged(ctx, "user", "pass", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.Update(ctx, admin1.ID, "", false, false, false, false); !errors.Is(err, auth.ErrLastAdmin) {
+		t.Fatalf("demote last admin error=%v, want ErrLastAdmin", err)
+	}
+	if err := repo.Delete(ctx, admin1.ID); !errors.Is(err, auth.ErrLastAdmin) {
+		t.Fatalf("delete last admin error=%v, want ErrLastAdmin", err)
+	}
+	if err := repo.Delete(ctx, user.ID); err != nil {
+		t.Fatalf("delete ordinary user: %v", err)
+	}
+	if err := repo.Delete(ctx, admin1.ID); !errors.Is(err, auth.ErrLastUser) {
+		t.Fatalf("delete final user error=%v, want ErrLastUser", err)
+	}
+
+	admin2, err := repo.CreateManaged(ctx, "admin2", "pass", "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Update(ctx, admin1.ID, "", false, false, false, false); err != nil {
+		t.Fatalf("demote admin while another remains: %v", err)
+	}
+	if err := repo.Delete(ctx, admin2.ID); !errors.Is(err, auth.ErrLastAdmin) {
+		t.Fatalf("delete sole remaining admin error=%v, want ErrLastAdmin", err)
 	}
 }
 

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -33,6 +34,12 @@ type Repo struct {
 	db *storage.DB
 }
 
+var (
+	ErrFirstUserMustBeAdmin = errors.New("первый пользователь должен быть администратором")
+	ErrLastAdmin            = errors.New("нельзя удалить или разжаловать последнего администратора")
+	ErrLastUser             = errors.New("нельзя удалить последнего пользователя; авторизация должна отключаться отдельным действием")
+)
+
 // NewRepo wires the auth repository to the storage layer. Internally Exec/
 // Query/QueryRow are routed to PostgreSQL or SQLite via the DB abstraction.
 func NewRepo(db *storage.DB) *Repo {
@@ -52,6 +59,16 @@ func (r *Repo) EnsureSchema(ctx context.Context) error {
 		)`, d.TypeUUID(), d.TypeBytes(), d.TypeBool(), boolFalseFor(d), d.TypeTimestamp(), d.CurrentTimestampTZ())
 	if _, err := r.db.Exec(ctx, usersDDL); err != nil {
 		return fmt.Errorf("auth: create _users: %w", err)
+	}
+	// Единственная строка служит переносимым mutex для инвариантов пользователей:
+	// UPDATE берёт write-lock в SQLite и row-lock в PostgreSQL.
+	if _, err := r.db.Exec(ctx, `CREATE TABLE IF NOT EXISTS _auth_user_guard (
+		id INTEGER PRIMARY KEY CHECK (id = 1)
+	)`); err != nil {
+		return fmt.Errorf("auth: create user guard: %w", err)
+	}
+	if _, err := r.db.Exec(ctx, `INSERT INTO _auth_user_guard (id) VALUES (1) ON CONFLICT (id) DO NOTHING`); err != nil {
+		return fmt.Errorf("auth: seed user guard: %w", err)
 	}
 	sessionsDDL := fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS _sessions (
@@ -182,11 +199,27 @@ func (r *Repo) GetByID(ctx context.Context, userID string) (*User, error) {
 
 // Update saves editable fields on a user.
 func (r *Repo) Update(ctx context.Context, userID, fullName string, isAdmin, denyPasswdChange, showInList, aiDataAccess bool) error {
-	d := r.db.Dialect()
-	q := fmt.Sprintf(`UPDATE _users SET full_name=%s, is_admin=%s, deny_passwd_change=%s, show_in_list=%s, ai_data_access=%s WHERE id=%s`,
-		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4), d.Placeholder(5), d.Placeholder(6))
-	_, err := r.db.Exec(ctx, q, fullName, isAdmin, denyPasswdChange, showInList, aiDataAccess, userID)
-	return err
+	return r.withUserInvariantLock(ctx, func(txCtx context.Context) error {
+		d := r.db.Dialect()
+		var currentAdmin any
+		qCurrent := fmt.Sprintf(`SELECT is_admin FROM _users WHERE id = %s`, d.Placeholder(1))
+		if err := r.db.QueryRow(txCtx, qCurrent, userID).Scan(&currentAdmin); err != nil {
+			return err
+		}
+		if scanBool(currentAdmin) && !isAdmin {
+			admins, err := r.adminCount(txCtx)
+			if err != nil {
+				return err
+			}
+			if admins <= 1 {
+				return ErrLastAdmin
+			}
+		}
+		q := fmt.Sprintf(`UPDATE _users SET full_name=%s, is_admin=%s, deny_passwd_change=%s, show_in_list=%s, ai_data_access=%s WHERE id=%s`,
+			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4), d.Placeholder(5), d.Placeholder(6))
+		_, err := r.db.Exec(txCtx, q, fullName, isAdmin, denyPasswdChange, showInList, aiDataAccess, userID)
+		return err
+	})
 }
 
 // SetShowInList toggles the show_in_list flag for a user.
@@ -258,11 +291,71 @@ func (r *Repo) Create(ctx context.Context, login, password, fullName string, isA
 	return &User{ID: id, Login: login, FullName: fullName, IsAdmin: isAdmin}, nil
 }
 
+// CreateManaged is the user-management entry point. Unlike low-level Create,
+// it enforces that authentication can only be enabled by an administrator.
+func (r *Repo) CreateManaged(ctx context.Context, login, password, fullName string, isAdmin bool) (*User, error) {
+	if !isAdmin {
+		err := r.withUserInvariantLock(ctx, func(txCtx context.Context) error {
+			hasUsers, err := r.HasUsers(txCtx)
+			if err != nil {
+				return err
+			}
+			if !hasUsers {
+				return ErrFirstUserMustBeAdmin
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return r.Create(ctx, login, password, fullName, isAdmin)
+}
+
 func (r *Repo) Delete(ctx context.Context, id string) error {
-	d := r.db.Dialect()
-	q := fmt.Sprintf(`DELETE FROM _users WHERE id = %s`, d.Placeholder(1))
-	_, err := r.db.Exec(ctx, q, id)
-	return err
+	return r.withUserInvariantLock(ctx, func(txCtx context.Context) error {
+		d := r.db.Dialect()
+		var targetAdmin any
+		qTarget := fmt.Sprintf(`SELECT is_admin FROM _users WHERE id = %s`, d.Placeholder(1))
+		if err := r.db.QueryRow(txCtx, qTarget, id).Scan(&targetAdmin); err != nil {
+			return err
+		}
+		var users int
+		if err := r.db.QueryRow(txCtx, `SELECT count(*) FROM _users`).Scan(&users); err != nil {
+			return err
+		}
+		if users <= 1 {
+			return ErrLastUser
+		}
+		if scanBool(targetAdmin) {
+			admins, err := r.adminCount(txCtx)
+			if err != nil {
+				return err
+			}
+			if admins <= 1 {
+				return ErrLastAdmin
+			}
+		}
+		q := fmt.Sprintf(`DELETE FROM _users WHERE id = %s`, d.Placeholder(1))
+		_, err := r.db.Exec(txCtx, q, id)
+		return err
+	})
+}
+
+func (r *Repo) withUserInvariantLock(ctx context.Context, fn func(context.Context) error) error {
+	return r.db.WithTxScope(ctx, func(txCtx context.Context) error {
+		if _, err := r.db.Exec(txCtx, `UPDATE _auth_user_guard SET id = 1 WHERE id = 1`); err != nil {
+			return fmt.Errorf("auth: lock user invariants: %w", err)
+		}
+		return fn(txCtx)
+	})
+}
+
+func (r *Repo) adminCount(ctx context.Context) (int, error) {
+	var count int
+	q := fmt.Sprintf(`SELECT count(*) FROM _users WHERE is_admin = %s`, r.db.Dialect().Placeholder(1))
+	err := r.db.QueryRow(ctx, q, true).Scan(&count)
+	return count, err
 }
 
 func (r *Repo) Authenticate(ctx context.Context, login, password string) (*User, error) {

--- a/internal/launcher/admin_handlers.go
+++ b/internal/launcher/admin_handlers.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -274,7 +275,7 @@ func (h *handler) cfgAdminUserCreate(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 400, map[string]any{"error": tr(lang, "Первый пользователь должен быть администратором")})
 		return
 	}
-	user, err := repo.Create(r.Context(), req.Login, req.Password, req.FullName, req.IsAdmin)
+	user, err := repo.CreateManaged(r.Context(), req.Login, req.Password, req.FullName, req.IsAdmin)
 	if err != nil {
 		writeJSON(w, 500, map[string]any{"error": err.Error()})
 		return
@@ -315,7 +316,11 @@ func (h *handler) cfgAdminUserDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	repo := auth.NewRepo(db)
 	if err := repo.Delete(r.Context(), req.ID); err != nil {
-		writeJSON(w, 500, map[string]any{"error": err.Error()})
+		status := http.StatusInternalServerError
+		if errors.Is(err, auth.ErrLastAdmin) || errors.Is(err, auth.ErrLastUser) {
+			status = http.StatusConflict
+		}
+		writeJSON(w, status, map[string]any{"error": err.Error()})
 		return
 	}
 	writeJSON(w, 200, map[string]any{"ok": true})

--- a/internal/launcher/cfgauth.go
+++ b/internal/launcher/cfgauth.go
@@ -240,19 +240,22 @@ func (h *handler) cfgAuthMiddleware(next http.Handler) http.Handler {
 
 		db, err := getAuthDB(r.Context(), b)
 		if err != nil {
-			// Cannot connect to DB — let request through (base may not exist yet)
-			next.ServeHTTP(w, r)
+			http.Error(w, "authentication service unavailable", http.StatusServiceUnavailable)
 			return
 		}
 
 		repo := auth.NewRepo(db)
 		if err := repo.EnsureSchema(r.Context()); err != nil {
-			next.ServeHTTP(w, r)
+			http.Error(w, "authentication service unavailable", http.StatusServiceUnavailable)
 			return
 		}
 
 		hasUsers, err := repo.HasUsers(r.Context())
-		if err != nil || !hasUsers {
+		if err != nil {
+			http.Error(w, "authentication service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !hasUsers {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -283,32 +286,32 @@ func (h *handler) cfgAuthMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// cfgAdminAuthorized повторяет проверку cfgAuthMiddleware, но возвращает bool
-// вместо 302-редиректа — для API-эндпоинтов (debug-прокси), которые зовёт JS:
-// им нужен 401 JSON, а не HTML логина. Passthrough-кейсы (БД недоступна, нет
-// схемы, нет пользователей) совпадают с cfgAuthMiddleware, чтобы поведение
-// первого запуска не отличалось. Жёсткая защита всё равно на app-стороне:
-// процесс базы требует X-OneBase-Debug-Token.
-func (h *handler) cfgAdminAuthorized(r *http.Request, b *Base) bool {
+// cfgAdminAuthorized повторяет проверку cfgAuthMiddleware, но возвращает ошибку
+// отдельно от отказа в доступе. Только успешно подтверждённое отсутствие
+// пользователей включает first-run режим; сбой БД должен закрывать доступ.
+func (h *handler) cfgAdminAuthorized(r *http.Request, b *Base) (bool, error) {
 	db, err := getAuthDB(r.Context(), b)
 	if err != nil {
-		return true
+		return false, err
 	}
 	repo := auth.NewRepo(db)
 	if err := repo.EnsureSchema(r.Context()); err != nil {
-		return true
+		return false, err
 	}
 	hasUsers, err := repo.HasUsers(r.Context())
-	if err != nil || !hasUsers {
-		return true
+	if err != nil {
+		return false, err
+	}
+	if !hasUsers {
+		return true, nil
 	}
 	cookie, err := r.Cookie("onebase_session")
 	if err != nil {
-		return false
+		return false, nil
 	}
 	user, err := repo.LookupSession(r.Context(), cookie.Value)
 	if err != nil || user == nil || !user.IsAdmin {
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }

--- a/internal/launcher/config_workflow_test.go
+++ b/internal/launcher/config_workflow_test.go
@@ -112,6 +112,30 @@ func TestCfgAdminUserCreate_FirstUserMustBeAdmin(t *testing.T) {
 	}
 }
 
+func TestCfgAuthMiddlewareFailsClosedWhenDatabaseCannotOpen(t *testing.T) {
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	base := &Base{ID: "broken-auth", Name: "Broken auth", DBType: "unsupported"}
+	if err := store.save([]*Base{base}); err != nil {
+		t.Fatal(err)
+	}
+	h := &handler{store: store, runner: NewRunner()}
+	called := false
+	protected := h.cfgAuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := requestWithBaseID(httptest.NewRequest(http.MethodGet, "/bases/broken-auth/configurator", nil), base.ID)
+	rec := httptest.NewRecorder()
+	protected.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if called {
+		t.Fatal("protected configurator handler was called after auth database error")
+	}
+}
+
 // Пустая/неверная папка не должна очищать _onebase_config. Раньше
 // ImportFromDir сначала делал DELETE, а пустой workspace считался успешным
 // импортом нулевой конфигурации.

--- a/internal/launcher/configurator_predefined_proxy.go
+++ b/internal/launcher/configurator_predefined_proxy.go
@@ -164,7 +164,12 @@ func (h *handler) oneTimeCodeProxy(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 404, map[string]string{"error": "base not found"})
 		return
 	}
-	if !h.cfgAdminAuthorized(r, b) {
+	authorized, authErr := h.cfgAdminAuthorized(r, b)
+	if authErr != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "Сервис аутентификации недоступен"})
+		return
+	}
+	if !authorized {
 		writeJSON(w, 401, map[string]string{"error": "Требуется вход администратора"})
 		return
 	}
@@ -209,7 +214,12 @@ func (h *handler) debugProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Требуем сессию админа конфигуратора. 401 JSON (не 302), т.к. это API для JS.
-	if !h.cfgAdminAuthorized(r, b) {
+	authorized, authErr := h.cfgAdminAuthorized(r, b)
+	if authErr != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "Сервис аутентификации недоступен"})
+		return
+	}
+	if !authorized {
 		writeJSON(w, 401, map[string]string{"error": "Требуется вход администратора"})
 		return
 	}

--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -296,7 +296,7 @@ func (s *Server) adminUserCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	u, err := s.authRepo.Create(r.Context(), login, password, fullName, isAdmin)
+	u, err := s.authRepo.CreateManaged(r.Context(), login, password, fullName, isAdmin)
 	if err != nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		adminTmpl.ExecuteTemplate(w, "admin-user-form", map[string]any{"Error": s.errText(r, err)})
@@ -452,7 +452,10 @@ func (s *Server) adminUserDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := chi.URLParam(r, "id")
-	s.authRepo.Delete(r.Context(), id)
+	if err := s.authRepo.Delete(r.Context(), id); err != nil {
+		http.Error(w, s.errText(r, err), http.StatusConflict)
+		return
+	}
 	http.Redirect(w, r, "/ui/admin/users", http.StatusFound)
 }
 
@@ -890,18 +893,23 @@ func (s *Server) recordHistory(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// isAdmin returns true if the current request has an admin user in context,
-// or if no auth is configured (open access).
+// isAdmin returns true for an authenticated administrator or for the explicit
+// first-run mode where auth middleware confirmed that the reachable database
+// contains no users. Database errors must never turn into administrator access.
 func (s *Server) isAdmin(r *http.Request) bool {
 	if s.authRepo == nil {
 		return true
 	}
-	hasUsers, err := s.authRepo.HasUsers(r.Context())
-	if err != nil || !hasUsers {
-		return true // no auth configured
+	if u := auth.UserFromContext(r.Context()); u != nil {
+		return u.IsAdmin
 	}
-	u := auth.UserFromContext(r.Context())
-	return u != nil && u.IsAdmin
+	if auth.OpenAccessFromContext(r.Context()) {
+		return true
+	}
+	// Direct handler tests and a few internal call sites do not pass through the
+	// middleware. Preserve bootstrap behavior only after a successful query.
+	hasUsers, err := s.authRepo.HasUsers(r.Context())
+	return err == nil && !hasUsers
 }
 
 const tplAdminPasswd = `{{define "admin-passwd"}}` + adminHead + `


### PR DESCRIPTION
## Summary

- return 503 instead of bypassing authentication when the auth database or schema is unavailable
- require an explicit middleware-confirmed bootstrap context for anonymous REST access
- enforce first/last administrator and final-user invariants under a portable database lock
- apply the same fail-closed behavior to configurator proxies and surface invariant conflicts

## Validation

- go test ./...
- go vet ./...
- go test -race ./internal/auth ./internal/api ./internal/ui ./internal/launcher