### PR TITLE
fix: bound HTTP inputs and enforce REST contracts

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -69,33 +71,163 @@ type createUpdateBody struct {
 	Action        string                      `json:"__action,omitempty"`
 }
 
-// decodeBody парсит JSON в createUpdateBody, отделяя служебные ключи (__tableparts,
-// __action) от собственных полей сущности. Делаем это вручную через generic map,
-// чтобы пользователю не нужно было оборачивать поля в "fields": {...}.
+var errIfMatchRequired = errors.New("If-Match header is required")
+
+// decodeBody парсит ровно один JSON-объект в createUpdateBody, отделяя
+// служебные ключи (__tableparts, __action) от собственных полей сущности.
+// Делаем это вручную через generic map, чтобы пользователю не нужно было
+// оборачивать поля в "fields": {...}.
 func decodeBody(r *http.Request) (createUpdateBody, error) {
+	return decodeRESTBody(r)
+}
+
+func decodeRESTBody(r *http.Request) (createUpdateBody, error) {
 	var raw map[string]json.RawMessage
-	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&raw); err != nil {
 		return createUpdateBody{}, err
+	}
+	if raw == nil {
+		return createUpdateBody{}, errors.New("request body must be a JSON object")
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return createUpdateBody{}, errors.New("request body must contain a single JSON object")
+		}
+		return createUpdateBody{}, fmt.Errorf("invalid trailing data: %w", err)
 	}
 	body := createUpdateBody{Fields: make(map[string]any, len(raw))}
 	if v, ok := raw["__tableparts"]; ok {
 		if err := json.Unmarshal(v, &body.TablePartRows); err != nil {
-			return createUpdateBody{}, err
+			return createUpdateBody{}, fmt.Errorf("__tableparts: %w", err)
 		}
 		delete(raw, "__tableparts")
 	}
 	if v, ok := raw["__action"]; ok {
-		_ = json.Unmarshal(v, &body.Action)
+		if err := json.Unmarshal(v, &body.Action); err != nil {
+			return createUpdateBody{}, fmt.Errorf("__action: %w", err)
+		}
 		delete(raw, "__action")
 	}
 	for k, v := range raw {
+		if strings.HasPrefix(k, "__") {
+			return createUpdateBody{}, fmt.Errorf("unknown metadata field %q", k)
+		}
 		var val any
 		if err := json.Unmarshal(v, &val); err != nil {
-			return createUpdateBody{}, err
+			return createUpdateBody{}, fmt.Errorf("%s: %w", k, err)
 		}
 		body.Fields[k] = val
 	}
 	return body, nil
+}
+
+func decodeBodyForEntity(r *http.Request, entity *metadata.Entity) (createUpdateBody, error) {
+	body, err := decodeRESTBody(r)
+	if err != nil {
+		return createUpdateBody{}, err
+	}
+	if err := validateRESTBody(&body, entity); err != nil {
+		return createUpdateBody{}, err
+	}
+	return body, nil
+}
+
+// decodeOptionalBodyForEntity distinguishes an absent body from an empty JSON
+// object. It deliberately attempts a decode when Content-Length is unknown
+// (HTTP/1.1 chunked and HTTP/2), instead of treating -1 as an empty request.
+func decodeOptionalBodyForEntity(r *http.Request, entity *metadata.Entity) (createUpdateBody, bool, error) {
+	if r.Body == nil || r.ContentLength == 0 {
+		return createUpdateBody{}, false, nil
+	}
+	body, err := decodeRESTBody(r)
+	if errors.Is(err, io.EOF) {
+		return createUpdateBody{}, false, nil
+	}
+	if err != nil {
+		return createUpdateBody{}, false, err
+	}
+	if err := validateRESTBody(&body, entity); err != nil {
+		return createUpdateBody{}, false, err
+	}
+	return body, true, nil
+}
+
+func validateRESTBody(body *createUpdateBody, entity *metadata.Entity) error {
+	if body == nil || entity == nil {
+		return errors.New("entity metadata is required")
+	}
+
+	fields := make(map[string]string, len(entity.Fields)+2)
+	for _, field := range entity.Fields {
+		fields[strings.ToLower(field.Name)] = field.Name
+	}
+	if entity.Hierarchical {
+		fields["parent_id"] = "parent_id"
+		fields["is_folder"] = "is_folder"
+	}
+	normalizedFields := make(map[string]any, len(body.Fields))
+	for name, value := range body.Fields {
+		canonical, ok := fields[strings.ToLower(name)]
+		if !ok {
+			return fmt.Errorf("unknown field %q", name)
+		}
+		if _, duplicate := normalizedFields[canonical]; duplicate {
+			return fmt.Errorf("duplicate field %q", canonical)
+		}
+		normalizedFields[canonical] = value
+	}
+	body.Fields = normalizedFields
+
+	tableParts := make(map[string]metadata.TablePart, len(entity.TableParts))
+	for _, tp := range entity.TableParts {
+		tableParts[strings.ToLower(tp.Name)] = tp
+	}
+	normalizedTPs := make(map[string][]map[string]any, len(body.TablePartRows))
+	for name, rows := range body.TablePartRows {
+		tp, ok := tableParts[strings.ToLower(name)]
+		if !ok {
+			return fmt.Errorf("unknown table part %q", name)
+		}
+		if _, duplicate := normalizedTPs[tp.Name]; duplicate {
+			return fmt.Errorf("duplicate table part %q", tp.Name)
+		}
+		rowFields := make(map[string]string, len(tp.Fields))
+		for _, field := range tp.Fields {
+			rowFields[strings.ToLower(field.Name)] = field.Name
+		}
+		normalizedRows := make([]map[string]any, len(rows))
+		for i, row := range rows {
+			normalizedRow := make(map[string]any, len(row))
+			for fieldName, value := range row {
+				canonical, ok := rowFields[strings.ToLower(fieldName)]
+				if !ok {
+					return fmt.Errorf("unknown field %q in table part %q row %d", fieldName, tp.Name, i+1)
+				}
+				if _, duplicate := normalizedRow[canonical]; duplicate {
+					return fmt.Errorf("duplicate field %q in table part %q row %d", canonical, tp.Name, i+1)
+				}
+				normalizedRow[canonical] = value
+			}
+			normalizedRows[i] = normalizedRow
+		}
+		normalizedTPs[tp.Name] = normalizedRows
+	}
+	body.TablePartRows = normalizedTPs
+
+	action := strings.ToLower(strings.TrimSpace(body.Action))
+	switch action {
+	case "":
+	case "post", "post_and_close":
+		if entity.Kind != metadata.KindDocument || !entity.Posting {
+			return fmt.Errorf("action %q is not supported for entity %q", action, entity.Name)
+		}
+	default:
+		return fmt.Errorf("unknown action %q", body.Action)
+	}
+	body.Action = action
+	return nil
 }
 
 func (h *handler) createObject(kind metadata.Kind) http.HandlerFunc {
@@ -108,7 +240,7 @@ func (h *handler) createObject(kind metadata.Kind) http.HandlerFunc {
 			return
 		}
 		limitRESTBody(w, r)
-		body, err := decodeBody(r)
+		body, err := decodeBodyForEntity(r, entity)
 		if err != nil {
 			writeDecodeError(w, err)
 			return
@@ -256,7 +388,7 @@ func (h *handler) updateObject(kind metadata.Kind) http.HandlerFunc {
 			return
 		}
 		limitRESTBody(w, r)
-		body, err := decodeBody(r)
+		body, err := decodeBodyForEntity(r, entity)
 		if err != nil {
 			writeDecodeError(w, err)
 			return
@@ -277,11 +409,10 @@ func (h *handler) updateObject(kind metadata.Kind) http.HandlerFunc {
 		// при чтении; если в БД сейчас другая — 409 Conflict вместо тихого
 		// перетирания чужих правок. Без заголовка проверка не делается
 		// (обратная совместимость для клиентов которые её ещё не используют).
-		var expectedVersion *int64
-		if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
-			if v, perr := strconv.ParseInt(strings.Trim(ifMatch, `"`), 10, 64); perr == nil {
-				expectedVersion = &v
-			}
+		expectedVersion, err := parseIfMatch(r, false)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error(), "", 0)
+			return
 		}
 
 		// План 88: масковый пользователь не перезаписывает реальное значение.
@@ -393,16 +524,16 @@ func (h *handler) postDocument() http.HandlerFunc {
 		// Тело опционально. Если есть — используем как обновление перед проведением;
 		// если пусто — читаем текущее состояние из БД, чтобы OnPost увидел актуальные
 		// данные документа.
+		limitRESTBody(w, r)
+		body, hasBody, decErr := decodeOptionalBodyForEntity(r, entity)
+		if decErr != nil {
+			writeDecodeError(w, decErr)
+			return
+		}
 		var fields map[string]any
 		var tpRows map[string][]map[string]any
-		if r.ContentLength > 0 {
+		if hasBody {
 			if !requireRESTPerm(w, r, metadata.KindDocument, entityName, "write") {
-				return
-			}
-			limitRESTBody(w, r)
-			body, decErr := decodeBody(r)
-			if decErr != nil {
-				writeDecodeError(w, decErr)
 				return
 			}
 			if !h.rowAllowedUpdate(r.Context(), entity, "write", id, body.Fields) ||
@@ -494,6 +625,30 @@ func isPostAction(action string) bool {
 	}
 }
 
+func parseIfMatch(r *http.Request, required bool) (*int64, error) {
+	raw := strings.TrimSpace(r.Header.Get("If-Match"))
+	if raw == "" {
+		if required {
+			return nil, errIfMatchRequired
+		}
+		return nil, nil
+	}
+	if strings.HasPrefix(raw, "W/") || strings.Contains(raw, ",") {
+		return nil, errors.New("invalid If-Match header")
+	}
+	if strings.HasPrefix(raw, `"`) || strings.HasSuffix(raw, `"`) {
+		if len(raw) < 2 || raw[0] != '"' || raw[len(raw)-1] != '"' {
+			return nil, errors.New("invalid If-Match header")
+		}
+		raw = raw[1 : len(raw)-1]
+	}
+	version, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || version < 0 {
+		return nil, errors.New("invalid If-Match header")
+	}
+	return &version, nil
+}
+
 func limitRESTBody(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, restMaxBodyBytes)
 }
@@ -504,7 +659,7 @@ func writeDecodeError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusRequestEntityTooLarge, "request body too large", "", 0)
 		return
 	}
-	writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error(), "", 0)
+	writeError(w, http.StatusBadRequest, "invalid request body: "+err.Error(), "", 0)
 }
 
 // generateAutoNumber генерирует номер документа для API так же, как UI: при

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -729,6 +729,7 @@ func TestAPIV2_CRUDRoundTripEnvelope(t *testing.T) {
 	}
 
 	updateReq := reqWithEntity("PUT", "/api/v2/catalog/Товар/"+created.Data.ID, []byte(`{"Наименование":"Дрель"}`), map[string]string{"name": "Товар", "id": created.Data.ID}, nil)
+	updateReq.Header.Set("If-Match", "1")
 	updateRec := httptest.NewRecorder()
 	h.updateObjectV2(metadata.KindCatalog).ServeHTTP(updateRec, updateReq)
 	if updateRec.Code != http.StatusOK {
@@ -902,6 +903,12 @@ func TestAPIV2_OpenAPIIncludesPathsAndSchemas(t *testing.T) {
 	catalogPut := paths["/api/v2/catalog/{name}/{id}"].(map[string]any)["put"].(map[string]any)
 	if !openAPIHasHeaderParam(catalogPut["parameters"].([]any), "If-Match") {
 		t.Fatalf("PUT parameters must include If-Match: %#v", catalogPut["parameters"])
+	}
+	for _, p := range catalogPut["parameters"].([]any) {
+		pm, ok := p.(map[string]any)
+		if ok && pm["name"] == "If-Match" && pm["required"] != true {
+			t.Fatalf("If-Match must be required: %#v", pm)
+		}
 	}
 	components := spec["components"].(map[string]any)
 	securitySchemes := components["securitySchemes"].(map[string]any)
@@ -1363,6 +1370,124 @@ func TestAPI_Update_IfMatchVersionConflict(t *testing.T) {
 
 	if w.Code != http.StatusConflict {
 		t.Fatalf("expected 409 Conflict, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDecodeBody_StrictSingleObject(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "null", body: `null`},
+		{name: "trailing document", body: `{"Наименование":"A"} {"Наименование":"B"}`},
+		{name: "invalid action type", body: `{"__action":true}`},
+		{name: "unknown metadata", body: `{"__actoin":"post"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
+			if _, err := decodeBody(r); err == nil {
+				t.Fatalf("decodeBody(%s) succeeded", tt.body)
+			}
+		})
+	}
+}
+
+func TestValidateRESTBody_NormalizesAndRejectsUnknownFields(t *testing.T) {
+	entity := &metadata.Entity{
+		Name:    "Поступление",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+		TableParts: []metadata.TablePart{{
+			Name:   "Товары",
+			Fields: []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+		}},
+	}
+	body := createUpdateBody{
+		Fields: map[string]any{"номер": "1"},
+		TablePartRows: map[string][]map[string]any{
+			"товары": {{"количество": float64(2)}},
+		},
+		Action: " POST ",
+	}
+	if err := validateRESTBody(&body, entity); err != nil {
+		t.Fatal(err)
+	}
+	if body.Fields["Номер"] != "1" || body.Action != "post" {
+		t.Fatalf("body was not normalized: %#v", body)
+	}
+	if _, ok := body.TablePartRows["Товары"][0]["Количество"]; !ok {
+		t.Fatalf("table part was not normalized: %#v", body.TablePartRows)
+	}
+
+	body.Fields["Опечатка"] = true
+	if err := validateRESTBody(&body, entity); err == nil {
+		t.Fatal("unknown field must be rejected")
+	}
+}
+
+func TestAPIV2_UpdateRequiresValidIfMatch(t *testing.T) {
+	entity := &metadata.Entity{
+		Name:   "Товар",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	h, _ := newAPITestHandler(t, []*metadata.Entity{entity}, nil)
+	id := uuid.New().String()
+
+	for _, tt := range []struct {
+		name   string
+		header string
+		status int
+	}{
+		{name: "missing", status: http.StatusPreconditionRequired},
+		{name: "invalid", header: `W/"1"`, status: http.StatusBadRequest},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := reqWithEntity(http.MethodPut, "/api/v2/catalog/Товар/"+id,
+				[]byte(`{"Наименование":"Новое"}`),
+				map[string]string{"name": "Товар", "id": id}, nil)
+			if tt.header != "" {
+				r.Header.Set("If-Match", tt.header)
+			}
+			w := httptest.NewRecorder()
+			h.updateObjectV2(metadata.KindCatalog).ServeHTTP(w, r)
+			if w.Code != tt.status {
+				t.Fatalf("status = %d, want %d: %s", w.Code, tt.status, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAPI_PostDocumentReadsChunkedBody(t *testing.T) {
+	entity := &metadata.Entity{
+		Name:    "Поступление",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	h, ctx := newAPITestHandler(t, []*metadata.Entity{entity}, nil)
+	id := uuid.New()
+	if err := h.store.Upsert(ctx, entity.Name, id, map[string]any{"Номер": "1"}, entity); err != nil {
+		t.Fatal(err)
+	}
+
+	r := reqWithEntity(http.MethodPost, "/documents/Поступление/"+id.String()+"/post",
+		[]byte(`{"Номер":"2"}`),
+		map[string]string{"entity": entity.Name, "id": id.String()}, nil)
+	r.ContentLength = -1
+	w := httptest.NewRecorder()
+	h.postDocument().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	row, err := h.store.GetByID(ctx, entity.Name, id, entity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row["Номер"] != "2" || row["posted"] != true {
+		t.Fatalf("chunked body was ignored: %#v", row)
 	}
 }
 

--- a/internal/api/v2.go
+++ b/internal/api/v2.go
@@ -153,7 +153,7 @@ func (h *handler) createObjectV2(kind metadata.Kind) http.HandlerFunc {
 			return
 		}
 		limitRESTBody(w, r)
-		body, err := decodeBody(r)
+		body, err := decodeBodyForEntity(r, entity)
 		if err != nil {
 			writeDecodeError(w, err)
 			return
@@ -209,8 +209,17 @@ func (h *handler) updateObjectV2(kind metadata.Kind) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "invalid id", "", 0)
 			return
 		}
+		expectedVersion, err := parseIfMatch(r, true)
+		if err != nil {
+			status := http.StatusBadRequest
+			if errors.Is(err, errIfMatchRequired) {
+				status = http.StatusPreconditionRequired
+			}
+			writeError(w, status, err.Error(), "", 0)
+			return
+		}
 		limitRESTBody(w, r)
-		body, err := decodeBody(r)
+		body, err := decodeBodyForEntity(r, entity)
 		if err != nil {
 			writeDecodeError(w, err)
 			return
@@ -225,13 +234,6 @@ func (h *handler) updateObjectV2(kind metadata.Kind) http.HandlerFunc {
 		if kind == metadata.KindDocument && isPostAction(body.Action) && !h.rowAllowedUpdate(r.Context(), entity, "post", id, body.Fields) {
 			writeError(w, http.StatusForbidden, "forbidden", "", 0)
 			return
-		}
-
-		var expectedVersion *int64
-		if ifMatch := r.Header.Get("If-Match"); ifMatch != "" {
-			if v, perr := strconv.ParseInt(strings.Trim(ifMatch, `"`), 10, 64); perr == nil {
-				expectedVersion = &v
-			}
 		}
 
 		// План 88: масковый пользователь не перезаписывает реальное значение.
@@ -467,14 +469,14 @@ func (h *handler) composeReportV2(rows []map[string]any, spec *reportpkg.Composi
 }
 
 func (h *handler) documentPostPayload(w http.ResponseWriter, r *http.Request, entity *metadata.Entity, entityName string, id uuid.UUID) (map[string]any, map[string][]map[string]any, bool) {
-	if r.ContentLength > 0 {
+	limitRESTBody(w, r)
+	body, hasBody, err := decodeOptionalBodyForEntity(r, entity)
+	if err != nil {
+		writeDecodeError(w, err)
+		return nil, nil, false
+	}
+	if hasBody {
 		if !requireRESTPerm(w, r, metadata.KindDocument, entityName, "write") {
-			return nil, nil, false
-		}
-		limitRESTBody(w, r)
-		body, err := decodeBody(r)
-		if err != nil {
-			writeDecodeError(w, err)
 			return nil, nil, false
 		}
 		if !h.rowAllowedUpdate(r.Context(), entity, "write", id, body.Fields) ||
@@ -879,7 +881,7 @@ func openAPIV2Paths() map[string]any {
 	ifMatchParam := map[string]any{
 		"name":        "If-Match",
 		"in":          "header",
-		"required":    false,
+		"required":    true,
 		"description": "Expected _version for optimistic locking.",
 		"schema":      map[string]any{"type": "integer", "minimum": 0},
 	}
@@ -894,7 +896,7 @@ func openAPIV2Paths() map[string]any {
 	}
 	jsonBody := func(ref string) map[string]any {
 		return map[string]any{
-			"required": false,
+			"required": true,
 			"content": map[string]any{
 				"application/json": map[string]any{"schema": map[string]any{"$ref": ref}},
 			},
@@ -912,6 +914,10 @@ func openAPIV2Paths() map[string]any {
 		"400": responseWithSchema("Bad Request", "#/components/schemas/Error"),
 		"403": responseWithSchema("Forbidden", "#/components/schemas/Error"),
 		"404": responseWithSchema("Not Found", "#/components/schemas/Error"),
+		"409": responseWithSchema("Conflict", "#/components/schemas/Error"),
+		"413": responseWithSchema("Request Entity Too Large", "#/components/schemas/Error"),
+		"422": responseWithSchema("Unprocessable Entity", "#/components/schemas/Error"),
+		"428": responseWithSchema("Precondition Required", "#/components/schemas/Error"),
 		"500": responseWithSchema("Internal Server Error", "#/components/schemas/Error"),
 	}
 	noContent := map[string]any{"description": "No Content"}
@@ -1108,15 +1114,20 @@ func titleAPIName(s string) string {
 
 func entityOpenAPISchema(e *metadata.Entity) map[string]any {
 	props := map[string]any{
-		"id":            map[string]any{"type": "string", "format": "uuid"},
-		"deletion_mark": map[string]any{"type": "boolean"},
+		"id":            map[string]any{"type": "string", "format": "uuid", "readOnly": true},
+		"deletion_mark": map[string]any{"type": "boolean", "readOnly": true},
+		"_version":      map[string]any{"type": "integer", "readOnly": true},
 	}
 	if e.Kind == metadata.KindDocument {
-		props["posted"] = map[string]any{"type": "boolean"}
+		props["posted"] = map[string]any{"type": "boolean", "readOnly": true}
 		props["__action"] = map[string]any{"type": "string", "enum": []string{"post", "post_and_close"}}
 	}
 	for _, f := range e.Fields {
 		props[f.Name] = fieldOpenAPISchema(f)
+	}
+	if e.Hierarchical {
+		props["parent_id"] = map[string]any{"type": "string", "format": "uuid", "nullable": true}
+		props["is_folder"] = map[string]any{"type": "boolean"}
 	}
 	if len(e.TableParts) > 0 {
 		tpProps := map[string]any{}
@@ -1127,12 +1138,12 @@ func entityOpenAPISchema(e *metadata.Entity) map[string]any {
 			}
 			tpProps[tp.Name] = map[string]any{
 				"type":  "array",
-				"items": map[string]any{"type": "object", "properties": rowProps},
+				"items": map[string]any{"type": "object", "properties": rowProps, "additionalProperties": false},
 			}
 		}
-		props["__tableparts"] = map[string]any{"type": "object", "properties": tpProps}
+		props["__tableparts"] = map[string]any{"type": "object", "properties": tpProps, "additionalProperties": false}
 	}
-	return map[string]any{"type": "object", "properties": props}
+	return map[string]any{"type": "object", "properties": props, "additionalProperties": false}
 }
 
 func fieldOpenAPISchema(f metadata.Field) map[string]any {

--- a/internal/dsl/interpreter/http_builtins.go
+++ b/internal/dsl/interpreter/http_builtins.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+const maxDSLHTTPResponseBytes int64 = 16 << 20
+
 // ─── dslHTTPConnection ────────────────────────────────────────────────────────
 
 type dslHTTPConnection struct {
@@ -65,7 +67,7 @@ func (c *dslHTTPConnection) do(req *dslHTTPRequest, method string) *dslHTTPRespo
 		panic(userError{Msg: "HTTPСоединение: " + err.Error()})
 	}
 	defer resp.Body.Close()
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyBytes := readDSLHTTPResponse(resp.Body, "HTTPСоединение")
 	return &dslHTTPResponse{
 		statusCode: resp.StatusCode,
 		headers:    resp.Header,
@@ -153,8 +155,8 @@ func NewHTTPFunctions(guard NetGuard) map[string]any {
 	m := map[string]any{
 		"__factory_HTTPСоединение": newHTTPConnFactory(guard),
 		"__factory_HTTPConnection": newHTTPConnFactory(guard),
-		"__factory_HTTPЗапрос":    newHTTPReqFactory(),
-		"__factory_HTTPRequest":   newHTTPReqFactory(),
+		"__factory_HTTPЗапрос":     newHTTPReqFactory(),
+		"__factory_HTTPRequest":    newHTTPReqFactory(),
 	}
 
 	httpGet := BuiltinFunc(func(args []any, file string, line int) (any, error) {
@@ -166,7 +168,7 @@ func NewHTTPFunctions(guard NetGuard) map[string]any {
 			panic(userError{Msg: "HTTPПолучить: " + err.Error()})
 		}
 		defer resp.Body.Close()
-		b, _ := io.ReadAll(resp.Body)
+		b := readDSLHTTPResponse(resp.Body, "HTTPПолучить")
 		return &dslHTTPResponse{statusCode: resp.StatusCode, headers: resp.Header, body: string(b)}, nil
 	})
 
@@ -181,7 +183,7 @@ func NewHTTPFunctions(guard NetGuard) map[string]any {
 			panic(userError{Msg: "HTTPОтправить: " + err.Error()})
 		}
 		defer resp.Body.Close()
-		b, _ := io.ReadAll(resp.Body)
+		b := readDSLHTTPResponse(resp.Body, "HTTPОтправить")
 		return &dslHTTPResponse{statusCode: resp.StatusCode, headers: resp.Header, body: string(b)}, nil
 	})
 
@@ -190,6 +192,17 @@ func NewHTTPFunctions(guard NetGuard) map[string]any {
 	m["HTTPОтправить"] = httpPost
 	m["HTTPPost"] = httpPost
 	return m
+}
+
+func readDSLHTTPResponse(body io.Reader, caller string) []byte {
+	data, err := io.ReadAll(io.LimitReader(body, maxDSLHTTPResponseBytes+1))
+	if err != nil {
+		panic(userError{Msg: caller + ": ошибка чтения ответа: " + err.Error()})
+	}
+	if int64(len(data)) > maxDSLHTTPResponseBytes {
+		panic(userError{Msg: fmt.Sprintf("%s: ответ превышает лимит %d MiB", caller, maxDSLHTTPResponseBytes>>20)})
+	}
+	return data
 }
 
 func newHTTPConnFactory(guard NetGuard) func([]any) any {

--- a/internal/dsl/interpreter/http_limits_test.go
+++ b/internal/dsl/interpreter/http_limits_test.go
@@ -1,0 +1,28 @@
+package interpreter
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadDSLHTTPResponseRejectsOversizedBody(t *testing.T) {
+	defer func() {
+		recovered := recover()
+		err, ok := recovered.(userError)
+		if !ok {
+			t.Fatalf("panic = %#v, want userError", recovered)
+		}
+		if !strings.Contains(err.Msg, "16 MiB") {
+			t.Fatalf("message = %q", err.Msg)
+		}
+	}()
+	readDSLHTTPResponse(io.LimitReader(zeroReader{}, maxDSLHTTPResponseBytes+1), "HTTPПолучить")
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -357,8 +357,13 @@ func (h *handler) backupUpload(w http.ResponseWriter, r *http.Request) {
 	os.MkdirAll(dir, 0o755)
 
 	lang := resolveLang(r)
+	r.Body = http.MaxBytesReader(w, r.Body, maxFullArchiveUpload)
 	file, header, err := r.FormFile("backup_file")
 	if err != nil {
+		if requestBodyErrorStatus(err) == http.StatusRequestEntityTooLarge {
+			http.Error(w, tr(lang, "Файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		data := h.loadCfgData(r.Context(), b, "backup")
 		data.Error = tr(lang, "Ошибка загрузки") + ": " + err.Error()
 		renderCfg(w, r, data)
@@ -374,15 +379,34 @@ func (h *handler) backupUpload(w http.ResponseWriter, r *http.Request) {
 		renderCfg(w, r, data)
 		return
 	}
-	f, err := os.Create(outPath)
+	f, err := os.CreateTemp(dir, ".backup-upload-*")
 	if err != nil {
 		data := h.loadCfgData(r.Context(), b, "backup")
 		data.Error = tr(lang, "Ошибка сохранения") + ": " + err.Error()
 		renderCfg(w, r, data)
 		return
 	}
-	defer f.Close()
-	io.Copy(f, file)
+	tmpPath := f.Name()
+	defer os.Remove(tmpPath)
+	if _, err := io.Copy(f, file); err != nil {
+		_ = f.Close()
+		data := h.loadCfgData(r.Context(), b, "backup")
+		data.Error = tr(lang, "Ошибка сохранения") + ": " + err.Error()
+		renderCfg(w, r, data)
+		return
+	}
+	if err := f.Close(); err != nil {
+		data := h.loadCfgData(r.Context(), b, "backup")
+		data.Error = tr(lang, "Ошибка сохранения") + ": " + err.Error()
+		renderCfg(w, r, data)
+		return
+	}
+	if err := os.Rename(tmpPath, outPath); err != nil {
+		data := h.loadCfgData(r.Context(), b, "backup")
+		data.Error = tr(lang, "Ошибка сохранения") + ": " + err.Error()
+		renderCfg(w, r, data)
+		return
+	}
 
 	data := h.loadCfgData(r.Context(), b, "backup")
 	data.FieldsSaved = true

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -361,7 +361,7 @@ func (h *handler) backupUpload(w http.ResponseWriter, r *http.Request) {
 	file, header, err := r.FormFile("backup_file")
 	if err != nil {
 		if requestBodyErrorStatus(err) == http.StatusRequestEntityTooLarge {
-			http.Error(w, tr(lang, "Файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, fmt.Sprintf(tr(lang, "файл превышает максимальный размер %d МБ"), maxFullArchiveUpload>>20), http.StatusRequestEntityTooLarge)
 			return
 		}
 		data := h.loadCfgData(r.Context(), b, "backup")

--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -227,7 +227,7 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 	const maxLogoBytes = int64(2 << 20)
 	r.Body = http.MaxBytesReader(w, r.Body, maxLogoBytes+(1<<20))
 	if err := r.ParseMultipartForm(maxLogoBytes); err != nil {
-		http.Error(w, tr(lang, "Ошибка чтения формы")+": "+err.Error(), requestBodyErrorStatus(err))
+		http.Error(w, tr(lang, "Ошибка разбора формы")+": "+err.Error(), requestBodyErrorStatus(err))
 		return
 	}
 	newName := strings.TrimSpace(r.FormValue("app_name"))

--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -222,9 +222,14 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	// Parse multipart form (up to 2MB for logo)
+	// Parse multipart form (up to 2 MiB for the logo plus framing).
 	lang := resolveLang(r)
-	r.ParseMultipartForm(2 << 20)
+	const maxLogoBytes = int64(2 << 20)
+	r.Body = http.MaxBytesReader(w, r.Body, maxLogoBytes+(1<<20))
+	if err := r.ParseMultipartForm(maxLogoBytes); err != nil {
+		http.Error(w, tr(lang, "Ошибка чтения формы")+": "+err.Error(), requestBodyErrorStatus(err))
+		return
+	}
 	newName := strings.TrimSpace(r.FormValue("app_name"))
 	newVersion := strings.TrimSpace(r.FormValue("app_version"))
 	newLang := strings.TrimSpace(r.FormValue("app_lang"))
@@ -256,15 +261,14 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 	file, header, ferr := r.FormFile("app_logo_file")
 	if ferr == nil {
 		defer file.Close()
-		// Read file content
-		data, rerr := io.ReadAll(file)
+		data, rerr := io.ReadAll(io.LimitReader(file, maxLogoBytes+1))
 		if rerr != nil {
 			data := h.loadCfgData(r.Context(), b, "tree")
 			data.Error = tr(lang, "Ошибка чтения логотипа") + ": " + rerr.Error()
 			renderCfg(w, r, data)
 			return
 		}
-		if len(data) > 2<<20 {
+		if int64(len(data)) > maxLogoBytes {
 			data := h.loadCfgData(r.Context(), b, "tree")
 			data.Error = tr(lang, "Логотип слишком большой (максимум 2 МБ)")
 			renderCfg(w, r, data)

--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -708,7 +708,7 @@ func (h *handler) configuratorFormsImport1C(w http.ResponseWriter, r *http.Reque
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxFormArchiveUpload)
 	if err := r.ParseMultipartForm(32 << 20); err != nil { // 32MB in memory; the rest spills to a bounded temp file
-		http.Error(w, err.Error(), 400)
+		http.Error(w, err.Error(), requestBodyErrorStatus(err))
 		return
 	}
 	lang := resolveLang(r)

--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -532,8 +532,9 @@ func (h *handler) configuratorReorder(w http.ResponseWriter, r *http.Request) {
 	// Клиент шлёт FormData (multipart/form-data). Нельзя ограничиться ParseForm:
 	// для multipart он не читает тело, а после него FormValue/r.Form уже не
 	// триггерят ParseMultipartForm (r.Form != nil) → group и name приходят пустыми.
+	r.Body = http.MaxBytesReader(w, r.Body, 4<<20)
 	if err := r.ParseMultipartForm(32 << 20); err != nil && err != http.ErrNotMultipart {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
+		writeJSON(w, requestBodyErrorStatus(err), map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
 	group := r.FormValue("group")

--- a/internal/launcher/layout_import_pdf.go
+++ b/internal/launcher/layout_import_pdf.go
@@ -42,6 +42,10 @@ func (h *handler) configuratorImportPDFLayout(w http.ResponseWriter, r *http.Req
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxPDFUpload)
 	if err := r.ParseMultipartForm(maxPDFUpload); err != nil {
+		if requestBodyErrorStatus(err) == http.StatusRequestEntityTooLarge {
+			http.Error(w, tr(lang, "Файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		h.layoutCreateError(w, r, b, lang, tr(lang, "Файл слишком большой или форма повреждена"))
 		return
 	}

--- a/internal/launcher/layout_import_pdf.go
+++ b/internal/launcher/layout_import_pdf.go
@@ -43,7 +43,7 @@ func (h *handler) configuratorImportPDFLayout(w http.ResponseWriter, r *http.Req
 	r.Body = http.MaxBytesReader(w, r.Body, maxPDFUpload)
 	if err := r.ParseMultipartForm(maxPDFUpload); err != nil {
 		if requestBodyErrorStatus(err) == http.StatusRequestEntityTooLarge {
-			http.Error(w, tr(lang, "Файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, tr(lang, "Файл слишком большой или форма повреждена"), http.StatusRequestEntityTooLarge)
 			return
 		}
 		h.layoutCreateError(w, r, b, lang, tr(lang, "Файл слишком большой или форма повреждена"))

--- a/internal/launcher/request_limits.go
+++ b/internal/launcher/request_limits.go
@@ -1,0 +1,14 @@
+package launcher
+
+import (
+	"errors"
+	"net/http"
+)
+
+func requestBodyErrorStatus(err error) int {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return http.StatusRequestEntityTooLarge
+	}
+	return http.StatusBadRequest
+}

--- a/internal/storage/blobs.go
+++ b/internal/storage/blobs.go
@@ -9,6 +9,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -48,6 +49,8 @@ type BlobOwner struct {
 
 // blobsDirName — подкаталог filesDir для дискового режима хранения.
 const blobsDirName = "_blobs"
+
+var ErrBlobTooLarge = errors.New("blob exceeds maximum size")
 
 // EnsureBlobTable создаёт таблицу _blobs (метаданные + данные для db-режима).
 // Колонка data заполняется только в режиме FileStorageDB; на диске она NULL.
@@ -112,7 +115,8 @@ func (db *DB) PutBlob(ctx context.Context, mime string, r io.Reader, maxSizeByte
 			return Blob{}, err
 		}
 		if int64(len(data)) > maxSizeBytes {
-			return Blob{}, i18nerr.Errorf("файл превышает максимальный размер %d МБ", maxSizeBytes/(1024*1024))
+			return Blob{}, fmt.Errorf("%w: %s", ErrBlobTooLarge,
+				i18nerr.Errorf("файл превышает максимальный размер %d МБ", maxSizeBytes/(1024*1024)))
 		}
 		q := fmt.Sprintf(`INSERT INTO _blobs (id, mime, size, data, owner_kind, owner_entity, created_at, dsl_managed) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)`,
 			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4), d.Placeholder(5), d.Placeholder(6), d.Placeholder(7), d.Placeholder(8))
@@ -140,7 +144,8 @@ func (db *DB) PutBlob(ctx context.Context, mime string, r io.Reader, maxSizeByte
 	}
 	if n > maxSizeBytes {
 		os.Remove(fp)
-		return Blob{}, i18nerr.Errorf("файл превышает максимальный размер %d МБ", maxSizeBytes/(1024*1024))
+		return Blob{}, fmt.Errorf("%w: %s", ErrBlobTooLarge,
+			i18nerr.Errorf("файл превышает максимальный размер %d МБ", maxSizeBytes/(1024*1024)))
 	}
 	q := fmt.Sprintf(`INSERT INTO _blobs (id, mime, size, owner_kind, owner_entity, created_at, dsl_managed) VALUES (%s,%s,%s,%s,%s,%s,%s)`,
 		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4), d.Placeholder(5), d.Placeholder(6), d.Placeholder(7))

--- a/internal/storage/blobs_test.go
+++ b/internal/storage/blobs_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -124,6 +125,32 @@ func TestBlobOwnerRoundtrip(t *testing.T) {
 	}
 	if got2.OwnerKind != "" || got2.OwnerEntity != "" {
 		t.Fatalf("ожидался пустой владелец, получено kind=%q entity=%q", got2.OwnerKind, got2.OwnerEntity)
+	}
+}
+
+func TestPutBlobReportsSizeLimit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := ConnectSQLite(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.filesDir = filepath.Join(dir, "files")
+	if err := db.EnsureBlobTable(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, mode := range []string{FileStorageDisk, FileStorageDB} {
+		t.Run(mode, func(t *testing.T) {
+			if err := db.SaveFileStorageMode(ctx, mode); err != nil {
+				t.Fatal(err)
+			}
+			_, err := db.PutBlob(ctx, "image/png", bytes.NewReader([]byte("12345")), 4, BlobOwner{})
+			if !errors.Is(err, ErrBlobTooLarge) {
+				t.Fatalf("error = %v, want ErrBlobTooLarge", err)
+			}
+		})
 	}
 }
 

--- a/internal/ui/extforms.go
+++ b/internal/ui/extforms.go
@@ -45,7 +45,7 @@ func (s *Server) adminExtFormUpload(w http.ResponseWriter, r *http.Request) {
 	maxSize := s.limitMultipartRequest(w, r)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		if uploadErrorStatus(err) == http.StatusRequestEntityTooLarge {
-			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, s.uploadTooLargeText(lang, maxSize), http.StatusRequestEntityTooLarge)
 			return
 		}
 		s.extFormRedirect(w, r, "", s.tr(lang, "не удалось прочитать файл")+": "+s.errText(r, err))
@@ -60,7 +60,7 @@ func (s *Server) adminExtFormUpload(w http.ResponseWriter, r *http.Request) {
 	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
 		if errors.Is(err, errUploadTooLarge) {
-			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, s.uploadTooLargeText(lang, maxSize), http.StatusRequestEntityTooLarge)
 			return
 		}
 		s.extFormRedirect(w, r, "", s.tr(lang, "ошибка чтения файла")+": "+s.errText(r, err))

--- a/internal/ui/extforms.go
+++ b/internal/ui/extforms.go
@@ -2,9 +2,9 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -42,7 +42,12 @@ func (s *Server) adminExtFormUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := s.resolveLang(r)
-	if err := r.ParseMultipartForm(s.maxFileSizeBytes); err != nil {
+	maxSize := s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		if uploadErrorStatus(err) == http.StatusRequestEntityTooLarge {
+			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.extFormRedirect(w, r, "", s.tr(lang, "не удалось прочитать файл")+": "+s.errText(r, err))
 		return
 	}
@@ -52,8 +57,12 @@ func (s *Server) adminExtFormUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer file.Close()
-	data, err := io.ReadAll(io.LimitReader(file, s.maxFileSizeBytes))
+	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
+		if errors.Is(err, errUploadTooLarge) {
+			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.extFormRedirect(w, r, "", s.tr(lang, "ошибка чтения файла")+": "+s.errText(r, err))
 		return
 	}

--- a/internal/ui/extprocessors.go
+++ b/internal/ui/extprocessors.go
@@ -2,9 +2,9 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -41,7 +41,12 @@ func (s *Server) adminExtProcessorUpload(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	lang := s.resolveLang(r)
-	if err := r.ParseMultipartForm(s.maxFileSizeBytes); err != nil {
+	maxSize := s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		if uploadErrorStatus(err) == http.StatusRequestEntityTooLarge {
+			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.extProcRedirect(w, r, "", s.tr(lang, "не удалось прочитать файл")+": "+s.errText(r, err))
 		return
 	}
@@ -51,8 +56,12 @@ func (s *Server) adminExtProcessorUpload(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	defer file.Close()
-	data, err := io.ReadAll(io.LimitReader(file, s.maxFileSizeBytes))
+	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
+		if errors.Is(err, errUploadTooLarge) {
+			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.extProcRedirect(w, r, "", s.tr(lang, "ошибка чтения файла")+": "+s.errText(r, err))
 		return
 	}

--- a/internal/ui/extprocessors.go
+++ b/internal/ui/extprocessors.go
@@ -44,7 +44,7 @@ func (s *Server) adminExtProcessorUpload(w http.ResponseWriter, r *http.Request)
 	maxSize := s.limitMultipartRequest(w, r)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		if uploadErrorStatus(err) == http.StatusRequestEntityTooLarge {
-			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, s.uploadTooLargeText(lang, maxSize), http.StatusRequestEntityTooLarge)
 			return
 		}
 		s.extProcRedirect(w, r, "", s.tr(lang, "не удалось прочитать файл")+": "+s.errText(r, err))
@@ -59,7 +59,7 @@ func (s *Server) adminExtProcessorUpload(w http.ResponseWriter, r *http.Request)
 	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
 		if errors.Is(err, errUploadTooLarge) {
-			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, s.uploadTooLargeText(lang, maxSize), http.StatusRequestEntityTooLarge)
 			return
 		}
 		s.extProcRedirect(w, r, "", s.tr(lang, "ошибка чтения файла")+": "+s.errText(r, err))

--- a/internal/ui/extreports.go
+++ b/internal/ui/extreports.go
@@ -2,9 +2,9 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -42,7 +42,12 @@ func (s *Server) adminExtReportUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := s.resolveLang(r)
-	if err := r.ParseMultipartForm(s.maxFileSizeBytes); err != nil {
+	maxSize := s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		if uploadErrorStatus(err) == http.StatusRequestEntityTooLarge {
+			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.extReportRedirect(w, r, "", s.tr(lang, "не удалось прочитать файл")+": "+s.errText(r, err))
 		return
 	}
@@ -52,8 +57,12 @@ func (s *Server) adminExtReportUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer file.Close()
-	data, err := io.ReadAll(io.LimitReader(file, s.maxFileSizeBytes))
+	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
+		if errors.Is(err, errUploadTooLarge) {
+			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.extReportRedirect(w, r, "", s.tr(lang, "ошибка чтения файла")+": "+s.errText(r, err))
 		return
 	}

--- a/internal/ui/extreports.go
+++ b/internal/ui/extreports.go
@@ -45,7 +45,7 @@ func (s *Server) adminExtReportUpload(w http.ResponseWriter, r *http.Request) {
 	maxSize := s.limitMultipartRequest(w, r)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		if uploadErrorStatus(err) == http.StatusRequestEntityTooLarge {
-			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, s.uploadTooLargeText(lang, maxSize), http.StatusRequestEntityTooLarge)
 			return
 		}
 		s.extReportRedirect(w, r, "", s.tr(lang, "не удалось прочитать файл")+": "+s.errText(r, err))
@@ -60,7 +60,7 @@ func (s *Server) adminExtReportUpload(w http.ResponseWriter, r *http.Request) {
 	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
 		if errors.Is(err, errUploadTooLarge) {
-			http.Error(w, s.tr(lang, "файл слишком большой"), http.StatusRequestEntityTooLarge)
+			http.Error(w, s.uploadTooLargeText(lang, maxSize), http.StatusRequestEntityTooLarge)
 			return
 		}
 		s.extReportRedirect(w, r, "", s.tr(lang, "ошибка чтения файла")+": "+s.errText(r, err))

--- a/internal/ui/handlers_attachments.go
+++ b/internal/ui/handlers_attachments.go
@@ -5,6 +5,7 @@ package ui
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -59,15 +60,11 @@ func (s *Server) attachmentUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	maxSize := s.maxFileSizeBytes
-	if maxSize == 0 {
-		maxSize = 50 * 1024 * 1024
-	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxSize+1024)
+	maxSize := s.limitMultipartRequest(w, r)
 
 	lang := s.resolveLang(r)
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		http.Error(w, s.tr(lang, "Ошибка разбора формы")+": "+s.errText(r, err), 400)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		http.Error(w, s.tr(lang, "Ошибка разбора формы")+": "+s.errText(r, err), uploadErrorStatus(err))
 		return
 	}
 	file, header, err := r.FormFile("file")
@@ -96,7 +93,11 @@ func (s *Server) attachmentUpload(w http.ResponseWriter, r *http.Request) {
 	_, err = s.store.UploadAttachment(r.Context(), string(entity.Kind), entity.Name, id,
 		filename, mimeType, uploadedBy, file, maxSize)
 	if err != nil {
-		http.Error(w, s.errText(r, err), 500)
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrAttachmentTooLarge) {
+			status = http.StatusRequestEntityTooLarge
+		}
+		http.Error(w, s.errText(r, err), status)
 		return
 	}
 

--- a/internal/ui/handlers_image.go
+++ b/internal/ui/handlers_image.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
@@ -31,15 +32,11 @@ func (s *Server) imageUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	maxSize := s.maxFileSizeBytes
-	if maxSize == 0 {
-		maxSize = 50 * 1024 * 1024
-	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxSize+1024)
+	maxSize := s.limitMultipartRequest(w, r)
 
 	lang := s.resolveLang(r)
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		http.Error(w, s.tr(lang, "Ошибка разбора формы")+": "+s.errText(r, err), 400)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		http.Error(w, s.tr(lang, "Ошибка разбора формы")+": "+s.errText(r, err), uploadErrorStatus(err))
 		return
 	}
 	file, _, err := r.FormFile("file")
@@ -72,7 +69,11 @@ func (s *Server) imageUpload(w http.ResponseWriter, r *http.Request) {
 	owner := storage.BlobOwner{Kind: string(entity.Kind), Entity: entity.Name}
 	b, err := s.store.PutBlob(r.Context(), mimeType, body, maxSize, owner)
 	if err != nil {
-		http.Error(w, s.errText(r, err), 500)
+		status := http.StatusInternalServerError
+		if errors.Is(err, storage.ErrBlobTooLarge) {
+			status = http.StatusRequestEntityTooLarge
+		}
+		http.Error(w, s.errText(r, err), status)
 		return
 	}
 

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -60,13 +60,11 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	enc := json.NewEncoder(w)
 
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		// ParseMultipartForm обрабатывает и URL-encoded, и multipart;
-		// fallback на ParseForm для GET/простых POST.
-		if err := r.ParseForm(); err != nil {
-			enc.Encode(formEventResponse{Error: "bad form: " + err.Error()})
-			return
-		}
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		w.WriteHeader(uploadErrorStatus(err))
+		enc.Encode(formEventResponse{Error: "bad form: " + err.Error()})
+		return
 	}
 
 	entityName := chi.URLParam(r, "entity")
@@ -658,11 +656,11 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	enc := json.NewEncoder(w)
 
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		if err := r.ParseForm(); err != nil {
-			enc.Encode(formEventResponse{Error: "bad form: " + err.Error()})
-			return
-		}
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		w.WriteHeader(uploadErrorStatus(err))
+		enc.Encode(formEventResponse{Error: "bad form: " + err.Error()})
+		return
 	}
 
 	procName := chi.URLParam(r, "name")

--- a/internal/ui/handlers_processors.go
+++ b/internal/ui/handlers_processors.go
@@ -6,7 +6,6 @@ package ui
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -158,18 +157,26 @@ func (s *Server) processorRun(w http.ResponseWriter, r *http.Request) {
 	opStatus := "ok"
 	defer func() { finish(opStatus, 0, false) }()
 
-	r.ParseMultipartForm(32 << 20) // 32 MB max
+	maxSize := s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, 32<<20); err != nil {
+		opStatus = "error"
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 	paramValues := map[string]any{}
 	for _, p := range proc.Params {
 		if p.Type == "file" {
 			file, _, err := r.FormFile(p.Name)
 			if err == nil {
-				data, err := io.ReadAll(file)
+				data, err := readUploadedBytes(file, maxSize)
 				file.Close()
-				if err == nil {
-					paramValues[p.Name] = decodeUploadText(data)
-					continue
+				if err != nil {
+					opStatus = "error"
+					http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+					return
 				}
+				paramValues[p.Name] = decodeUploadText(data)
+				continue
 			}
 			paramValues[p.Name] = ""
 			continue

--- a/internal/ui/upload_limits.go
+++ b/internal/ui/upload_limits.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultUIUploadBytes = int64(50 << 20)
+	uiMultipartOverhead  = int64(2 << 20)
+)
+
+var errUploadTooLarge = errors.New("uploaded file is too large")
+
+func (s *Server) effectiveUploadLimit() int64 {
+	if s.maxFileSizeBytes > 0 {
+		return s.maxFileSizeBytes
+	}
+	return defaultUIUploadBytes
+}
+
+func (s *Server) limitMultipartRequest(w http.ResponseWriter, r *http.Request) int64 {
+	limit := s.effectiveUploadLimit()
+	r.Body = http.MaxBytesReader(w, r.Body, limit+uiMultipartOverhead)
+	return limit
+}
+
+// parseBoundedForm avoids ParseMultipartForm's misleading ErrNotMultipart for
+// ordinary urlencoded forms while retaining its bounded temp-file behavior for
+// actual multipart requests.
+func parseBoundedForm(r *http.Request, maxMemory int64) error {
+	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if strings.EqualFold(contentType, "multipart/form-data") {
+		return r.ParseMultipartForm(maxMemory)
+	}
+	return r.ParseForm()
+}
+
+func readUploadedBytes(file multipart.File, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, errUploadTooLarge
+	}
+	return data, nil
+}
+
+func uploadErrorStatus(err error) int {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) || errors.Is(err, errUploadTooLarge) {
+		return http.StatusRequestEntityTooLarge
+	}
+	return http.StatusBadRequest
+}

--- a/internal/ui/upload_limits.go
+++ b/internal/ui/upload_limits.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -57,4 +58,8 @@ func uploadErrorStatus(err error) int {
 		return http.StatusRequestEntityTooLarge
 	}
 	return http.StatusBadRequest
+}
+
+func (s *Server) uploadTooLargeText(lang string, limit int64) string {
+	return fmt.Sprintf(s.tr(lang, "файл превышает максимальный размер %d МБ"), limit>>20)
 }

--- a/internal/ui/upload_limits_test.go
+++ b/internal/ui/upload_limits_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadUploadedBytesRejectsOversizedFile(t *testing.T) {
+	file := &memoryMultipartFile{Reader: bytes.NewReader([]byte("12345"))}
+	if _, err := readUploadedBytes(file, 4); !errors.Is(err, errUploadTooLarge) {
+		t.Fatalf("error = %v, want errUploadTooLarge", err)
+	}
+}
+
+func TestParseBoundedFormReportsRequestEntityTooLarge(t *testing.T) {
+	s := &Server{maxFileSizeBytes: 4}
+	body := "field=" + strings.Repeat("x", int(uiMultipartOverhead)+5)
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.limitMultipartRequest(w, r)
+
+	err := parseBoundedForm(r, 32<<20)
+	if status := uploadErrorStatus(err); status != http.StatusRequestEntityTooLarge {
+		t.Fatalf("error = %v, status = %d", err, status)
+	}
+}
+
+type memoryMultipartFile struct {
+	*bytes.Reader
+}
+
+func (f *memoryMultipartFile) Close() error { return nil }


### PR DESCRIPTION
## Summary

- decode exactly one REST JSON object and reject unknown fields, table parts, metadata keys, actions, and malformed action values
- honor optional chunked request bodies; require a valid If-Match version on REST v2 PUT and document the 409/413/422/428 responses
- bound external form/report/processor uploads, managed form events, image/attachment uploads, launcher logo/form/backup requests, and make backup uploads atomic
- cap DSL HTTP responses at 16 MiB and propagate read/size errors instead of silently retaining unbounded responses
- report oversized blobs and multipart bodies as HTTP 413

## Compatibility

REST v2 PUT now requires If-Match with the _version returned by GET. Missing headers return 428; malformed headers return 400; stale versions return 409. REST v1 keeps the header optional for compatibility but rejects malformed values.

## Validation

- go test ./...
- go vet ./...
- go test -race ./internal/api ./internal/dsl/interpreter ./internal/storage ./internal/ui ./internal/launcher
- git diff --check