### PR TITLE
fix(query): поддержать оператор МЕЖДУ

### DIFF
--- a/internal/dsl/langref/query.go
+++ b/internal/dsl/langref/query.go
@@ -95,6 +95,13 @@ var queryDescriptors = []Descriptor{
 		Example:   "ГДЕ Склад В (&СписокСкладов)",
 	},
 	{
+		Name: "между", Display: "МЕЖДУ", Aliases: []string{"BETWEEN"},
+		Kind: KindQuery, Group: "Запрос",
+		Signature: "<поле> МЕЖДУ <начало> И <конец>",
+		Doc:       "Проверяет, входит ли значение в указанный диапазон, включая обе границы.",
+		Example:   "ГДЕ Дата МЕЖДУ &ДатаНачала И &ДатаОкончания",
+	},
+	{
 		Name: "есть", Display: "ЕСТЬ", Aliases: []string{"IS"},
 		Kind: KindQuery, Group: "Запрос",
 		Signature: "<поле> ЕСТЬ ПУСТО",

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -361,6 +361,7 @@ var kwMap = map[string]string{
 	"ЕСТЬ":          "IS",
 	"ПУСТО":         "NULL",
 	"В":             "IN",
+	"МЕЖДУ":         "BETWEEN",
 	"ОБЪЕДИНИТЬ":    "UNION",
 	"ВСЕ":           "ALL",
 	// JOIN keywords (Russian)
@@ -393,6 +394,7 @@ var kwMap = map[string]string{
 	"IS":       "IS",
 	"NULL":     "NULL",
 	"IN":       "IN",
+	"BETWEEN":  "BETWEEN",
 	"UNION":    "UNION",
 	"ALL":      "ALL",
 	// JOIN keywords (English pass-through)

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -3,6 +3,7 @@ package query_test
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/query"
@@ -54,6 +55,38 @@ func TestCompile_WithParam(t *testing.T) {
 	}
 	if len(r.Args) != 1 || r.Args[0] != "Приход" {
 		t.Errorf("expected args=[Приход], got %v", r.Args)
+	}
+}
+
+func TestCompile_Between(t *testing.T) {
+	src := `ВЫБРАТЬ id ИЗ Документ.ЗаЧас ГДЕ Дата МЕЖДУ &ДатаНачала И &ДатаОкончания`
+	params := map[string]any{
+		"ДатаНачала":    time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
+		"ДатаОкончания": time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name    string
+		dialect storage.Dialect
+		want    string
+	}{
+		{name: "postgres", want: "WHERE дата BETWEEN $1::timestamptz AND $2::timestamptz"},
+		{name: "sqlite", dialect: storage.SQLiteDialect{}, want: "WHERE дата BETWEEN ? AND ?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := query.Compile(src, query.CompileOpts{Params: params, Dialect: tt.dialect})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(r.SQL, tt.want) {
+				t.Fatalf("expected %q, got: %s", tt.want, r.SQL)
+			}
+			if len(r.Args) != 2 {
+				t.Fatalf("expected 2 args, got %d: %v", len(r.Args), r.Args)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Что изменено

- русское ключевое слово МЕЖДУ транслируется в SQL BETWEEN;
- английское BETWEEN явно поддерживается как ключевое слово;
- добавлен регрессионный тест для PostgreSQL и SQLite с параметрами времени;
- оператор добавлен во встроенную справку языка запросов.

## Проверки

- go test ./... -count=1
- go test -race ./internal/query ./internal/dsl/langref -count=1
- go vet ./...
- git diff --check

Closes #426