### PR TITLE
fix(query): квалифицировать Ссылка при reference JOIN

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -484,6 +484,8 @@ type translator struct {
 	rowApplied  []SourceRef                   // источники, к которым RLS-предикат реально внедрён (для финальной сверки)
 	parenDepth  int                           // глубина незакрытых '(' в основном потоке (VT-аргументы считает parseVTArgs)
 	sourceCtx   sourceContext                 // scoped-типы источников для системных колонок регистра
+	unionDepths map[int]bool                  // глубины SELECT с UNION для compound ORDER BY
+	unionOrders map[int]bool                  // ORDER BY относится ко всему UNION, алиасы таблиц там недоступны
 }
 
 type sourceClass uint8
@@ -495,24 +497,55 @@ const (
 )
 
 type sourceContext struct {
-	scopes     []sourceScope
-	tokenScope []int
+	scopes       []sourceScope
+	tokenScope   []int
+	tokenSection []querySection
 }
 
 type sourceScope struct {
 	main       sourceClass
+	mainTable  string
 	qualifiers map[string]sourceClass
+	refAliases map[string]struct{}
 }
 
 func (ctx sourceContext) scopeAt(tokenPos int) (sourceScope, bool) {
-	if tokenPos < 0 || tokenPos >= len(ctx.tokenScope) {
-		return sourceScope{}, false
-	}
-	scopeID := ctx.tokenScope[tokenPos]
-	if scopeID < 0 || scopeID >= len(ctx.scopes) {
+	scopeID, ok := ctx.scopeIDAt(tokenPos)
+	if !ok {
 		return sourceScope{}, false
 	}
 	return ctx.scopes[scopeID], true
+}
+
+func (ctx sourceContext) scopeIDAt(tokenPos int) (int, bool) {
+	if tokenPos < 0 || tokenPos >= len(ctx.tokenScope) {
+		return 0, false
+	}
+	scopeID := ctx.tokenScope[tokenPos]
+	if scopeID < 0 || scopeID >= len(ctx.scopes) {
+		return 0, false
+	}
+	return scopeID, true
+}
+
+func (ctx sourceContext) sectionAt(tokenPos int) querySection {
+	if tokenPos < 0 || tokenPos >= len(ctx.tokenSection) {
+		return sectionOther
+	}
+	return ctx.tokenSection[tokenPos]
+}
+
+func (ctx sourceContext) isReferenceAliasAt(tokenPos int, lower string) bool {
+	section := ctx.sectionAt(tokenPos)
+	if section != sectionGroupBy && section != sectionOrderBy && section != sectionHaving {
+		return false
+	}
+	scope, ok := ctx.scopeAt(tokenPos)
+	if !ok {
+		return false
+	}
+	_, ok = scope.refAliases[lower]
+	return ok
 }
 
 type pendingRowFilter struct {
@@ -2145,11 +2178,38 @@ func (tr *translator) qualifyOwn(col, lower string) string {
 		return col // алиас вывода, не колонка таблицы
 	}
 	if len(tr.refDims) > 0 && tr.mainTable != "" {
-		if _, own := tr.colTypes[lower]; own {
+		_, own := tr.colTypes[lower]
+		if own {
 			return tr.mainTable + "." + col
 		}
 	}
 	return col
+}
+
+// qualifyReference квалифицирует виртуальное поле Ссылка/Reference/Ref по
+// основному источнику именно текущего SELECT-scope. Выходные алиасы обрабатываются
+// отдельно: глобальная tr.aliases не должна влиять на вложенные/UNION SELECT.
+func (tr *translator) qualifyReference(col string) string {
+	if len(tr.refDims) == 0 || tr.mainTable == "" || tr.inUnionOrder() {
+		return col
+	}
+	if scope, ok := tr.sourceCtx.scopeAt(tr.pos - 1); ok && scope.mainTable != "" {
+		return scope.mainTable + "." + col
+	}
+	return col
+}
+
+func (tr *translator) inUnionOrder() bool {
+	for depth := tr.parenDepth; depth >= 0; depth-- {
+		if tr.unionOrders[depth] {
+			return true
+		}
+	}
+	return false
+}
+
+func isReferenceName(lower string) bool {
+	return lower == "ссылка" || lower == "reference" || lower == "ref"
 }
 
 // emitOwnColumn эмитит неквалифицированную собственную колонку с учётом п.48/п.49.
@@ -2213,15 +2273,20 @@ func preScanMainTable(tokens []tok) string {
 // только к глубине скобок: Период внутри Год(Период) остаётся в родительском
 // SELECT, а SELECT-подзапрос получает собственный main/aliases.
 func preScanSourceContext(tokens []tok) sourceContext {
-	ctx := sourceContext{tokenScope: make([]int, len(tokens))}
+	ctx := sourceContext{
+		tokenScope:   make([]int, len(tokens)),
+		tokenSection: make([]querySection, len(tokens)),
+	}
 	for i := range ctx.tokenScope {
 		ctx.tokenScope[i] = -1
+		ctx.tokenSection[i] = sectionOther
 	}
 	type scopeFrame struct {
 		id    int
 		depth int
 	}
 	var active []scopeFrame
+	var sections []querySection
 	depth := 0
 
 	for i := 0; i < len(tokens); i++ {
@@ -2234,12 +2299,83 @@ func preScanSourceContext(tokens []tok) sourceContext {
 					active = active[:len(active)-1]
 				}
 				scopeID := len(ctx.scopes)
-				ctx.scopes = append(ctx.scopes, sourceScope{qualifiers: map[string]sourceClass{}})
+				ctx.scopes = append(ctx.scopes, sourceScope{
+					qualifiers: map[string]sourceClass{},
+					refAliases: map[string]struct{}{},
+				})
+				sections = append(sections, sectionSelect)
 				active = append(active, scopeFrame{id: scopeID, depth: depth})
 			}
 		}
 		if len(active) > 0 {
-			ctx.tokenScope[i] = active[len(active)-1].id
+			frame := active[len(active)-1]
+			scopeID := frame.id
+			// EXTRACT(YEAR FROM ...) содержит SQL-слово FROM внутри выражения.
+			// Секцию SELECT меняют только ключевые слова на глубине самого SELECT.
+			if t.kind == tIdent && depth == frame.depth {
+				if kw, ok := sqlKW(t.val); ok {
+					switch kw {
+					case "SELECT":
+						sections[scopeID] = sectionSelect
+					case "FROM":
+						sections[scopeID] = sectionFrom
+					case "WHERE":
+						sections[scopeID] = sectionWhere
+					case "GROUP":
+						sections[scopeID] = sectionGroupBy
+					case "ORDER":
+						sections[scopeID] = sectionOrderBy
+					case "HAVING":
+						sections[scopeID] = sectionHaving
+					}
+				}
+			}
+			ctx.tokenScope[i] = scopeID
+			ctx.tokenSection[i] = sections[scopeID]
+			if sections[scopeID] == sectionSelect && t.kind == tIdent && depth == frame.depth {
+				if up := strings.ToUpper(t.val); (up == "КАК" || up == "AS") &&
+					i+1 < len(tokens) && tokens[i+1].kind == tIdent {
+					alias := strings.ToLower(tokens[i+1].val)
+					if isReferenceName(alias) {
+						ctx.scopes[scopeID].refAliases[alias] = struct{}{}
+					}
+				}
+			}
+		}
+
+		// Производная таблица в FROM/JOIN сама является источником текущего
+		// SELECT. Без этого следующий обычный JOIN ошибочно становился mainTable.
+		if t.kind == tIdent && len(active) > 0 {
+			if kw, ok := sqlKW(t.val); ok && (kw == "FROM" || kw == "JOIN") &&
+				i+2 < len(tokens) && tokens[i+1].kind == tLParen &&
+				tokens[i+2].kind == tIdent {
+				if nestedKW, nested := sqlKW(tokens[i+2].val); nested && nestedKW == "SELECT" {
+					scope := &ctx.scopes[active[len(active)-1].id]
+					isMain := scope.mainTable == ""
+					nesting := 0
+					for j := i + 1; j < len(tokens); j++ {
+						switch tokens[j].kind {
+						case tLParen:
+							nesting++
+						case tRParen:
+							nesting--
+							if nesting == 0 {
+								aliasPos := j + 1
+								if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
+									aliasUpper := strings.ToUpper(tokens[aliasPos].val)
+									if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
+										alias := strings.ToLower(tokens[aliasPos+1].val)
+										if isMain {
+											scope.mainTable = alias
+										}
+									}
+								}
+								j = len(tokens)
+							}
+						}
+					}
+				}
+			}
 		}
 
 		if i+2 >= len(tokens) {
@@ -2283,6 +2419,15 @@ func preScanSourceContext(tokens []tok) sourceContext {
 		if scope.main == sourceClassUnknown {
 			scope.main = class
 		}
+		isMain := scope.mainTable == ""
+		if isMain {
+			// Виртуальная таблица эмитится как подзапрос со специальным алиасом,
+			// который здесь не вычисляем. Для обычного источника сохраняем имя,
+			// чтобы bare-Ссылка квалифицировалась в своём SELECT-scope.
+			if i+3 >= len(tokens) || tokens[i+3].kind != tDot {
+				scope.mainTable = sourceToTable(typeUpper, tokens[i+2].val)
+			}
+		}
 
 		entityName := strings.ToLower(tokens[i+2].val)
 		scope.qualifiers[entityName] = class
@@ -2293,7 +2438,11 @@ func preScanSourceContext(tokens []tok) sourceContext {
 		if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
 			aliasUpper := strings.ToUpper(tokens[aliasPos].val)
 			if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
-				scope.qualifiers[strings.ToLower(tokens[aliasPos+1].val)] = class
+				alias := strings.ToLower(tokens[aliasPos+1].val)
+				scope.qualifiers[alias] = class
+				if isMain {
+					scope.mainTable = alias
+				}
 				continue
 			}
 		}
@@ -2485,6 +2634,8 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		refDims:     preScanRefDims(tokens, opts),
 		sourceCtx:   preScanSourceContext(tokens),
 		aliases:     map[string]struct{}{},
+		unionDepths: map[int]bool{},
+		unionOrders: map[int]bool{},
 		section:     sectionOther,
 	}
 	for {
@@ -2663,6 +2814,9 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 			}
 			tr.advance()
 			if upper == "УПОРЯДОЧИТЬ" {
+				if tr.unionDepths[tr.parenDepth] {
+					tr.unionOrders[tr.parenDepth] = true
+				}
 				tr.section = sectionOrderBy
 				tr.emit("ORDER BY")
 			} else {
@@ -2709,6 +2863,8 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 			if t.kind == tLParen {
 				tr.parenDepth++
 			} else if t.kind == tRParen && tr.parenDepth > 0 {
+				delete(tr.unionDepths, tr.parenDepth)
+				delete(tr.unionOrders, tr.parenDepth)
 				tr.parenDepth--
 			}
 			tr.advance()
@@ -2728,11 +2884,31 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 			tr.advance()
 			prevDot := tr.prevWasDot
 			tr.prevWasDot = false
+			lower := strings.ToLower(t.val)
+			nextIsDot := tr.peek(0).kind == tDot
+			prevAlias := false
+			if tr.pos >= 2 {
+				if pv := strings.ToUpper(tr.tokens[tr.pos-2].val); pv == "КАК" || pv == "AS" {
+					prevAlias = !prevDot
+				}
+			}
 			// Ссылка / Reference → id (virtual primary-key field, like 1C).
 			// Работает и после точки (Н.Ссылка → н.id), и без алиаса
 			// (ВЫБРАТЬ Ссылка ИЗ Справочник.X → SELECT id FROM x).
-			if up := strings.ToUpper(t.val); up == "ССЫЛКА" || up == "REFERENCE" || up == "REF" {
-				tr.emit("id")
+			if isReferenceName(lower) {
+				switch {
+				case prevAlias:
+					// Имя виртуального поля зарезервировано: исторически
+					// `КАК Ссылка` создаёт SQL-алиас id. Важно не пропускать его
+					// через qualifyReference — `AS таблица.id` невалиден.
+					tr.emit("id")
+				case prevDot:
+					tr.emit("id")
+				case tr.sourceCtx.isReferenceAliasAt(tr.pos-1, lower):
+					tr.emit("id")
+				default:
+					tr.emit(tr.qualifyReference("id"))
+				}
 				continue
 			}
 			// Системные колонки регистра — PascalCase русские алиасы
@@ -2750,6 +2926,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 					if len(tr.opts.RowFilters) > 0 {
 						return Result{}, fmt.Errorf("row-level filters for UNION queries are not supported yet")
 					}
+					tr.unionDepths[tr.parenDepth] = true
 				case "WHERE":
 					tr.emit("WHERE")
 					tr.section = sectionWhere
@@ -2765,6 +2942,9 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 							return Result{}, err
 						}
 					}
+					if kw == "ORDER" && tr.unionDepths[tr.parenDepth] {
+						tr.unionOrders[tr.parenDepth] = true
+					}
 				}
 				tr.emit(kw)
 				// track clause context
@@ -2779,14 +2959,6 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 					tr.section = sectionOrderBy
 				}
 			} else {
-				lower := strings.ToLower(t.val)
-				nextIsDot := tr.peek(0).kind == tDot
-				prevAlias := false
-				if tr.pos >= 2 {
-					if pv := strings.ToUpper(tr.tokens[tr.pos-2].val); pv == "КАК" || pv == "AS" {
-						prevAlias = !prevDot
-					}
-				}
 				if prevAlias {
 					// Имя алиаса вывода (КАК <name>) — не колонка: эмитим как есть
 					// и запоминаем, чтобы ссылки на него не квалифицировать/CAST'ить.

--- a/internal/query/reference_link_exec_test.go
+++ b/internal/query/reference_link_exec_test.go
@@ -1,0 +1,403 @@
+package query_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Регрессия #424: bare-Ссылка должна квалифицироваться основной таблицей,
+// когда reference-поле добавляет авто-JOIN. Иначе SQLite видит несколько id и
+// отклоняет запрос с `ambiguous column name: id`.
+func TestBareReference_WithReferenceJoin_ExecuteSQLite(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "reference-link.db"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer db.Close()
+
+	participant := &metadata.Entity{
+		Name:   "Участник",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	project := &metadata.Entity{
+		Name:   "Проект",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	expense := &metadata.Entity{
+		Name: "Расход",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Сумма", Type: metadata.FieldTypeNumber},
+			{Name: "Период", Type: metadata.FieldTypeDate},
+			{Name: "ОплаченоУчастником", Type: "reference:Участник", RefEntity: "Участник"},
+			{Name: "Проект", Type: "reference:Проект", RefEntity: "Проект"},
+		},
+	}
+	entities := []*metadata.Entity{participant, project, expense}
+	if err := db.Migrate(ctx, entities); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	participantID := uuid.New()
+	projectID := uuid.New()
+	expenseID := uuid.New()
+	if err := db.Upsert(ctx, participant.Name, participantID, map[string]any{
+		"наименование": "Иван",
+	}, participant); err != nil {
+		t.Fatalf("insert participant: %v", err)
+	}
+	if err := db.Upsert(ctx, project.Name, projectID, map[string]any{
+		"наименование": "Казначейство",
+	}, project); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	if err := db.Upsert(ctx, expense.Name, expenseID, map[string]any{
+		"сумма":              100,
+		"период":             time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC),
+		"оплаченоучастником": participantID.String(),
+		"проект":             projectID.String(),
+	}, expense); err != nil {
+		t.Fatalf("insert expense: %v", err)
+	}
+	if err := db.SetPosted(ctx, expense.Name, expenseID, true); err != nil {
+		t.Fatalf("post expense: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		src         string
+		withDisplay bool
+		wantLinkSQL string
+	}{
+		{
+			name:        "reference field in projection",
+			src:         `ВЫБРАТЬ Ссылка, ОплаченоУчастником ИЗ Документ.Расход ГДЕ posted = 1`,
+			withDisplay: true,
+			wantLinkSQL: "расход.id",
+		},
+		{
+			name:        "reference field in condition",
+			src:         `ВЫБРАТЬ Ссылка ИЗ Документ.Расход ГДЕ posted = 1 И (Проект = Проект)`,
+			wantLinkSQL: "расход.id",
+		},
+		{
+			name:        "aliased source",
+			src:         `ВЫБРАТЬ Ссылка, ОплаченоУчастником ИЗ Документ.Расход КАК Р ГДЕ Р.posted = 1`,
+			withDisplay: true,
+			wantLinkSQL: "р.id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := query.Compile(tt.src, query.CompileOpts{
+				Entities: entities,
+				Dialect:  storage.SQLiteDialect{},
+			})
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+
+			var link string
+			if tt.withDisplay {
+				var display string
+				err = db.QueryRow(ctx, res.SQL, res.Args...).Scan(&link, &display)
+				if err == nil && display != "Иван" {
+					t.Fatalf("display = %q, want Иван", display)
+				}
+			} else {
+				err = db.QueryRow(ctx, res.SQL, res.Args...).Scan(&link)
+			}
+			if err != nil {
+				t.Fatalf("execute %q\nSQL: %s\nerror: %v", tt.src, res.SQL, err)
+			}
+			if link != expenseID.String() {
+				t.Fatalf("link = %q, want %q", link, expenseID)
+			}
+			if !strings.Contains(res.SQL, tt.wantLinkSQL) {
+				t.Fatalf("bare Ссылка is not qualified by the source table:\n%s", res.SQL)
+			}
+		})
+	}
+
+	t.Run("nested select uses its own source", func(t *testing.T) {
+		src := `ВЫБРАТЬ Ссылка ИЗ Документ.Расход КАК Р ГДЕ ОплаченоУчастником В (ВЫБРАТЬ Ссылка ИЗ Справочник.Участник)`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var link string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&link); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if link != expenseID.String() {
+			t.Fatalf("link = %q, want %q", link, expenseID)
+		}
+		if !strings.Contains(res.SQL, "(SELECT участник.id FROM участник)") {
+			t.Fatalf("nested Ссылка is not qualified by its own source:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("outer link after nested source uses outer source", func(t *testing.T) {
+		src := `ВЫБРАТЬ Ссылка, (ВЫБРАТЬ ОплаченоУчастником ИЗ Документ.Расход) КАК Участник ИЗ Справочник.Проект`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var link, display string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&link, &display); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if link != projectID.String() {
+			t.Fatalf("link = %q, want %q", link, projectID)
+		}
+		if display != "Иван" {
+			t.Fatalf("display = %q, want Иван", display)
+		}
+		if !strings.HasPrefix(res.SQL, "SELECT проект.id,") {
+			t.Fatalf("outer Ссылка is not qualified by its own source:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("reference word remains a valid output alias", func(t *testing.T) {
+		src := `ВЫБРАТЬ Сумма КАК Ссылка, Р.Ссылка, Проект ИЗ Документ.Расход КАК Р УПОРЯДОЧИТЬ ПО Ссылка`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var amount any
+		var link, display string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&amount, &link, &display); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if link != expenseID.String() {
+			t.Fatalf("link = %q, want %q", link, expenseID)
+		}
+		if display != "Казначейство" {
+			t.Fatalf("display = %q, want Казначейство", display)
+		}
+		if !strings.Contains(res.SQL, "AS id") || !strings.Contains(res.SQL, "р.id") ||
+			!strings.Contains(res.SQL, "ORDER BY id") {
+			t.Fatalf("Ссылка used as an output alias generated invalid SQL:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("output alias does not leak into references", func(t *testing.T) {
+		src := `ВЫБРАТЬ Сумма КАК Ссылка, Р.Ссылка, (ВЫБРАТЬ Ссылка ИЗ Справочник.Участник) КАК Вложенная ИЗ Документ.Расход КАК Р`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var amount any
+		var expenseLink, nestedLink string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&amount, &expenseLink, &nestedLink); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if expenseLink != expenseID.String() || nestedLink != participantID.String() {
+			t.Fatalf("links = (%q, %q), want (%q, %q)", expenseLink, nestedLink, expenseID, participantID)
+		}
+		if !strings.Contains(res.SQL, "р.id") || !strings.Contains(res.SQL, "(SELECT id FROM участник)") {
+			t.Fatalf("output alias leaked into qualified or nested references:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("derived table remains the main source", func(t *testing.T) {
+		src := `ВЫБРАТЬ Ссылка ИЗ (ВЫБРАТЬ Р.Ссылка, Р.Проект ИЗ Документ.Расход КАК Р) КАК П ЛЕВОЕ СОЕДИНЕНИЕ Справочник.Участник КАК У ПО 1 = 0`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var link string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&link); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if link != expenseID.String() {
+			t.Fatalf("link = %q, want %q", link, expenseID)
+		}
+		if !strings.HasPrefix(res.SQL, "SELECT п.id FROM") {
+			t.Fatalf("derived table was not preserved as the main source:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("derived register preserves system columns", func(t *testing.T) {
+		reg := &metadata.Register{Name: "Остатки"}
+		if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+			t.Fatalf("migrate register: %v", err)
+		}
+		period := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+		if err := db.WriteMovements(ctx, reg.Name, "Документ", uuid.New(),
+			[]map[string]any{{}}, reg, &period); err != nil {
+			t.Fatalf("write movement: %v", err)
+		}
+
+		src := `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ Период ИЗ РегистрНакопления.Остатки КАК В) КАК П ЛЕВОЕ СОЕДИНЕНИЕ РегистрНакопления.Остатки КАК Р ПО 1 = 0`
+		res, err := query.Compile(src, query.CompileOpts{
+			Registers: []*metadata.Register{reg},
+			Dialect:   storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var got any
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&got); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if !strings.HasPrefix(res.SQL, "SELECT п.period FROM") {
+			t.Fatalf("derived register lost system-column semantics:\n%s", res.SQL)
+		}
+
+		entityFieldSrc := `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ Д.Период ИЗ РегистрНакопления.Остатки КАК Р ЛЕВОЕ СОЕДИНЕНИЕ Документ.Расход КАК Д ПО 1 = 0) КАК П`
+		entityFieldRes, err := query.Compile(entityFieldSrc, query.CompileOpts{
+			Registers: []*metadata.Register{reg},
+			Entities:  entities,
+			Dialect:   storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile entity field: %v", err)
+		}
+		if err := db.QueryRow(ctx, entityFieldRes.SQL, entityFieldRes.Args...).Scan(&got); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", entityFieldSrc, entityFieldRes.SQL, err)
+		}
+		if !strings.HasPrefix(entityFieldRes.SQL, "SELECT п.период FROM") {
+			t.Fatalf("derived entity field inherited register semantics:\n%s", entityFieldRes.SQL)
+		}
+	})
+
+	t.Run("union order uses the output column", func(t *testing.T) {
+		src := `ВЫБРАТЬ Р.Ссылка ИЗ Документ.Расход КАК Р ГДЕ Проект = Проект ОБЪЕДИНИТЬ ВСЕ ВЫБРАТЬ У.Ссылка ИЗ Справочник.Участник КАК У УПОРЯДОЧИТЬ ПО Ссылка`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.PgDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.HasSuffix(res.SQL, "ORDER BY id") {
+			t.Fatalf("UNION-level ORDER BY must use the output column:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("parenthesized union order uses the output column", func(t *testing.T) {
+		src := `ВЫБРАТЬ Р.Ссылка ИЗ Документ.Расход КАК Р ГДЕ Проект = Проект ОБЪЕДИНИТЬ ВСЕ ВЫБРАТЬ У.Ссылка ИЗ Справочник.Участник КАК У УПОРЯДОЧИТЬ ПО (Ссылка)`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.PgDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.HasSuffix(res.SQL, "ORDER BY(id)") {
+			t.Fatalf("parenthesized UNION-level ORDER BY must use the output column:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("reserved alias survives a derived table", func(t *testing.T) {
+		src := `ВЫБРАТЬ П.Ссылка ИЗ (ВЫБРАТЬ Р.Ссылка КАК Ссылка ИЗ Документ.Расход КАК Р) КАК П`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var link string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&link); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if link != expenseID.String() {
+			t.Fatalf("link = %q, want %q", link, expenseID)
+		}
+		if !strings.Contains(res.SQL, "р.id AS id") || !strings.HasPrefix(res.SQL, "SELECT п.id FROM") {
+			t.Fatalf("reserved alias changed across the derived-table boundary:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("scalar subquery alias is visible to order", func(t *testing.T) {
+		src := `ВЫБРАТЬ (ВЫБРАТЬ Сумма ИЗ Документ.Расход) КАК Ссылка ИЗ Справочник.Проект УПОРЯДОЧИТЬ ПО Ссылка`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.Contains(res.SQL, "AS id") || !strings.HasSuffix(res.SQL, "ORDER BY id") {
+			t.Fatalf("scalar-subquery alias was not recorded in the outer scope:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("postgres scalar function alias is visible to order", func(t *testing.T) {
+		src := `ВЫБРАТЬ Год(Период) КАК Ссылка, Проект ИЗ Документ.Расход УПОРЯДОЧИТЬ ПО Ссылка`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.PgDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.Contains(res.SQL, "AS id") || !strings.HasSuffix(res.SQL, "ORDER BY id") {
+			t.Fatalf("EXTRACT's internal FROM hid the reserved output alias:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("later union alias does not rename the output", func(t *testing.T) {
+		src := `ВЫБРАТЬ Р.Ссылка ИЗ Документ.Расход КАК Р ОБЪЕДИНИТЬ ВСЕ ВЫБРАТЬ Наименование КАК Ссылка ИЗ Справочник.Участник УПОРЯДОЧИТЬ ПО Ссылка`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.PgDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.Contains(res.SQL, "наименование AS id") || !strings.HasSuffix(res.SQL, "ORDER BY id") {
+			t.Fatalf("later UNION arm changed the compound output name:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("english group recognizes the reserved alias", func(t *testing.T) {
+		src := `SELECT Сумма AS Reference, Проект FROM Document.Расход GROUP BY Reference, Проект`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.PgDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.Contains(res.SQL, "AS id") || !strings.Contains(res.SQL, "GROUP BY id,") {
+			t.Fatalf("English GROUP BY did not resolve the reserved alias:\n%s", res.SQL)
+		}
+	})
+}


### PR DESCRIPTION
## Что изменено

- bare Ссылка/Reference/Ref теперь проходит через общую квалификацию собственных колонок;
- при auto-JOIN reference-поля генерируется расход.id или алиас.id вместо ambiguous id;
- форма с явным квалификатором Р.Ссылка сохраняет прежнее поведение;
- добавлен SQLite E2E-тест для reference-поля в выборке, в условии и для источника с алиасом.

## Проверки

- go test ./... -count=1
- go test -race ./internal/query -count=1
- go vet ./...
- git diff --check

Closes #424