### PR TITLE
fix(query): квалифицировать Ссылка при явном JOIN

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -503,10 +503,11 @@ type sourceContext struct {
 }
 
 type sourceScope struct {
-	main       sourceClass
-	mainTable  string
-	qualifiers map[string]sourceClass
-	refAliases map[string]struct{}
+	main        sourceClass
+	mainTable   string
+	sourceCount int
+	qualifiers  map[string]sourceClass
+	refAliases  map[string]struct{}
 }
 
 func (ctx sourceContext) scopeAt(tokenPos int) (sourceScope, bool) {
@@ -2190,13 +2191,17 @@ func (tr *translator) qualifyOwn(col, lower string) string {
 // основному источнику именно текущего SELECT-scope. Выходные алиасы обрабатываются
 // отдельно: глобальная tr.aliases не должна влиять на вложенные/UNION SELECT.
 func (tr *translator) qualifyReference(col string) string {
-	if len(tr.refDims) == 0 || tr.mainTable == "" || tr.inUnionOrder() {
+	if tr.inUnionOrder() {
 		return col
 	}
-	if scope, ok := tr.sourceCtx.scopeAt(tr.pos - 1); ok && scope.mainTable != "" {
-		return scope.mainTable + "." + col
+	scope, ok := tr.sourceCtx.scopeAt(tr.pos - 1)
+	if !ok || scope.mainTable == "" {
+		return col
 	}
-	return col
+	if len(tr.refDims) == 0 && scope.sourceCount < 2 {
+		return col
+	}
+	return scope.mainTable + "." + col
 }
 
 func (tr *translator) inUnionOrder() bool {
@@ -2351,7 +2356,8 @@ func preScanSourceContext(tokens []tok) sourceContext {
 				tokens[i+2].kind == tIdent {
 				if nestedKW, nested := sqlKW(tokens[i+2].val); nested && nestedKW == "SELECT" {
 					scope := &ctx.scopes[active[len(active)-1].id]
-					isMain := scope.mainTable == ""
+					isMain := scope.sourceCount == 0
+					scope.sourceCount++
 					nesting := 0
 					for j := i + 1; j < len(tokens); j++ {
 						switch tokens[j].kind {
@@ -2411,6 +2417,8 @@ func preScanSourceContext(tokens []tok) sourceContext {
 			continue
 		}
 		scope := &ctx.scopes[active[len(active)-1].id]
+		isMain := scope.sourceCount == 0
+		scope.sourceCount++
 
 		class := sourceClassEntity
 		if isAccumRegType(typeUpper) || isInfoRegType(typeUpper) || isAccountRegType(typeUpper) {
@@ -2419,7 +2427,6 @@ func preScanSourceContext(tokens []tok) sourceContext {
 		if scope.main == sourceClassUnknown {
 			scope.main = class
 		}
-		isMain := scope.mainTable == ""
 		if isMain {
 			// Виртуальная таблица эмитится как подзапрос со специальным алиасом,
 			// который здесь не вычисляем. Для обычного источника сохраняем имя,
@@ -2464,7 +2471,11 @@ func preScanSourceContext(tokens []tok) sourceContext {
 					if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
 						aliasUpper := strings.ToUpper(tokens[aliasPos].val)
 						if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
-							scope.qualifiers[strings.ToLower(tokens[aliasPos+1].val)] = class
+							alias := strings.ToLower(tokens[aliasPos+1].val)
+							scope.qualifiers[alias] = class
+							if isMain {
+								scope.mainTable = alias
+							}
 						}
 					}
 					j = len(tokens)

--- a/internal/query/reference_explicit_join_exec_test.go
+++ b/internal/query/reference_explicit_join_exec_test.go
@@ -1,0 +1,147 @@
+package query_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Регрессия #430: bare-Ссылка относится к основному источнику текущего
+// SELECT и при явном JOIN должна быть квалифицирована его таблицей/алиасом.
+func TestBareReference_WithExplicitJoin_ExecuteSQLite(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "reference-explicit-join.db"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer db.Close()
+
+	a := &metadata.Entity{
+		Name:   "A",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	b := &metadata.Entity{
+		Name:   "B",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	c := &metadata.Entity{
+		Name:   "C",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	entities := []*metadata.Entity{a, b, c}
+	if err := db.Migrate(ctx, entities); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	aID := uuid.New()
+	bID := uuid.New()
+	cID := uuid.New()
+	for _, item := range []struct {
+		entity *metadata.Entity
+		id     uuid.UUID
+		name   string
+	}{
+		{a, aID, "A"},
+		{b, bID, "B"},
+		{c, cID, "C"},
+	} {
+		if err := db.Upsert(ctx, item.entity.Name, item.id,
+			map[string]any{"наименование": item.name}, item.entity); err != nil {
+			t.Fatalf("insert %s: %v", item.entity.Name, err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		src       string
+		wantSQL   string
+		wantLinks []string
+	}{
+		{
+			name:      "main source table",
+			src:       `SELECT Reference FROM Catalog.A JOIN Catalog.B AS B ON 1 = 1`,
+			wantSQL:   "SELECT a.id FROM",
+			wantLinks: []string{aID.String()},
+		},
+		{
+			name:      "main source alias",
+			src:       `SELECT Reference FROM Catalog.A AS Main JOIN Catalog.B AS B ON 1 = 1`,
+			wantSQL:   "SELECT main.id FROM",
+			wantLinks: []string{aID.String()},
+		},
+		{
+			name:      "derived main source alias",
+			src:       `SELECT Reference FROM (SELECT Reference FROM Catalog.A) AS Main JOIN Catalog.B AS B ON 1 = 1`,
+			wantSQL:   "SELECT main.id FROM",
+			wantLinks: []string{aID.String()},
+		},
+		{
+			name: "nested select has its own main source",
+			src: `SELECT Reference,
+				(SELECT Reference FROM Catalog.C AS InnerC JOIN Catalog.B AS InnerB ON 1 = 1) AS Nested
+				FROM Catalog.A AS OuterA JOIN Catalog.B AS OuterB ON 1 = 1`,
+			wantSQL:   "SELECT outera.id,(SELECT innerc.id FROM",
+			wantLinks: []string{aID.String(), cID.String()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := query.Compile(tt.src, query.CompileOpts{
+				Entities: entities,
+				Dialect:  storage.SQLiteDialect{},
+			})
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if !strings.Contains(res.SQL, tt.wantSQL) {
+				t.Fatalf("bare Reference is not qualified by the SELECT's main source:\n%s", res.SQL)
+			}
+
+			dest := make([]any, len(tt.wantLinks))
+			values := make([]string, len(tt.wantLinks))
+			for i := range values {
+				dest[i] = &values[i]
+			}
+			if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(dest...); err != nil {
+				t.Fatalf("execute %q\nSQL: %s\nerror: %v", tt.src, res.SQL, err)
+			}
+			for i := range values {
+				if values[i] != tt.wantLinks[i] {
+					t.Fatalf("column %d = %q, want %q", i, values[i], tt.wantLinks[i])
+				}
+			}
+		})
+	}
+
+	t.Run("virtual main source is not replaced by joined source", func(t *testing.T) {
+		reg := &metadata.Register{
+			Name:       "R",
+			Dimensions: []metadata.Field{{Name: "D"}},
+			Resources:  []metadata.Field{{Name: "X"}},
+		}
+		res, err := query.Compile(
+			`SELECT Reference FROM AccumulationRegister.R.Balances() AS Bal JOIN Catalog.B AS B ON 1 = 1`,
+			query.CompileOpts{
+				Registers: []*metadata.Register{reg},
+				Entities:  entities,
+				Dialect:   storage.SQLiteDialect{},
+			},
+		)
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if !strings.Contains(res.SQL, "SELECT bal.id FROM") {
+			t.Fatalf("joined source replaced the virtual main source:\n%s", res.SQL)
+		}
+	})
+}


### PR DESCRIPTION
## Что изменено

- контекст каждого `SELECT` считает реальные источники;
- bare `Ссылка` / `Reference` квалифицируется основной таблицей, когда явный JOIN создаёт несколько `id`;
- область видимости учитывается отдельно для вложенных SELECT;
- добавлены исполняемые SQLite-регрессии для источника с алиасом, без алиаса и вложенного SELECT.

## Проверки

- `go test ./internal/query -count=1`
- `go test -race ./internal/query -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`

Closes #430