### PR TITLE
fix(query): развернуть алиас Ссылка в GROUP BY и HAVING

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -2486,6 +2486,116 @@ func preScanSourceContext(tokens []tok) sourceContext {
 	return ctx
 }
 
+// rewriteGroupingReferenceAliases разворачивает зарезервированный выходной
+// алиас Ссылка/Reference/Ref обратно в выражение SELECT при обращении из
+// GROUP BY/HAVING. PostgreSQL не разрешает SELECT-алиасы в HAVING, а при
+// авто-JOIN оба диалекта могут трактовать id как неоднозначную входную колонку.
+// ORDER BY оставляем без изменений: там выходной алиас имеет нужный приоритет.
+func rewriteGroupingReferenceAliases(tokens []tok) []tok {
+	ctx := preScanSourceContext(tokens)
+	expressions := make(map[int][]tok)
+
+	for i := 0; i+1 < len(tokens); i++ {
+		if tokens[i].kind != tIdent || tokens[i+1].kind != tIdent {
+			continue
+		}
+		kw, ok := sqlKW(tokens[i].val)
+		if !ok || kw != "AS" || !isReferenceName(strings.ToLower(tokens[i+1].val)) {
+			continue
+		}
+		scopeID, ok := ctx.scopeIDAt(i)
+		if !ok || ctx.sectionAt(i) != sectionSelect {
+			continue
+		}
+		start := selectExpressionStart(tokens, ctx, scopeID, i)
+		if start >= i {
+			continue
+		}
+		expressions[scopeID] = copyGroupingAliasExpression(tokens, ctx, start, i)
+	}
+	if len(expressions) == 0 {
+		return tokens
+	}
+
+	out := make([]tok, 0, len(tokens))
+	for i, t := range tokens {
+		section := ctx.sectionAt(i)
+		if t.kind == tIdent && isReferenceName(strings.ToLower(t.val)) &&
+			(section == sectionGroupBy || section == sectionHaving) &&
+			(i == 0 || tokens[i-1].kind != tDot) {
+			if scopeID, ok := ctx.scopeIDAt(i); ok {
+				if expr := expressions[scopeID]; len(expr) > 0 {
+					out = append(out, tok{kind: tLParen, val: "("})
+					out = append(out, expr...)
+					out = append(out, tok{kind: tRParen, val: ")"})
+					continue
+				}
+			}
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func selectExpressionStart(tokens []tok, ctx sourceContext, scopeID, aliasPos int) int {
+	nesting := 0
+	for i := aliasPos - 1; i >= 0; i-- {
+		switch tokens[i].kind {
+		case tRParen:
+			nesting++
+			continue
+		case tLParen:
+			if nesting > 0 {
+				nesting--
+				continue
+			}
+		}
+		if nesting != 0 {
+			continue
+		}
+		if id, ok := ctx.scopeIDAt(i); !ok || id != scopeID {
+			continue
+		}
+		if tokens[i].kind == tComma {
+			return i + 1
+		}
+		if tokens[i].kind == tIdent {
+			if kw, ok := sqlKW(tokens[i].val); ok && kw == "SELECT" {
+				start := i + 1
+				if start < aliasPos && tokens[start].kind == tIdent {
+					if kw, ok := sqlKW(tokens[start].val); ok && (kw == "DISTINCT" || kw == "ALL") {
+						start++
+					}
+				}
+				return start
+			}
+		}
+	}
+	return aliasPos
+}
+
+func copyGroupingAliasExpression(tokens []tok, ctx sourceContext, start, end int) []tok {
+	expr := make([]tok, 0, end-start)
+	for i := start; i < end; i++ {
+		t := tokens[i]
+		if t.kind == tIdent && isReferenceName(strings.ToLower(t.val)) &&
+			(i == start || tokens[i-1].kind != tDot) {
+			prevAlias := i > start && tokens[i-1].kind == tIdent &&
+				(strings.EqualFold(tokens[i-1].val, "КАК") || strings.EqualFold(tokens[i-1].val, "AS"))
+			if !prevAlias && !ctx.isReferenceAliasAt(i, strings.ToLower(t.val)) {
+				if scope, ok := ctx.scopeAt(i); ok && scope.mainTable != "" {
+					expr = append(expr,
+						tok{kind: tIdent, val: scope.mainTable},
+						tok{kind: tDot, val: "."},
+					)
+				}
+			}
+		}
+		expr = append(expr, t)
+	}
+	return expr
+}
+
 // systemColumnAlias разрешает русское имя системной колонки только в контексте
 // регистра. Для документов и справочников такое имя является обычным
 // прикладным полем и должно остаться кириллическим.
@@ -2630,6 +2740,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		opts.Params = map[string]any{}
 	}
 	projectionFields := projectionFieldNames(tokens)
+	tokens = rewriteGroupingReferenceAliases(tokens)
 	// расширяем НачалоДня/Год/Месяц/ОКР/АБС/ЦЕЛ/... в SQL-эквиваленты
 	// до основной трансляции, чтобы остальные шаги ничего не знали о них.
 	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect))
@@ -2964,6 +3075,8 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 					tr.section = sectionSelect
 				case "FROM":
 					tr.section = sectionFrom
+				case "GROUP":
+					tr.section = sectionGroupBy
 				case "HAVING":
 					tr.section = sectionHaving
 				case "ORDER":

--- a/internal/query/reference_link_exec_test.go
+++ b/internal/query/reference_link_exec_test.go
@@ -205,6 +205,92 @@ func TestBareReference_WithReferenceJoin_ExecuteSQLite(t *testing.T) {
 		}
 	})
 
+	t.Run("reference output alias is usable in having", func(t *testing.T) {
+		src := `SELECT SUM(Сумма) AS Reference, Проект
+			FROM Document.Расход
+			GROUP BY Проект
+			HAVING Reference > 50`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var total float64
+		var display string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&total, &display); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if total != 100 || display != "Казначейство" {
+			t.Fatalf("row = (%v, %q), want (100, Казначейство)", total, display)
+		}
+		if !strings.Contains(res.SQL, "HAVING(SUM(CAST(расход.сумма AS NUMERIC))) > 50") {
+			t.Fatalf("HAVING did not expand the reserved output alias:\n%s", res.SQL)
+		}
+
+		pgRes, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.PgDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile PostgreSQL: %v", err)
+		}
+		if !strings.Contains(pgRes.SQL, "HAVING(SUM(расход.сумма)) > 50") ||
+			strings.Contains(pgRes.SQL, "HAVING id") {
+			t.Fatalf("PostgreSQL HAVING still references the SELECT alias:\n%s", pgRes.SQL)
+		}
+	})
+
+	t.Run("reference output alias is usable in group by", func(t *testing.T) {
+		src := `SELECT Сумма AS Reference, Проект
+			FROM Document.Расход
+			GROUP BY Reference, Проект`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+
+		var amount float64
+		var display string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&amount, &display); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+		if amount != 100 || display != "Казначейство" {
+			t.Fatalf("row = (%v, %q), want (100, Казначейство)", amount, display)
+		}
+		if !strings.Contains(res.SQL, "GROUP BY(расход.сумма),") {
+			t.Fatalf("GROUP BY did not expand the reserved output alias:\n%s", res.SQL)
+		}
+	})
+
+	t.Run("select all modifier is not copied into group by", func(t *testing.T) {
+		src := `SELECT ALL Сумма AS Reference, Проект
+			FROM Document.Расход
+			GROUP BY Reference, Проект`
+		res, err := query.Compile(src, query.CompileOpts{
+			Entities: entities,
+			Dialect:  storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		if strings.Contains(res.SQL, "GROUP BY(ALL ") ||
+			!strings.Contains(res.SQL, "GROUP BY(расход.сумма),") {
+			t.Fatalf("SELECT ALL leaked into the grouped expression:\n%s", res.SQL)
+		}
+
+		var amount float64
+		var display string
+		if err := db.QueryRow(ctx, res.SQL, res.Args...).Scan(&amount, &display); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", src, res.SQL, err)
+		}
+	})
+
 	t.Run("output alias does not leak into references", func(t *testing.T) {
 		src := `ВЫБРАТЬ Сумма КАК Ссылка, Р.Ссылка, (ВЫБРАТЬ Ссылка ИЗ Справочник.Участник) КАК Вложенная ИЗ Документ.Расход КАК Р`
 		res, err := query.Compile(src, query.CompileOpts{
@@ -396,8 +482,8 @@ func TestBareReference_WithReferenceJoin_ExecuteSQLite(t *testing.T) {
 		if err != nil {
 			t.Fatalf("compile: %v", err)
 		}
-		if !strings.Contains(res.SQL, "AS id") || !strings.Contains(res.SQL, "GROUP BY id,") {
-			t.Fatalf("English GROUP BY did not resolve the reserved alias:\n%s", res.SQL)
+		if !strings.Contains(res.SQL, "AS id") || !strings.Contains(res.SQL, "GROUP BY(расход.сумма),") {
+			t.Fatalf("English GROUP BY did not expand the reserved alias:\n%s", res.SQL)
 		}
 	})
 }


### PR DESCRIPTION
## Что изменено

- Зарезервированный выходной алиас `Ссылка` / `Reference` / `Ref` разворачивается в исходное SELECT-выражение в `GROUP BY` и `HAVING` внутри своего scope.
- Устранена неоднозначность `id` при авто-JOIN ссылочного поля в SQLite.
- PostgreSQL больше не получает неподдерживаемую ссылку на SELECT-алиас из `HAVING`.
- `ORDER BY` сохранён без изменений, поскольку там выходной алиас имеет корректный приоритет.

## Проверки

- SQLite E2E для `HAVING` и `GROUP BY` с авто-JOIN
- PostgreSQL SQL-регрессия
- `go test ./internal/query -count=1`
- `go test -race ./internal/query -count=1`
- `go test ./... -count=1`
- `go vet ./...`

Closes #431