### PR TITLE
fix(query): сохранить системные колонки регистра через производные таблицы

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -500,14 +500,16 @@ type sourceContext struct {
 	scopes       []sourceScope
 	tokenScope   []int
 	tokenSection []querySection
+	tokenDepth   []int
 }
 
 type sourceScope struct {
-	main        sourceClass
-	mainTable   string
-	sourceCount int
-	qualifiers  map[string]sourceClass
-	refAliases  map[string]struct{}
+	main           sourceClass
+	mainTable      string
+	sourceCount    int
+	qualifiers     map[string]sourceClass
+	derivedAliases map[string]int
+	refAliases     map[string]struct{}
 }
 
 func (ctx sourceContext) scopeAt(tokenPos int) (sourceScope, bool) {
@@ -2281,6 +2283,7 @@ func preScanSourceContext(tokens []tok) sourceContext {
 	ctx := sourceContext{
 		tokenScope:   make([]int, len(tokens)),
 		tokenSection: make([]querySection, len(tokens)),
+		tokenDepth:   make([]int, len(tokens)),
 	}
 	for i := range ctx.tokenScope {
 		ctx.tokenScope[i] = -1
@@ -2296,6 +2299,7 @@ func preScanSourceContext(tokens []tok) sourceContext {
 
 	for i := 0; i < len(tokens); i++ {
 		t := tokens[i]
+		ctx.tokenDepth[i] = depth
 		if t.kind == tIdent {
 			if kw, ok := sqlKW(t.val); ok && kw == "SELECT" {
 				// UNION starts a sibling SELECT at the same depth; nested SELECT
@@ -2305,8 +2309,9 @@ func preScanSourceContext(tokens []tok) sourceContext {
 				}
 				scopeID := len(ctx.scopes)
 				ctx.scopes = append(ctx.scopes, sourceScope{
-					qualifiers: map[string]sourceClass{},
-					refAliases: map[string]struct{}{},
+					qualifiers:     map[string]sourceClass{},
+					derivedAliases: map[string]int{},
+					refAliases:     map[string]struct{}{},
 				})
 				sections = append(sections, sectionSelect)
 				active = append(active, scopeFrame{id: scopeID, depth: depth})
@@ -2483,7 +2488,214 @@ func preScanSourceContext(tokens []tok) sourceContext {
 			}
 		}
 	}
+	linkDerivedSourceScopes(tokens, &ctx)
 	return ctx
+}
+
+func linkDerivedSourceScopes(tokens []tok, ctx *sourceContext) {
+	for i := 0; i+2 < len(tokens); i++ {
+		if tokens[i].kind != tIdent || tokens[i+1].kind != tLParen || tokens[i+2].kind != tIdent {
+			continue
+		}
+		kw, ok := sqlKW(tokens[i].val)
+		if !ok || (kw != "FROM" && kw != "JOIN") {
+			continue
+		}
+		nestedKW, ok := sqlKW(tokens[i+2].val)
+		if !ok || nestedKW != "SELECT" {
+			continue
+		}
+		parentID, parentOK := ctx.scopeIDAt(i)
+		childID, childOK := ctx.scopeIDAt(i + 2)
+		if !parentOK || !childOK || parentID == childID {
+			continue
+		}
+
+		nesting := 0
+		for j := i + 1; j < len(tokens); j++ {
+			switch tokens[j].kind {
+			case tLParen:
+				nesting++
+			case tRParen:
+				nesting--
+				if nesting != 0 {
+					continue
+				}
+				aliasPos := j + 1
+				if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
+					aliasKW, aliasOK := sqlKW(tokens[aliasPos].val)
+					if aliasOK && aliasKW == "AS" && tokens[aliasPos+1].kind == tIdent {
+						alias := strings.ToLower(tokens[aliasPos+1].val)
+						ctx.scopes[parentID].derivedAliases[alias] = childID
+					}
+				}
+				j = len(tokens)
+			}
+		}
+	}
+}
+
+func (ctx sourceContext) scopeProjectsSystemColumn(tokens []tok, scopeID int, name string, seen map[int]bool) bool {
+	if scopeID < 0 || scopeID >= len(ctx.scopes) || seen[scopeID] {
+		return false
+	}
+	seen[scopeID] = true
+	defer delete(seen, scopeID)
+
+	selectPos := -1
+	baseDepth := 0
+	for i, t := range tokens {
+		id, ok := ctx.scopeIDAt(i)
+		if !ok || id != scopeID || t.kind != tIdent {
+			continue
+		}
+		if kw, ok := sqlKW(t.val); ok && kw == "SELECT" {
+			selectPos = i
+			baseDepth = ctx.tokenDepth[i]
+			break
+		}
+	}
+	if selectPos < 0 {
+		return false
+	}
+
+	end := len(tokens)
+	for i := selectPos + 1; i < len(tokens); i++ {
+		id, ok := ctx.scopeIDAt(i)
+		if !ok || id != scopeID || ctx.tokenDepth[i] != baseDepth || tokens[i].kind != tIdent {
+			continue
+		}
+		if kw, ok := sqlKW(tokens[i].val); ok && kw == "FROM" {
+			end = i
+			break
+		}
+	}
+
+	exprStart := selectPos + 1
+	for i := exprStart; i <= end; i++ {
+		if i < end && (tokens[i].kind != tComma || ctx.tokenDepth[i] != baseDepth) {
+			continue
+		}
+		if ctx.projectionIsSystemColumn(tokens, scopeID, baseDepth, exprStart, i, name, seen) {
+			return true
+		}
+		exprStart = i + 1
+	}
+	return false
+}
+
+func (ctx sourceContext) projectionIsSystemColumn(
+	tokens []tok,
+	scopeID, baseDepth, start, end int,
+	name string,
+	seen map[int]bool,
+) bool {
+	for start < end && tokens[start].kind == tIdent {
+		if kw, ok := sqlKW(tokens[start].val); ok && (kw == "DISTINCT" || kw == "ALL") {
+			start++
+			continue
+		}
+		break
+	}
+	if start >= end {
+		return false
+	}
+
+	for i := start; i+1 < end; i++ {
+		id, ok := ctx.scopeIDAt(i)
+		if !ok || id != scopeID || ctx.tokenDepth[i] != baseDepth || tokens[i].kind != tIdent {
+			continue
+		}
+		if kw, ok := sqlKW(tokens[i].val); ok && kw == "AS" && tokens[i+1].kind == tIdent {
+			if !strings.EqualFold(tokens[i+1].val, name) {
+				return false
+			}
+			return ctx.systemColumnIdentifierAt(tokens, i+1, seen)
+		}
+	}
+
+	start, end = trimProjectionParentheses(tokens, start, end)
+	if end-start == 1 && tokens[start].kind == tStar {
+		scope := ctx.scopes[scopeID]
+		if childID, derived := scope.derivedAliases[scope.mainTable]; derived {
+			return ctx.scopeProjectsSystemColumn(tokens, childID, name, seen)
+		}
+		return scope.main == sourceClassRegister
+	}
+	if end-start == 3 && tokens[start].kind == tIdent && tokens[start+1].kind == tDot &&
+		tokens[start+2].kind == tStar {
+		scope := ctx.scopes[scopeID]
+		qualifier := strings.ToLower(tokens[start].val)
+		if class, known := scope.qualifiers[qualifier]; known {
+			return class == sourceClassRegister
+		}
+		if childID, derived := scope.derivedAliases[qualifier]; derived {
+			return ctx.scopeProjectsSystemColumn(tokens, childID, name, seen)
+		}
+		return false
+	}
+	if end-start == 1 && tokens[start].kind == tIdent && strings.EqualFold(tokens[start].val, name) {
+		return ctx.systemColumnIdentifierAt(tokens, start, seen)
+	}
+	if end-start == 3 && tokens[start].kind == tIdent && tokens[start+1].kind == tDot &&
+		tokens[start+2].kind == tIdent && strings.EqualFold(tokens[start+2].val, name) {
+		return ctx.systemColumnIdentifierAt(tokens, start+2, seen)
+	}
+	return false
+}
+
+func trimProjectionParentheses(tokens []tok, start, end int) (int, int) {
+	for end-start >= 2 && tokens[start].kind == tLParen && tokens[end-1].kind == tRParen {
+		nesting := 0
+		match := -1
+		for i := start; i < end; i++ {
+			switch tokens[i].kind {
+			case tLParen:
+				nesting++
+			case tRParen:
+				nesting--
+				if nesting == 0 {
+					match = i
+					i = end
+				}
+			}
+		}
+		if match != end-1 {
+			break
+		}
+		start++
+		end--
+	}
+	return start, end
+}
+
+func (ctx sourceContext) systemColumnIdentifierAt(tokens []tok, tokenPos int, seen map[int]bool) bool {
+	if tokenPos < 0 || tokenPos >= len(tokens) || tokens[tokenPos].kind != tIdent {
+		return false
+	}
+	name := tokens[tokenPos].val
+	if _, ok := systemColAlias(name); !ok {
+		return false
+	}
+	scopeID, ok := ctx.scopeIDAt(tokenPos)
+	if !ok {
+		return false
+	}
+	scope := ctx.scopes[scopeID]
+	if tokenPos >= 2 && tokens[tokenPos-1].kind == tDot {
+		qualifier := strings.ToLower(tokens[tokenPos-2].val)
+		if class, known := scope.qualifiers[qualifier]; known {
+			return class == sourceClassRegister
+		}
+		if childID, derived := scope.derivedAliases[qualifier]; derived {
+			return ctx.scopeProjectsSystemColumn(tokens, childID, name, seen)
+		}
+		return false
+	}
+	if childID, derived := scope.derivedAliases[scope.mainTable]; derived {
+		return ctx.scopeProjectsSystemColumn(tokens, childID, name, seen)
+	}
+	return scope.main == sourceClassRegister
 }
 
 // rewriteGroupingReferenceAliases разворачивает зарезервированный выходной
@@ -2613,11 +2825,27 @@ func (tr *translator) systemColumnAlias(name string, prevDot bool) (string, bool
 		if class, known := scope.qualifiers[qualifier]; known {
 			return col, class == sourceClassRegister
 		}
+		if childID, derived := scope.derivedAliases[qualifier]; derived {
+			return col, tr.sourceCtx.scopeProjectsSystemColumn(
+				tr.tokens,
+				childID,
+				name,
+				map[int]bool{},
+			)
+		}
 		// Обращение через ссылочное поле регистра ведёт к документу или
 		// справочнику, поэтому Регистр.Документ.Период — не системный period.
 		if tr.findRefDim(qualifier) != nil {
 			return "", false
 		}
+	}
+	if childID, derived := scope.derivedAliases[scope.mainTable]; derived {
+		return col, tr.sourceCtx.scopeProjectsSystemColumn(
+			tr.tokens,
+			childID,
+			name,
+			map[int]bool{},
+		)
 	}
 	return col, scope.main == sourceClassRegister
 }

--- a/internal/query/reference_link_exec_test.go
+++ b/internal/query/reference_link_exec_test.go
@@ -364,6 +364,85 @@ func TestBareReference_WithReferenceJoin_ExecuteSQLite(t *testing.T) {
 			t.Fatalf("derived register lost system-column semantics:\n%s", res.SQL)
 		}
 
+		for _, tt := range []struct {
+			name      string
+			src       string
+			wantStart string
+		}{
+			{
+				name:      "qualified without outer register join",
+				src:       `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ Период ИЗ РегистрНакопления.Остатки КАК В) КАК П`,
+				wantStart: "SELECT п.period FROM",
+			},
+			{
+				name:      "bare without outer register join",
+				src:       `ВЫБРАТЬ Период ИЗ (ВЫБРАТЬ Период ИЗ РегистрНакопления.Остатки КАК В) КАК П`,
+				wantStart: "SELECT period FROM",
+			},
+			{
+				name: "nested derived chain",
+				src: `ВЫБРАТЬ К.Период
+					ИЗ (ВЫБРАТЬ П.Период
+						ИЗ (ВЫБРАТЬ Период ИЗ РегистрНакопления.Остатки КАК В) КАК П
+					) КАК К`,
+				wantStart: "SELECT к.period FROM",
+			},
+			{
+				name:      "wildcard projection",
+				src:       `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ * ИЗ РегистрНакопления.Остатки КАК Р) КАК П`,
+				wantStart: "SELECT п.period FROM",
+			},
+			{
+				name:      "qualified wildcard projection",
+				src:       `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ Р.* ИЗ РегистрНакопления.Остатки КАК Р) КАК П`,
+				wantStart: "SELECT п.period FROM",
+			},
+			{
+				name:      "parenthesized projection",
+				src:       `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ (Период) ИЗ РегистрНакопления.Остатки КАК Р) КАК П`,
+				wantStart: "SELECT п.period FROM",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				derivedRes, err := query.Compile(tt.src, query.CompileOpts{
+					Registers: []*metadata.Register{reg},
+					Dialect:   storage.SQLiteDialect{},
+				})
+				if err != nil {
+					t.Fatalf("compile: %v", err)
+				}
+				if err := db.QueryRow(ctx, derivedRes.SQL, derivedRes.Args...).Scan(&got); err != nil {
+					t.Fatalf("execute %q\nSQL: %s\nerror: %v", tt.src, derivedRes.SQL, err)
+				}
+				if !strings.HasPrefix(derivedRes.SQL, tt.wantStart) {
+					t.Fatalf("derived register lost system-column semantics:\n%s", derivedRes.SQL)
+				}
+			})
+		}
+
+		allSystemSrc := `ВЫБРАТЬ П.Период, П.ВидДвижения, П.Регистратор, П.НомерСтроки
+			ИЗ (ВЫБРАТЬ Период, ВидДвижения, Регистратор, НомерСтроки
+				ИЗ РегистрНакопления.Остатки КАК В
+			) КАК П`
+		allSystemRes, err := query.Compile(allSystemSrc, query.CompileOpts{
+			Registers: []*metadata.Register{reg},
+			Dialect:   storage.SQLiteDialect{},
+		})
+		if err != nil {
+			t.Fatalf("compile all system columns: %v", err)
+		}
+		var movement, recorder, line any
+		if err := db.QueryRow(ctx, allSystemRes.SQL, allSystemRes.Args...).
+			Scan(&got, &movement, &recorder, &line); err != nil {
+			t.Fatalf("execute %q\nSQL: %s\nerror: %v", allSystemSrc, allSystemRes.SQL, err)
+		}
+		if !strings.HasPrefix(
+			allSystemRes.SQL,
+			"SELECT п.period, п.вид_движения, п.recorder, п.line_number FROM",
+		) {
+			t.Fatalf("derived table lost register system columns:\n%s", allSystemRes.SQL)
+		}
+
 		entityFieldSrc := `ВЫБРАТЬ П.Период ИЗ (ВЫБРАТЬ Д.Период ИЗ РегистрНакопления.Остатки КАК Р ЛЕВОЕ СОЕДИНЕНИЕ Документ.Расход КАК Д ПО 1 = 0) КАК П`
 		entityFieldRes, err := query.Compile(entityFieldSrc, query.CompileOpts{
 			Registers: []*metadata.Register{reg},


### PR DESCRIPTION
## Что изменено

- Алиасы производных таблиц связываются с вложенными SELECT-scope.
- Для системных колонок регистра сохраняется реальная семантика проекции через одну или несколько производных таблиц.
- Bare- и qualified-доступ преобразуют `Период`, `ВидДвижения`, `Регистратор`, `НомерСтроки` в физические имена колонок.
- Поля документов/справочников с теми же именами не наследуют семантику регистра.

## Проверки

- SQLite E2E без внешнего register JOIN
- bare и qualified формы
- цепочка из двух производных таблиц
- все четыре системные колонки регистра
- защитный кейс `Документ.Период`
- `go test ./internal/query -count=1`
- `go test -race ./internal/query -count=1`
- `go test ./... -count=1`
- `go vet ./...`

Closes #432