### PR TITLE
fix(dsl): keep reference loads in active transaction

### DIFF
--- a/internal/ui/dsl_reference_tx_test.go
+++ b/internal/ui/dsl_reference_tx_test.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Regression #436: a reference copied into a table-part row before Записать()
+// carries a manager bound to the processor's pre-transaction context. OnWrite
+// must rebind it to the current transaction; otherwise ПолучитьОбъект() waits
+// for a second connection forever because SQLite deliberately uses a pool of 1.
+func TestDocWriterOnWriteRebindsTablePartReferenceToTransaction(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	outgoing := &metadata.Entity{
+		Name:   "ИсходящееПисьмо",
+		Kind:   metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+	packet := &metadata.Entity{
+		Name: "ПакетПочтовойОтправки",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "ПроверенныйНомер", Type: metadata.FieldTypeString},
+		},
+		TableParts: []metadata.TablePart{{
+			Name: "Письма",
+			Fields: []metadata.Field{{
+				Name: "ИсходящееПисьмо", RefEntity: outgoing.Name,
+			}},
+		}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{outgoing, packet}); err != nil {
+		t.Fatal(err)
+	}
+	outgoingID := uuid.New()
+	if err := db.Upsert(ctx, outgoing.Name, outgoingID, map[string]any{"Номер": "ИП-001"}, outgoing); err != nil {
+		t.Fatal(err)
+	}
+
+	program := mustParse(t, `Процедура ПриЗаписи()
+  Для Каждого СтрокаПакета Из ЭтотОбъект.Письма Цикл
+    ИсходящийОбъект = СтрокаПакета.ИсходящееПисьмо.ПолучитьОбъект();
+    ЭтотОбъект.ПроверенныйНомер = ИсходящийОбъект.Номер;
+  КонецЦикла;
+КонецПроцедуры`)
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{outgoing, packet},
+		Programs: map[string]*ast.Program{packet.Name: program},
+	})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{
+		store: db, reg: registry, interp: interp,
+		lockMgr: runtime.NewLockManager(), messages: NewMessageStore(),
+	}
+
+	// Both proxies start with the outer context. The reference therefore has a
+	// stale manager by the time packet.write opens its transaction.
+	root := newDocsRoot(s, interpreter.NewTxState(ctx))
+	outgoingProxy := root.Get(outgoing.Name).(*docProxy)
+	staleRef := &interpreter.Ref{
+		UUID: outgoingID.String(), Name: "ИП-001",
+		Type: outgoing.Name, Manager: outgoingProxy,
+	}
+	writer := root.Get(packet.Name).(*docProxy).CallMethod("создать", nil).(*docWriter)
+	writer.Set("Номер", "ПП-001")
+	row := writer.Get("Письма").(*tpProxy).CallMethod("добавить", nil).(*interpreter.MapThis)
+	row.Set("ИсходящееПисьмо", staleRef)
+
+	if err := writer.write(); err != nil {
+		t.Fatalf("Записать с ПолучитьОбъект в ПриЗаписи: %v", err)
+	}
+	if got := writer.obj.Get("ПроверенныйНомер"); got != "ИП-001" {
+		t.Fatalf("ПроверенныйНомер = %v, want ИП-001", got)
+	}
+}

--- a/internal/ui/enrich_header_refs_test.go
+++ b/internal/ui/enrich_header_refs_test.go
@@ -136,9 +136,10 @@ func TestEnrichHeaderRefs_NoDuplicateKey(t *testing.T) {
 	}
 }
 
-// Поле, уже являющееся *Ref (проведение из обработки), не должно
-// перезаписываться — двойной обработки нет.
-func TestEnrichHeaderRefs_SkipsExistingRef(t *testing.T) {
+// Поле, уже являющееся *Ref (проведение из обработки), сохраняет идентичность
+// ссылки, но получает manager текущего контекста. Это не даёт старому manager
+// выйти из открытой SQLite-транзакции за вторым соединением (#436).
+func TestEnrichHeaderRefs_RebindsExistingRefManager(t *testing.T) {
 	ctx := context.Background()
 	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {
@@ -179,7 +180,13 @@ func TestEnrichHeaderRefs_SkipsExistingRef(t *testing.T) {
 	if !ok {
 		t.Fatalf("Склад → %T, ожидался *interpreter.Ref", v)
 	}
-	if ref != orig {
-		t.Error("существующий *Ref был перезаписан — должен пропускаться")
+	if ref == orig {
+		t.Error("существующий *Ref сохранил manager старого контекста")
+	}
+	if ref.UUID != orig.UUID || ref.Name != orig.Name || ref.Type != orig.Type {
+		t.Fatalf("перепривязка изменила ссылку: got=%+v want=%+v", ref, orig)
+	}
+	if ref.Manager == nil {
+		t.Fatal("перепривязанная ссылка не получила manager текущего контекста")
 	}
 }

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -929,14 +929,29 @@ func (s *Server) enrichTPRowsWithRefs(ctx context.Context, tp metadata.TablePart
 		for idStr, refRow := range refRows {
 			labels[idStr] = s.maskedRecordLabel(ctx, refEntity, refRow)
 		}
-		// replace plain UUID strings with *interpreter.Ref{UUID, Name, Manager}
+		// Replace plain UUID strings and rebind existing references to a manager
+		// backed by the current context. A Ref copied into a new document before
+		// Записать() may still carry a manager bound to the outer processor
+		// context. Keeping that manager inside OnWrite makes ПолучитьОбъект()
+		// request a second SQLite connection while the current transaction owns
+		// the only one.
 		mgr := s.refManagerFor(refEntity, ctx)
 		for _, row := range rows {
 			matchKey, v, ok := lookupMapCI(row, f.Name)
 			if !ok || v == nil {
 				continue
 			}
-			if _, isRef := v.(*interpreter.Ref); isRef {
+			if ref, isRef := v.(*interpreter.Ref); isRef {
+				if ref == nil {
+					continue
+				}
+				name := ref.Name
+				if label, ok := labels[ref.UUID]; ok {
+					name = label
+				}
+				row[matchKey] = &interpreter.Ref{
+					UUID: ref.UUID, Name: name, Type: refEntity.Name, Manager: mgr,
+				}
 				continue
 			}
 			idStr, _, ok := uuidFromValue(v)
@@ -981,7 +996,15 @@ func (s *Server) enrichHeaderRefs(ctx context.Context, entity *metadata.Entity, 
 		if matchKey == "" || matchVal == nil {
 			continue
 		}
-		if _, isRef := matchVal.(*interpreter.Ref); isRef {
+		if ref, isRef := matchVal.(*interpreter.Ref); isRef {
+			if ref != nil {
+				obj.Fields[matchKey] = &interpreter.Ref{
+					UUID:    ref.UUID,
+					Name:    ref.Name,
+					Type:    refEntity.Name,
+					Manager: s.refManagerFor(refEntity, ctx),
+				}
+			}
 			continue
 		}
 		idStr := fmt.Sprintf("%v", matchVal)

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -301,6 +301,14 @@ func (s *Server) runOnWriteCtx(ctx context.Context, obj *runtime.Object, mc *run
 	// и Строка(ref) работали в ПриЗаписи так же, как при проведении.
 	if entity := s.reg.GetEntity(obj.Type); entity != nil {
 		s.enrichHeaderRefs(ctx, entity, obj)
+		for _, tp := range entity.TableParts {
+			for name, rows := range obj.TablePartRows {
+				if strings.EqualFold(name, tp.Name) {
+					s.enrichTPRowsWithRefs(ctx, tp, rows)
+					break
+				}
+			}
+		}
 	}
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)


### PR DESCRIPTION
Closes #436

## Summary
- rebind document references to the active OnWrite transaction context
- enrich table-part references before running OnWrite
- cover the single-connection SQLite deadlock regression

## Verification
- `go test ./... -count=1`
- `go test -race ./internal/ui -run 'TestDocWriterOnWriteRebindsTablePartReferenceToTransaction|TestEnrichHeaderRefs_RebindsExistingRefManager' -count=1`