### PR TITLE
fix(configurator): сохранять состав подсистем в configdb

### DIFF
--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -102,18 +102,6 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 		title = subName
 	}
 
-	dir := b.Path
-	if b.ConfigSource == "database" {
-		dir, err = workspacePath(b.ID)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-	}
-
-	subDir := filepath.Join(dir, "subsystems")
-	os.MkdirAll(subDir, 0o755)
-
 	type yamlContents struct {
 		Catalogs   []string `yaml:"catalogs,omitempty"`
 		Documents  []string `yaml:"documents,omitempty"`
@@ -124,24 +112,18 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 		Journals   []string `yaml:"journals,omitempty"`
 		Pages      []string `yaml:"pages,omitempty"`
 	}
-	type yamlHomePage struct {
-		Title   string                    `yaml:"title,omitempty"`
-		Titles  map[string]string         `yaml:"titles,omitempty"`
-		Layout  string                    `yaml:"layout,omitempty"`
-		Rows    []metadata.HomePageRow    `yaml:"rows,omitempty"`
-		Widgets []metadata.HomePageWidget `yaml:"widgets,omitempty"`
-	}
 	type yamlSubsystem struct {
-		Name     string            `yaml:"name"`
-		Title    string            `yaml:"title"`
-		Titles   map[string]string `yaml:"titles,omitempty"`
-		Icon     string            `yaml:"icon,omitempty"`
-		Order    int               `yaml:"order"`
-		Contents yamlContents      `yaml:"contents"`
-		HomePage *yamlHomePage     `yaml:"home_page,omitempty"`
+		Name     string             `yaml:"name"`
+		Title    string             `yaml:"title"`
+		Titles   map[string]string  `yaml:"titles,omitempty"`
+		Icon     string             `yaml:"icon,omitempty"`
+		Order    int                `yaml:"order"`
+		Roles    []string           `yaml:"roles,omitempty"`
+		Contents yamlContents       `yaml:"contents"`
+		HomePage *metadata.HomePage `yaml:"home_page,omitempty"`
 	}
 
-	targetFile := filepath.Join(subDir, nameToFilename(subName)+".yaml")
+	relPath := "subsystems/" + nameToFilename(subName) + ".yaml"
 
 	ys := yamlSubsystem{
 		Name:  subName,
@@ -159,23 +141,19 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 
 	// Сохраняем переводы (titles) и метаданные рабочего стола из уже
 	// существующего файла, чтобы перезапись не теряла данные, которых нет в форме.
-	if existing, lerr := metadata.LoadSubsystemFile(targetFile); lerr == nil && existing != nil {
-		// Страницы в «Составе подсистемы» пока не показываются галочками —
-		// переносим их из существующего файла, чтобы сохранение подсистемы не
-		// затирало contents.pages (журналы и остальные категории берутся из формы).
-		ys.Contents.Pages = existing.Contents.Pages
-		if formHasMapField(r, "titles") {
-			ys.Titles = parseMapForm(r, "titles")
-		} else {
-			ys.Titles = existing.Titles
-		}
-		if existing.HomePage != nil {
-			ys.HomePage = &yamlHomePage{
-				Title:   existing.HomePage.Title,
-				Titles:  existing.HomePage.Titles,
-				Layout:  existing.HomePage.Layout,
-				Widgets: existing.HomePage.Widgets,
+	if raw, ok := h.readConfigFileRaw(r.Context(), b, relPath); ok {
+		var existing yamlSubsystem
+		if yaml.Unmarshal(raw, &existing) == nil {
+			// Страницы и роли пока не редактируются этой формой — переносим их
+			// из текущей конфигурации, чтобы сохранение состава их не затирало.
+			ys.Roles = existing.Roles
+			ys.Contents.Pages = existing.Contents.Pages
+			if formHasMapField(r, "titles") {
+				ys.Titles = parseMapForm(r, "titles")
+			} else {
+				ys.Titles = existing.Titles
 			}
+			ys.HomePage = existing.HomePage
 		}
 	} else if formHasMapField(r, "titles") {
 		ys.Titles = parseMapForm(r, "titles")
@@ -187,7 +165,7 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 	rows, layout := rowsFromForm(r)
 	if len(rows) > 0 {
 		if ys.HomePage == nil {
-			ys.HomePage = &yamlHomePage{}
+			ys.HomePage = &metadata.HomePage{}
 		}
 		ys.HomePage.Rows = rows
 		ys.HomePage.Layout = layout
@@ -201,10 +179,12 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	out, _ := yaml.Marshal(&ys)
-
+	out, err := yaml.Marshal(&ys)
+	if err == nil {
+		err = saveConfigFile(r, h, b, relPath, out)
+	}
 	data := h.loadCfgData(r.Context(), b, "tree")
-	if err := os.WriteFile(targetFile, out, 0o644); err != nil {
+	if err != nil {
 		data.Error = tr(lang, "Ошибка сохранения") + ": " + err.Error()
 		renderCfg(w, r, data)
 		return

--- a/internal/launcher/configurator_subsystem_save_test.go
+++ b/internal/launcher/configurator_subsystem_save_test.go
@@ -1,0 +1,118 @@
+package launcher
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/configdb"
+	"gopkg.in/yaml.v3"
+)
+
+// Состав подсистемы в database-режиме должен сохраняться в _onebase_config:
+// именно оттуда конфигуратор и рантайм перечитывают конфигурацию после POST.
+func TestSaveSubsystem_DBModePersistsContents(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store := newTestStore(t)
+	base := &Base{
+		ID:           "subsystem-db-test",
+		Name:         "ТестБД",
+		ConfigSource: "database",
+		DBType:       "sqlite",
+		DBPath:       filepath.Join(t.TempDir(), "config.db"),
+	}
+	if err := store.Add(base); err != nil {
+		t.Fatalf("store.Add: %v", err)
+	}
+
+	ctx := context.Background()
+	db, err := OpenDB(ctx, base)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	repo := configdb.New(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		db.Close()
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	if err := repo.SaveFiles(ctx, []configdb.ConfigFile{
+		{Path: "config/app.yaml", Content: []byte("name: Тест\n")},
+		{Path: "catalogs/гп_атс.yaml", Content: []byte("name: ГП_атс\nfields: []\n")},
+		{Path: "catalogs/гтп_атс.yaml", Content: []byte("name: ГТП_атс\nfields: []\n")},
+		{Path: "catalogs/сайт_атс.yaml", Content: []byte("name: сайт_атс\nfields: []\n")},
+		{
+			Path: "subsystems/атс.yaml",
+			Content: []byte(
+				"name: АТС\n" +
+					"title: АТС\n" +
+					"roles: [Диспетчер]\n" +
+					"order: 10\n" +
+					"contents:\n" +
+					"  catalogs: [ГП_атс]\n",
+			),
+		},
+	}, configdb.VersionOptions{Message: "seed subsystem"}); err != nil {
+		db.Close()
+		t.Fatalf("seed configdb: %v", err)
+	}
+	db.Close()
+
+	h := &handler{store: store, runner: NewRunner()}
+	form := url.Values{
+		"subsystem_name": {"АТС"},
+		"title":          {"АТС"},
+		"order":          {"10"},
+		"catalogs":       {"ГП_атс", "ГТП_атс", "сайт_атс"},
+	}
+	rec := postCfgRv(
+		t,
+		base.ID,
+		"/bases/"+base.ID+"/configurator/subsystem",
+		form,
+		h.configuratorSaveSubsystem,
+	)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+	var response struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("ответ не JSON: %v (%s)", err, rec.Body.String())
+	}
+	if !response.OK {
+		t.Fatalf("конфигуратор не перечитал сохранённую конфигурацию: %s", response.Error)
+	}
+
+	db, err = OpenDB(ctx, base)
+	if err != nil {
+		t.Fatalf("повторный OpenDB: %v", err)
+	}
+	defer db.Close()
+	raw, ok, err := configdb.New(db).ReadFile(ctx, "subsystems/атс.yaml")
+	if err != nil || !ok {
+		t.Fatalf("ReadFile: ok=%v err=%v", ok, err)
+	}
+	var saved struct {
+		Roles    []string `yaml:"roles"`
+		Contents struct {
+			Catalogs []string `yaml:"catalogs"`
+		} `yaml:"contents"`
+	}
+	if err := yaml.Unmarshal(raw, &saved); err != nil {
+		t.Fatalf("сохранённый YAML не разбирается: %v\n%s", err, raw)
+	}
+	wantCatalogs := []string{"ГП_атс", "ГТП_атс", "сайт_атс"}
+	if !slices.Equal(saved.Contents.Catalogs, wantCatalogs) {
+		t.Fatalf("catalogs = %v, ожидалось %v", saved.Contents.Catalogs, wantCatalogs)
+	}
+	if !slices.Equal(saved.Roles, []string{"Диспетчер"}) {
+		t.Fatalf("скрытый от формы whitelist roles потерян: %v", saved.Roles)
+	}
+}


### PR DESCRIPTION
## Что исправлено

- сохранение состава подсистемы в database-config режиме теперь пишет напрямую в `_onebase_config`;
- после POST конфигуратор перечитывает уже обновлённую конфигурацию;
- при сохранении сохраняются поля подсистемы, отсутствующие в форме (`roles`, `pages`, настройки рабочего стола);
- добавлен регрессионный тест сценария из issue.

## Проверки

- `go test ./... -count=1`
- `go test -race ./internal/launcher -count=1`
- `go vet ./...`
- `go build ./...`
- `go run ./tools/i18ncheck`
- `golangci-lint run ./internal/launcher/...`

Closes #447