### PR TITLE
fix(configurator): удалять объекты из дерева

### DIFF
--- a/internal/launcher/configurator_entity.go
+++ b/internal/launcher/configurator_entity.go
@@ -797,63 +797,220 @@ func (h *handler) configuratorDeleteEntity(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	entityName := r.FormValue("entity")
-	if entityName == "" {
-		http.Error(w, "entity name required", 400)
+	if !validObjectName(entityName) {
+		http.Error(w, "valid entity name required", 400)
 		return
 	}
+	objectKind := r.FormValue("kind")
 
-	var delErr error
-	if b.ConfigSource == "database" {
-		delErr = h.deleteEntityFromDB(r.Context(), b, entityName)
-	} else {
-		delErr = deleteEntityFromFile(b.Path, entityName)
-	}
-
+	delErr := h.deleteConfiguratorObject(r, b, objectKind, entityName)
 	data := h.loadCfgData(r.Context(), b, "tree")
 	if delErr != nil {
 		data.Error = tr(lang, "Ошибка удаления") + ": " + errText(r, delErr)
 	} else {
-		data.Error = tr(lang, "Сущность «") + entityName + tr(lang, "» удалена")
+		data.SavedMessage = tr(lang, "Сущность «") + entityName + tr(lang, "» удалена")
 	}
 	renderCfg(w, r, data)
 }
 
-func deleteEntityFromFile(dir, entityName string) error {
-	path, err := findEntityFilePath(dir, entityName)
-	if err != nil {
-		return err
-	}
-	return os.Remove(path)
+type configuratorDeleteSpec struct {
+	metadataDirs []string
+	sourceSuffix []string
+	forms        bool
 }
 
-func (h *handler) deleteEntityFromDB(ctx context.Context, b *Base, entityName string) error {
-	db, err := OpenDB(ctx, b)
-	if err != nil {
-		return fmt.Errorf("connect: %w", err)
-	}
-	defer db.Close()
-	repo := configdb.New(db)
+var configuratorDeleteSpecs = map[string]configuratorDeleteSpec{
+	"catalog":    {metadataDirs: []string{"catalogs"}, sourceSuffix: []string{".manager.os", ".os"}, forms: true},
+	"document":   {metadataDirs: []string{"documents"}, sourceSuffix: []string{".posting.os", ".manager.os", ".os"}, forms: true},
+	"entity":     {metadataDirs: []string{"catalogs", "documents"}, sourceSuffix: []string{".posting.os", ".manager.os", ".os"}, forms: true},
+	"register":   {metadataDirs: []string{"registers"}},
+	"inforeg":    {metadataDirs: []string{"inforegs"}},
+	"accountreg": {metadataDirs: []string{"accountregs"}},
+	"enum":       {metadataDirs: []string{"enums"}},
+	"report":     {metadataDirs: []string{"reports"}, sourceSuffix: []string{".rep.os"}},
+	"processor":  {metadataDirs: []string{"processors"}, sourceSuffix: []string{".proc.layout.yaml", ".proc.os"}, forms: true},
+	"module":     {sourceSuffix: []string{".module.os"}},
+	"printform":  {metadataDirs: []string{"printforms"}},
+	"subsystem":  {metadataDirs: []string{"subsystems"}},
+}
 
-	// Scan all YAML-object folders so deletion works for catalogs, documents,
-	// registers, enums, reports and subsystems alike (not just catalogs/documents).
-	rows, err := db.Query(ctx,
-		`SELECT path, content FROM _onebase_config WHERE path LIKE 'catalogs/%.yaml' OR path LIKE 'documents/%.yaml' OR path LIKE 'registers/%.yaml' OR path LIKE 'inforegisters/%.yaml' OR path LIKE 'accountregisters/%.yaml' OR path LIKE 'enums/%.yaml' OR path LIKE 'reports/%.yaml' OR path LIKE 'subsystems/%.yaml'`)
+var configuratorDeleteKindFallback = []string{
+	"catalog", "document", "register", "inforeg", "accountreg", "enum",
+	"report", "processor", "module", "printform", "subsystem",
+}
+
+func (h *handler) deleteConfiguratorObject(r *http.Request, b *Base, kind, name string) error {
+	files, err := h.listConfiguratorFiles(r.Context(), b)
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var p string
+	paths, resolvedKind, err := configuratorObjectDeletePaths(files, kind, name)
+	if err != nil {
+		return err
+	}
+	return deleteConfigFilesWithVersion(r, h, b, paths, configdb.VersionOptions{
+		AuthorLogin: cfgLogin(r.Context()),
+		Message:     "delete " + resolvedKind + " " + name,
+	})
+}
+
+// listConfiguratorFiles читает снимок конфигурации и закрывает соединение до
+// начала удаления. Раньше deleteEntityFromDB вызывал Repo.DeleteFile, пока
+// SELECT-курсор ещё держал единственное SQLite-соединение, и навсегда ждал
+// свободного connection slot. В PostgreSQL результат зависел от размера пула.
+func (h *handler) listConfiguratorFiles(ctx context.Context, b *Base) ([]configdb.ConfigFile, error) {
+	if b.ConfigSource == "database" {
+		db, err := OpenDB(ctx, b)
+		if err != nil {
+			return nil, fmt.Errorf("connect: %w", err)
+		}
+		defer db.Close()
+		return configdb.New(db).ListByPrefix(ctx, "")
+	}
+
+	var files []configdb.ConfigFile
+	err := filepath.WalkDir(b.Path, func(full string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".onebase", "backups", "node_modules", "workspace":
+				if full != b.Path {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(b.Path, full)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if err := configdb.ValidatePath(rel); err != nil {
+			return err
+		}
 		var content []byte
-		if err := rows.Scan(&p, &content); err != nil {
+		ext := strings.ToLower(filepath.Ext(rel))
+		if ext == ".yaml" || ext == ".yml" {
+			content, err = os.ReadFile(full)
+			if err != nil {
+				return err
+			}
+		}
+		files = append(files, configdb.ConfigFile{Path: rel, Content: content})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
+}
+
+func configuratorObjectDeletePaths(files []configdb.ConfigFile, kind, name string) ([]string, string, error) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		for _, candidate := range configuratorDeleteKindFallback {
+			paths, _, err := configuratorObjectDeletePaths(files, candidate, name)
+			if err == nil {
+				return paths, candidate, nil
+			}
+		}
+		return nil, "", i18nerr.Errorf("сущность %q не найдена", name)
+	}
+	spec, ok := configuratorDeleteSpecs[kind]
+	if !ok {
+		return nil, "", i18nerr.Errorf("Неизвестный тип объекта")
+	}
+
+	var metadataPaths []string
+	for _, file := range files {
+		rel := filepath.ToSlash(file.Path)
+		dir, base := filepath.ToSlash(filepath.Dir(rel)), filepath.Base(rel)
+		if !stringInSlice(dir, spec.metadataDirs) ||
+			(!strings.HasSuffix(strings.ToLower(base), ".yaml") && !strings.HasSuffix(strings.ToLower(base), ".yml")) {
 			continue
 		}
 		var hdr struct {
 			Name string `yaml:"name"`
 		}
-		if yaml.Unmarshal(content, &hdr) == nil && hdr.Name == entityName {
-			return repo.DeleteFile(ctx, p)
+		if yaml.Unmarshal(file.Content, &hdr) == nil && strings.EqualFold(hdr.Name, name) {
+			metadataPaths = append(metadataPaths, rel)
 		}
 	}
-	return i18nerr.Errorf("сущность %q не найдена", entityName)
+	if len(spec.metadataDirs) > 0 && len(metadataPaths) == 0 {
+		return nil, "", i18nerr.Errorf("сущность %q не найдена", name)
+	}
+
+	associated := make(map[string]struct{})
+	foundSource := false
+	for _, file := range files {
+		rel := filepath.ToSlash(file.Path)
+		if configuratorSourceBelongsToObject(rel, name, spec.sourceSuffix) {
+			associated[rel] = struct{}{}
+			foundSource = true
+			continue
+		}
+		if spec.forms && configuratorFormBelongsToObject(rel, name) {
+			associated[rel] = struct{}{}
+		}
+	}
+	if len(spec.metadataDirs) == 0 && !foundSource {
+		return nil, "", i18nerr.Errorf("сущность %q не найдена", name)
+	}
+
+	sort.Strings(metadataPaths)
+	associatedPaths := make([]string, 0, len(associated))
+	for rel := range associated {
+		if !stringInSlice(rel, metadataPaths) {
+			associatedPaths = append(associatedPaths, rel)
+		}
+	}
+	sort.Strings(associatedPaths)
+	return append(metadataPaths, associatedPaths...), kind, nil
+}
+
+func configuratorSourceBelongsToObject(rel, name string, suffixes []string) bool {
+	if filepath.ToSlash(filepath.Dir(rel)) != "src" {
+		return false
+	}
+	base := filepath.Base(rel)
+	for _, suffix := range suffixes {
+		if !strings.HasSuffix(strings.ToLower(base), strings.ToLower(suffix)) {
+			continue
+		}
+		stem := base[:len(base)-len(suffix)]
+		if strings.EqualFold(stem, name) ||
+			strings.EqualFold(strings.ReplaceAll(stem, "_", " "), name) {
+			return true
+		}
+	}
+	return false
+}
+
+func configuratorFormBelongsToObject(rel, name string) bool {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) >= 3 && parts[0] == "forms" {
+		if strings.EqualFold(parts[1], name) ||
+			strings.EqualFold(strings.ReplaceAll(parts[1], "_", " "), name) {
+			return true
+		}
+	}
+	if len(parts) != 2 || parts[0] != "src" || !strings.HasSuffix(strings.ToLower(parts[1]), ".form.os") {
+		return false
+	}
+	stem := strings.TrimSuffix(parts[1], ".form.os")
+	nameLower := strings.ToLower(name)
+	stemLower := strings.ToLower(stem)
+	return stemLower == nameLower || strings.HasPrefix(stemLower, nameLower+"_")
+}
+
+func stringInSlice(value string, values []string) bool {
+	for _, candidate := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/launcher/configurator_object_delete_test.go
+++ b/internal/launcher/configurator_object_delete_test.go
@@ -1,0 +1,292 @@
+package launcher
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/configdb"
+)
+
+// Контекстное меню дерева отправляет обработки, справочники и документы в
+// один handler. В database-режиме он должен удалить не только YAML объекта,
+// но и принадлежащие ему модули, макет обработки и формы.
+func TestConfiguratorDeleteObject_DBModeRemovesOwnedFiles(t *testing.T) {
+	store := newTestStore(t)
+	base := &Base{
+		ID:           "delete-object-db",
+		Name:         "Тест удаления",
+		ConfigSource: "database",
+		DBType:       "sqlite",
+		DBPath:       filepath.Join(t.TempDir(), "config.db"),
+	}
+	if err := store.Add(base); err != nil {
+		t.Fatalf("store.Add: %v", err)
+	}
+
+	ctx := context.Background()
+	db, err := OpenDB(ctx, base)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	repo := configdb.New(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		db.Close()
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	processorLayout := `name: Обработка1
+areas:
+  Заголовок:
+    rows:
+      - cells:
+          - text: "Тест"
+`
+	seed := []configdb.ConfigFile{
+		{Path: "config/app.yaml", Content: []byte("name: Тест\n")},
+		{Path: "catalogs/клиент.yaml", Content: []byte("name: Клиент\nfields: []\n")},
+		{Path: "src/клиент.os", Content: []byte("")},
+		{Path: "src/клиент.manager.os", Content: []byte("")},
+		{Path: "src/клиент.form.os", Content: []byte("")},
+		{Path: "forms/клиент/_resources/icon.json", Content: []byte("{}")},
+		{Path: "documents/заказ.yaml", Content: []byte("name: Заказ\nfields: []\n")},
+		{Path: "src/заказ.os", Content: []byte("")},
+		{Path: "src/заказ.posting.os", Content: []byte("")},
+		{Path: "src/заказ.manager.os", Content: []byte("")},
+		{Path: "src/заказ_list.form.os", Content: []byte("")},
+		{Path: "forms/заказ/_resources/icon.json", Content: []byte("{}")},
+		{Path: "processors/обработка1.yaml", Content: []byte("name: Обработка1\ntitle: Обработка 1\n")},
+		{Path: "src/обработка1.proc.os", Content: []byte("Процедура Выполнить()\nКонецПроцедуры\n")},
+		{Path: "src/обработка1.proc.layout.yaml", Content: []byte(processorLayout)},
+		{Path: "forms/обработка1/_resources/icon.json", Content: []byte("{}")},
+		{Path: "processors/оставить.yaml", Content: []byte("name: Оставить\n")},
+	}
+	if err := repo.SaveFiles(ctx, seed, configdb.VersionOptions{Message: "seed delete objects"}); err != nil {
+		db.Close()
+		t.Fatalf("seed configdb: %v", err)
+	}
+	db.Close()
+
+	h := &handler{store: store, runner: NewRunner()}
+	cases := []struct {
+		kind  string
+		name  string
+		paths []string
+	}{
+		{
+			kind: "processor",
+			name: "Обработка1",
+			paths: []string{
+				"processors/обработка1.yaml",
+				"src/обработка1.proc.os",
+				"src/обработка1.proc.layout.yaml",
+				"forms/обработка1/_resources/icon.json",
+			},
+		},
+		{
+			kind: "catalog",
+			name: "Клиент",
+			paths: []string{
+				"catalogs/клиент.yaml",
+				"src/клиент.os",
+				"src/клиент.manager.os",
+				"src/клиент.form.os",
+				"forms/клиент/_resources/icon.json",
+			},
+		},
+		{
+			kind: "document",
+			name: "Заказ",
+			paths: []string{
+				"documents/заказ.yaml",
+				"src/заказ.os",
+				"src/заказ.posting.os",
+				"src/заказ.manager.os",
+				"src/заказ_list.form.os",
+				"forms/заказ/_resources/icon.json",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			form := url.Values{
+				"entity": {tc.name},
+				"kind":   {tc.kind},
+			}
+			rec := postCfgRv(
+				t,
+				base.ID,
+				"/bases/"+base.ID+"/configurator/entity-delete",
+				form,
+				h.configuratorDeleteEntity,
+			)
+			var response struct {
+				OK    bool   `json:"ok"`
+				Error string `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("ответ не JSON: %v (%s)", err, rec.Body.String())
+			}
+			if !response.OK {
+				t.Fatalf("удаление %s не выполнено: %s", tc.name, response.Error)
+			}
+
+			checkDB, err := OpenDB(ctx, base)
+			if err != nil {
+				t.Fatalf("OpenDB для проверки: %v", err)
+			}
+			checkRepo := configdb.New(checkDB)
+			for _, path := range tc.paths {
+				if _, ok, err := checkRepo.ReadFile(ctx, path); err != nil || ok {
+					checkDB.Close()
+					t.Fatalf("%s остался после удаления: ok=%v err=%v", path, ok, err)
+				}
+			}
+			checkDB.Close()
+		})
+	}
+
+	checkDB, err := OpenDB(ctx, base)
+	if err != nil {
+		t.Fatalf("OpenDB для проверки несвязанного объекта: %v", err)
+	}
+	defer checkDB.Close()
+	if _, ok, err := configdb.New(checkDB).ReadFile(ctx, "processors/оставить.yaml"); err != nil || !ok {
+		t.Fatalf("несвязанный объект удалён: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestConfiguratorDeleteObject_FileModeRemovesProcessorFiles(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+
+	writeCfgFileRv(t, cfgDir, "config", "app.yaml", "name: Тест\n")
+	writeCfgFileRv(t, cfgDir, "processors", "обработка1.yaml", "name: Обработка1\n")
+	writeCfgFileRv(t, cfgDir, "processors", "оставить.yaml", "name: Оставить\n")
+	writeCfgFileRv(t, cfgDir, "src", "обработка1.proc.os", "Процедура Выполнить()\nКонецПроцедуры\n")
+	writeCfgFileRv(t, cfgDir, "src", "обработка1.proc.layout.yaml", `name: Обработка1
+areas:
+  Заголовок:
+    rows:
+      - cells:
+          - text: "Тест"
+`)
+	resource := writeCfgFileRv(t, cfgDir, "forms/обработка1/_resources", "icon.json", "{}")
+
+	rec := postCfgRv(
+		t,
+		"test",
+		"/bases/test/configurator/entity-delete",
+		url.Values{"entity": {"Обработка1"}, "kind": {"processor"}},
+		h.configuratorDeleteEntity,
+	)
+	var response struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("ответ не JSON: %v (%s)", err, rec.Body.String())
+	}
+	if !response.OK {
+		t.Fatalf("удаление обработки не выполнено: %s", response.Error)
+	}
+
+	for _, path := range []string{
+		filepath.Join(cfgDir, "processors", "обработка1.yaml"),
+		filepath.Join(cfgDir, "src", "обработка1.proc.os"),
+		filepath.Join(cfgDir, "src", "обработка1.proc.layout.yaml"),
+		resource,
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s остался после удаления (err=%v)", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(cfgDir, "processors", "оставить.yaml")); err != nil {
+		t.Fatalf("несвязанная обработка удалена: %v", err)
+	}
+}
+
+func TestConfiguratorObjectDeletePathsUsesCurrentMetadataDirs(t *testing.T) {
+	tests := []struct {
+		kind string
+		path string
+	}{
+		{kind: "register", path: "registers/остатки.yaml"},
+		{kind: "inforeg", path: "inforegs/цены.yaml"},
+		{kind: "accountreg", path: "accountregs/хозрасчётный.yaml"},
+		{kind: "enum", path: "enums/статус.yaml"},
+		{kind: "report", path: "reports/продажи.yaml"},
+		{kind: "processor", path: "processors/загрузка.yaml"},
+		{kind: "printform", path: "printforms/накладная.yaml"},
+		{kind: "subsystem", path: "subsystems/торговля.yaml"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.kind, func(t *testing.T) {
+			files := []configdb.ConfigFile{{
+				Path:    tc.path,
+				Content: []byte("name: Объект\n"),
+			}}
+			paths, kind, err := configuratorObjectDeletePaths(files, tc.kind, "Объект")
+			if err != nil {
+				t.Fatalf("configuratorObjectDeletePaths: %v", err)
+			}
+			if kind != tc.kind || !slices.Equal(paths, []string{tc.path}) {
+				t.Fatalf("kind=%q paths=%v, ожидались %q и [%s]", kind, paths, tc.kind, tc.path)
+			}
+		})
+	}
+
+	modulePath := "src/общийМодуль.module.os"
+	paths, kind, err := configuratorObjectDeletePaths(
+		[]configdb.ConfigFile{{Path: modulePath, Content: []byte("")}},
+		"module",
+		"ОбщийМодуль",
+	)
+	if err != nil || kind != "module" || !slices.Equal(paths, []string{modulePath}) {
+		t.Fatalf("общий модуль: kind=%q paths=%v err=%v", kind, paths, err)
+	}
+
+	// Одинаковые имена допустимы в разных пространствах метаданных: тип узла
+	// не должен позволить удалению справочника задеть одноимённый документ.
+	sameName := []configdb.ConfigFile{
+		{Path: "catalogs/заказ.yaml", Content: []byte("name: Заказ\n")},
+		{Path: "documents/заказ.yaml", Content: []byte("name: Заказ\n")},
+	}
+	paths, kind, err = configuratorObjectDeletePaths(sameName, "catalog", "Заказ")
+	if err != nil || kind != "catalog" || !slices.Equal(paths, []string{"catalogs/заказ.yaml"}) {
+		t.Fatalf("одноимённые объекты: kind=%q paths=%v err=%v", kind, paths, err)
+	}
+}
+
+func TestConfiguratorDeleteContextMenuSendsObjectKind(t *testing.T) {
+	js, err := os.ReadFile("static/configurator.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(js)
+	for _, fragment := range []string{
+		`data-delete-kind="catalog"`,
+		`data-delete-kind="document"`,
+	} {
+		if !strings.Contains(cfgTabTree, fragment) {
+			t.Errorf("дерево не различает типы узлов: нет %q", fragment)
+		}
+	}
+	for _, fragment := range []string{
+		"item.dataset.deleteKind",
+		"e:'entity'",
+		"proc:'processor'",
+		"ir:'inforeg'",
+		"ar:'accountreg'",
+		"kindInp.name='kind'",
+	} {
+		if !strings.Contains(source, fragment) {
+			t.Errorf("контекстное удаление не передаёт тип узла: нет %q", fragment)
+		}
+	}
+}

--- a/internal/launcher/configurator_tmpl_tree.go
+++ b/internal/launcher/configurator_tmpl_tree.go
@@ -38,7 +38,7 @@ const cfgTabTree = `{{define "tab-tree"}}
 
   <details class="cfg-tree" data-group="catalogs"><summary class="cfg-group cfg-group-hd"><span class="tree-toggle">▸</span><span>{{t $.Lang "Справочники"}}</span><span class="cfg-add-btn" onclick="event.stopPropagation();cfgNewObj('catalog')" title="{{t $.Lang "Добавить справочник"}}">+</span></summary>
   {{range .Catalogs}}
-  <div class="cfg-item" data-id="e-{{.Name}}" onclick="selItem(this)">
+  <div class="cfg-item" data-id="e-{{.Name}}" data-delete-kind="catalog" onclick="selItem(this)">
     <span class="ic">📕</span>{{.Name}}
   </div>
   {{end}}
@@ -46,7 +46,7 @@ const cfgTabTree = `{{define "tab-tree"}}
 
   <details class="cfg-tree" data-group="documents"><summary class="cfg-group cfg-group-hd"><span class="tree-toggle">▸</span><span>{{t $.Lang "Документы"}}</span><span class="cfg-add-btn" onclick="event.stopPropagation();cfgNewObj('document')" title="{{t $.Lang "Добавить документ"}}">+</span></summary>
   {{range .Docs}}
-  <div class="cfg-item" data-id="e-{{.Name}}" onclick="selItem(this)">
+  <div class="cfg-item" data-id="e-{{.Name}}" data-delete-kind="document" onclick="selItem(this)">
     <span class="ic">📄</span>{{.Name}}{{if .Posting}}<span class="bp">✓</span>{{end}}
   </div>
   {{end}}

--- a/internal/launcher/static/configurator.js
+++ b/internal/launcher/static/configurator.js
@@ -827,6 +827,11 @@ document.addEventListener('contextmenu', function(ev) {
   var menu = document.createElement('div');
   menu.id = 'cfg-ctx-menu';
   menu.style.cssText = 'position:fixed;left:'+ev.clientX+'px;top:'+ev.clientY+'px;background:#fff;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.2);padding:4px 0;z-index:9999;min-width:150px';
+  var prefix = (did.match(/^([a-z]+)-/) || [])[1] || '';
+  var kind = item.dataset.deleteKind || {
+    e:'entity', r:'register', ir:'inforeg', ar:'accountreg', en:'enum',
+    rep:'report', mod:'module', proc:'processor', pf:'printform', sub:'subsystem'
+  }[prefix] || '';
   var dname = did.replace(/^[a-z]+-/, '');
   var delBtn = document.createElement('div');
   delBtn.textContent = 'Удалить «' + dname + '»';
@@ -841,6 +846,8 @@ document.addEventListener('contextmenu', function(ev) {
     form.action = '/bases/' + _dbgBase + '/configurator/entity-delete';
     var inp = document.createElement('input'); inp.type='hidden'; inp.name='entity'; inp.value=dname;
     form.appendChild(inp);
+    var kindInp = document.createElement('input'); kindInp.type='hidden'; kindInp.name='kind'; kindInp.value=kind;
+    form.appendChild(kindInp);
     document.body.appendChild(form);
     form.submit();
   };


### PR DESCRIPTION
Closes #445

## Что изменено
- контекстное меню передаёт точный тип объекта, включая различение справочников и документов
- удаление ищет метаданные в актуальных каталогах и удаляет связанные модули, макеты и формы
- в database-режиме снимок закрывается до транзакции удаления, а все файлы удаляются атомарно одной версией
- добавлены регрессионные тесты для database/file режимов и всех поддержанных типов узлов

## Проверки
- `go test ./... -count=1`
- `go test -race ./internal/launcher -count=1`
- `go vet ./...`
- `go build ./...`
- `golangci-lint ./internal/launcher/...`
- `go run ./tools/i18ncheck`