### PR TITLE
fix(ui): блокировать выбор readonly-ссылки

### DIFF
--- a/internal/ui/managed_form_test.go
+++ b/internal/ui/managed_form_test.go
@@ -170,6 +170,50 @@ func TestPageManagedForm_Renders(t *testing.T) {
 	}
 }
 
+func TestPageManagedForm_ReadOnlyRefDisablesPickerActions(t *testing.T) {
+	ent := &metadata.Entity{
+		Name: "Заказ",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{
+			Name:      "Клиент",
+			Type:      metadata.FieldType("reference:Клиент"),
+			RefEntity: "Клиент",
+		}},
+	}
+	el := &metadata.FormElement{
+		Kind:     metadata.FormElementField,
+		Name:     "ПолеКлиент",
+		DataPath: "Объект.Клиент",
+		ReadOnly: true,
+	}
+	ctx := map[string]any{
+		"Entity":      ent,
+		"Values":      map[string]string{"Клиент": ""},
+		"RefOptions":  map[string]any{},
+		"EnumOptions": map[string]any{},
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "managed-element", map[string]any{"El": el, "Ctx": ctx}); err != nil {
+		t.Fatalf("execute managed-element: %v", err)
+	}
+	html := buf.String()
+	for _, marker := range []string{
+		`id="ref-Клиент"`,
+		`data-ob-ref-picker="ref-Клиент"`,
+		`data-ob-ref-current="ref-Клиент"`,
+	} {
+		start := strings.Index(html, marker)
+		if start < 0 {
+			t.Fatalf("managed ref control is missing %q:\n%s", marker, html)
+		}
+		end := strings.Index(html[start:], ">")
+		if end < 0 || !strings.Contains(html[start:start+end], " disabled") {
+			t.Errorf("read-only ref control %q must be disabled:\n%s", marker, html)
+		}
+	}
+}
+
 // ГруппаФормы с orientation: horizontal раскладывает дочерние реквизиты в ряд
 // в runtime managed-форме (#205).
 func TestPageManagedForm_GroupHorizontalOrientation(t *testing.T) {

--- a/internal/ui/ref_picker_security_test.go
+++ b/internal/ui/ref_picker_security_test.go
@@ -27,3 +27,22 @@ func TestRefPickerDoesNotInjectOptionLabelAsHTML(t *testing.T) {
 		}
 	}
 }
+
+func TestRefPickerRejectsReadOnlyTargetBeforeOpening(t *testing.T) {
+	src := string(uiJS)
+	start := strings.Index(src, "function openRefPicker(selOrId)")
+	end := strings.Index(src, "function openRefCurrent(selOrId)")
+	if start < 0 || end < 0 || end <= start {
+		t.Fatal("openRefPicker function not found in ui.js")
+	}
+	picker := src[start:end]
+
+	guard := strings.Index(picker, "sel.disabled || sel.readOnly || sel.hasAttribute('readonly')")
+	firstRead := strings.Index(picker, "sel.getAttribute(")
+	if guard < 0 {
+		t.Fatal("openRefPicker must reject disabled and readonly targets")
+	}
+	if firstRead < 0 || guard > firstRead {
+		t.Fatal("openRefPicker must check target editability before reading picker attributes")
+	}
+}

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -2074,6 +2074,7 @@ function openItemPicker(payload, elementName) {
 function openRefPicker(selOrId) {
   var sel = (typeof selOrId === 'string') ? document.getElementById(selOrId) : selOrId;
   if (!sel) return;
+  if (sel.disabled || sel.readOnly || sel.hasAttribute('readonly')) return;
   var refEntity = sel.getAttribute('data-ref-entity') || '';
   var allowCreate = sel.getAttribute('data-ref-allow-create') === '1';
   var localOpts = [];

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -67,8 +67,8 @@ const tplManagedForm = `
             <option value="{{index . "id"}}" {{if eq (index . "id") (index $ctx.Values $fn)}}selected{{end}}>{{index . "_label"}}</option>
             {{end}}
           </select>
-          <button type="button" data-ob-ref-picker="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
-          <button type="button" data-ob-ref-current="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
+          <button type="button" data-ob-ref-picker="ref-{{$fn}}"{{if $el.ReadOnly}} disabled{{end}} style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
+          <button type="button" data-ob-ref-current="ref-{{$fn}}"{{if $el.ReadOnly}} disabled{{end}} style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
         </div>
       {{else if isEnum (str $f.Type)}}
         <select name="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>


### PR DESCRIPTION
## Что изменено

- кнопки выбора и открытия карточки блокируются вместе с readonly ref-полем managed-формы;
- `openRefPicker` прекращает работу для `disabled`/`readonly` цели до открытия диалога;
- добавлены регрессионные тесты шаблона и защитного JS-гейта.

## Проверки

- `go test ./...`
- `go vet ./...`
- `go run ./tools/i18ncheck`
- `node --check internal/ui/static/ui.js`
- lint всех `examples/*` и `templates/*`

Closes #449