### PR TITLE
fix(dsl): не перехватывать прикладную процедуру аудита

### DIFF
--- a/internal/dsl/interpreter/builtins.go
+++ b/internal/dsl/interpreter/builtins.go
@@ -13,6 +13,13 @@ import (
 // BuiltinFunc is a callable value that can be injected via extraVars (e.g. Сообщить).
 type BuiltinFunc func(args []any, file string, line int) (any, error)
 
+// FallbackBuiltinFunc is an injected platform function that is used only when
+// the application does not declare a procedure with the same name. It is meant
+// for compatibility-sensitive additions to the global DSL namespace: existing
+// common-module and same-file procedures keep their historical meaning, while
+// new configurations can still call the platform function directly.
+type FallbackBuiltinFunc BuiltinFunc
+
 // DSLError is returned by Error() built-in; stops execution and cancels Save.
 type DSLError struct {
 	File string

--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -683,6 +683,7 @@ func (i *Interpreter) evalCall(c *ast.CallExpr, e *env) any {
 	switch callee := c.Callee.(type) {
 	case *ast.Ident:
 		fnName := callee.Tok.Literal
+		var fallback FallbackBuiltinFunc
 		// Вычислить(Выражение) — разбор строки как выражения и вычисление в
 		// текущем окружении (видит локальные переменные). Обрабатывается до
 		// обычного поиска builtin, т.к. требует доступа к env.
@@ -696,6 +697,9 @@ func (i *Interpreter) evalCall(c *ast.CallExpr, e *env) any {
 					panic(dslStop{err: err})
 				}
 				return result
+			}
+			if bf, ok2 := val.(FallbackBuiltinFunc); ok2 {
+				fallback = bf
 			}
 		}
 		if i.LookupProc != nil {
@@ -719,6 +723,13 @@ func (i *Interpreter) evalCall(c *ast.CallExpr, e *env) any {
 					return i.callUserProc(proc, e, args)
 				}
 			}
+		}
+		if fallback != nil {
+			result, err := fallback(args, callee.Tok.File, callee.Tok.Line)
+			if err != nil {
+				panic(dslStop{err: err})
+			}
+			return result
 		}
 		fn, ok := builtins[strings.ToLower(fnName)]
 		if !ok {

--- a/internal/dsl/interpreter/interpreter_test.go
+++ b/internal/dsl/interpreter/interpreter_test.go
@@ -175,6 +175,83 @@ func TestInterpreter_SiblingProcResolution(t *testing.T) {
 	}
 }
 
+func TestInterpreter_FallbackBuiltinDefersToUserProcedure(t *testing.T) {
+	src := `Процедура ПриЗаписи()
+  ЗаписатьСобытиеАудита("Запись");
+КонецПроцедуры
+
+Процедура ЗаписатьСобытиеАудита(Событие)
+  ЭтотОбъект.Результат = Событие;
+КонецПроцедуры`
+
+	prog, err := parser.New(lexer.New(src, "document.posting.os")).ParseProgram()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var entry, helper *ast.ProcedureDecl
+	for _, proc := range prog.Procedures {
+		switch {
+		case strings.EqualFold(proc.Name.Literal, "ПриЗаписи"):
+			entry = proc
+		case strings.EqualFold(proc.Name.Literal, "ЗаписатьСобытиеАудита"):
+			helper = proc
+		}
+	}
+	if entry == nil || helper == nil {
+		t.Fatal("test procedures not found")
+	}
+
+	fallbackCalled := false
+	interp := interpreter.New()
+	interp.LookupSiblingProc = func(file, name string) *ast.ProcedureDecl {
+		if file == "document.posting.os" && strings.EqualFold(name, "ЗаписатьСобытиеАудита") {
+			return helper
+		}
+		return nil
+	}
+	obj := runtime.NewObject("Документ", metadata.KindDocument)
+	err = interp.Run(entry, obj, map[string]any{
+		"ЗаписатьСобытиеАудита": interpreter.FallbackBuiltinFunc(func(_ []any, _ string, _ int) (any, error) {
+			fallbackCalled = true
+			return nil, nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if fallbackCalled {
+		t.Fatal("fallback builtin intercepted an application procedure")
+	}
+	if got := obj.Get("Результат"); got != "Запись" {
+		t.Fatalf("application procedure result = %v, want Запись", got)
+	}
+}
+
+func TestInterpreter_FallbackBuiltinRunsWithoutUserProcedure(t *testing.T) {
+	src := `Процедура Выполнить()
+  ПлатформеннаяФункция("ok");
+КонецПроцедуры`
+	prog, err := parser.New(lexer.New(src, "processor.proc.os")).ParseProgram()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var got any
+	interp := interpreter.New()
+	err = interp.Run(prog.Procedures[0], nil, map[string]any{
+		"ПлатформеннаяФункция": interpreter.FallbackBuiltinFunc(func(args []any, _ string, _ int) (any, error) {
+			got = args[0]
+			return nil, nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got != "ok" {
+		t.Fatalf("fallback argument = %v, want ok", got)
+	}
+}
+
 // Module.Proc() namespaced calls.
 func TestInterpreter_NamespacedModuleProc(t *testing.T) {
 	helperSrc := `Функция Удвоить(Х)

--- a/internal/ui/dsl_audit_compat_test.go
+++ b/internal/ui/dsl_audit_compat_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Regression for #453: v0.9.6 injected a platform builtin named
+// ЗаписатьСобытиеАудита before resolving application procedures. Existing
+// configurations with a common-module procedure of that name were therefore
+// routed to the new publish/rollback validator and could no longer save a
+// document from DSL.
+func TestDocsRoot_OnWriteApplicationAuditProcedureShadowsPlatformFallback(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "audit-compat.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	doc := &metadata.Entity{
+		Name: "МинимальныйДокумент",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "АудитСобытие", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+
+	onWrite := mustParse(t, `Процедура ПриЗаписи()
+  ЗаписатьСобытиеАудита("Запись", "МинимальныйДокумент", ЭтотОбъект);
+КонецПроцедуры`)
+	appAudit := mustParse(t, `Процедура ЗаписатьСобытиеАудита(Событие, Сущность, Объект)
+  Объект.АудитСобытие = Событие;
+КонецПроцедуры`)
+
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{doc},
+		Programs: map[string]*ast.Program{doc.Name: onWrite},
+	})
+	registry.LoadModules(map[string]*ast.Program{"ПрикладнойАудит": appAudit})
+
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	interp.LookupSiblingProc = registry.GetSiblingProc
+	server := &Server{
+		store: db, reg: registry, interp: interp,
+		lockMgr: runtime.NewLockManager(), messages: NewMessageStore(),
+	}
+
+	writer := newDocsRoot(server, interpreter.NewTxState(ctx)).Get(doc.Name).(*docProxy).
+		CallMethod("создать", nil).(*docWriter)
+	writer.Set("Наименование", "test")
+	writer.CallMethod("записать", nil)
+
+	var name, auditEvent string
+	if err := db.QueryRow(ctx,
+		`SELECT наименование, аудитсобытие FROM минимальныйдокумент LIMIT 1`,
+	).Scan(&name, &auditEvent); err != nil {
+		t.Fatal(err)
+	}
+	if name != "test" || auditEvent != "Запись" {
+		t.Fatalf("saved document = (%q, %q), want (test, Запись)", name, auditEvent)
+	}
+}

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -116,7 +116,10 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 	userNameFn := interpreter.BuiltinFunc(func(_ []any, _ string, _ int) (any, error) {
 		return curUserLogin, nil
 	})
-	auditDecisionFn := interpreter.BuiltinFunc(func(args []any, _ string, _ int) (any, error) {
+	// Compatibility-sensitive fallback: before v0.9.6 configurations could
+	// freely declare an application procedure named ЗаписатьСобытиеАудита.
+	// Such a procedure must win over the platform governance API.
+	auditDecisionFn := interpreter.FallbackBuiltinFunc(func(args []any, _ string, _ int) (any, error) {
 		if len(args) < 5 {
 			return nil, fmt.Errorf("ЗаписатьСобытиеАудита: нужны действие, вид, объект, ссылка и идентификатор решения")
 		}


### PR DESCRIPTION
Closes #453

## Что исправлено
- новый платформенный `ЗаписатьСобытиеАудита` зарегистрирован как fallback-функция
- процедуры общих модулей, текущего файла и формы с тем же именем имеют приоритет
- системный governance-аудит сохраняет прежнее поведение, если прикладной процедуры нет

## Причина регрессии
В v0.9.6 коммит `ced4320f` добавил builtin `ЗаписатьСобытиеАудита` через `extraVars`. Интерпретатор разрешал такие функции раньше процедур конфигурации, поэтому существующий DocFlow-вызов попадал в валидатор `publish|rollback`.

## Проверка
- `go test ./internal/dsl/interpreter ./internal/ui -count=1`
- `go test ./... -count=1`