### PR TITLE
fix(configurator): восстановить формы из configdb

### DIFF
--- a/internal/configdb/path_test.go
+++ b/internal/configdb/path_test.go
@@ -71,6 +71,36 @@ func TestRepoRejectsUnsafePaths(t *testing.T) {
 	}
 }
 
+func TestListByPrefixAcceptsSafeDirectoryBoundary(t *testing.T) {
+	repo, _, ctx := newSQLiteRepo(t)
+	for path, body := range map[string]string{
+		"forms/заказ/формаобъекта.form.yaml": "managed form",
+		"forms_backup/заказ/форма.form.yaml": "must not match",
+		"forms.yaml": "must not match",
+	} {
+		if err := repo.SaveFile(ctx, path, []byte(body)); err != nil {
+			t.Fatalf("SaveFile(%q): %v", path, err)
+		}
+	}
+
+	files, err := repo.ListByPrefix(ctx, "forms/")
+	if err != nil {
+		t.Fatalf("ListByPrefix(forms/): %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("ListByPrefix(forms/) returned %d files, want 1: %+v", len(files), files)
+	}
+	if files[0].Path != "forms/заказ/формаобъекта.form.yaml" || string(files[0].Content) != "managed form" {
+		t.Fatalf("unexpected directory-prefix result: %+v", files[0])
+	}
+
+	for _, unsafe := range []string{"../", "forms//"} {
+		if _, err := repo.ListByPrefix(ctx, unsafe); err == nil {
+			t.Fatalf("ListByPrefix(%q) accepted an unsafe prefix", unsafe)
+		}
+	}
+}
+
 func TestExportToDirRejectsStoredTraversalPath(t *testing.T) {
 	repo, db, ctx := newSQLiteRepo(t)
 	_, err := db.Exec(ctx, `INSERT INTO _onebase_config(path, content) VALUES (?, ?)`, "../evil.yaml", []byte("x"))

--- a/internal/configdb/repo.go
+++ b/internal/configdb/repo.go
@@ -308,10 +308,15 @@ func applyFilesMessage(saves []ConfigFile, deletes []string) string {
 
 // ListByPrefix возвращает все файлы конфигурации, чьи path начинаются
 // с указанного префикса. Префикс может быть пустым — тогда возвращается
-// всё содержимое.
+// всё содержимое. Безопасный каталог с завершающим "/" поддерживается как
+// точная граница префикса, например "forms/" не захватывает "forms_backup/".
 func (r *Repo) ListByPrefix(ctx context.Context, prefix string) ([]ConfigFile, error) {
 	if prefix != "" {
-		if err := ValidatePath(prefix); err != nil {
+		// A directory boundary is a valid and useful prefix: "forms/" must
+		// not also match "forms_backup/...". Validate the directory itself,
+		// but keep the trailing slash in the SQL LIKE pattern.
+		safePrefix := strings.TrimSuffix(prefix, "/")
+		if err := ValidatePath(safePrefix); err != nil {
 			return nil, fmt.Errorf("configdb: unsafe prefix %q: %w", prefix, err)
 		}
 	}

--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -261,7 +261,11 @@ func (h *handler) configuratorFormsEdit(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var form *cfgManagedForm
-	all, _ := h.listManagedForms(r, b)
+	all, listErr := h.listManagedForms(r, b)
+	if listErr != nil {
+		http.Error(w, tr(resolveLang(r), "Не удалось прочитать список форм")+": "+listErr.Error(), http.StatusInternalServerError)
+		return
+	}
 	for i := range all {
 		if strings.EqualFold(all[i].Entity, entity) && strings.EqualFold(all[i].Name, name) {
 			form = &all[i]

--- a/internal/launcher/forms_handlers_test.go
+++ b/internal/launcher/forms_handlers_test.go
@@ -88,6 +88,61 @@ form:
 	}
 }
 
+func TestListManagedFormsFromDBReadsSavedForm(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "managed-forms.db")
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := configdb.New(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	yamlBody := `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: сайт_атс
+elements:
+  - kind: ПолеВвода
+    name: ТолькоНужноеПоле
+    data_path: Объект.Наименование
+`
+	if err := repo.SaveFiles(ctx, []configdb.ConfigFile{
+		{Path: "forms/сайт_атс/формаобъекта.form.yaml", Content: []byte(yamlBody)},
+	}, configdb.VersionOptions{Message: "seed managed form"}); err != nil {
+		t.Fatal(err)
+	}
+
+	base := &Base{ConfigSource: "database", DBType: "sqlite", DBPath: dbPath}
+	req := httptest.NewRequest("GET", "/configurator/forms", nil)
+	t.Cleanup(CloseAuthPools)
+	h := &handler{}
+
+	forms, err := h.listManagedForms(req, base)
+	if err != nil {
+		t.Fatalf("listManagedForms: %v", err)
+	}
+	if len(forms) != 1 {
+		t.Fatalf("managed forms = %d, want 1: %+v", len(forms), forms)
+	}
+	if forms[0].Entity != "сайт_атс" || forms[0].Name != "формаобъекта" ||
+		!strings.Contains(forms[0].YAML, "ТолькоНужноеПоле") {
+		t.Fatalf("saved managed form was replaced or misread: %+v", forms[0])
+	}
+
+	treeForms, err := h.listManagedFormsFromDBNoRequest(ctx, base)
+	if err != nil {
+		t.Fatalf("listManagedFormsFromDBNoRequest: %v", err)
+	}
+	if len(treeForms) != 1 || !strings.Contains(treeForms[0].YAML, "ТолькоНужноеПоле") {
+		t.Fatalf("configurator tree did not load saved managed form: %+v", treeForms)
+	}
+}
+
 func TestDeleteManagedFormDBKeepsSimilarName(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "forms.db")


### PR DESCRIPTION
Closes #454

## Что исправлено
- `ListByPrefix` безопасно принимает каталог-префикс с завершающим `/`
- граница `forms/` не захватывает соседние пути вроде `forms_backup/`
- редактор формы больше не проглатывает ошибку чтения и не подменяет сохранённую форму дефолтным шаблоном

## Причина
После усиления проверки путей в `7c62e432` prefix `forms/` стал отвергаться как unclean path. Оба DB-загрузчика форм продолжали передавать именно каталог-префикс. Страница списка показывала ошибку, а редактор игнорировал её и создавал новый шаблон, из-за чего сохранённая форма выглядела потерянной.

## Проверка
- регрессионный тест configdb на безопасную границу каталог-префикса
- регрессионный тест чтения сохранённой DB-формы страницей и деревом конфигуратора
- `go test ./internal/configdb ./internal/launcher -count=1`
- `go test ./... -count=1`