### PR TITLE
fix(query): корректно сравнивать даты SQLite с параметрами

### DIFF
--- a/internal/query/date_param_sqlite_exec_test.go
+++ b/internal/query/date_param_sqlite_exec_test.go
@@ -1,0 +1,70 @@
+package query_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Регресс на issue #462: дата документа и параметр запроса должны сравниваться
+// как одинаково сериализованные UTC-моменты даже при не-UTC зоне процесса.
+func TestSQLiteDateFieldComparisonWithTimeParam(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(ctx, `
+		CREATE TABLE закрытиемесяца (
+			номер TEXT,
+			месяц TEXT
+		)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx,
+		"INSERT INTO закрытиемесяца(номер, месяц) VALUES(?, ?)",
+		"0001", "2026-06-30T20:59:00Z",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	moscow := time.FixedZone("Europe/Moscow", 3*60*60)
+	boundary := time.Date(2026, 7, 1, 0, 0, 0, 0, moscow) // 2026-06-30T21:00:00Z
+	entity := &metadata.Entity{
+		Name: "ЗакрытиеМесяца",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Месяц", Type: metadata.FieldTypeDate},
+		},
+	}
+	result, err := query.Compile(
+		`ВЫБРАТЬ Номер ИЗ Документ.ЗакрытиеМесяца ГДЕ Месяц < &Граница`,
+		query.CompileOpts{
+			Dialect:  db.Dialect(),
+			Entities: []*metadata.Entity{entity},
+			Params:   map[string]any{"Граница": boundary},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Args) != 1 || result.Args[0] != "2026-06-30T21:00:00Z" {
+		t.Fatalf("параметр даты = %v, want RFC3339 UTC", result.Args)
+	}
+
+	var number string
+	if err := db.QueryRow(ctx, result.SQL, result.Args...).Scan(&number); err != nil {
+		t.Fatalf("запрос не вернул документ 20:59Z перед границей 21:00Z: %v", err)
+	}
+	if number != "0001" {
+		t.Fatalf("номер = %q, want 0001", number)
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -2173,6 +2173,88 @@ func (tr *translator) needsNumberCast(lower string) bool {
 	return false
 }
 
+// sqliteDateParamComparedToField распознаёт time.Time-параметр в прямом
+// сравнении с полем date. Такие параметры сериализуются тем же UTC RFC3339,
+// что и значения полей сущностей: иначе SQLite сравнивает разные TEXT-форматы
+// лексикографически по разделителю ('T' против пробела) и ошибается (#462).
+func (tr *translator) sqliteDateParamComparedToField(idx int) bool {
+	if dialectOrDefault(tr.opts.Dialect).Name() != "sqlite" || !tr.timeParamAt(idx) {
+		return false
+	}
+	if tr.dateFieldAt(idx-2) && tr.comparisonOpAt(idx-1) {
+		return true
+	}
+	if tr.comparisonOpAt(idx+1) && tr.dateFieldAt(idx+2) {
+		return true
+	}
+	// Первый или второй параметр правой части BETWEEN.
+	if tr.dateFieldAt(idx-2) && tr.keywordAt(idx-1, "МЕЖДУ", "BETWEEN") {
+		return true
+	}
+	return tr.dateFieldAt(idx-4) &&
+		tr.keywordAt(idx-3, "МЕЖДУ", "BETWEEN") &&
+		tr.timeParamAt(idx-2) &&
+		tr.keywordAt(idx-1, "И", "AND")
+}
+
+func (tr *translator) addSQLiteDateParam(name string) string {
+	var value any
+	switch v := tr.paramValues[name].(type) {
+	case time.Time:
+		value = v.UTC().Format(time.RFC3339)
+	case *time.Time:
+		if v != nil {
+			value = v.UTC().Format(time.RFC3339)
+		}
+	}
+	tr.args = append(tr.args, value)
+	return dialectOrDefault(tr.opts.Dialect).Placeholder(len(tr.args))
+}
+
+func (tr *translator) dateFieldAt(idx int) bool {
+	if idx < 0 || idx >= len(tr.tokens) || tr.tokens[idx].kind != tIdent {
+		return false
+	}
+	return tr.colTypes[strings.ToLower(tr.tokens[idx].val)] == metadata.FieldTypeDate
+}
+
+func (tr *translator) timeParamAt(idx int) bool {
+	if idx < 0 || idx >= len(tr.tokens) || tr.tokens[idx].kind != tParam {
+		return false
+	}
+	switch tr.paramValues[tr.tokens[idx].val].(type) {
+	case time.Time, *time.Time:
+		return true
+	default:
+		return false
+	}
+}
+
+func (tr *translator) comparisonOpAt(idx int) bool {
+	if idx < 0 || idx >= len(tr.tokens) || tr.tokens[idx].kind != tOp {
+		return false
+	}
+	switch tr.tokens[idx].val {
+	case "=", "<>", "!=", "<", "<=", ">", ">=":
+		return true
+	default:
+		return false
+	}
+}
+
+func (tr *translator) keywordAt(idx int, names ...string) bool {
+	if idx < 0 || idx >= len(tr.tokens) || tr.tokens[idx].kind != tIdent {
+		return false
+	}
+	got := strings.ToUpper(tr.tokens[idx].val)
+	for _, name := range names {
+		if got == name {
+			return true
+		}
+	}
+	return false
+}
+
 // qualifyOwn префиксует собственную колонку основной таблицы её именем/алиасом,
 // когда активны авто-JOIN'ы (п.48) — иначе одноимённая колонка присоединённого
 // каталога вызывает ambiguous column. Неизвестные идентификаторы не трогаем.
@@ -3182,8 +3264,13 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		// Parameter: &Name → $N or NULL
 		if t.kind == tParam {
 			tr.prevWasDot = false
+			normalizeDate := tr.sqliteDateParamComparedToField(tr.pos)
 			tr.advance()
-			tr.emit(tr.addParam(t.val))
+			if normalizeDate {
+				tr.emit(tr.addSQLiteDateParam(t.val))
+			} else {
+				tr.emit(tr.addParam(t.val))
+			}
 			continue
 		}
 

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -64,6 +64,13 @@ func TestCompile_Between(t *testing.T) {
 		"ДатаНачала":    time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC),
 		"ДатаОкончания": time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC),
 	}
+	entity := &metadata.Entity{
+		Name: "ЗаЧас",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Дата", Type: metadata.FieldTypeDate},
+		},
+	}
 
 	tests := []struct {
 		name    string
@@ -76,7 +83,11 @@ func TestCompile_Between(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r, err := query.Compile(src, query.CompileOpts{Params: params, Dialect: tt.dialect})
+			r, err := query.Compile(src, query.CompileOpts{
+				Params:   params,
+				Entities: []*metadata.Entity{entity},
+				Dialect:  tt.dialect,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -85,6 +96,11 @@ func TestCompile_Between(t *testing.T) {
 			}
 			if len(r.Args) != 2 {
 				t.Fatalf("expected 2 args, got %d: %v", len(r.Args), r.Args)
+			}
+			if tt.name == "sqlite" {
+				if r.Args[0] != "2026-07-26T00:00:00Z" || r.Args[1] != "2026-07-27T00:00:00Z" {
+					t.Fatalf("SQLite date args must use RFC3339 UTC, got %v", r.Args)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Что изменено

- `time.Time` рядом с метаданным полем `date` в SQLite-запросе привязывается как UTC RFC3339 — в формате хранения даты сущности;
- сохранён глобальный формат SQLite-периодов регистров и индексируемость date-колонки;
- добавлены сквозной регрессионный тест для `TZ=Europe/Moscow` и проверка `МЕЖДУ/BETWEEN`.

## Проверки

- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `go test -race ./internal/query -count=1`
- `go run ./tools/i18ncheck`

Closes #462