### PR TITLE
fix(dsl): заполнять this.Ссылка в ПриЗаписи на пути записи документа

### DIFF
--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -634,6 +634,12 @@ func (w *docWriter) writeInContext(ctx context.Context) error {
 		return err
 	}
 	w.autoNumber(ctx)
+	// Псевдо-реквизит «Ссылка» самого документа — до запуска OnWrite, как это уже
+	// делается на пути проведения (ensureSelfRef перед OnPost) и в entityservice.Save.
+	// Без него this.Ссылка в ПриЗаписи был бы пуст на DSL-пути записи, из-за чего
+	// запись ссылки на себя (Дв.X = this.Ссылка) или чтение пре-образа по своей
+	// ссылке в хуке не работали. autoNumber уже проставил Номер → displayName корректен.
+	w.ensureSelfRef()
 	mc := runtime.NewMovementsCollector(w.entity.Name, w.obj.ID)
 	setPeriodFromFields(mc, w.entity, w.obj.Fields)
 	if errMsg, _ := w.s.runOnWriteCtx(ctx, w.obj, mc); errMsg != "" {

--- a/internal/ui/dsl_documents_test.go
+++ b/internal/ui/dsl_documents_test.go
@@ -859,6 +859,65 @@ func TestDocsRoot_OnWriteRunsOnSave(t *testing.T) {
 	}
 }
 
+// ПриЗаписи (OnWrite) на DSL-пути записи должен видеть заполненный псевдо-реквизит
+// «Ссылка» самого документа — симметрично OnPost и entityservice.Save. Регресс:
+// ensureSelfRef ранее вызывался только перед OnPost, из-за чего this.Ссылка в
+// ПриЗаписи был пуст (запись ссылки на себя и чтение пре-образа по своей ссылке
+// в хуке не работали).
+func TestDocsRoot_OnWriteHasSelfRef(t *testing.T) {
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	doc := &metadata.Entity{
+		Name: "СамоДок",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "ЕстьСсылка", Type: metadata.FieldTypeNumber},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+
+	onWriteSrc := `Процедура ПриЗаписи()
+  Если ЗначениеЗаполнено(ЭтотОбъект.Ссылка) Тогда
+    ЭтотОбъект.ЕстьСсылка = 1;
+  Иначе
+    ЭтотОбъект.ЕстьСсылка = 0;
+  КонецЕсли;
+КонецПроцедуры`
+	prog := mustParse(t, onWriteSrc)
+
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{
+		Entities: []*metadata.Entity{doc},
+		Programs: map[string]*ast.Program{"СамоДок": prog},
+	})
+
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+	s := &Server{store: db, reg: registry, interp: interp, lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+
+	root := newDocsRoot(s, interpreter.NewTxState(ctx))
+	dp := root.Get("СамоДок").(*docProxy)
+	w := dp.CallMethod("создать", nil).(*docWriter)
+	w.Set("Номер", "СД-1")
+	w.CallMethod("записать", nil)
+
+	var flag float64
+	if err := db.QueryRow(ctx, "SELECT естьссылка FROM самодок LIMIT 1").Scan(&flag); err != nil {
+		t.Fatal(err)
+	}
+	if flag != 1 {
+		t.Errorf("this.Ссылка в ПриЗаписи не заполнена (ЕстьСсылка=%v, ожидалось 1) — ensureSelfRef не вызван на пути записи", flag)
+	}
+}
+
 // parseNum приводит значение из БД (число или строка вида "300.0") к float64.
 func parseNum(v any) float64 {
 	switch n := v.(type) {


### PR DESCRIPTION
## Проблема

OnWrite-хук (`Процедура ПриЗаписи`) документа, записываемого **из DSL** —
`Документы.X.Создать().Записать()` или `Ссылка.ПолучитьОбъект().Записать()` —
не видел псевдо-реквизит **«Ссылка» самого документа**: `this.Ссылка` был пуст.

Причина: `ensureSelfRef()` вызывался только на пути **проведения** (перед
`OnPost`) и в `entityservice.Save` (форма), а на DSL-пути записи
(`docWriter.writeInContext`) — нет.

Последствия внутри `ПриЗаписи`:
- запись ссылки на себя (`Дв.X = this.Ссылка`, напр. DocumentRef в регистр
  сведений) давала NULL;
- чтение **пре-образа** документа по своей ссылке (`ГДЕ З.Ссылка = &Ссылка`)
  возвращало пусто.

Проведение (`OnPost`) и форма (`entityservice.Save`) от этого не страдали — там
self-ref ставится.

## Фикс

Вызвать `ensureSelfRef()` в `writeInContext` до запуска `OnWrite` — после
`autoNumber` (чтобы `displayName` содержал Номер), симметрично пути проведения.
Псевдо-реквизиты `ссылка`/`reference` уже корректно игнорируются storage-слоем
при upsert (тот же путь уже используется перед `OnPost`).

## Тест

`TestDocsRoot_OnWriteHasSelfRef` — документ с хуком `ПриЗаписи`, ставящим флаг
`ЗначениеЗаполнено(ЭтотОбъект.Ссылка)`. Без фикса флаг = 0 (проверено ручным
откатом). `go test ./...` — зелёный.

## Контекст

Обнаружено при сборке прикладной конфигурации КЦ (заморозка производственных
реквизитов принятой заявки — хук читает пре-образ по своей ссылке). Пока
обхожу чтением по `Номер`; фикс убирает необходимость обхода.

Generated-with: Claude Code