### PR TITLE
fix(dsl): не показывать путь к .os в ошибках UI/REST

### DIFF
--- a/internal/dsl/interpreter/builtins.go
+++ b/internal/dsl/interpreter/builtins.go
@@ -1,6 +1,7 @@
 package interpreter
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -36,6 +37,28 @@ func (e *DSLError) Error() string {
 		return fmt.Sprintf("%s:%d: %s", e.File, e.Line, e.Msg)
 	}
 	return e.Msg
+}
+
+// UserMessage — текст для пользователя (UI/REST), без пути к модулю и номера строки.
+// Error() по-прежнему отдаёт file:line: msg для check, логов и отладчика.
+func (e *DSLError) UserMessage() string {
+	if e == nil {
+		return ""
+	}
+	return e.Msg
+}
+
+// FormatUserError отдаёт пользовательский текст бизнес-ошибки DSL.
+// Для *DSLError — только Msg; иначе err.Error().
+func FormatUserError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var dsl *DSLError
+	if errors.As(err, &dsl) {
+		return dsl.UserMessage()
+	}
+	return err.Error()
 }
 
 func (e *DSLError) Unwrap() error { return e.Err }

--- a/internal/dsl/interpreter/dsl_error_user_message_test.go
+++ b/internal/dsl/interpreter/dsl_error_user_message_test.go
@@ -1,0 +1,47 @@
+package interpreter_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+)
+
+func TestDSLError_UserMessage_omitsFileLine(t *testing.T) {
+	err := &interpreter.DSLError{
+		File: "/root/controlling/demo-app/src/показаниясчётчика.posting.os",
+		Line: 60,
+		Msg:  "Показание уже зафиксировано, сначала отмените проведение",
+	}
+	got := err.UserMessage()
+	if got != err.Msg {
+		t.Fatalf("UserMessage = %q, want %q", got, err.Msg)
+	}
+	if strings.Contains(got, ".os:") || strings.Contains(got, "/root/") {
+		t.Fatalf("UserMessage must not expose source path: %q", got)
+	}
+	debug := err.Error()
+	if !strings.Contains(debug, ".posting.os:60:") {
+		t.Fatalf("Error() must keep file:line for tools, got %q", debug)
+	}
+}
+
+func TestFormatUserError_DSLErrorAndPlain(t *testing.T) {
+	dsl := &interpreter.DSLError{File: "x.os", Line: 1, Msg: "только текст"}
+	if got := interpreter.FormatUserError(dsl); got != "только текст" {
+		t.Fatalf("FormatUserError(DSLError) = %q", got)
+	}
+	wrapped := fmt.Errorf("wrap: %w", dsl)
+	if got := interpreter.FormatUserError(wrapped); got != "только текст" {
+		t.Fatalf("FormatUserError(wrapped) = %q", got)
+	}
+	plain := errors.New("техническая ошибка")
+	if got := interpreter.FormatUserError(plain); got != "техническая ошибка" {
+		t.Fatalf("FormatUserError(plain) = %q", got)
+	}
+	if got := interpreter.FormatUserError(nil); got != "" {
+		t.Fatalf("FormatUserError(nil) = %q", got)
+	}
+}

--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -378,7 +378,7 @@ func (s *Service) Save(ctx context.Context, req SaveRequest) (SaveResult, error)
 	if err != nil {
 		var hookErr *hookRunError
 		if errors.As(err, &hookErr) {
-			return SaveResult{ID: req.ID, DSLError: hookErr.err.Error(), DSLMessages: msgs, Movements: mc}, nil
+			return SaveResult{ID: req.ID, DSLError: interpreter.FormatUserError(hookErr.err), DSLMessages: msgs, Movements: mc}, nil
 		}
 		return SaveResult{}, err
 	}
@@ -489,7 +489,7 @@ func (s *Service) Unpost(ctx context.Context, entity *metadata.Entity, id uuid.U
 	if err != nil {
 		var hookErr *hookRunError
 		if errors.As(err, &hookErr) {
-			result.DSLError = hookErr.err.Error()
+			result.DSLError = interpreter.FormatUserError(hookErr.err)
 			return result, nil
 		}
 		return SaveResult{}, err
@@ -637,7 +637,7 @@ func (s *Service) Fill(ctx context.Context, req FillRequest) (FillResult, error)
 	if err := s.Interp.Run(proc, thisVal, vars); err != nil {
 		normalizeTPRowKeys(recvObj.TablePartRows, req.Receiver)
 		if dslErr, ok := err.(*interpreter.DSLError); ok {
-			return FillResult{Fields: recvObj.Fields, TablePartRows: recvObj.TablePartRows, DSLError: dslErr.Error(), DSLMessages: msgs}, nil
+			return FillResult{Fields: recvObj.Fields, TablePartRows: recvObj.TablePartRows, DSLError: dslErr.UserMessage(), DSLMessages: msgs}, nil
 		}
 		return FillResult{Fields: recvObj.Fields, TablePartRows: recvObj.TablePartRows, DSLError: err.Error(), DSLMessages: msgs}, nil
 	}

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -331,10 +331,7 @@ func (s *Server) runOnWriteCtx(ctx context.Context, obj *runtime.Object, mc *run
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)
 	if err := s.interp.Run(proc, obj, vars); err != nil {
-		if dslErr, ok := err.(*interpreter.DSLError); ok {
-			return dslErr.Error(), msgs
-		}
-		return err.Error(), msgs
+		return interpreter.FormatUserError(err), msgs
 	}
 	return "", msgs
 }
@@ -385,10 +382,7 @@ func (s *Server) runOnPostCtx(ctx context.Context, obj *runtime.Object, mc *runt
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(ctx, mc, &msgs)
 	if err := s.interp.Run(proc, obj, vars); err != nil {
-		if dslErr, ok := err.(*interpreter.DSLError); ok {
-			return dslErr.Error(), msgs
-		}
-		return err.Error(), msgs
+		return interpreter.FormatUserError(err), msgs
 	}
 	return "", msgs
 }


### PR DESCRIPTION
## Summary
- Для UI/REST бизнес-ошибки DSL (`ВызватьИсключение`) отдаются без префикса `путь:строка:` — только текст сообщения.
- `DSLError.Error()` по-прежнему с `file:line` для check, логов и отладчика.
- Точки: `entityservice.Save` / `Unpost` / `Fill`, `handlers_dsl` OnWrite/OnPost.

Closes #466  
Связано с https://github.com/6205268-creator/controlling/issues/117

## Test plan
- [x] `go test ./internal/dsl/interpreter/ -run UserMessage|FormatUserError`
- [x] `go test ./internal/entityservice/ -run Unpost|Posting|DSLError`
- [ ] Ручная проверка: провести дубль показания счётчика — в красной плашке только текст без `/root/...posting.os:N:`