### PR TITLE
fix(dsl): expose reserved reference aliases in query rows

### DIFF
--- a/internal/dsl/interpreter/query_proxy.go
+++ b/internal/dsl/interpreter/query_proxy.go
@@ -147,13 +147,26 @@ func (q *queryProxy) execute() *Array {
 	}
 	arr := &Array{}
 	for _, row := range rows {
-		s := &Struct{vals: make(map[string]any)}
-		for k, v := range row {
-			k = strings.ToLower(k)
-			s.keys = append(s.keys, k)
-			s.vals[k] = v
-		}
-		arr.items = append(arr.items, s)
+		arr.items = append(arr.items, newQueryResultRow(row))
 	}
 	return arr
+}
+
+func newQueryResultRow(row map[string]any) *Struct {
+	s := NewStructFromMap(row)
+	id, hasID := s.vals["id"]
+	if !hasID {
+		return s
+	}
+
+	// The query compiler intentionally maps the reserved output names
+	// Ссылка/Reference/Ref to the SQL alias "id". Keep that SQL contract while
+	// making the materialized value available through the DSL names that
+	// produced it.
+	for _, alias := range []string{"ссылка", "reference", "ref"} {
+		if _, exists := s.vals[alias]; !exists {
+			s.Set(alias, id)
+		}
+	}
+	return s
 }

--- a/internal/dsl/interpreter/query_test.go
+++ b/internal/dsl/interpreter/query_test.go
@@ -95,6 +95,47 @@ func TestQuery_Execute_AccessFields(t *testing.T) {
 	assert.Equal(t, "Кабель", result)
 }
 
+func TestQuery_Execute_AccessReferenceReservedAlias(t *testing.T) {
+	const id = "11111111-1111-1111-1111-111111111111"
+	tests := []struct {
+		name  string
+		query string
+		field string
+	}{
+		{
+			name:  "Russian",
+			query: "ВЫБРАТЬ О.Ссылка КАК Ссылка ИЗ Документ.Обращение КАК О",
+			field: "Ссылка",
+		},
+		{
+			name:  "English",
+			query: "SELECT O.Reference AS Reference FROM Document.Обращение AS O",
+			field: "Reference",
+		},
+		{
+			name:  "short English alias",
+			query: "SELECT O.Ref AS Ref FROM Document.Обращение AS O",
+			field: "Ref",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &stubDB{rows: []map[string]any{{"id": id}}}
+			src := `Процедура Тест()
+				Запрос = Новый Запрос;
+				Запрос.Текст = "` + tt.query + `";
+				Результат = Запрос.Выполнить();
+				Возврат Результат[0].` + tt.field + `;
+			КонецПроцедуры`
+
+			result := evalQuery(t, src, db, &stubReg{})
+
+			assert.Equal(t, id, result)
+		})
+	}
+}
+
 func TestQuery_SetParameter(t *testing.T) {
 	var capturedSQL string
 	var capturedArgs []any


### PR DESCRIPTION
## Что изменено

- строки результата запроса публикуют SQL-колонку `id` под зарезервированными DSL-именами `Ссылка`, `Reference` и `Ref`;
- существующие одноимённые значения не перезаписываются;
- добавлен регрессионный тест на русское и английские имена.

## Проверки

- `go test -count=1 ./...`
- `go test -race ./internal/dsl/interpreter -run '^TestQuery_Execute_' -count=1`
- `go vet ./...`
- `go run ./tools/i18ncheck`
- `CGO_ENABLED=0 go build ./...`

Closes #469