### PR TITLE
fix(dsl): surface document hook messages in processors

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -787,6 +787,9 @@ func (s *Scheduler) runProcessor(ctx context.Context, job *metadata.ScheduledJob
 	if dslVars == nil {
 		dslVars = make(map[string]any)
 	}
+	if documents, ok := dslVars["Документы"].(interface{ SetDSLMessageCollector(*[]string) }); ok {
+		documents.SetDSLMessageCollector(&messages)
+	}
 	dslVars["Параметры"] = paramsThis
 	dslVars["Сообщить"] = msgFunc
 	dslVars["Message"] = msgFunc

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -21,6 +21,20 @@ type docsCtxSource interface {
 	Ctx() context.Context
 }
 
+type dslMessageCollectorContextKey struct{}
+
+func withDSLMessageCollector(ctx context.Context, messages *[]string) context.Context {
+	if messages == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, dslMessageCollectorContextKey{}, messages)
+}
+
+func dslMessageCollectorFromContext(ctx context.Context) *[]string {
+	messages, _ := ctx.Value(dslMessageCollectorContextKey{}).(*[]string)
+	return messages
+}
+
 // refManagerFor строит менеджера для ссылки на сущность по её метаданным:
 // CatalogProxy для справочников, docProxy для документов. Используется в
 // enrichHeaderRefs/enrichTPRowsWithRefs и dsl_object_attr, чтобы ссылки,
@@ -38,7 +52,12 @@ func (s *Server) refManagerFor(entity *metadata.Entity, ctx context.Context) int
 			WithExchangeRegistrar(s.exchangeRegistrar()).
 			WithObjectFactory(s.catObjectFactory(ctxSrc))
 	case metadata.KindDocument:
-		return &docProxy{s: s, ctxSrc: ctxSrc, entity: entity}
+		return &docProxy{
+			s:        s,
+			ctxSrc:   ctxSrc,
+			entity:   entity,
+			messages: dslMessageCollectorFromContext(ctx),
+		}
 	}
 	return nil
 }
@@ -47,12 +66,23 @@ func (s *Server) refManagerFor(entity *metadata.Entity, ctx context.Context) int
 // Документы.X.Создать() → пишущий объект документа с табличными частями
 // и методами Записать()/Провести().
 type docsRoot struct {
-	s      *Server
-	ctxSrc docsCtxSource
+	s        *Server
+	ctxSrc   docsCtxSource
+	messages *[]string
 }
 
 func newDocsRoot(s *Server, ctxSrc docsCtxSource) *docsRoot {
-	return &docsRoot{s: s, ctxSrc: ctxSrc}
+	root := &docsRoot{s: s, ctxSrc: ctxSrc}
+	if ctxSrc != nil {
+		root.messages = dslMessageCollectorFromContext(ctxSrc.Ctx())
+	}
+	return root
+}
+
+// SetDSLMessageCollector connects document-hook messages to the collector of
+// the processor or scheduled job that owns this Documents root.
+func (d *docsRoot) SetDSLMessageCollector(messages *[]string) {
+	d.messages = messages
 }
 
 func (d *docsRoot) Get(name string) any {
@@ -60,16 +90,17 @@ func (d *docsRoot) Get(name string) any {
 	if entity == nil || entity.Kind != metadata.KindDocument {
 		return nil
 	}
-	return &docProxy{s: d.s, ctxSrc: d.ctxSrc, entity: entity}
+	return &docProxy{s: d.s, ctxSrc: d.ctxSrc, entity: entity, messages: d.messages}
 }
 
 func (d *docsRoot) Set(_ string, _ any) {}
 
 // docProxy — Документы.ПоступлениеТоваров.
 type docProxy struct {
-	s      *Server
-	ctxSrc docsCtxSource
-	entity *metadata.Entity
+	s        *Server
+	ctxSrc   docsCtxSource
+	entity   *metadata.Entity
+	messages *[]string
 }
 
 func (p *docProxy) Get(_ string) any    { return nil }
@@ -86,9 +117,10 @@ func (p *docProxy) CallMethod(method string, args []any) any {
 	switch strings.ToLower(method) {
 	case "создать", "create":
 		return &docWriter{
-			s:      p.s,
-			ctxSrc: p.ctxSrc,
-			entity: p.entity,
+			s:        p.s,
+			ctxSrc:   p.ctxSrc,
+			entity:   p.entity,
+			messages: p.messages,
 			obj: &runtime.Object{
 				ID:            uuid.New(),
 				Type:          p.entity.Name,
@@ -388,6 +420,7 @@ func (p *docProxy) LoadObject(uuidStr string) (any, error) {
 		ctxSrc:          p.ctxSrc,
 		entity:          p.entity,
 		obj:             obj,
+		messages:        p.messages,
 		loaded:          true,
 		expectedVersion: &version,
 	}, nil
@@ -402,10 +435,11 @@ func (p *docProxy) LoadObject(uuidStr string) (any, error) {
 //	Док.Записать();
 //	Док.Провести();
 type docWriter struct {
-	s      *Server
-	ctxSrc docsCtxSource
-	entity *metadata.Entity
-	obj    *runtime.Object
+	s        *Server
+	ctxSrc   docsCtxSource
+	entity   *metadata.Entity
+	obj      *runtime.Object
+	messages *[]string
 	// loaded — объект получен из БД (Ссылка.ПолучитьОбъект), а не создан.
 	// saved — объект уже записан в этой сессии. Оба используются ЭтоНовый().
 	loaded          bool
@@ -642,7 +676,9 @@ func (w *docWriter) writeInContext(ctx context.Context) error {
 	w.ensureSelfRef()
 	mc := runtime.NewMovementsCollector(w.entity.Name, w.obj.ID)
 	setPeriodFromFields(mc, w.entity, w.obj.Fields)
-	if errMsg, _ := w.s.runOnWriteCtx(ctx, w.obj, mc); errMsg != "" {
+	errMsg, hookMessages := w.s.runOnWriteCtx(ctx, w.obj, mc)
+	w.appendHookMessages(hookMessages)
+	if errMsg != "" {
 		return fmt.Errorf("%s", errMsg)
 	}
 	if w.expectedVersion == nil {
@@ -728,7 +764,9 @@ func (w *docWriter) postInContext(ctx context.Context) error {
 			return storage.PostingFrozenError(lock)
 		}
 	}
-	if errMsg, _ := w.s.runOnPostCtx(ctx, w.obj, mc); errMsg != "" {
+	errMsg, hookMessages := w.s.runOnPostCtx(ctx, w.obj, mc)
+	w.appendHookMessages(hookMessages)
+	if errMsg != "" {
 		return fmt.Errorf("%s", errMsg)
 	}
 	// OnPost мог изменить реквизиты шапки (расчётные поля) — персистим их upsert'ом
@@ -752,6 +790,12 @@ func (w *docWriter) postInContext(ctx context.Context) error {
 	return nil
 }
 
+func (w *docWriter) appendHookMessages(messages []string) {
+	if w.messages != nil && len(messages) > 0 {
+		*w.messages = append(*w.messages, messages...)
+	}
+}
+
 // ensureSelfRef устанавливает псевдо-реквизит «Ссылка» самого документа, чтобы
 // this.Ссылка в OnPost/OnWrite указывал на сам документ (нужно для записи
 // DocumentRef на себя в регистр сведений: Дв.Спецификация = this.Ссылка).
@@ -771,7 +815,7 @@ func (w *docWriter) ref() *interpreter.Ref {
 		UUID:    w.obj.ID.String(),
 		Name:    w.displayName(),
 		Type:    w.entity.Name,
-		Manager: &docProxy{s: w.s, ctxSrc: w.ctxSrc, entity: w.entity},
+		Manager: &docProxy{s: w.s, ctxSrc: w.ctxSrc, entity: w.entity, messages: w.messages},
 	}
 }
 

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -291,6 +291,7 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 }
 
 func (s *Server) buildDSLVarsWithMessages(ctx context.Context, mc *runtime.MovementsCollector, msgs *[]string) map[string]any {
+	ctx = withDSLMessageCollector(ctx, msgs)
 	vars := s.buildDSLVars(ctx, mc)
 	userKey := userKeyFromCtx(ctx)
 	msgFunc := interpreter.BuiltinFunc(func(args []any, file string, line int) (any, error) {

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -800,23 +800,12 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		userKey := userKeyFromRequest(r)
 		var msgs []string
-		msgFunc := interpreter.BuiltinFunc(func(args []any, file string, line int) (any, error) {
-			if len(args) > 0 {
-				text := fmt.Sprintf("%v", args[0])
-				msgs = append(msgs, text)
-				s.messages.Push(userKey, text)
-			}
-			return nil, nil
-		})
 
 		paramsThis := &interpreter.MapThis{M: paramValues}
 		mc := runtime.NewMovementsCollector("processor", uuid.Nil)
-		dslVars := s.buildDSLVars(r.Context(), mc)
+		dslVars := s.buildDSLVarsWithMessages(r.Context(), mc, &msgs)
 		dslVars["Параметры"] = paramsThis
-		dslVars["Сообщить"] = msgFunc
-		dslVars["Message"] = msgFunc
 		interpreter.InjectMaket(dslVars, proc.Layout)
 
 		err := s.interp.Run(procDecl, paramsThis, dslVars)

--- a/internal/ui/handlers_processors.go
+++ b/internal/ui/handlers_processors.go
@@ -202,23 +202,12 @@ func (s *Server) processorRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userKey := userKeyFromRequest(r)
 	var messages []string
-	msgFunc := interpreter.BuiltinFunc(func(args []any, file string, line int) (any, error) {
-		if len(args) > 0 {
-			text := fmt.Sprintf("%v", args[0])
-			messages = append(messages, text)
-			s.messages.Push(userKey, text)
-		}
-		return nil, nil
-	})
 
 	paramsThis := &interpreter.MapThis{M: paramValues}
 	mc := runtime.NewMovementsCollector("processor", uuid.Nil)
-	dslVars := s.buildDSLVars(opCtx, mc)
+	dslVars := s.buildDSLVarsWithMessages(opCtx, mc, &messages)
 	dslVars["Параметры"] = paramsThis
-	dslVars["Сообщить"] = msgFunc
-	dslVars["Message"] = msgFunc
 	interpreter.InjectMaket(dslVars, proc.Layout)
 	var err error
 	if timeout := s.operationTimeout(opProcessorRun); timeout > 0 {

--- a/internal/ui/offline.go
+++ b/internal/ui/offline.go
@@ -87,19 +87,10 @@ func RunProcessorOffline(ctx context.Context, proj *project.Project, db *storage
 		paramValues[p.Name] = parseParamValue(strParams[p.Name], p.Type)
 	}
 
-	msgFunc := interpreter.BuiltinFunc(func(args []any, _ string, _ int) (any, error) {
-		if len(args) > 0 {
-			messages = append(messages, fmt.Sprintf("%v", args[0]))
-		}
-		return nil, nil
-	})
-
 	paramsThis := &interpreter.MapThis{M: paramValues}
 	mc := runtime.NewMovementsCollector("processor", uuid.Nil)
-	dslVars := s.buildDSLVars(ctx, mc)
+	dslVars := s.buildDSLVarsWithMessages(ctx, mc, &messages)
 	dslVars["Параметры"] = paramsThis
-	dslVars["Сообщить"] = msgFunc
-	dslVars["Message"] = msgFunc
 	interpreter.InjectMaket(dslVars, proc.Layout)
 
 	runErr = s.interp.Run(procDecl, paramsThis, dslVars)

--- a/internal/ui/processor_layout_run_test.go
+++ b/internal/ui/processor_layout_run_test.go
@@ -120,3 +120,70 @@ func TestProcessorWithoutLayoutStillRuns(t *testing.T) {
 		t.Fatalf("ожидалось сообщение ok, получено %v", messages)
 	}
 }
+
+func TestRunProcessorOffline_ReturnsDocumentHookMessages(t *testing.T) {
+	procOS := `Процедура Выполнить()
+  Док = Документы.СообщениеХука.Создать();
+  Док.Номер = "1";
+  Ссылка = Док.Записать();
+  ЗагруженныйДокумент = Ссылка.ПолучитьОбъект();
+  ЗагруженныйДокумент.Провести();
+КонецПроцедуры
+`
+	dir := writeProcLayoutProject(t, procOS, false)
+	docDir := filepath.Join(dir, "documents")
+	if err := os.MkdirAll(docDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	docYAML := "name: СообщениеХука\nposting: true\nfields:\n  - name: Номер\n    type: string\n"
+	if err := os.WriteFile(filepath.Join(docDir, "сообщениехука.yaml"), []byte(docYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	onWriteOS := `Процедура ПриЗаписи()
+  Сообщить("из ПриЗаписи");
+КонецПроцедуры
+`
+	if err := os.WriteFile(filepath.Join(dir, "src", "сообщениехука.os"), []byte(onWriteOS), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	onPostOS := `Процедура ОбработкаПроведения()
+  Сообщить("из ОбработкиПроведения");
+КонецПроцедуры
+`
+	if err := os.WriteFile(filepath.Join(dir, "src", "сообщениехука.posting.os"), []byte(onPostOS), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(ctx, proj.Entities); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	messages, runErr, err := RunProcessorOffline(ctx, proj, db, "ЗагрузкаКурсов", nil, nil)
+	if err != nil {
+		t.Fatalf("RunProcessorOffline: %v", err)
+	}
+	if runErr != nil {
+		t.Fatalf("ошибка выполнения обработки: %v", runErr)
+	}
+	wantMessages := []string{"из ПриЗаписи", "из ПриЗаписи", "из ОбработкиПроведения"}
+	if len(messages) != len(wantMessages) {
+		t.Fatalf("сообщения обработки = %v, ожидались %v", messages, wantMessages)
+	}
+	for i, want := range wantMessages {
+		if messages[i] != want {
+			t.Fatalf("сообщения обработки = %v, ожидались %v", messages, wantMessages)
+		}
+	}
+}


### PR DESCRIPTION
## Что изменено

- collector сообщений текущего DSL-запуска передаётся через `Документы` в `docProxy` и `docWriter`;
- сообщения `ПриЗаписи` и `ОбработкаПроведения` добавляются в результат обработки, в том числе после `Ссылка.ПолучитьОбъект()`;
- offline, UI-обработки, managed-form fallback и регламентные задания используют общий путь сбора сообщений;
- добавлен e2e-тест `RunProcessorOffline` на запись, загрузку документа по ссылке и проведение.

## Проверки

- `go test -count=1 ./...`
- `go test -race ./internal/ui ./internal/scheduler -run '^(TestRunProcessorOffline_ReturnsDocumentHookMessages|TestRunProcessor_UsesVarsBuilder)$' -count=1`
- `go vet ./...`
- `go run ./tools/i18ncheck`
- `CGO_ENABLED=0 go build ./...`

Closes #465