### PR TITLE
fix(cli): передавать диалект БД в report/widget explain --sample (#473)

### DIFF
--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -12,6 +12,7 @@ import (
 	querylang "github.com/ivantit66/onebase/internal/query"
 	"github.com/ivantit66/onebase/internal/report"
 	"github.com/ivantit66/onebase/internal/scheduler"
+	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/widget"
 	"github.com/spf13/cobra"
 )
@@ -106,27 +107,37 @@ func runWidgetExplain(cmd *cobra.Command, args []string) error {
 	if len(params) > 0 {
 		out.Params = params
 	}
+	// Открываем БД заранее, если запрошен --sample: её диалект нужен и для
+	// исполнения виджета, и чтобы показанный SQL совпадал с фактическим (иначе
+	// на SQLite генерятся Postgres-плейсхолдеры $N::text). См. issue #473.
+	sample, _ := cmd.Flags().GetInt("sample")
+	var db *storage.DB
+	if sample > 0 {
+		db, err = bc.OpenDB(context.Background())
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+	}
 	if strings.TrimSpace(w.Query) != "" {
-		compiled, err := querylang.Compile(w.Query, querylang.CompileOpts{
+		opts := querylang.CompileOpts{
 			Params:      params,
 			Entities:    proj.Entities,
 			Registers:   proj.Registers,
 			InfoRegs:    proj.InfoRegisters,
 			AccountRegs: proj.AccountRegisters,
-		})
+		}
+		if db != nil {
+			opts.Dialect = db.Dialect()
+		}
+		compiled, err := querylang.Compile(w.Query, opts)
 		if err != nil {
 			out.Error = "compile: " + err.Error()
 		} else {
 			out.SQL, out.Args, out.Sources = compiled.SQL, compiled.Args, toQuerySourceOutput(compiled.Sources)
 		}
 	}
-	sample, _ := cmd.Flags().GetInt("sample")
 	if sample > 0 {
-		db, err := bc.OpenDB(context.Background())
-		if err != nil {
-			return err
-		}
-		defer db.Close()
 		reg := buildRuntimeRegistry(proj)
 		res := widget.New(reg, db).Run(context.Background(), w)
 		if res.Error != "" {
@@ -179,24 +190,34 @@ func runReportExplain(cmd *cobra.Command, args []string) error {
 		out.Variants = append(out.Variants, v.Name)
 	}
 	if strings.TrimSpace(rep.Query) != "" {
-		compiled, err := querylang.Compile(rep.Query, querylang.CompileOpts{
+		// При --sample открываем БД до компиляции: без её диалекта компилятор
+		// генерит Postgres-плейсхолдеры $N::text, и исполнение на SQLite падает
+		// с «missing named argument». См. issue #473.
+		sample, _ := cmd.Flags().GetInt("sample")
+		var db *storage.DB
+		if sample > 0 {
+			db, err = bc.OpenDB(context.Background())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+		}
+		opts := querylang.CompileOpts{
 			Params:      params,
 			Entities:    proj.Entities,
 			Registers:   proj.Registers,
 			InfoRegs:    proj.InfoRegisters,
 			AccountRegs: proj.AccountRegisters,
-		})
+		}
+		if db != nil {
+			opts.Dialect = db.Dialect()
+		}
+		compiled, err := querylang.Compile(rep.Query, opts)
 		if err != nil {
 			out.Error = "compile: " + err.Error()
 		} else {
 			out.SQL, out.Args, out.Sources = compiled.SQL, compiled.Args, toQuerySourceOutput(compiled.Sources)
-			sample, _ := cmd.Flags().GetInt("sample")
 			if sample > 0 {
-				db, err := bc.OpenDB(context.Background())
-				if err != nil {
-					return err
-				}
-				defer db.Close()
 				rows, cols, err := db.RunQuery(context.Background(), "SELECT * FROM ("+compiled.SQL+") _onebase_r LIMIT "+fmt.Sprint(sample), compiled.Args)
 				if err != nil {
 					out.Error = "execute: " + err.Error()

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestReportExplainSampleSQLiteWithParams — регрессия на issue #473:
+// `report explain --sample N` с переданными значениями параметров на SQLite
+// падал «missing named argument "1::text"», потому что запрос компилировался
+// без диалекта открытой БД (генерились Postgres-плейсхолдеры $N::text).
+func TestReportExplainSampleSQLiteWithParams(t *testing.T) {
+	projectDir := t.TempDir()
+	writeProcrunFixture(t, projectDir, "config/app.yaml", "name: explain-test\nversion: \"1.0\"\n")
+	writeProcrunFixture(t, projectDir, "catalogs/Товар.yaml", "name: Товар\nfields:\n  - name: Наименование\n    type: string\n")
+	writeProcrunFixture(t, projectDir, "reports/ПоТовару.yaml", `name: ПоТовару
+title: По товару
+params:
+  - name: Имя
+    type: string
+    label: "Имя"
+query: |
+  ВЫБРАТЬ Наименование
+  ИЗ Справочник.Товар
+  ГДЕ (&Имя ЕСТЬ ПУСТО ИЛИ Наименование = &Имя)
+`)
+
+	dbPath := filepath.Join(t.TempDir(), "explain.db")
+
+	// Схема БД.
+	migrate := &cobra.Command{}
+	addBaseFlags(migrate)
+	if err := migrate.Flags().Set("project", projectDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := migrate.Flags().Set("sqlite", dbPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := runMigrate(migrate, nil); err != nil {
+		t.Fatalf("runMigrate: %v", err)
+	}
+
+	// report explain --sample с переданным значением параметра.
+	cmd := &cobra.Command{}
+	addBaseFlags(cmd)
+	cmd.Flags().Int("sample", 0, "")
+	cmd.Flags().String("params", "", "")
+	cmd.Flags().Bool("json", false, "")
+	for k, v := range map[string]string{
+		"project": projectDir,
+		"sqlite":  dbPath,
+		"sample":  "5",
+		"params":  `{"Имя":"Молоко"}`,
+	} {
+		if err := cmd.Flags().Set(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runReportExplain(cmd, []string{"ПоТовару"})
+	})
+	if err != nil {
+		t.Fatalf("runReportExplain: %v", err)
+	}
+
+	if strings.Contains(out, "missing named argument") {
+		t.Fatalf("исполнение --sample на SQLite снова упало:\n%s", out)
+	}
+	if strings.Contains(out, "$1::text") {
+		t.Fatalf("SQL содержит Postgres-плейсхолдеры вместо SQLite-диалекта:\n%s", out)
+	}
+	if strings.Contains(out, "Ошибка:") {
+		t.Fatalf("explain вернул ошибку:\n%s", out)
+	}
+}


### PR DESCRIPTION
Закрывает #473.

## Проблема

`onebase report explain <Имя> --sample N` и `onebase widget explain <Имя> --sample N` на **SQLite** падали с ошибкой `execute: run query: missing named argument "1::text"`, если отчёту/виджету **передано значение параметра**. При пустых/NULL-параметрах `--sample` работал (компилятор инлайнит литерал `NULL`, плейсхолдеров нет).

## Первопричина

`internal/cli/explain.go` компилировал запрос без указания диалекта БД. По умолчанию `CompileOpts.Dialect == nil` трактуется как PostgreSQL → генерились плейсхолдеры `$N::text`. При `--sample` этот SQL исполнялся на фактической SQLite-БД, и драйвер разбирал `$1::text` как **именованный** параметр с именем `1::text`, которого нет в аргументах. Команда `onebase query` корректна, потому что передаёт `Dialect: db.Dialect()`.

## Фикс

В обеих explain-функциях БД при `--sample` открывается **до** компиляции, и её диалект передаётся в `CompileOpts.Dialect`:

- `report explain` — SQL теперь исполняется с SQLite-плейсхолдерами `?` вместо `$N::text`, ошибки нет;
- `widget explain` — показанный SQL приведён к диалекту БД, совпадает с фактически исполняемым (исполнение виджета и раньше шло через `widget.Run` с диалектом).

PostgreSQL не затронут — `$N` его родной синтаксис. Правка применена симметрично к обоим explain.

## Проверка

Репро из issue после фикса — SQL с `?`-плейсхолдерами, без ошибки:

```
onebase report explain СделкиПоМенеджерам --project examples/crm --sqlite /tmp/crm.db \
  --params '{"Начало":"2020-01-01","Конец":"2030-01-01"}' --sample 5
# SQL: ... WHERE(? IS NULL OR period >= ?) AND(? IS NULL OR period <= ?) ...
```

Добавлен регресс-тест `TestReportExplainSampleSQLiteWithParams` (SQLite + переданное значение параметра). `go test ./internal/cli/` — зелёный.

Generated-with: Claude Code