### PR TITLE
fix(api): FK-нарушение по несуществующей ссылке даёт 422, а не сырой 500 (#475)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -289,7 +289,7 @@ func (h *handler) createObject(kind metadata.Kind) http.HandlerFunc {
 			Action:        body.Action,
 		})
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			writeSaveError(w, err)
 			return
 		}
 		if result.DSLError != "" {
@@ -431,11 +431,7 @@ func (h *handler) updateObject(kind metadata.Kind) http.HandlerFunc {
 			ExpectedVersion: expectedVersion,
 		})
 		if err != nil {
-			if errors.Is(err, storage.ErrVersionConflict) {
-				writeError(w, http.StatusConflict, "version conflict: object was modified by another client", "", 0)
-				return
-			}
-			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			writeSaveError(w, err)
 			return
 		}
 		if result.DSLError != "" {
@@ -574,7 +570,7 @@ func (h *handler) postDocument() http.HandlerFunc {
 			Action:        "post",
 		})
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+			writeSaveError(w, err)
 			return
 		}
 		if result.DSLError != "" {
@@ -758,6 +754,22 @@ func writeError(w http.ResponseWriter, code int, msg, file string, line int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(errorResponse{Error: msg, File: file, Line: line})
+}
+
+// writeSaveError отдаёт структурированную HTTP-ошибку для неуспешного
+// entitySvc.Save, маппя известные ошибки storage в точные коды статуса:
+// конфликт версий → 409, нарушение внешнего ключа (ссылка на несуществующий
+// объект) → 422. Прочее — 500 с текстом ошибки, как прежде. Общий для v1 и v2
+// REST, чтобы сырой текст драйвера БД не утекал в ответ по create/update/post.
+func writeSaveError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, storage.ErrVersionConflict):
+		writeError(w, http.StatusConflict, "version conflict: object was modified by another client", "", 0)
+	case errors.Is(err, storage.ErrForeignKeyViolation):
+		writeError(w, http.StatusUnprocessableEntity, "ссылка на несуществующий объект", "", 0)
+	default:
+		writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+	}
 }
 
 func capitalize(s string) string {

--- a/internal/api/v2.go
+++ b/internal/api/v2.go
@@ -559,11 +559,7 @@ func ensureDocumentNumber(ctx context.Context, store *storage.DB, entity *metada
 
 func writeSaveResultV2(w http.ResponseWriter, result entityservice.SaveResult, err error, id uuid.UUID, posted bool) {
 	if err != nil {
-		if errors.Is(err, storage.ErrVersionConflict) {
-			writeError(w, http.StatusConflict, "version conflict: object was modified by another client", "", 0)
-			return
-		}
-		writeError(w, http.StatusInternalServerError, err.Error(), "", 0)
+		writeSaveError(w, err)
 		return
 	}
 	if result.DSLError != "" {

--- a/internal/storage/constraint_errors.go
+++ b/internal/storage/constraint_errors.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	sqlite "modernc.org/sqlite"
+)
+
+// ErrForeignKeyViolation возвращается из путей записи (upsert), когда драйвер БД
+// отклонил INSERT/UPDATE из-за нарушения внешнего ключа — например, поле-ссылка
+// указывает на UUID, которого нет в целевой таблице.
+//
+// Нарушение распознаётся по коду ошибки драйвера, а не по тексту:
+//   - SQLite (modernc.org/sqlite): расширенный код 787
+//     (SQLITE_CONSTRAINT_FOREIGNKEY);
+//   - PostgreSQL (pgconn): SQLSTATE 23503 (foreign_key_violation).
+//
+// Вызывающий HTTP-код перехватывает через errors.Is и отдаёт структурированный
+// 422 вместо сырого 500 с текстом драйвера. Ср. ErrVersionConflict.
+var ErrForeignKeyViolation = errors.New("storage: нарушение внешнего ключа (ссылка на несуществующий объект)")
+
+// sqliteConstraintForeignKey — расширенный result-код SQLite для нарушения FK
+// (SQLITE_CONSTRAINT | (3<<8)). modernc.org/sqlite отдаёт именно расширенный код.
+const sqliteConstraintForeignKey = 787
+
+// pgForeignKeyViolation — SQLSTATE PostgreSQL для foreign_key_violation.
+const pgForeignKeyViolation = "23503"
+
+// classifyConstraintErr оборачивает ошибку драйвера в типизированную
+// ErrForeignKeyViolation, если это нарушение внешнего ключа. Остальные ошибки
+// (включая другие нарушения ограничений) возвращаются без изменений — их текст
+// не утекает в API-ответ по этому пути.
+func classifyConstraintErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var sqErr *sqlite.Error
+	if errors.As(err, &sqErr) && sqErr.Code() == sqliteConstraintForeignKey {
+		return fmt.Errorf("%w: %v", ErrForeignKeyViolation, err)
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgForeignKeyViolation {
+		return fmt.Errorf("%w: %v", ErrForeignKeyViolation, err)
+	}
+	return err
+}

--- a/internal/storage/constraint_errors_test.go
+++ b/internal/storage/constraint_errors_test.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// TestUpsert_ForeignKeyViolation: запись справочника с reference-полем, которое
+// указывает на несуществующий UUID, должна вернуть ErrForeignKeyViolation
+// (а не сырую ошибку драйвера), чтобы REST-слой смог отдать 422 вместо 500.
+func TestUpsert_ForeignKeyViolation(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	org := &metadata.Entity{
+		Name:   "Организация",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	client := &metadata.Entity{
+		Name: "Контрагент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Организация", Type: "reference:Организация", RefEntity: "Организация"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{org, client}); err != nil {
+		t.Fatal(err)
+	}
+
+	// UUID синтаксически валиден, но такой организации нет.
+	err = db.Upsert(ctx, "Контрагент", uuid.New(), map[string]any{
+		"Наименование": "ООО Ромашка",
+		"Организация":  "00000000-0000-0000-0000-000000000000",
+	}, client)
+	if err == nil {
+		t.Fatal("ожидали ошибку нарушения внешнего ключа, получили nil")
+	}
+	if !errors.Is(err, ErrForeignKeyViolation) {
+		t.Fatalf("ошибка = %v, не оборачивает ErrForeignKeyViolation", err)
+	}
+}
+
+// TestUpsert_NoFalsePositive: успешная запись с валидной ссылкой не должна
+// классифицироваться как нарушение FK, а прочие ошибки — не подменяться.
+func TestUpsert_ForeignKeyValidRef(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	org := &metadata.Entity{
+		Name:   "Организация",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	client := &metadata.Entity{
+		Name: "Контрагент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Организация", Type: "reference:Организация", RefEntity: "Организация"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{org, client}); err != nil {
+		t.Fatal(err)
+	}
+
+	orgID := uuid.New()
+	if err := db.Upsert(ctx, "Организация", orgID, map[string]any{"Наименование": "Головная"}, org); err != nil {
+		t.Fatalf("создать организацию: %v", err)
+	}
+	if err := db.Upsert(ctx, "Контрагент", uuid.New(), map[string]any{
+		"Наименование": "ООО Ромашка",
+		"Организация":  orgID.String(),
+	}, client); err != nil {
+		t.Fatalf("запись с валидной ссылкой не должна падать: %v", err)
+	}
+}

--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -153,7 +153,7 @@ func (db *DB) upsert(ctx context.Context, entityName string, id uuid.UUID, field
 			table, strings.Join(cols, ", "), strings.Join(placeholders, ", "), strings.Join(updates, ", "))
 	}
 	if err := db.exec(ctx, sql, args...); err != nil {
-		return fmt.Errorf("upsert %s: %w", entityName, err)
+		return fmt.Errorf("upsert %s: %w", entityName, classifyConstraintErr(err))
 	}
 
 	// Audit (best-effort, non-blocking)

--- a/internal/storage/optimistic_lock.go
+++ b/internal/storage/optimistic_lock.go
@@ -99,7 +99,7 @@ func (db *DB) UpsertVersioned(ctx context.Context, entityName string, id uuid.UU
 		table, strings.Join(sets, ", "), idPH, versionPH)
 	tag, err := db.Exec(ctx, sql, args...)
 	if err != nil {
-		return fmt.Errorf("upsert versioned %s: %w", entityName, err)
+		return fmt.Errorf("upsert versioned %s: %w", entityName, classifyConstraintErr(err))
 	}
 	if tag.RowsAffected != 1 {
 		return ErrVersionConflict


### PR DESCRIPTION
Закрывает #475.

## Проблема

`POST /api/v2/catalog/<Справочник>` (и v1 create/update/post) при синтаксически
валидном, но несуществующем reference-UUID отдавал **HTTP 500** с сырым текстом
драйвера SQLite:

```json
{"error":"upsert <Справочник>: constraint failed: FOREIGN KEY constraint failed (787)"}
```

Внутренняя ошибка целостности БД утекала в ответ API как есть; `writeSaveResultV2`
различал только `ErrVersionConflict`, всё остальное шло в 500 с `err.Error()`.

## Фикс (минимальный, по форме уже существующего `ErrVersionConflict`)

- **`internal/storage/constraint_errors.go`** — типизированная
  `ErrForeignKeyViolation` + `classifyConstraintErr`, распознающая нарушение FK
  по **коду драйвера**, а не по тексту: расширенный код SQLite `787`
  (`SQLITE_CONSTRAINT_FOREIGNKEY`, modernc.org/sqlite) и SQLSTATE PostgreSQL
  `23503` (`foreign_key_violation`).
- Пути записи `upsert()` и `UpsertVersioned()` оборачивают ошибку через
  `classifyConstraintErr`.
- Общий helper `writeSaveError` (api) маппит `ErrForeignKeyViolation` → **422**
  «ссылка на несуществующий объект», `ErrVersionConflict` → 409; применён в v1
  (create/update/post) и v2 REST. Прочие ошибки — прежний 500.

FK-ограничение и инвариант «insert перед хуком» для нового объекта **не тронуты**
(как и просили в issue — второй пункт про перехват в DSL сюда не входит).

## Проверка

Юнит-тесты `TestUpsert_ForeignKeyViolation` / `TestUpsert_ForeignKeyValidRef`
(SQLite, реальный FK) — зелёные; `go test ./internal/api ./internal/storage` — ок.

Живьём на `examples/crm` (справочник `Клиент`, поле `Ответственный` →
`reference:Сотрудник`):

```
POST /api/v2/catalog/Клиент {"Наименование":"ТестФК","Ответственный":"00000000-0000-0000-0000-000000000000"}
→ HTTP 422  {"error":"ссылка на несуществующий объект"}

POST /api/v2/catalog/Клиент {"Наименование":"ТестОК"}
→ HTTP 200  {"data":{"id":"…"}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
