### PR TITLE
fix(dsl): sibling-резолв в .proc.os по файлу вызова (#477)

### DIFF
--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -707,10 +707,13 @@ func (i *Interpreter) evalCall(c *ast.CallExpr, e *env) any {
 				return i.callUserProc(proc, e, args)
 			}
 		}
-		// Помощник из того же файла (.proc.os / .posting.os / .rep.os),
-		// см.
-		if i.LookupSiblingProc != nil && e.ec.curFile != "" {
-			if proc := i.LookupSiblingProc(e.ec.curFile, fnName); proc != nil {
+		// Помощник из того же файла (.proc.os / .posting.os / .rep.os).
+		// Файл берём из токена самого вызова (callee.Tok.File), а не из
+		// e.ec.curFile: curFile — «последняя исполненная позиция» и портится
+		// вычислением аргументов, если среди них есть вызов из другого модуля
+		// (тогда sibling-резолв искал бы в чужом файле → unknown function).
+		if i.LookupSiblingProc != nil && callee.Tok.File != "" {
+			if proc := i.LookupSiblingProc(callee.Tok.File, fnName); proc != nil {
 				return i.callUserProc(proc, e, args)
 			}
 		}

--- a/internal/dsl/interpreter/interpreter_test.go
+++ b/internal/dsl/interpreter/interpreter_test.go
@@ -1,6 +1,7 @@
 package interpreter_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -323,5 +324,62 @@ func TestInterpreter_SiblingProcScopedByFile(t *testing.T) {
 	obj := runtime.NewObject("X", metadata.KindDocument)
 	if err := interp.Run(main, obj); err == nil {
 		t.Fatal("ожидалась ошибка: чужой файл не должен резолвиться")
+	}
+}
+
+// #477: вызов локального помощника proc-файла, в аргументе которого — вызов
+// функции из другого модуля. Вычисление аргумента уводит e.ec.curFile в чужой
+// файл; sibling-резолв должен опираться на файл самого вызова (callee.Tok.File),
+// иначе помощник не находится → «unknown function».
+func TestInterpreter_SiblingResolutionWithCrossModuleArg(t *testing.T) {
+	// Функция из другого модуля (резолвится через LookupProc).
+	modProg, err := parser.New(lexer.New(
+		"Функция УдвоитьМод(Х)\n  Возврат Х * 2;\nКонецФункции",
+		"хелперы.module.os")).ParseProgram()
+	if err != nil {
+		t.Fatalf("parse module: %v", err)
+	}
+	dbl := modProg.Procedures[0]
+
+	// proc-файл: Главная зовёт локальную Обёртку, а в её аргументе — УдвоитьМод.
+	mainProg, err := parser.New(lexer.New(
+		"Процедура Главная()\n  ЭтотОбъект.Результат = Обёртка(УдвоитьМод(21));\nКонецПроцедуры\n\n"+
+			"Функция Обёртка(Значение)\n  Возврат Значение + 1;\nКонецФункции",
+		"test.proc.os")).ParseProgram()
+	if err != nil {
+		t.Fatalf("parse main: %v", err)
+	}
+	var main, wrap *ast.ProcedureDecl
+	for _, pr := range mainProg.Procedures {
+		switch {
+		case strings.EqualFold(pr.Name.Literal, "Главная"):
+			main = pr
+		case strings.EqualFold(pr.Name.Literal, "Обёртка"):
+			wrap = pr
+		}
+	}
+	if main == nil || wrap == nil {
+		t.Fatal("процедуры не нашлись")
+	}
+
+	interp := interpreter.New()
+	interp.LookupProc = func(name string) *ast.ProcedureDecl {
+		if strings.EqualFold(name, "УдвоитьМод") {
+			return dbl
+		}
+		return nil
+	}
+	interp.LookupSiblingProc = func(file, name string) *ast.ProcedureDecl {
+		if file == "test.proc.os" && strings.EqualFold(name, "Обёртка") {
+			return wrap
+		}
+		return nil
+	}
+	obj := runtime.NewObject("X", metadata.KindDocument)
+	if err := interp.Run(main, obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := obj.Get("Результат"); fmt.Sprintf("%v", got) != "43" {
+		t.Errorf("expected Результат=43, got %v (%T)", got, got)
 	}
 }


### PR DESCRIPTION
## Что и почему

Вызов **локальной** функции/процедуры `.proc.os` (`.posting.os`, `.rep.os`) падал с `unknown function`, если в её аргументе был вызов функции из **другого модуля**.

Причина: аргументы вычисляются до резолва вызываемого. Межмодульный вызов в аргументе через `callUserProc` уводил `e.ec.curFile` в чужой файл и не возвращал его, а sibling-резолв использовал именно `e.ec.curFile` → искал помощника не в том файле.

## Фикс

`internal/dsl/interpreter/interpreter.go`: резолвим sibling по `callee.Tok.File` — файлу, где синтаксически стоит вызов. Он не зависит от вычисления аргументов.

```go
-  if i.LookupSiblingProc != nil && e.ec.curFile != "" {
-    if proc := i.LookupSiblingProc(e.ec.curFile, fnName); proc != nil {
+  if i.LookupSiblingProc != nil && callee.Tok.File != "" {
+    if proc := i.LookupSiblingProc(callee.Tok.File, fnName); proc != nil {
```

## Тест

`TestInterpreter_SiblingResolutionWithCrossModuleArg` (Главная → `Обёртка(УдвоитьМод(21))`, где `Обёртка` — локальная, `УдвоитьМод` — из модуля):
- без фикса: `unknown function "Обёртка"`;
- с фиксом: `Результат = 43`.

## Проверка

- `go test ./internal/dsl/interpreter/` — зелёный, регрессий нет; `go vet` чист.
- Строгая проверка: временный откат фикса → тест краснеет (`unknown function`), возврат → зелёный.
- End-to-end: пересобранный `onebase`, автономный репро (`Обёртка(УдвоитьМод(...))`) — было `unknown function`, стало `Результат: 43`.

Fixes #477