### PR TITLE
feat(ui): заголовок вкладки = представление записи (#481)

### DIFF
--- a/internal/ui/handlers_managed.go
+++ b/internal/ui/handlers_managed.go
@@ -41,6 +41,15 @@ func pickManagedForm(entity *metadata.Entity, kind string) *metadata.FormModule 
 // .form.yaml продолжает работать существующая авто-форма без изменений.
 func (s *Server) renderEntityForm(w http.ResponseWriter, r *http.Request, kind string, data map[string]any) {
 	entity, _ := data["Entity"].(*metadata.Entity)
+	// #481: заголовок вкладки/карточки = представление записи (Наименование…),
+	// а не имя сущности. Для существующей записи кладём TabTitle (его читает
+	// ui.js и шлёт оболочке obSetTitle) и RecordTitle (для заголовка h1).
+	if isNew, _ := data["IsNew"].(bool); !isNew {
+		if title := recordCardTitle(entity, data["Values"]); title != "" {
+			data["TabTitle"] = title
+			data["RecordTitle"] = title
+		}
+	}
 	managed := pickManagedForm(entity, kind)
 	if managed != nil {
 		data["Form"] = managed
@@ -116,4 +125,27 @@ func appendManagedFormWarnings(existing any, warnings []string) []string {
 	out, _ := existing.([]string)
 	out = append(out, warnings...)
 	return out
+}
+
+// recordCardTitle возвращает представление записи для заголовка карточки/вкладки:
+// значение поля-представления (Наименование→Description→Имя→Name→Номер→первый
+// строковый — как aiRefLookupField) из Values. "" — если поля нет или пусто
+// (напр. новая запись). Используется для #481.
+func recordCardTitle(entity *metadata.Entity, values any) string {
+	if entity == nil {
+		return ""
+	}
+	field := aiRefLookupField(entity)
+	if field == "" {
+		return ""
+	}
+	switch m := values.(type) {
+	case map[string]string:
+		return strings.TrimSpace(m[field])
+	case map[string]any:
+		if s, ok := m[field].(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
 }

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -3,6 +3,23 @@
 window.__obEmbedded = window.self !== window.top;
 if (window.__obEmbedded) {
   document.documentElement.className += ' ob-embedded';
+  // #481: заголовок вкладки = представление записи. Сервер рендерит на карточке
+  // существующей записи <meta name="ob-tab-title">; сообщаем его оболочке
+  // (приёмник obSetTitle в tabs.go). ui.js подключён в <head>, поэтому читаем
+  // мету после готовности DOM.
+  (function () {
+    function sendTabTitle() {
+      try {
+        var mt = document.querySelector('meta[name="ob-tab-title"]');
+        var tt = mt && mt.getAttribute('content');
+        if (tt && window.parent && window.parent !== window) {
+          window.parent.postMessage({ source: 'obSetTitle', title: tt }, window.location.origin);
+        }
+      } catch (_) {}
+    }
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', sendTabTitle);
+    else sendTabTitle();
+  })();
   // Фаза 2: открытие записи/новой формы/отчёта внутри вкладки — это новая
   // вкладка рядом, а не замена текущей (пагинация/сортировка/фильтры остаются
   // в той же вкладке — у них тот же путь списка, без id-сегмента).

--- a/internal/ui/tab_title_test.go
+++ b/internal/ui/tab_title_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// #481: представление записи для заголовка вкладки/карточки.
+func TestRecordCardTitle(t *testing.T) {
+	catalog := &metadata.Entity{
+		Name: "Клиенты",
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Комментарий", Type: metadata.FieldTypeString},
+		},
+	}
+	document := &metadata.Entity{
+		Name: "Продажа",
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Комментарий", Type: metadata.FieldTypeString},
+		},
+	}
+
+	cases := []struct {
+		name   string
+		entity *metadata.Entity
+		values any
+		want   string
+	}{
+		{"каталог по Наименованию", catalog, map[string]string{"Наименование": "ООО Ромашка"}, "ООО Ромашка"},
+		{"обрезка пробелов", catalog, map[string]string{"Наименование": "  ООО Ромашка  "}, "ООО Ромашка"},
+		{"пустое Наименование → пусто", catalog, map[string]string{"Наименование": "   "}, ""},
+		{"документ без Наименования → Номер", document, map[string]string{"Номер": "000000123"}, "000000123"},
+		{"values как map[string]any", catalog, map[string]any{"Наименование": "Иванов И.И."}, "Иванов И.И."},
+		{"nil entity → пусто", nil, map[string]string{"Наименование": "x"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := recordCardTitle(c.entity, c.values); got != c.want {
+				t.Errorf("recordCardTitle = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// #481: карточка существующей записи через реальный обработчик формы отдаёт
+// <meta name="ob-tab-title"> с представлением записи, а h1 показывает его
+// вместо «Редактировать — <Сущность>».
+func TestManagedForm_TabTitleMetaFromRecord(t *testing.T) {
+	srv, ent, id := setupDeleteActionServer(t) // запись с Наименование="X"
+	body := renderObjectFormGET(t, srv, ent, id)
+
+	if !strings.Contains(body, `<meta name="ob-tab-title" content="X">`) {
+		t.Errorf("нет <meta ob-tab-title content=\"X\"> на карточке записи")
+	}
+	if strings.Contains(body, "Редактировать —") {
+		t.Errorf("h1 карточки всё ещё «Редактировать — <Сущность>», а не представление записи")
+	}
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1322,9 +1322,10 @@ const tplList = `
 const tplForm = `
 {{define "page-form"}}
 {{template "head" .}}{{if not .IsPopup}}{{template "nav" .}}{{end}}
+{{if .TabTitle}}<meta name="ob-tab-title" content="{{.TabTitle}}">{{end}}
 <main>
 <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;max-width:1400px">
-  <h2 style="margin-bottom:0">{{if .IsNew}}{{t $.Lang "Создать"}}{{else}}{{t $.Lang "Редактировать"}}{{end}} — {{.Entity.DisplayName $.Lang}}</h2>
+  <h2 style="margin-bottom:0">{{if .IsNew}}{{t $.Lang "Создать"}} — {{.Entity.DisplayName $.Lang}}{{else}}{{if .RecordTitle}}{{.RecordTitle}}{{else}}{{t $.Lang "Редактировать"}} — {{.Entity.DisplayName $.Lang}}{{end}}{{end}}</h2>
   {{if .IsPopup}}
   <a href="#" data-ob-popup-cancel title="{{t $.Lang "Закрыть"}}" style="font-size:22px;line-height:1;color:#94a3b8;text-decoration:none;padding:2px 8px;border-radius:5px;background:#f1f5f9;font-weight:300">×</a>
   {{else}}

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -359,6 +359,7 @@ const tplManagedForm = `
 
 {{define "page-managed-form"}}
 {{template "head" .}}{{if not .IsPopup}}{{template "nav" .}}{{end}}
+{{if .TabTitle}}<meta name="ob-tab-title" content="{{.TabTitle}}">{{end}}
 <style>
 .managed-group-horizontal>.managed-group-body{display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start}
 .managed-group-horizontal>.managed-group-body>.form-group{flex:1 1 220px;min-width:180px;margin-bottom:0}
@@ -389,7 +390,7 @@ const tplManagedForm = `
 <main>
 <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;max-width:1400px">
   <h2 style="margin-bottom:0">
-    {{if .IsProcessor}}{{.Processor.DisplayName $.Lang}}{{else}}{{if .IsNew}}{{t $.Lang "Создать"}}{{else}}{{t $.Lang "Редактировать"}}{{end}} — {{.Entity.DisplayName $.Lang}}{{end}}
+    {{if .IsProcessor}}{{.Processor.DisplayName $.Lang}}{{else}}{{if .IsNew}}{{t $.Lang "Создать"}} — {{.Entity.DisplayName $.Lang}}{{else}}{{if .RecordTitle}}{{.RecordTitle}}{{else}}{{t $.Lang "Редактировать"}} — {{.Entity.DisplayName $.Lang}}{{end}}{{end}}{{end}}
     <span style="font-size:11px;color:#10b981;background:#d1fae5;padding:2px 8px;border-radius:10px;vertical-align:middle;font-weight:500" title="Управляемая форма из forms/{{if .IsProcessor}}{{lower .Processor.Name}}{{else}}{{lower .Entity.Name}}{{end}}/">◇ managed</span>
   </h2>
   {{if .IsPopup}}


### PR DESCRIPTION
## Что и почему

Issue #481: при открытии карточки элемента заголовок вкладки (и `<h1>` карточки) показывал имя **сущности** («Редактировать — Клиенты»), а не *представление записи*. Просьба — как в 1С показывать Наименование записи.

## Реализация

Механизм обновления заголовка вкладки уже был наполовину: приёмник `obSetTitle` в `internal/ui/tabs.go` существовал, но **отправителя не было**. Добавил недостающее и источник представления:

- **`renderEntityForm`** (единая точка рендера формы объекта — покрывает managed и autogen): для существующей записи кладёт `TabTitle`/`RecordTitle` из значения поля-представления.
- **`recordCardTitle`** выбирает поле-представление через существующий `aiRefLookupField` (`Наименование → Description → Имя → Name → Номер → первый строковый`) и берёт значение из `Values`. С nil-guard.
- **Шаблоны** `page-managed-form` и `page-form`: рендерят `<meta name="ob-tab-title" content="…">`, а `<h1>` для существующей записи показывает представление (для новой — «Создать — <Сущность>»).
- **`ui.js`** (embedded-блок): после готовности DOM читает мету и шлёт оболочке `postMessage({source:'obSetTitle', …})`. Внешний скрипт → CSP-safe, инлайна не добавляю.

Представление для документов (нет Наименования) → Номер. `«Номер от Дата»` можно добавить отдельно, если нужно.

## Проверка

- `TestRecordCardTitle` — выбор поля-представления, обрезка, пустое→"", документ→Номер, nil-guard (поймал реальный panic в `aiRefLookupField(nil)`).
- `TestManagedForm_TabTitleMetaFromRecord` — через **реальный обработчик** `formEdit`→`renderEntityForm`: карточка записи отдаёт `<meta ob-tab-title content="X">` и h1 без «Редактировать —».
- `go test ./internal/ui/` и `go vet ./internal/ui/` — зелёные; сервер поднимал на копии БД, отдаваемый `/static/ui.js` содержит новый код.

Fixes #481