### PR TITLE
fix(storage): дата загруженного объекта (ПолучитьОбъект) — time.Time, а не строка

### DIFF
--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -279,10 +279,33 @@ func normalizeNumber(v any) any {
 }
 
 // normalizeFieldValue нормализует значение с учётом типа поля. Числовые поля
-// всегда возвращаются как decimal.Decimal — единая точность на PG и SQLite.
+// всегда возвращаются как decimal.Decimal, поля-даты — как time.Time — единая
+// типизация на PG и SQLite.
 func normalizeFieldValue(f metadata.Field, v any) any {
 	if f.Type == metadata.FieldTypeNumber {
 		return normalizeNumber(v)
+	}
+	if f.Type == metadata.FieldTypeDate {
+		return normalizeDate(v)
+	}
+	return normalizeValue(v)
+}
+
+// normalizeDate приводит значение поля-даты к time.Time. На PostgreSQL драйвер
+// уже отдаёт time.Time; на SQLite дата хранится строкой (RFC3339), и без
+// приведения загруженный объект (Ссылка.ПолучитьОбъект) нёс бы Дату строкой —
+// в отличие от свежесозданного (Создать), у которого это time.Time. Из-за
+// этого арифметика дат (КонецДня, Дата + Число) и сравнения в проведении
+// перезаписанного документа молча ломались. Нераспознанную строку и nil
+// оставляем как есть (безопасный откат к прежнему поведению).
+func normalizeDate(v any) any {
+	switch t := v.(type) {
+	case time.Time:
+		return t
+	case string:
+		if parsed, ok := ParseRegPeriod(t); ok {
+			return parsed
+		}
 	}
 	return normalizeValue(v)
 }

--- a/internal/storage/normalize_date_test.go
+++ b/internal/storage/normalize_date_test.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// normalizeDate приводит дату-строку из SQLite к time.Time; так загруженный
+// объект (Ссылка.ПолучитьОбъект) несёт настоящую Дату, как и свежесозданный.
+func TestNormalizeDate(t *testing.T) {
+	// RFC3339 (формат хранения даты в SQLite, см. bindFieldArg) → time.Time.
+	got := normalizeDate("2026-02-20T00:00:00Z")
+	tt, ok := got.(time.Time)
+	if !ok {
+		t.Fatalf("RFC3339-строка должна стать time.Time, получено %T", got)
+	}
+	if tt.Year() != 2026 || tt.Month() != time.February || tt.Day() != 20 {
+		t.Fatalf("разобранная дата = %v, ожидалось 2026-02-20", tt)
+	}
+
+	// Уже time.Time (PostgreSQL) — пропускаем без изменений.
+	src := time.Date(2025, 3, 4, 5, 6, 7, 0, time.UTC)
+	if got := normalizeDate(src); !got.(time.Time).Equal(src) {
+		t.Fatalf("time.Time должен пройти без изменений, получено %v", got)
+	}
+
+	// nil остаётся nil.
+	if got := normalizeDate(nil); got != nil {
+		t.Fatalf("nil должен остаться nil, получено %v", got)
+	}
+
+	// Нераспознанная строка возвращается как есть (безопасный откат).
+	if got := normalizeDate("не дата"); got != "не дата" {
+		t.Fatalf("нераспознанная строка должна вернуться как есть, получено %v", got)
+	}
+}
+
+// normalizeFieldValue для поля-даты даёт time.Time, для числа — decimal.
+func TestNormalizeFieldValue_Date(t *testing.T) {
+	dateField := metadata.Field{Name: "Дата", Type: metadata.FieldTypeDate}
+	got := normalizeFieldValue(dateField, "2026-01-15T00:00:00Z")
+	if _, ok := got.(time.Time); !ok {
+		t.Fatalf("поле-дата должно нормализоваться в time.Time, получено %T", got)
+	}
+}

--- a/internal/ui/reload_date_test.go
+++ b/internal/ui/reload_date_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/project"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Ссылка.ПолучитьОбъект() у записанного документа должен нести поле-дату как
+// настоящую Дату (time.Time), а не строку — иначе арифметика дат (КонецДня,
+// Дата + Число) в проведении перезаписанного документа молча ломается.
+// Регресс: раньше на SQLite дата грузилась RFC3339-строкой, КонецДня(строка)=nil.
+func TestReloadedDocumentDateIsTyped(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(sub string) string {
+		p := filepath.Join(dir, sub)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	docDir := mk("documents")
+	procDir := mk("processors")
+	srcDir := mk("src")
+
+	if err := os.WriteFile(filepath.Join(docDir, "заказ.yaml"),
+		[]byte("name: Заказ\nposting: false\nfields:\n  - name: Дата\n    type: date\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "проба.yaml"),
+		[]byte("name: Проба\nparams: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	proc := "Процедура Выполнить()\n" +
+		"  Д = Документы.Заказ.Создать();\n" +
+		"  Д.Дата = Дата(2026, 2, 20);\n" +
+		"  Ссылка = Д.Записать();\n" +
+		"  Об = Ссылка.ПолучитьОбъект();\n" +
+		"  Кон = КонецДня(Об.Дата);\n" +
+		"  Если НЕ ЗначениеЗаполнено(Кон) Тогда\n" +
+		"    ВызватьИсключение(\"КонецДня(Об.Дата) пуст — дата загружена строкой\");\n" +
+		"  КонецЕсли;\n" +
+		"  Сообщить(ТипЗнч(Об.Дата));\n" +
+		"КонецПроцедуры\n"
+	if err := os.WriteFile(filepath.Join(srcDir, "проба.proc.os"), []byte(proc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "reload.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(ctx, proj.Entities); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	messages, runErr, err := RunProcessorOffline(ctx, proj, db, "Проба", nil, nil)
+	if err != nil {
+		t.Fatalf("RunProcessorOffline: %v", err)
+	}
+	if runErr != nil {
+		t.Fatalf("перезагруженная дата не типизирована (КонецДня упал): %v", runErr)
+	}
+	if len(messages) != 1 || messages[0] != "Дата" {
+		t.Fatalf("ТипЗнч(Об.Дата) = %v, ожидался [Дата]", messages)
+	}
+}


### PR DESCRIPTION
## Проблема

`Ссылка.ПолучитьОбъект()` у записанного документа/справочника на SQLite нёс
поле-дату **RFC3339-строкой**, тогда как у свежесозданного через `Создать()` это
`time.Time`. Из-за расхождения типов арифметика дат в проведении **перезаписанного**
документа молча ломалась: `КонецДня(this.Дата)` на строке возвращает
`Неопределено`, и `База + Дней*86400` давало число секунд вместо даты.

Обнаружено при написании интеграционного теста продления доступа: после
`Записать() → ПолучитьОбъект() → Провести()` движение получало окончание
`2592000` (0 + 30·86400) вместо даты — продление считалось от нулевой базы.

Воспроизведение (SQLite):
```
Д = Документы.Заказ.Создать(); Д.Дата = Дата(2026, 2, 20);
Об = Д.Записать().ПолучитьОбъект();
// до фикса: ТипЗнч(Об.Дата) = Строка, КонецДня(Об.Дата) = Неопределено
// после:    ТипЗнч(Об.Дата) = Дата,   КонецДня(Об.Дата) = 20.02.2026 23:59:59
```

## Причина и фикс

`normalizeFieldValue` (читающий путь `GetByID`/`List`/регистры) приводил к типу
только числовые поля (→ `decimal.Decimal`), даты оставлял как есть — на SQLite
это TEXT (RFC3339). Добавлен `normalizeDate`:
- строка → `time.Time` через `ParseRegPeriod` (RFC3339 + SQLite-раскладки);
- `time.Time` (PostgreSQL уже типизирован) — без изменений;
- `nil`/нераспознанное — как есть (безопасный откат).

Правка централизована в `normalizeFieldValue`, поэтому все read-пути отдают дату
единообразно. **JSON API не меняется** — `time.Time` сериализуется в тот же
RFC3339. **Запросы (`Запрос`) идут отдельным путём** и по-прежнему возвращают
строки — задокументированное поведение не затронуто.

## Тесты

- `normalizeDate` — строка/`time.Time`/`nil`/нераспознанное;
- `normalizeFieldValue` для поля-даты → `time.Time`;
- e2e (`TestReloadedDocumentDateIsTyped`) — перезагруженный документ несёт `Дата`
  как `time.Time`, `КонецДня(Об.Дата)` работает.

Локально `go test ./internal/...`, `go vet`, `i18ncheck` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
