### PR TITLE
perf(auth): кэш HasUsers и ролей на горячем пути миддлвары (план 111, P0-2)

### DIFF
--- a/internal/auth/cache.go
+++ b/internal/auth/cache.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"context"
+	"time"
+)
+
+// hasUsersCached is the auth hot-path variant of HasUsers. Once any user is
+// observed it latches true for the process lifetime (Repo.usersExist), so after
+// bootstrap protected requests no longer run SELECT count(*) FROM _users. While
+// still unlatched (fresh base, no users yet) it queries every time — that window
+// carries negligible traffic. See Plans/111-scalability-review.md §3.2.
+func (r *Repo) hasUsersCached(ctx context.Context) (bool, error) {
+	if r.usersExist.Load() {
+		return true, nil
+	}
+	has, err := r.HasUsers(ctx)
+	if err != nil {
+		return false, err
+	}
+	if has {
+		r.usersExist.Store(true)
+	}
+	return has, nil
+}
+
+// rolesForUserCached returns the user's roles from a short-TTL cache, loading
+// via GetRolesForUser on a miss. The returned slice is shared across requests
+// until invalidated or expired — callers must treat it as read-only.
+func (r *Repo) rolesForUserCached(ctx context.Context, userID string) ([]*Role, error) {
+	now := time.Now()
+	r.rolesMu.RLock()
+	e, ok := r.rolesCache[userID]
+	r.rolesMu.RUnlock()
+	if ok && now.Before(e.expires) {
+		return e.roles, nil
+	}
+	roles, err := r.GetRolesForUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	r.rolesMu.Lock()
+	r.rolesCache[userID] = cachedRoles{roles: roles, expires: now.Add(rolesCacheTTL)}
+	r.rolesMu.Unlock()
+	return roles, nil
+}
+
+// invalidateUserRoles drops one user's cached roles. Call after changing that
+// user's role assignments (AssignRole/UnassignRole).
+func (r *Repo) invalidateUserRoles(userID string) {
+	r.rolesMu.Lock()
+	delete(r.rolesCache, userID)
+	r.rolesMu.Unlock()
+}
+
+// invalidateAllRoles clears the whole roles cache. Call after a change that can
+// affect many users at once: role permission sync or role deletion.
+func (r *Repo) invalidateAllRoles() {
+	r.rolesMu.Lock()
+	clear(r.rolesCache)
+	r.rolesMu.Unlock()
+}

--- a/internal/auth/cache_internal_test.go
+++ b/internal/auth/cache_internal_test.go
@@ -1,0 +1,106 @@
+package auth
+
+// White-box tests for the auth hot-path caches (Plans/111 §3.2, P0-2). They live
+// in package auth to reach the unexported cached accessors and the latch field.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func newCacheTestRepo(t *testing.T) (*Repo, *storage.DB, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "auth.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+	r := NewRepo(db)
+	if err := r.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	if err := r.EnsureRolesSchema(ctx); err != nil {
+		t.Fatalf("EnsureRolesSchema: %v", err)
+	}
+	return r, db, ctx
+}
+
+func TestHasUsersCachedLatches(t *testing.T) {
+	r, db, ctx := newCacheTestRepo(t)
+
+	// Fresh base: no users, latch stays unset so it keeps checking ground truth.
+	if has, err := r.hasUsersCached(ctx); err != nil || has {
+		t.Fatalf("fresh base: has=%v err=%v, want false/nil", has, err)
+	}
+	if r.usersExist.Load() {
+		t.Fatal("latch must stay false while there are no users")
+	}
+
+	if _, err := r.Create(ctx, "ivan", "secret123", "Ivan", true); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if has, err := r.hasUsersCached(ctx); err != nil || !has {
+		t.Fatalf("after Create: has=%v err=%v, want true/nil", has, err)
+	}
+	if !r.usersExist.Load() {
+		t.Fatal("latch must be set once users are observed")
+	}
+
+	// The latch is authoritative: even if rows vanish (impossible via supported
+	// deletes — ErrLastUser guards the last one), the cached answer stays true,
+	// while raw HasUsers still reports ground truth because it is uncached.
+	if _, err := db.Exec(ctx, `DELETE FROM _users`); err != nil {
+		t.Fatalf("raw delete: %v", err)
+	}
+	if has, _ := r.hasUsersCached(ctx); !has {
+		t.Fatal("latched hasUsersCached must stay true")
+	}
+	if has, _ := r.HasUsers(ctx); has {
+		t.Fatal("uncached HasUsers must reflect ground truth (false)")
+	}
+}
+
+func TestRolesForUserCachedInvalidation(t *testing.T) {
+	r, db, ctx := newCacheTestRepo(t)
+
+	user, err := r.Create(ctx, "ivan", "secret123", "Ivan", true)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	role := &Role{Name: "manager"}
+	if err := r.SyncRoles(ctx, []*Role{role}); err != nil {
+		t.Fatalf("SyncRoles: %v", err)
+	}
+
+	// Miss → loads 0 roles and caches them.
+	if got, err := r.rolesForUserCached(ctx, user.ID); err != nil || len(got) != 0 {
+		t.Fatalf("initial roles: got=%d err=%v, want 0/nil", len(got), err)
+	}
+
+	// AssignRole invalidates the user's entry → next read reflects the grant.
+	if err := r.AssignRole(ctx, user.ID, role.ID); err != nil {
+		t.Fatalf("AssignRole: %v", err)
+	}
+	if got, err := r.rolesForUserCached(ctx, user.ID); err != nil || len(got) != 1 {
+		t.Fatalf("after AssignRole: got=%d err=%v, want 1/nil", len(got), err)
+	}
+
+	// Prove it actually caches: remove the assignment via raw SQL, bypassing
+	// UnassignRole's invalidation. Within the TTL the cached role still shows.
+	if _, err := db.Exec(ctx, `DELETE FROM _user_roles WHERE user_id = `+db.Dialect().Placeholder(1), user.ID); err != nil {
+		t.Fatalf("raw unassign: %v", err)
+	}
+	if got, _ := r.rolesForUserCached(ctx, user.ID); len(got) != 1 {
+		t.Fatalf("within TTL the cache must still return 1 role, got %d", len(got))
+	}
+
+	// Explicit invalidation → reflects the removal immediately.
+	r.invalidateAllRoles()
+	if got, _ := r.rolesForUserCached(ctx, user.ID); len(got) != 0 {
+		t.Fatalf("after invalidateAllRoles: want 0 roles, got %d", len(got))
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -20,7 +20,7 @@ func (r *Repo) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		hasUsers, err := r.HasUsers(ctx)
+		hasUsers, err := r.hasUsersCached(ctx)
 		if err != nil {
 			writeAuthUnavailable(w, false)
 			return
@@ -70,7 +70,7 @@ func (r *Repo) serveWithSession(next http.Handler, w http.ResponseWriter, req *h
 func (r *Repo) APITokenOrSessionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		hasUsers, err := r.HasUsers(ctx)
+		hasUsers, err := r.hasUsersCached(ctx)
 		if err != nil {
 			writeAuthUnavailable(w, true)
 			return
@@ -115,7 +115,8 @@ func bearerToken(req *http.Request) (string, bool) {
 
 func (r *Repo) contextWithUser(ctx context.Context, user *User) context.Context {
 	// Load roles for this user (best-effort — don't fail if table missing yet).
-	if roles, err := r.GetRolesForUser(ctx, user.ID); err == nil {
+	// Cached on the hot path; invalidated on role changes (see cache.go).
+	if roles, err := r.rolesForUserCached(ctx, user.ID); err == nil {
 		user.Roles = roles
 	}
 	ctx = context.WithValue(ctx, userKey, user)

--- a/internal/auth/roles.go
+++ b/internal/auth/roles.go
@@ -348,6 +348,8 @@ func (r *Repo) SyncRoles(ctx context.Context, roles []*Role) error {
 		}
 		role.ID = id
 	}
+	// Role definitions/permissions changed for potentially every user.
+	r.invalidateAllRoles()
 	return nil
 }
 
@@ -426,6 +428,9 @@ func (r *Repo) AssignRole(ctx context.Context, userID, roleID string) error {
 		`INSERT INTO _user_roles (user_id, role_id) VALUES (%s, %s) ON CONFLICT DO NOTHING`,
 		d.Placeholder(1), d.Placeholder(2))
 	_, err := r.db.Exec(ctx, q, userID, roleID)
+	if err == nil {
+		r.invalidateUserRoles(userID)
+	}
 	return err
 }
 
@@ -435,6 +440,9 @@ func (r *Repo) UnassignRole(ctx context.Context, userID, roleID string) error {
 	q := fmt.Sprintf(`DELETE FROM _user_roles WHERE user_id = %s AND role_id = %s`,
 		d.Placeholder(1), d.Placeholder(2))
 	_, err := r.db.Exec(ctx, q, userID, roleID)
+	if err == nil {
+		r.invalidateUserRoles(userID)
+	}
 	return err
 }
 
@@ -443,6 +451,9 @@ func (r *Repo) DeleteRoleByName(ctx context.Context, name string) error {
 	d := r.db.Dialect()
 	q := fmt.Sprintf(`DELETE FROM _roles WHERE name = %s`, d.Placeholder(1))
 	_, err := r.db.Exec(ctx, q, name)
+	if err == nil {
+		r.invalidateAllRoles()
+	}
 	return err
 }
 

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,7 +35,34 @@ type User struct {
 type Repo struct {
 	db             *storage.DB
 	passwordPolicy PasswordPolicy
+
+	// usersExist latches true once the auth middleware observes that the base
+	// has at least one user. HasUsers can never go true→false — deleting the
+	// last user is refused (ErrLastUser) — so the latch is authoritative for the
+	// process lifetime and lets protected requests skip SELECT count(*) FROM
+	// _users. Only the middleware hot path reads it (hasUsersCached); HasUsers
+	// itself stays an uncached ground-truth query for every other caller.
+	// План 111 (P0-2).
+	usersExist atomic.Bool
+
+	// rolesCache memoizes GetRolesForUser per user for rolesCacheTTL on the auth
+	// hot path, cutting a roles JOIN off every protected request. Invalidated
+	// eagerly on role assignment/definition changes; the TTL is only a backstop.
+	// План 111 (P0-2).
+	rolesMu    sync.RWMutex
+	rolesCache map[string]cachedRoles
 }
+
+// cachedRoles is one memoized GetRolesForUser result. The slice is shared across
+// requests until invalidated or expired — treat it as read-only.
+type cachedRoles struct {
+	roles   []*Role
+	expires time.Time
+}
+
+// rolesCacheTTL bounds how long stale roles can survive a change the eager
+// invalidation somehow missed. The review suggests 30–60s (Plans/111 §3.2).
+const rolesCacheTTL = 60 * time.Second
 
 var (
 	ErrFirstUserMustBeAdmin = errors.New("первый пользователь должен быть администратором")
@@ -45,7 +73,11 @@ var (
 // NewRepo wires the auth repository to the storage layer. Internally Exec/
 // Query/QueryRow are routed to PostgreSQL or SQLite via the DB abstraction.
 func NewRepo(db *storage.DB) *Repo {
-	return &Repo{db: db, passwordPolicy: passwordPolicyFromEnv()}
+	return &Repo{
+		db:             db,
+		passwordPolicy: passwordPolicyFromEnv(),
+		rolesCache:     make(map[string]cachedRoles),
+	}
 }
 
 func (r *Repo) EnsureSchema(ctx context.Context) error {


### PR DESCRIPTION
## P0-2 — кэш auth-миддлвары (план 111)

Реализация второй находки из ревью масштабируемости (`Plans/111-scalability-review.md`, §3.2).

### Проблема

`serveWithSession`/`contextWithUser` на **каждый** защищённый запрос делали минимум
**3 round-trip к БД**:

1. `HasUsers` → `SELECT count(*) FROM _users` — без кэша, только чтобы решить, включена ли авторизация.
2. `LookupSession` — JOIN сессии↔пользователя (нужен, оставлен как есть).
3. `GetRolesForUser` — JOIN ролей, без кэша.

На UI, который бьёт десятками XHR на страницу, при 100 пользователях — прямая
нагрузка на маленький пул из [P0-1](https://github.com/ivanarama/onebase/pull/491).

### Что сделано

- **`HasUsers` → latch `atomic.Bool`** (`hasUsersCached`). Ключевое наблюдение:
  `count(*)` **не может** вернуться из true в false — удаление последнего
  пользователя запрещено (`ErrLastUser`). Значит, один раз увидев пользователей,
  процесс больше никогда не спрашивает. Пока пользователей нет (bootstrap) —
  запрос идёт каждый раз (трафика там нет). Сырой `HasUsers` не тронут —
  остаётся ground-truth для ~15 прочих вызывающих.
- **Роли → кэш `userID → []*Role` с TTL 60с** (`rolesForUserCached`). Инвалидация
  **eager**: `AssignRole`/`UnassignRole` — по пользователю; `SyncRoles`/
  `DeleteRoleByName` — целиком. TTL — только backstop, не основной механизм.
- Кэш включён **только на пути миддлвары** (`Middleware`,
  `APITokenOrSessionMiddleware`, `contextWithUser`). Прочие вызовы
  `GetRolesForUser` (UI-сервисы, change-publisher, API-токены) не трогаются.
- Кэшируемый `[]*Role` шарится между запросами — проверил, что везде ниже он
  read-only (шаблоны, RowAccess-проверки; мутаций нет).

**Эффект:** после bootstrap на каждый защищённый запрос (включая статику под auth
и SSE-реконнекты) убираются 2 из 3 round-trip — остаётся только `LookupSession`.

### Проверка

- `go test ./internal/auth/` — весь пакет зелёный; 2 новых white-box теста:
  latch `HasUsers` и инвалидация ролей (кэширование доказано сырым `DELETE` в
  обход инвалидации — в пределах TTL кэш держит старое значение).
- `go vet` + `go build ./...` — чисто.
- ⚠️ `-race` локально не гонялся (нет cgo/gcc в окружении). Код race-safe по
  построению: `atomic.Bool` + `RWMutex`, единственная гонка на miss —
  безобидная двойная загрузка одинаковых данных. Покрывается CI.

### Известные ограничения / вне scope

- **Bulk-restore и демо-сброс** пишут `_user_roles` в обход `Repo`-методов
  (`internal/backup/*`) → кэш ролей самонаводится за ≤60с (TTL). Для редких/демо
  операций приемлемо; при желании — отдельный хук инвалидации в будущем.
- **Кросс-процессная** пуш-инвалидация через hub (план 87) **не нужна**: модель —
  один процесс на базу; ролями управляет тот же процесс, что и обслуживает
  пользователя. Общий стор понадобится только с горизонтальным масштабированием
  (P3-1).
- `LookupSession` (round-trip №2) намеренно **не** кэшируется — ревью помечает его
  как «по желанию»; оставлено ground-truth.

Generated-with: Claude Code
