### PR TITLE
perf(ui): батч-разворот ссылок в списках/регистрах через GetFieldsByIDs (план 111, P1-1)

### DIFF
--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -406,46 +406,53 @@ type refCol struct {
 // Если labelSuffix != "" — наименование записывается в row[key+labelSuffix],
 // а оригинальное значение (UUID) остаётся нетронутым.
 func (s *Server) resolveRefColumns(ctx context.Context, rows []map[string]any, cols []refCol, labelSuffix string) {
-	// Build lookup: RefEntity → set of UUIDs to resolve
-	entityUUIDs := make(map[string]map[string]string) // entityName → {uuid: label}
+	// Group unique referenced UUIDs by declared RefEntity ("" = unknown type,
+	// legacy string columns that store a UUID). Keys are canonical id strings.
+	entityUUIDs := make(map[string]map[string]uuid.UUID) // entityName → {idStr: id}
 	for _, row := range rows {
 		for _, c := range cols {
 			v := asString(row[c.Key])
 			if v == "" {
 				continue
 			}
-			if _, err := uuid.Parse(v); err != nil {
+			id, err := uuid.Parse(v)
+			if err != nil {
 				continue
 			}
 			if entityUUIDs[c.RefEntity] == nil {
-				entityUUIDs[c.RefEntity] = make(map[string]string)
+				entityUUIDs[c.RefEntity] = make(map[string]uuid.UUID)
 			}
-			entityUUIDs[c.RefEntity][v] = ""
+			entityUUIDs[c.RefEntity][id.String()] = id
 		}
 	}
 
-	// Resolve UUIDs: for known RefEntity — targeted lookup; for unknown — scan all.
+	// Resolve to labels. Known RefEntity → one batched query. Unknown type →
+	// probe each entity once with the whole remaining set (one query per entity,
+	// stopping as soon as every id is resolved) instead of GetByID per
+	// (uuid × entity). First match wins, preserved by pruning resolved ids.
+	// План 111 (P1-1).
 	uuidToLabel := make(map[string]string)
-	for entName, uuids := range entityUUIDs {
-		var entities []*metadata.Entity
+	for entName, idset := range entityUUIDs {
 		if entName != "" {
 			if e := s.reg.GetEntity(entName); e != nil {
-				entities = []*metadata.Entity{e}
-			}
-		}
-		if len(entities) == 0 {
-			entities = s.reg.Entities()
-		}
-		for idStr := range uuids {
-			if _, done := uuidToLabel[idStr]; done {
+				s.batchLabels(ctx, e, idset, uuidToLabel)
 				continue
 			}
-			id, _ := uuid.Parse(idStr)
-			for _, entity := range entities {
-				refRow, err := s.store.GetByID(ctx, entity.Name, id, entity)
-				if err == nil {
-					uuidToLabel[idStr] = s.maskedRecordLabel(ctx, entity, refRow)
-					break
+		}
+		remaining := make(map[string]uuid.UUID, len(idset))
+		for k, id := range idset {
+			if _, done := uuidToLabel[k]; !done {
+				remaining[k] = id
+			}
+		}
+		for _, e := range s.reg.Entities() {
+			if len(remaining) == 0 {
+				break
+			}
+			s.batchLabels(ctx, e, remaining, uuidToLabel)
+			for k := range remaining {
+				if _, done := uuidToLabel[k]; done {
+					delete(remaining, k)
 				}
 			}
 		}
@@ -457,7 +464,11 @@ func (s *Server) resolveRefColumns(ctx context.Context, rows []map[string]any, c
 			if v == "" {
 				continue
 			}
-			if label, found := uuidToLabel[v]; found && label != "" {
+			id, err := uuid.Parse(v)
+			if err != nil {
+				continue
+			}
+			if label, found := uuidToLabel[id.String()]; found && label != "" {
 				if labelSuffix == "" {
 					row[c.Key] = label
 				} else {
@@ -853,6 +864,10 @@ func formValues(r *http.Request, entity *metadata.Entity) map[string]string {
 
 // resolveRefs replaces UUID values of reference fields with the display name
 // of the referenced entity (first string field). Modifies rows in place.
+//
+// Each reference field is resolved with a single batched query (via batchLabels
+// → GetFieldsByIDs) instead of one GetByID per unique id — this is a hot path
+// (entity/document lists and export). План 111 (P1-1).
 func (s *Server) resolveRefs(ctx context.Context, entity *metadata.Entity, rows []map[string]any) {
 	for _, f := range entity.Fields {
 		if f.RefEntity == "" {
@@ -862,33 +877,58 @@ func (s *Server) resolveRefs(ctx context.Context, entity *metadata.Entity, rows 
 		if refEntity == nil {
 			continue
 		}
-		// collect unique IDs referenced in this field
-		seen := map[string]bool{}
+		// collect unique referenced ids in this field (canonical string keys)
+		idset := map[string]uuid.UUID{}
 		for _, row := range rows {
-			if v := row[f.Name]; v != nil {
-				seen[fmt.Sprintf("%v", v)] = true
+			if idStr, id, ok := uuidFromValue(row[f.Name]); ok {
+				idset[idStr] = id
 			}
 		}
-		// resolve each unique ID to a display label
-		labels := make(map[string]string, len(seen))
-		for idStr := range seen {
-			id, err := uuid.Parse(idStr)
-			if err != nil {
-				continue
-			}
-			refRow, err := s.store.GetByID(ctx, refEntity.Name, id, refEntity)
-			if err != nil {
-				continue
-			}
-			labels[idStr] = s.maskedRecordLabel(ctx, refEntity, refRow)
+		if len(idset) == 0 {
+			continue
 		}
+		labels := make(map[string]string, len(idset))
+		s.batchLabels(ctx, refEntity, idset, labels)
 		// replace UUIDs with labels in all rows
 		for _, row := range rows {
-			if v := row[f.Name]; v != nil {
-				if label, ok := labels[fmt.Sprintf("%v", v)]; ok {
+			if idStr, _, ok := uuidFromValue(row[f.Name]); ok {
+				if label, ok := labels[idStr]; ok {
 					row[f.Name] = label
 				}
 			}
+		}
+	}
+}
+
+// refLabelBatchSize bounds how many ids go into one GetFieldsByIDs IN(...) query.
+// Keeps parameter counts under SQLite's 999-parameter cap on wide exports while
+// still collapsing an N+1 into O(ids/batch) queries. План 111 (P1-1).
+const refLabelBatchSize = 500
+
+// batchLabels resolves a set of unique ids (canonical string → id) against one
+// entity, writing display labels into out keyed by canonical id string. Ids not
+// present in the entity are simply absent from out. Runs one query per batch of
+// refLabelBatchSize ids. Shared by resolveRefs and resolveRefColumns.
+func (s *Server) batchLabels(ctx context.Context, e *metadata.Entity, idset map[string]uuid.UUID, out map[string]string) {
+	if e == nil || len(idset) == 0 {
+		return
+	}
+	ids := make([]uuid.UUID, 0, len(idset))
+	for _, id := range idset {
+		ids = append(ids, id)
+	}
+	fields := displayField(e)
+	for start := 0; start < len(ids); start += refLabelBatchSize {
+		end := start + refLabelBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		refRows, err := s.store.GetFieldsByIDs(ctx, e, ids[start:end], fields)
+		if err != nil {
+			return
+		}
+		for idStr, refRow := range refRows {
+			out[idStr] = s.maskedRecordLabel(ctx, e, refRow)
 		}
 	}
 }

--- a/internal/ui/ref_batch_test.go
+++ b/internal/ui/ref_batch_test.go
@@ -1,0 +1,130 @@
+package ui
+
+// Разворот ссылок после перевода с N+1 GetByID на батч GetFieldsByIDs
+// (план 111, P1-1): корректность для плоских списков (resolveRefs), колонок
+// регистра с известным и неизвестным типом ссылки (resolveRefColumns), а также
+// разбиения на батчи при числе id больше refLabelBatchSize.
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func refTestCatalog() *metadata.Entity {
+	return &metadata.Entity{
+		Name: "Контрагент",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+		},
+	}
+}
+
+func TestResolveRefs_Batched(t *testing.T) {
+	client := refTestCatalog()
+	doc := &metadata.Entity{
+		Name: "Заказ",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Контрагент", Type: "reference:Контрагент", RefEntity: client.Name},
+		},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{client, doc})
+
+	id1, id2 := uuid.New(), uuid.New()
+	if err := s.store.Upsert(ctx, client.Name, id1, map[string]any{"Наименование": "Ромашка"}, client); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.store.Upsert(ctx, client.Name, id2, map[string]any{"Наименование": "Лютик"}, client); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := []map[string]any{
+		{"Контрагент": id1.String()},
+		{"Контрагент": id2.String()},
+		{"Контрагент": id1.String()}, // дубль того же уникального id
+		{"Контрагент": nil},          // пустая ссылка не должна ломать разворот
+	}
+	s.resolveRefs(ctx, doc, rows)
+
+	if rows[0]["Контрагент"] != "Ромашка" {
+		t.Errorf("row0 = %v, want Ромашка", rows[0]["Контрагент"])
+	}
+	if rows[1]["Контрагент"] != "Лютик" {
+		t.Errorf("row1 = %v, want Лютик", rows[1]["Контрагент"])
+	}
+	if rows[2]["Контрагент"] != "Ромашка" {
+		t.Errorf("row2 (дубль) = %v, want Ромашка", rows[2]["Контрагент"])
+	}
+}
+
+func TestResolveRefColumns_KnownAndUnknownType(t *testing.T) {
+	client := refTestCatalog()
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{client})
+
+	id := uuid.New()
+	if err := s.store.Upsert(ctx, client.Name, id, map[string]any{"Наименование": "Ромашка"}, client); err != nil {
+		t.Fatal(err)
+	}
+
+	// Известный тип → адресный батч, замена in-place.
+	rowsKnown := []map[string]any{{"Контрагент": id.String()}}
+	s.resolveRefColumns(ctx, rowsKnown, []refCol{{Key: "Контрагент", RefEntity: client.Name}}, "")
+	if rowsKnown[0]["Контрагент"] != "Ромашка" {
+		t.Errorf("known: %v, want Ромашка", rowsKnown[0]["Контрагент"])
+	}
+
+	// Неизвестный тип ("") → перебор сущностей всё равно находит запись; подпись
+	// пишется в колонку с суффиксом, исходный UUID сохраняется.
+	rowsUnknown := []map[string]any{{"Субконто": id.String()}}
+	s.resolveRefColumns(ctx, rowsUnknown, []refCol{{Key: "Субконто", RefEntity: ""}}, "_label")
+	if rowsUnknown[0]["Субконто_label"] != "Ромашка" {
+		t.Errorf("unknown: %v, want Ромашка", rowsUnknown[0]["Субконто_label"])
+	}
+	if rowsUnknown[0]["Субконто"] != id.String() {
+		t.Errorf("unknown: исходный UUID должен сохраниться, got %v", rowsUnknown[0]["Субконто"])
+	}
+}
+
+// Число уникальных ссылок больше refLabelBatchSize → GetFieldsByIDs зовётся
+// несколькими батчами; все подписи должны развернуться (граница батча и защита
+// от лимита параметров SQLite на широком экспорте).
+func TestResolveRefs_ChunksBeyondBatchSize(t *testing.T) {
+	client := refTestCatalog()
+	doc := &metadata.Entity{
+		Name: "Заказ",
+		Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Контрагент", Type: "reference:Контрагент", RefEntity: client.Name},
+		},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{client, doc})
+
+	n := refLabelBatchSize + 5
+	rows := make([]map[string]any, 0, n)
+	want := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		id := uuid.New()
+		name := "К" + uuid.NewString()[:8]
+		if err := s.store.Upsert(ctx, client.Name, id, map[string]any{"Наименование": name}, client); err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, map[string]any{"Контрагент": id.String()})
+		want[id.String()] = name
+	}
+	// снимок ожидаемого по позициям до мутации строк
+	expect := make([]string, n)
+	for i, r := range rows {
+		expect[i] = want[r["Контрагент"].(string)]
+	}
+
+	s.resolveRefs(ctx, doc, rows)
+
+	for i, r := range rows {
+		if r["Контрагент"] != expect[i] {
+			t.Fatalf("row %d = %v, want %s (батч не развернул все id)", i, r["Контрагент"], expect[i])
+		}
+	}
+}


### PR DESCRIPTION
## P1-1 — батч-разворот ссылок (план 111)

Реализация третьей находки из ревью масштабируемости (`Plans/111-scalability-review.md`, §3.3) — самая заметная находка уровня кода.

### Проблема

Разворот UUID→представление в списках/экспорте/регистрах шёл **по одному
`GetByID` на каждый уникальный id**:

- `resolveRefs` (списки сущностей/документов, экспорт): 50 контрагентов × 3
  ссылочные колонки = до 150 запросов на рендер одной страницы.
- `resolveRefColumns` (регистры) — **хуже**: при неизвестном типе ссылки
  перебирал **все** сущности реестра, делая `GetByID` по каждой таблице →
  O(строки × id × число_сущностей) запросов.

При этом батч-примитив уже был в кодовой базе — `enrichTPRowsWithRefs` разворачивает
ссылки табличных частей **одним** `GetFieldsByIDs`.

### Что сделано

- **Общий помощник `batchLabels`**: один `GetFieldsByIDs` на ссылочную сущность
  вместо N. Разбивает id на батчи по **500** — под лимит параметров SQLite (999)
  на широком экспорте (`export_max_rows`).
- **`resolveRefs`** → сбор уникальных id (`uuidFromValue`, канонический ключ) →
  `batchLabels` → замена. Маскирование ПДн подписи сохранено — тот же
  `displayField`+`maskedRecordLabel`, что и в TP-пути.
- **`resolveRefColumns`** → известный тип: один батч; неизвестный тип: перебор
  сущностей **по одному запросу на сущность** со всем остатком id и ранним
  выходом — **O(сущности)** вместо O(id × сущности). Семантика first-match-wins
  сохранена вычёркиванием уже разрешённых id.

**Эффект:** на странице списка/регистра — один запрос на ссылочную сущность
вместо десятков-сотен `GetByID`. Самая дешёвая по трудозатратам и заметная по
эффекту правка для read-heavy нагрузки.

### Проверка

- `go test ./internal/ui/` — весь пакет зелёный (вкл. существующий
  `TestUI_ReferenceLabelsMaskFirstStringField` — доказывает, что маскирование
  ПДн подписи сохранено через batched-путь).
- 3 новых теста: разворот списка (дубли/пустые ссылки), регистр с известным и
  неизвестным типом ссылки, **граница батча** (>500 уникальных id — защита
  экспорта от лимита параметров SQLite).
- `go vet` + `go build ./...` — чисто.

### Замечания

- Корректность ключей проверена: `uuidFromValue` и `GetFieldsByIDs` дают один и
  тот же канонический `id.String()`; всё сведено к каноническому ключу.
- Экспорт по-прежнему буферизует весь датасет в память (это отдельная находка
  **P2-3**) — здесь снят только N+1 внутри него.

Generated-with: Claude Code
