### PR TITLE
perf(ui): вынести встроенную статику из-под auth-миддлвары (план 111, P1-2)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -112,6 +112,14 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 	// session-middleware: базы аутентифицируются общим Bearer-токеном плана.
 	uiSrv.MountExchange(r)
 
+	// Встроенная статика — вендор-ассеты (Monaco/ECharts/SlickGrid/Quill) и
+	// app-JS. Несекретны и одинаковы для всех, поэтому монтируются ВНЕ
+	// auth-мидлвары (план 111, P1-2): иначе каждый чанк Monaco и каждая
+	// ревалидация app-JS (no-cache → 304) проходили через сессионную
+	// авторизацию. Вендор уже отдаётся с immutable-кэшем; app-JS сохраняет
+	// ETag-ревалидацию, но больше не платит за auth на каждый 304.
+	uiSrv.MountStatic(r)
+
 	// REST API v2 accepts either an integration Bearer token or the existing
 	// browser session cookie. Keep it outside the UI/session-only group so
 	// headless clients do not need a cookie.

--- a/internal/api/static_public_test.go
+++ b/internal/api/static_public_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestStaticAssetsPublicWhenUsersExist: app-JS и вендор-ассеты доступны БЕЗ
+// аутентификации, даже когда в базе есть пользователи и cookie сессии нет
+// (план 111, P1-2). Раньше они монтировались под auth-мидлварой, поэтому каждая
+// ревалидация app-JS (no-cache → 304) и каждый чанк Monaco/ECharts проходили
+// через сессионную авторизацию. newServerWithUser (см. pwa_public_test.go)
+// создаёт пользователя, так что auth активна — и до правки эти пути отдавали 401.
+func TestStaticAssetsPublicWhenUsersExist(t *testing.T) {
+	srv := newServerWithUser(t)
+
+	routes := []string{
+		"/static/ui.js",
+		"/static/managed.js",
+		"/static/query-builder.js",
+		"/vendor/echarts/echarts.min.js",
+	}
+	for _, path := range routes {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Errorf("неаутентифицированный GET %s = %d, ожидался 200 (ассет должен быть публичным)", path, rec.Code)
+			}
+		})
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -266,8 +266,19 @@ func (s *Server) tr(lang, key string) string {
 	return key
 }
 
-func (s *Server) Mount(r chi.Router) {
+// MountStatic serves embedded vendor assets (Monaco/ECharts/SlickGrid/Quill) and
+// the app JS bundles. They are non-secret and identical for every user, so they
+// mount OUTSIDE the auth middleware (план 111, P1-2). Previously each request to
+// /vendor/* or /static/*.js traversed the auth stack (a session lookup per
+// request), and the no-cache app JS revalidated on every navigation — all of it
+// hitting auth. Vendor assets already carry immutable long-cache headers
+// (webassets), so browsers refetch them rarely; the app JS keeps ETag
+// revalidation but no longer pays for auth on each 304.
+func (s *Server) MountStatic(r chi.Router) {
 	mountStatic(r)
+}
+
+func (s *Server) Mount(r chi.Router) {
 	r.Get("/ui", s.index)
 	r.Get("/ui/", s.index)
 	r.Get("/ui/app", s.appShell)           // оболочка вкладок (issue #129/#130, фаза 1)


### PR DESCRIPTION
## P1-2 — статика вне auth-миддлвары (план 111)

Реализация четвёртой (последней из ближнего горизонта) находки ревью
масштабируемости (`Plans/111-scalability-review.md`, §3.4).

### Проблема

`mountStatic` (`/vendor/*` — Monaco/ECharts/SlickGrid/Quill — и `/static/*.js`)
вызывался внутри `uiSrv.Mount`, а тот смонтирован в **защищённой группе**
(`authRepo.Middleware`). Значит:

- каждый чанк Monaco (их десятки; открытие конфигуратора/отчёта = десятки запросов)
  проходил через сессионную авторизацию;
- app-JS отдаётся с `Cache-Control: no-cache` + ETag → браузер **ревалидирует на
  каждой навигации** (условный GET → 304), и даже 304 сперва прогонял весь
  auth-стек.

### Что сделано

- Новый публичный метод **`MountStatic`**; вызывается в `api/server.go` рядом с
  `MountPWA`/`MountServices`/`MountExchange` — **вне** auth-групп. Ассеты
  несекретны и одинаковы для всех.
- `mountStatic` (свободная функция) **не тронут** — единственный вызывающий
  `Mount` это `api/server.go`; `static_test.go` продолжает звать `mountStatic`
  напрямую.
- Перенос хирургический: `r.Group` в chi — это один и тот же роутер, меняется
  только обёртка мидлварой, не матчинг путей. Поэтому маршрутизация идентична,
  снимается только auth.

### Про immutable-кэш

Оказалось, **уже сделано**: `webassets.*Handler()` отдают вендор с
`Cache-Control: public, max-age=31536000, immutable`, а безопасность при апгрейде
обеспечивает **service worker** (имя кэша = ревизия сборки), а не версия в URL.
Так что «проверить заголовки webassets» из ревью → заголовки корректны; оставалось
снять auth. app-JS сознательно остаётся `no-cache`/ETag (путь фиксирован, код
меняется с билдом — immutable отдавал бы устаревший скрипт), но теперь без auth на
каждый 304.

### Проверка (реальный сервер, httptest)

Новый `TestStaticAssetsPublicWhenUsersExist` (по образцу `pwa_public_test.go`) на
`api.Server` **с пользователем** (auth активна, сессии нет):

| Путь | До правки | После |
|------|-----------|-------|
| `/static/ui.js`, `managed.js`, `query-builder.js` | 401 | **200** |
| `/vendor/echarts/echarts.min.js` (1 МБ) | 401 | **200** |
| контроль `/ui/` | 401 | **401** (по-прежнему за auth) |

- `go test ./internal/api/ ./internal/ui/ ./internal/webassets/` — зелёные.
- `go vet` + `go build ./...` — чисто.
- Лаунчер монтирует `/vendor/*` сам (`launcher/server.go`) — не затронут.

С этим PR закрыт весь **ближний горизонт** роадмапа (P0-1, P0-2, P1-1, P1-2).

Generated-with: Claude Code
