### PR TITLE
perf(excel): потоковый XLSX-экспорт списка вместо буфера в памяти (план 111, P2-3)

### DIFF
--- a/internal/excel/excel.go
+++ b/internal/excel/excel.go
@@ -2,6 +2,7 @@ package excel
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/xuri/excelize/v2"
@@ -16,36 +17,7 @@ func ExportList(cols []string, rows [][]any) ([]byte, error) {
 	sheet := "Лист1"
 	f.SetSheetName("Sheet1", sheet)
 
-	// Styles
-	boldStyle, _ := f.NewStyle(&excelize.Style{
-		Fill: excelize.Fill{Type: "pattern", Color: []string{"E2E8F0"}, Pattern: 1},
-		Font: &excelize.Font{Bold: true},
-		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center", WrapText: true},
-		Border: []excelize.Border{
-			{Type: "left", Color: "CBD5E1", Style: 1},
-			{Type: "right", Color: "CBD5E1", Style: 1},
-			{Type: "top", Color: "CBD5E1", Style: 1},
-			{Type: "bottom", Color: "CBD5E1", Style: 1},
-		},
-	})
-	cellStyle, _ := f.NewStyle(&excelize.Style{
-		Alignment: &excelize.Alignment{Vertical: "top", WrapText: false},
-		Border: []excelize.Border{
-			{Type: "left", Color: "E2E8F0", Style: 1},
-			{Type: "right", Color: "E2E8F0", Style: 1},
-			{Type: "top", Color: "E2E8F0", Style: 1},
-			{Type: "bottom", Color: "E2E8F0", Style: 1},
-		},
-	})
-	numStyle, _ := f.NewStyle(&excelize.Style{
-		Alignment: &excelize.Alignment{Horizontal: "right", Vertical: "top"},
-		Border: []excelize.Border{
-			{Type: "left", Color: "E2E8F0", Style: 1},
-			{Type: "right", Color: "E2E8F0", Style: 1},
-			{Type: "top", Color: "E2E8F0", Style: 1},
-			{Type: "bottom", Color: "E2E8F0", Style: 1},
-		},
-	})
+	boldStyle, cellStyle, numStyle := listStyles(f)
 
 	// Header row
 	for ci, col := range cols {
@@ -114,4 +86,130 @@ func ExportList(cols []string, rows [][]any) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// listStyles registers the shared list-export cell styles on f and returns their
+// IDs: bold frozen header, bordered data cell, and right-aligned number cell.
+// Shared by ExportList and WriteList so both render identically.
+func listStyles(f *excelize.File) (bold, cell, num int) {
+	bold, _ = f.NewStyle(&excelize.Style{
+		Fill: excelize.Fill{Type: "pattern", Color: []string{"E2E8F0"}, Pattern: 1},
+		Font: &excelize.Font{Bold: true},
+		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center", WrapText: true},
+		Border: []excelize.Border{
+			{Type: "left", Color: "CBD5E1", Style: 1},
+			{Type: "right", Color: "CBD5E1", Style: 1},
+			{Type: "top", Color: "CBD5E1", Style: 1},
+			{Type: "bottom", Color: "CBD5E1", Style: 1},
+		},
+	})
+	cell, _ = f.NewStyle(&excelize.Style{
+		Alignment: &excelize.Alignment{Vertical: "top", WrapText: false},
+		Border: []excelize.Border{
+			{Type: "left", Color: "E2E8F0", Style: 1},
+			{Type: "right", Color: "E2E8F0", Style: 1},
+			{Type: "top", Color: "E2E8F0", Style: 1},
+			{Type: "bottom", Color: "E2E8F0", Style: 1},
+		},
+	})
+	num, _ = f.NewStyle(&excelize.Style{
+		Alignment: &excelize.Alignment{Horizontal: "right", Vertical: "top"},
+		Border: []excelize.Border{
+			{Type: "left", Color: "E2E8F0", Style: 1},
+			{Type: "right", Color: "E2E8F0", Style: 1},
+			{Type: "top", Color: "E2E8F0", Style: 1},
+			{Type: "bottom", Color: "E2E8F0", Style: 1},
+		},
+	})
+	return
+}
+
+// WriteList streams an xlsx workbook (headers + rows) straight to w with a
+// StreamWriter, so neither the full cell model nor the finished file is held in
+// memory — unlike ExportList, which returns the whole workbook as a []byte. Same
+// visual result as ExportList (bold frozen header, bordered cells, right-aligned
+// numbers, dd.mm.yyyy dates, approximate auto column width). Use it for large
+// HTTP exports. rows is expected to already be in memory here, so scanning it for
+// column widths costs time but not extra memory. План 111 (P2-3).
+//
+// StreamWriter requires ascending row order and column widths set before any
+// row; SetRow errors surface before any bytes reach w, so a caller can still
+// send an error status as long as it has not written to w yet.
+func WriteList(w io.Writer, cols []string, rows [][]any) error {
+	f := excelize.NewFile()
+	defer f.Close()
+
+	sheet := "Лист1"
+	f.SetSheetName("Sheet1", sheet)
+	boldStyle, cellStyle, numStyle := listStyles(f)
+
+	sw, err := f.NewStreamWriter(sheet)
+	if err != nil {
+		return err
+	}
+
+	// Column widths must be set before any row is written in stream mode.
+	for ci := range cols {
+		maxLen := len(cols[ci])
+		for _, row := range rows {
+			if ci < len(row) {
+				if s := fmt.Sprintf("%v", row[ci]); len(s) > maxLen {
+					maxLen = len(s)
+				}
+			}
+		}
+		width := float64(maxLen) * 1.1
+		if width < 8 {
+			width = 8
+		}
+		if width > 40 {
+			width = 40
+		}
+		if err := sw.SetColWidth(ci+1, ci+1, width); err != nil {
+			return err
+		}
+	}
+
+	// Freeze the header row.
+	if err := sw.SetPanes(&excelize.Panes{
+		Freeze: true, Split: false, YSplit: 1,
+		TopLeftCell: "A2", ActivePane: "bottomLeft",
+	}); err != nil {
+		return err
+	}
+
+	// Header row.
+	header := make([]any, len(cols))
+	for ci, col := range cols {
+		header[ci] = excelize.Cell{StyleID: boldStyle, Value: col}
+	}
+	if err := sw.SetRow("A1", header, excelize.RowOpts{Height: 22}); err != nil {
+		return err
+	}
+
+	// Data rows.
+	for ri, row := range rows {
+		cells := make([]any, len(row))
+		for ci, val := range row {
+			switch v := val.(type) {
+			case time.Time:
+				cells[ci] = excelize.Cell{StyleID: cellStyle, Value: v.Format("02.01.2006")}
+			case float64, float32, int, int32, int64, uint, uint32, uint64:
+				cells[ci] = excelize.Cell{StyleID: numStyle, Value: v}
+			case nil:
+				cells[ci] = excelize.Cell{StyleID: cellStyle, Value: ""}
+			default:
+				cells[ci] = excelize.Cell{StyleID: cellStyle, Value: fmt.Sprintf("%v", v)}
+			}
+		}
+		cellRef, _ := excelize.CoordinatesToCellName(1, ri+2)
+		if err := sw.SetRow(cellRef, cells, excelize.RowOpts{Height: 18}); err != nil {
+			return err
+		}
+	}
+
+	if err := sw.Flush(); err != nil {
+		return err
+	}
+	return f.Write(w)
 }

--- a/internal/excel/excel_test.go
+++ b/internal/excel/excel_test.go
@@ -45,3 +45,72 @@ func TestExportListEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
 }
+
+func TestWriteList(t *testing.T) {
+	cols := []string{"Наименование", "Цена", "Дата"}
+	rows := [][]any{
+		{"Яблоко", 15.5, time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)},
+		{"Банан", 20.0, time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)},
+		{"Груша", nil, nil},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteList(&buf, cols, rows))
+	require.NotEmpty(t, buf.Bytes())
+
+	f, err := excelize.OpenReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	sheet := "Лист1"
+
+	a1, _ := f.GetCellValue(sheet, "A1")
+	require.Equal(t, "Наименование", a1)
+	c1, _ := f.GetCellValue(sheet, "C1")
+	require.Equal(t, "Дата", c1)
+
+	a2, _ := f.GetCellValue(sheet, "A2")
+	require.Equal(t, "Яблоко", a2)
+	b2, _ := f.GetCellValue(sheet, "B2")
+	require.Equal(t, "15.5", b2)
+	c2, _ := f.GetCellValue(sheet, "C2")
+	require.Equal(t, "01.05.2026", c2)
+
+	// nil-ячейки → пусто
+	b4, _ := f.GetCellValue(sheet, "B4")
+	require.Equal(t, "", b4)
+
+	rowsRead, err := f.GetRows(sheet)
+	require.NoError(t, err)
+	require.Len(t, rowsRead, 4) // шапка + 3 строки данных
+}
+
+// WriteList (StreamWriter) должен давать те же значения ячеек, что и ExportList,
+// — потоковый вариант эквивалентен буферному по содержимому.
+func TestWriteListMatchesExportList(t *testing.T) {
+	cols := []string{"Товар", "Кол-во", "Сумма"}
+	rows := [][]any{
+		{"Стол", 3, 1500.0},
+		{"Стул", 12, 800.5},
+	}
+	data, err := ExportList(cols, rows)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, WriteList(&buf, cols, rows))
+
+	fe, err := excelize.OpenReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	fw, err := excelize.OpenReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	sheet := "Лист1"
+	for _, ref := range []string{"A1", "B1", "C1", "A2", "B2", "C2", "A3", "B3", "C3"} {
+		ve, _ := fe.GetCellValue(sheet, ref)
+		vw, _ := fw.GetCellValue(sheet, ref)
+		require.Equal(t, ve, vw, "ячейка %s должна совпадать", ref)
+	}
+}
+
+func TestWriteListEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, WriteList(&buf, []string{"A", "B"}, nil))
+	require.NotEmpty(t, buf.Bytes())
+}

--- a/internal/ui/handlers_export.go
+++ b/internal/ui/handlers_export.go
@@ -49,14 +49,17 @@ func (s *Server) listExcel(w http.ResponseWriter, r *http.Request) {
 		xlsRows[i] = cells
 	}
 
-	data, err := excel.ExportList(cols, xlsRows)
-	if err != nil {
+	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	w.Header().Set("Content-Disposition", contentDisposition(entity.Name+".xlsx"))
+	// Stream the workbook straight to the client instead of buffering the whole
+	// file in memory (план 111, P2-3). StreamWriter errors surface before any
+	// bytes reach w, so a failure here still yields a clean 500 rather than a
+	// truncated download.
+	if err := excel.WriteList(w, cols, xlsRows); err != nil {
+		w.Header().Del("Content-Disposition")
 		http.Error(w, "Excel error: "+s.errText(r, err), 500)
 		return
 	}
-	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	w.Header().Set("Content-Disposition", contentDisposition(entity.Name+".xlsx"))
-	w.Write(data)
 }
 
 // contentDisposition собирает заголовок Content-Disposition по RFC 6266:


### PR DESCRIPTION
## P2-3 — потоковый XLSX-экспорт списка (план 111)

Реализация находки §3.7 ревью масштабируемости (`Plans/111-scalability-review.md`).

### Проблема

`listExcel` держал весь экспорт в памяти: `rows` → `xlsRows` → `excel.ExportList`
собирал **весь XLSX в `[]byte`**, затем `w.Write(data)`. Пиковая память ≈
датасет × 3. (N+1 разворота ссылок в экспорте уже снят в
[P1-1](https://github.com/ivanarama/onebase/pull/493).)

### Что сделано

- **`excel.WriteList(w io.Writer, cols, rows)`** на excelize **StreamWriter**:
  строки пишутся инкрементально (флаш в temp, а не полная cell-модель в памяти),
  готовый файл стримится **прямо в `io.Writer`** — `[]byte` целиком не
  материализуется. Визуально идентично `ExportList` (общий `listStyles`: жирная
  замороженная шапка, рамки, число справа, дата `ДД.ММ.ГГГГ`, авто-ширина).
- **`listExcel`** стримит в `http.ResponseWriter`. Ошибки StreamWriter возникают
  **до** первой записи в `w`, поэтому при сбое отдаётся чистый `500`, а не
  обрезанная выгрузка.
- **`ExportList` не тронут** (у него ещё 6 вызывающих: отчёты, журналы,
  фоновые job'ы, DSL-билтин, кросс/compose-отчёты) — только вынес стили в
  общий `listStyles`, чтобы оба пути рисовали одинаково.

**Эффект:** пиковая память экспорта падает с ≈ датасет × 3 до ≈ датасет × 1
(остаётся `rows`/`xlsRows`; полный файл и cell-модель больше не буферизуются).

### Проверка

- `go test ./internal/excel/` — новые тесты: значения/дата/nil/число строк
  `WriteList`, **эквивалентность `ExportList` по ячейкам**, пустой случай.
- `go test ./internal/ui/` — зелёный (регресс экспорта).
- `go vet` + `go build ./...` — чисто.

### Осознанно вне scope

- **CSV-стриминг** и **пейджинг выборки из БД** (чтобы не держать `rows` в
  памяти вовсе) — следующий шаг; здесь снят самый большой буфер (весь файл в
  `[]byte`). Размер выборки уже ограничен `export_max_rows`.
- Фоновые job'ы экспорта (`export_jobs.go`) по-прежнему через `ExportList` —
  там результат кладётся в файл/хранилище, отдельная история.

Generated-with: Claude Code
