### PR TITLE
build(ci): включить bodyclose в golangci-lint (план 109, этап A)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,8 @@
 # Стратегия — прогрессивное ужесточение: включено то, что проходит на текущем
 # коде (CI остаётся зелёным), остальное включается по мере чистки baseline.
 # Staticcheck включён после закрытия baseline в 2026-07.
-# Оставшаяся очередь: errcheck, unused, gosec, bodyclose.
+# bodyclose включён по плану 109 (этап A): baseline был 0 находок.
+# Оставшаяся очередь (план 109): unused, errcheck, gosec.
 # После чистки соответствующего линтера — переносить его в enable.
 version: "2"
 
@@ -13,6 +14,7 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+    - bodyclose
 
 run:
   timeout: 10m


### PR DESCRIPTION
Первый шаг плана **109** (поэтапное ужесточение блокирующих CI-линтеров).

`bodyclose` добавлен в `linters.enable` в `.golangci.yml`. Baseline — **0 находок**, подтверждено полным запуском:

```
golangci-lint v2.11.4 run --enable-only=bodyclose --max-issues-per-linter=0 --max-same-issues=0 ./...
→ 0 issues.
```

Поэтому линтер включается отдельным минимальным PR, как и предписывает план (этап A). Оставшаяся очередь плана 109: `unused` → `errcheck` → `gosec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)