### PR TITLE
refactor(109B): удалить мёртвый код и включить unused в CI (план 109, этап B)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,8 @@
 # коде (CI остаётся зелёным), остальное включается по мере чистки baseline.
 # Staticcheck включён после закрытия baseline в 2026-07.
 # bodyclose включён по плану 109 (этап A): baseline был 0 находок.
-# Оставшаяся очередь (план 109): unused, errcheck, gosec.
+# unused включён по плану 109 (этап B): 29 находок мёртвого кода удалены.
+# Оставшаяся очередь (план 109): errcheck, gosec.
 # После чистки соответствующего линтера — переносить его в enable.
 version: "2"
 
@@ -15,6 +16,7 @@ linters:
     - ineffassign
     - staticcheck
     - bodyclose
+    - unused
 
 run:
   timeout: 10m

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -107,14 +107,6 @@ func (h *Handlers) IssueOneTimeCode(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{"code": code})
 }
 
-func (h *Handlers) loginPageData() map[string]any {
-	return map[string]any{"Error": "", "Users": h.listUsers()}
-}
-
-func (h *Handlers) listUsers() []*User {
-	return nil // populated in LoginPage via request context
-}
-
 func (h *Handlers) LoginPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	var users []*User

--- a/internal/backup/universal_test.go
+++ b/internal/backup/universal_test.go
@@ -771,25 +771,6 @@ func TestJSONColValue_PassesThroughObject(t *testing.T) {
 	}
 }
 
-// zipOpen returns the contents of name from a zip archive in memory.
-func zipOpen(data []byte, name string) ([]byte, error) {
-	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		return nil, err
-	}
-	for _, f := range zr.File {
-		if f.Name == name {
-			rc, err := f.Open()
-			if err != nil {
-				return nil, err
-			}
-			defer rc.Close()
-			return io.ReadAll(rc)
-		}
-	}
-	return nil, fs.ErrNotExist
-}
-
 // TestImportTableJSONL_CP1251StringColumn pins down the deploy failure
 // for _audit: a row in the JSONL has a TEXT column whose value is a
 // JSON string literal that contains raw Windows-1251 bytes (e.g. a

--- a/internal/dsl/interpreter/debug_hooks.go
+++ b/internal/dsl/interpreter/debug_hooks.go
@@ -156,37 +156,3 @@ func getTypeName(v any) string {
 		return fmt.Sprintf("%T", v)
 	}
 }
-
-// formatValue formats a value for display in the debugger
-func formatValue(v any) string {
-	if v == nil {
-		return ""
-	}
-	switch val := v.(type) {
-	case string:
-		if len(val) > 50 {
-			return val[:50] + "..."
-		}
-		return val
-	case float64:
-		return fmt.Sprintf("%.2f", val)
-	case decimal.Decimal:
-		return val.String()
-	case bool:
-		if val {
-			return "Истина"
-		}
-		return "Ложь"
-	case time.Time:
-		if val.Hour() == 0 && val.Minute() == 0 && val.Second() == 0 {
-			return val.Format("02.01.2006")
-		}
-		return val.Format("02.01.2006 15:04:05")
-	default:
-		str := fmt.Sprintf("%v", v)
-		if len(str) > 50 {
-			return str[:50] + "..."
-		}
-		return str
-	}
-}

--- a/internal/dsl/interpreter/env.go
+++ b/internal/dsl/interpreter/env.go
@@ -89,14 +89,6 @@ func newEnv(this This) *env {
 	return e
 }
 
-func (e *env) child() *env {
-	return e.frame(e, e.depth+1)
-}
-
-func (e *env) frame(parent *env, depth int) *env {
-	return e.frameWithModule(parent, e.module, depth)
-}
-
 func (e *env) frameWithModule(parent, module *env, depth int) *env {
 	root := e.root
 	if root == nil {

--- a/internal/dsl/loader/form_loader.go
+++ b/internal/dsl/loader/form_loader.go
@@ -13,9 +13,7 @@ import (
 )
 
 // FormLoader loads form modules from .os files
-type FormLoader struct {
-	parser *parser.Parser
-}
+type FormLoader struct{}
 
 // NewFormLoader creates form loader
 func NewFormLoader() *FormLoader {

--- a/internal/launcher/configurator_load.go
+++ b/internal/launcher/configurator_load.go
@@ -650,7 +650,6 @@ func (h *handler) listManagedFormsFromDBNoRequest(ctx context.Context, b *Base) 
 	if err != nil {
 		return nil, err
 	}
-	type pair struct{ yaml, os string }
 	groups := map[string]*cfgManagedForm{}
 	for _, f := range files {
 		parts := strings.Split(strings.TrimPrefix(f.Path, "forms/"), "/")

--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -141,7 +141,6 @@ func (h *handler) listManagedFormsFromDB(r *http.Request, b *Base) ([]cfgManaged
 	}
 
 	// группируем по entity + name
-	type pair struct{ yaml, os string }
 	groups := map[string]*cfgManagedForm{}
 	for _, f := range files {
 		// f.Path = forms/<entity>/<name>.form.yaml | .form.os

--- a/internal/pdfimport/pdfparse/lex.go
+++ b/internal/pdfimport/pdfparse/lex.go
@@ -21,7 +21,6 @@ import (
 //	string, a PDF string literal
 //	keyword, a PDF keyword
 //	name, a PDF name without the leading slash
-//
 type token interface{}
 
 // A name is a PDF name, without the leading slash.
@@ -58,13 +57,6 @@ func newBuffer(r io.Reader, offset int64) *buffer {
 		allowObjptr: true,
 		allowStream: true,
 	}
-}
-
-func (b *buffer) seek(offset int64) {
-	b.offset = offset
-	b.buf = b.buf[:0]
-	b.pos = 0
-	b.unread = b.unread[:0]
 }
 
 func (b *buffer) readByte() byte {

--- a/internal/pdfimport/pdfparse/ps.go
+++ b/internal/pdfimport/pdfparse/ps.go
@@ -5,7 +5,6 @@
 package pdfparse
 
 import (
-	"fmt"
 	"io"
 )
 
@@ -124,18 +123,4 @@ Reading:
 		}
 		stk.Push(Value{nil, objptr{}, obj})
 	}
-}
-
-type seqReader struct {
-	rd     io.Reader
-	offset int64
-}
-
-func (r *seqReader) ReadAt(buf []byte, offset int64) (int, error) {
-	if offset != r.offset {
-		return 0, fmt.Errorf("non-sequential read of stream")
-	}
-	n, err := io.ReadFull(r.rd, buf)
-	r.offset += int64(n)
-	return n, err
 }

--- a/internal/pdfimport/pdfparse/read.go
+++ b/internal/pdfimport/pdfparse/read.go
@@ -4,7 +4,7 @@
 
 // Package pdf implements reading of PDF files.
 //
-// Overview
+// # Overview
 //
 // PDF is Adobe's Portable Document Format, ubiquitous on the internet.
 // A PDF document is a complex data format built on a fairly simple structure.
@@ -43,7 +43,6 @@
 // they are implemented only in terms of the Value API and could be moved outside
 // the package. Equally important, traversal of other PDF data structures can be implemented
 // in other packages as needed.
-//
 package pdfparse
 
 // BUG(rsc): The package is incomplete, although it has been used successfully on some
@@ -91,10 +90,6 @@ type xref struct {
 	inStream bool
 	stream   objptr
 	offset   int64
-}
-
-func (r *Reader) errorf(format string, args ...interface{}) {
-	panic(fmt.Errorf(format, args...))
 }
 
 // Open opens a file for reading.
@@ -621,7 +616,7 @@ func (v Value) RawString() string {
 	return x
 }
 
-// Text returns v's string value interpreted as a ``text string'' (defined in the PDF spec)
+// Text returns v's string value interpreted as a “text string” (defined in the PDF spec)
 // and converted to UTF-8.
 // If v.Kind() != String, Text returns the empty string.
 func (v Value) Text() string {
@@ -725,13 +720,13 @@ func (v Value) Len() int {
 	}
 	return len(x)
 }
-//
+
 // resolve xrefs
+//
 //	in: the parent and the key or reference to resolve
 //	out: the reference
 //
-//	bugfix: in case the object-ref is within a stream than nothing was returned 
-//
+//	bugfix: in case the object-ref is within a stream than nothing was returned
 func (r *Reader) resolve(parent objptr, x interface{}) Value {
 
 	if ptr, ok := x.(objptr); ok {
@@ -745,7 +740,7 @@ func (r *Reader) resolve(parent objptr, x interface{}) Value {
 		// var obj object
 		if xref.inStream {
 			strm := r.resolve(parent, xref.stream)
-			
+
 		Search:
 			for {
 				if strm.Kind() != Stream {
@@ -826,7 +821,7 @@ func (e *errorReadCloser) Close() error {
 
 // Reader returns the data contained in the stream v.
 // If v.Kind() != Stream, Reader returns a ReadCloser that
-// responds to all reads with a ``stream not present'' error.
+// responds to all reads with a “stream not present” error.
 func (v Value) Reader() io.ReadCloser {
 	x, ok := v.data.(stream)
 	if !ok {

--- a/internal/pdfimport/util.go
+++ b/internal/pdfimport/util.go
@@ -15,7 +15,5 @@ func containsAny(s string, subs ...string) bool {
 	return false
 }
 
-const ptPerMM = 72.0 / 25.4 // 1 мм = 2.8346 pt
-
 // ptToMM конвертирует пункты в миллиметры.
 func ptToMM(pt float64) float64 { return pt * 25.4 / 72.0 }

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -2222,10 +2222,6 @@ func buildVTRefDimInfos(dims []metadata.Field, entities []*metadata.Entity) []re
 	return result
 }
 
-func buildRefDimInfos(dims []metadata.Field) []refDimInfo {
-	return buildRefDimInfosWithEntities(dims, nil)
-}
-
 func buildRefDimInfosWithEntities(dims []metadata.Field, entities []*metadata.Entity) []refDimInfo {
 	var result []refDimInfo
 	for _, d := range dims {

--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -324,11 +324,6 @@ func normalizeBool(v any) bool {
 	return false
 }
 
-// normalizeUUID is a convenience alias for UUID normalization only.
-func normalizeUUID(v any) any {
-	return normalizeValue(v)
-}
-
 // List returns rows for an entity with optional filtering and sorting.
 // For documents, also returns "posted" bool.
 // dateUpperBound возвращает верхнюю границу фильтра по дате и оператор. Для
@@ -813,12 +808,6 @@ func (db *DB) SetPosted(ctx context.Context, entityName string, id uuid.UUID, po
 		}
 	}
 	return err
-}
-
-// fieldValue extracts the value for a field from the fields map, handling reference UUID strings.
-// Deprecated: use fieldValueDialect to get values typed for the active backend.
-func fieldValue(f metadata.Field, fields map[string]any) any {
-	return fieldValueDialect(PgDialect{}, f, fields)
 }
 
 // uuidProvider is implemented by *interpreter.Ref to expose its UUID without

--- a/internal/storage/pgx_adapter.go
+++ b/internal/storage/pgx_adapter.go
@@ -12,10 +12,10 @@ type pgxRows struct {
 	r pgx.Rows
 }
 
-func (p *pgxRows) Next() bool          { return p.r.Next() }
+func (p *pgxRows) Next() bool            { return p.r.Next() }
 func (p *pgxRows) Scan(dst ...any) error { return p.r.Scan(dst...) }
-func (p *pgxRows) Err() error          { return p.r.Err() }
-func (p *pgxRows) Close()              { p.r.Close() }
+func (p *pgxRows) Err() error            { return p.r.Err() }
+func (p *pgxRows) Close()                { p.r.Close() }
 func (p *pgxRows) FieldNames() []string {
 	fds := p.r.FieldDescriptions()
 	out := make([]string, len(fds))
@@ -63,14 +63,4 @@ func (t *pgxTx) Commit(ctx context.Context) error {
 
 func (t *pgxTx) Rollback(ctx context.Context) error {
 	return t.tx.Rollback(ctx)
-}
-
-// unwrapPgxTx extracts the underlying pgx.Tx from a storage.Tx. Used inside
-// the storage package while we still rely on pgx directly. Will go away when
-// the SQLite driver lands.
-func unwrapPgxTx(t Tx) (pgx.Tx, bool) {
-	if pt, ok := t.(*pgxTx); ok {
-		return pt.tx, true
-	}
-	return nil, false
 }

--- a/internal/storage/tx.go
+++ b/internal/storage/tx.go
@@ -210,16 +210,3 @@ func (db *DB) exec(ctx context.Context, sql string, args ...any) error {
 	_, err := db.Exec(ctx, sql, args...)
 	return err
 }
-
-// querier returns a query executor that respects the transaction in ctx.
-type querier interface {
-	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
-	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
-}
-
-func (db *DB) q(ctx context.Context) querier {
-	if tx, ok := ctx.Value(txKey{}).(pgx.Tx); ok {
-		return tx
-	}
-	return db.pool
-}

--- a/internal/ui/fill_test.go
+++ b/internal/ui/fill_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -140,17 +139,6 @@ func TestFill_OnFillHook_CopiesFieldsAndTablePart(t *testing.T) {
 	if _, has := rows[0]["номенклатура"]; has {
 		t.Errorf("дублирующий lowercase-ключ остался в ТЧ: %v", rows[0])
 	}
-}
-
-// mapValue — регистронезависимое чтение ключа из row (DSL пишет в lower-case,
-// читать удобнее в PascalCase для совпадения с YAML-метаданными).
-func mapValue(row map[string]any, key string) any {
-	for k, v := range row {
-		if strings.EqualFold(k, key) {
-			return v
-		}
-	}
-	return nil
 }
 
 // Fill отклоняет источник, который не разрешён в based_on приёмника.

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -208,10 +207,6 @@ func (s *Server) loadRefOptions(ctx context.Context, entity *metadata.Entity) (m
 	return s.loadRefOptionsWithMode(ctx, entity, refOptionsChoice)
 }
 
-func (s *Server) loadRefFilterOptions(ctx context.Context, entity *metadata.Entity) (map[string][]map[string]any, error) {
-	return s.loadRefOptionsWithMode(ctx, entity, refOptionsFilter)
-}
-
 func (s *Server) loadRefOptionsWithMode(ctx context.Context, entity *metadata.Entity, mode refOptionsMode) (map[string][]map[string]any, error) {
 	opts := make(map[string][]map[string]any)
 	for _, f := range entity.Fields {
@@ -276,34 +271,6 @@ func (s *Server) loadInitialRefFilterOptions(ctx context.Context, entity *metada
 		opts[f.Name] = rows
 	}
 	return opts, nil
-}
-
-// loadTPRefOptions returns select options for reference fields in all table parts.
-// Result: tpName → fieldName → [{id, _label, ...}]
-func (s *Server) loadTPRefOptions(ctx context.Context, entity *metadata.Entity) (map[string]map[string][]map[string]any, error) {
-	result := make(map[string]map[string][]map[string]any)
-	for _, tp := range entity.TableParts {
-		tpOpts := make(map[string][]map[string]any)
-		for _, f := range tp.Fields {
-			if f.RefEntity == "" {
-				continue
-			}
-			// Always mark the field as a reference (even if catalog empty or missing)
-			tpOpts[f.Name] = []map[string]any{}
-			refEntity := s.reg.GetEntity(f.RefEntity)
-			if refEntity == nil {
-				continue
-			}
-			rows, err := s.initialReferenceOptions(ctx, refEntity, refOptionsChoice, nil)
-			if err != nil {
-				continue
-			}
-			tpOpts[f.Name] = rows
-		}
-		// Always add TP entry so JS knows which fields are references
-		result[tp.Name] = tpOpts
-	}
-	return result, nil
 }
 
 func (s *Server) loadInitialTPRefOptions(ctx context.Context, entity *metadata.Entity, tpRows map[string][]map[string]any) (map[string]map[string][]map[string]any, error) {
@@ -1160,16 +1127,6 @@ func capitalize(s string) string {
 	runes := []rune(s)
 	runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
 	return string(runes)
-}
-
-// sortKeys returns map keys in sorted order (for deterministic template output).
-func sortKeys(m map[string]storage.FilterValue) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 // filterValue returns the FilterValue for a field from ListParams, or empty.

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -55,11 +55,6 @@ func langFromCtx(ctx context.Context) string {
 	return ""
 }
 
-func (s *Server) runOnWrite(obj *runtime.Object, mc *runtime.MovementsCollector) string {
-	errMsg, _ := s.runOnWriteCtx(context.Background(), obj, mc)
-	return errMsg
-}
-
 func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollector) map[string]any {
 	// TxState is created before the common variable set so path resolvers and
 	// all write-capable DSL objects observe the same live transaction context.

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -468,27 +468,6 @@ func (s *Server) buildReportParams(ctx context.Context, lang string, params []re
 	return out
 }
 
-// loadReportRefOpts returns bounded select options for report params with type "reference:EntityName".
-func (s *Server) loadReportRefOpts(ctx context.Context, params []reportpkg.Param) map[string][]map[string]any {
-	opts := make(map[string][]map[string]any)
-	for _, p := range params {
-		if !strings.HasPrefix(p.Type, "reference:") {
-			continue
-		}
-		entityName := strings.TrimPrefix(p.Type, "reference:")
-		entity := s.reg.GetEntity(entityName)
-		if entity == nil {
-			continue
-		}
-		rows, err := s.initialReferenceOptions(ctx, entity, refOptionsChoice, nil)
-		if err != nil {
-			continue
-		}
-		opts[p.Name] = rows
-	}
-	return opts
-}
-
 type reportExportError struct {
 	status int
 	prefix string

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -528,11 +528,6 @@ func (s *Server) MountDebug(r chi.Router) {
 	})
 }
 
-type navSection struct {
-	Kind     string
-	Entities []*metadata.Entity
-}
-
 type navItem struct {
 	Label string
 	URL   string

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -78,7 +78,7 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			}
 			return strings.Join(e.ListRefreshOn, " ")
 		},
-		"treeColumn":  isTreeListColumn,
+		"treeColumn": isTreeListColumn,
 		"hasValue": func(v any) bool {
 			if v == nil {
 				return false
@@ -452,7 +452,6 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			return template.URL("&" + strings.Join(parts, "&"))
 		},
 		"reportParamQuery": func(params any, values map[string]any) string {
-			type param interface{ GetName() string }
 			// Use reflection-free approach: just iterate over values map
 			parts := []string{}
 			for k, v := range values {

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -53,18 +53,6 @@ func (rec *recorder) count() int {
 	return len(rec.bodies)
 }
 
-func waitFor(t *testing.T, cond func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("условие не выполнилось за 5 секунд")
-}
-
 func TestDispatcher_FiresOnMatchingEvent(t *testing.T) {
 	rec := &recorder{}
 	srv := httptest.NewServer(rec.handler())


### PR DESCRIPTION
Этап **B** плана 109 (ужесточение CI-линтеров, после 109A `bodyclose`).

Закрыты все **29 находок `unused`** (baseline 2026-07-27): удалены неиспользуемые функции/методы/типы/константы/поля в `auth`, `backup`(test), `dsl/interpreter`, `dsl/loader`, `launcher`, `pdfimport`, `query`, `storage`, `ui`, `webhook`.

**Проверка безопасности удаления:** каждый идентификатор сверён с build-tagged файлами (`integration`/`webview`) — ни один из них не использует удаляемое (проверено grep'ом по всем tagged-файлам). `go build ./...`, `go vet ./...`, `go test ./...` — зелёные; полный `golangci-lint` (govet, ineffassign, staticcheck, bodyclose, **unused**) — 0 issues. Импорты подчищены `goimports`.

`unused` добавлен в `.golangci.yml`. Итог: −253 строки мёртвого кода. Оставшаяся очередь плана 109: `errcheck` → `gosec` (перед ними — этап C, changed-code gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)