### PR TITLE
feat(storage,access): strict-RLS чокпоинт для store.List (план 79F)

### DIFF
--- a/Plans/79-row-level-access.md
+++ b/Plans/79-row-level-access.md
@@ -73,6 +73,19 @@
 
 Эстимейт: 2–3 дня (сканер путей + строгий флаг storage + тесты).
 
+**Реализация (вариант B — рантайм-гейт, по умолчанию выключен):**
+- `storage.DB.SetStrictRLSGuard(guard)` + поле `rlsGuard` (`pg.go`): nil = выключено.
+- `ListParams.RowFilterEvaluated` (`crud.go`): признак «строковый доступ вычислен»,
+  ставится всеми хелперами доступа (`ui.applyRowFilter`/`rowFilterFor`,
+  `api.applyRowFilter`) и явными gated-вызовами `store.List`.
+- `storage.List` fail-closed отклоняет список guarded-сущности без `RowFilterEvaluated`.
+- `access.GuardedEntitiesFromRoles(roles)` — множество сущностей с политиками
+  (catalogs/documents) из всех ролей.
+- Активация: env `ONEBASE_STRICT_RLS` в `onebase run` (`cli/run.go`). Тест —
+  `storage/strict_rls_test.go`.
+- ⬜ Осталось (опц.): вариант A (статический сканер путей `store.GetByID`),
+  распространение на регистры и на `run --id`/launcher/dev.
+
 ## Контекст
 
 В onebase уже есть объектный RBAC:

--- a/Plans/README.md
+++ b/Plans/README.md
@@ -61,9 +61,9 @@
 2. ~~**План 80** — итоги регистров~~ ✅ **Закрыт** (накопления + бухгалтерии):
    предрасчёт, инкремент в транзакции проводки, быстрый путь остатков/на-момент/
    оборотов, CLI `recalc-totals`, бенч ~150×. Опц. остаток — `totals.period`/свёртка.
-3. **План 79F** — RLS defense-in-depth: перенос enforcement строковых политик в
-   storage-чокпоинт вместо соглашения в хендлерах (2–3 дня). Закрывает арку
-   доступа после 112/113.
+3. ~~**План 79F**~~ 🟡 storage-чокпоинт для `store.List` реализован (fail-closed
+   рантайм-гейт под env `ONEBASE_STRICT_RLS`, по умолчанию выкл.; хелперы доступа
+   ставят `RowFilterEvaluated`). Опц. остаток — сканер `GetByID` и регистры.
 4. Стратегические направления, каждое — отдельный проект: **81** (безопасная
    реструктуризация схемы), **82** (полнотекстовый поиск), **83** (секреты —
    начато), **84** (enterprise-auth: 2FA/SSO/LDAP), **85** (бизнес-процессы —
@@ -196,7 +196,7 @@
 | 62 | [62-network-safety-switch.md](62-network-safety-switch.md) | Предохранитель сети: галочка `net.enabled` лочит хуки/HTTP/сервисы/email; сброс при restore | 0.5 дня | ✅ Реализовано |
 | 67 | [67-exec-command.md](67-exec-command.md) | Выполнение команд ОС из DSL (`ВыполнитьКоманду`) за флагом `AllowExec` (выкл. по умолчанию, без shell, таймаут, аудит) | 1–1.5 дня | ✅ Реализовано |
 | 76 | [76-multi-user-scale-readiness.md](76-multi-user-scale-readiness.md) | Готовность к 100+ активным пользователям: REST RBAC, лимиты, индексы, reference picker, атомарная запись, observability и путь к горизонтальному масштабированию | 2–4 недели по этапам | ⬜ Запланировано |
-| 79 | [79-row-level-access.md](79-row-level-access.md) | Строковые политики доступа поверх RBAC: декларативные row filters в ролях, SQL-side фильтрация UI/REST/picker и безопасный контур отчетов/AI | 1–2 недели по этапам | ✅ Core влит (query compiler fail-closed `assertRowFiltersApplied`); остаётся этап **79F** (storage-чокпоинт) |
+| 79 | [79-row-level-access.md](79-row-level-access.md) | Строковые политики доступа поверх RBAC: декларативные row filters в ролях, SQL-side фильтрация UI/REST/picker и безопасный контур отчетов/AI | 1–2 недели по этапам | ✅ Core влит (query compiler fail-closed `assertRowFiltersApplied`); **79F** storage-чокпоинт для `store.List` реализован (рантайм-гейт, по умолчанию выкл.) |
 
 ### Направление Г — Интеграции и экосистема (продолжение)
 
@@ -235,7 +235,7 @@
 | 84 | [84-enterprise-auth.md](84-enterprise-auth.md) | Enterprise-аутентификация: TOTP-2FA, SSO (OIDC), опц. LDAP — всё opt-in | 7–10 дней | ⬜ Проект |
 | 85 | [85-business-processes-tasks.md](85-business-processes-tasks.md) | Бизнес-процессы и задачи: карта маршрута, «Мои задачи», согласование документов | 2–3 недели | 🟡 Фаза 1: маршрут согласования заявок (задачи и состояния) |
 | 86 | [86-data-exchange.md](86-data-exchange.md) | Обмен данными между базами: планы обмена, регистрация изменений, пакеты, конфликты | 3–4 недели | 🟡 Фаза 1 (файловый обмен) сделана |
-| 79F | [79-row-level-access.md](79-row-level-access.md) | RLS defense-in-depth: storage-чокпоинт вместо enforcement по соглашению в хендлерах | 2–3 дня | ⬜ Проект (этап плана 79) |
+| 79F | [79-row-level-access.md](79-row-level-access.md) | RLS defense-in-depth: storage-чокпоинт вместо enforcement по соглашению в хендлерах | 2–3 дня | 🟡 Рантайм-гейт `store.List` реализован (env `ONEBASE_STRICT_RLS`, по умолчанию выкл.); осталось опц. — сканер `GetByID`, регистры |
 
 > SOAP-веб-сервисы сознательно **не** вносятся: их роль закрывают HTTP-сервисы
 > (план 61) и REST API v2 (план 26).

--- a/internal/access/row_access.go
+++ b/internal/access/row_access.go
@@ -73,6 +73,26 @@ func HasRestrictedPolicy(u *auth.User, kind, entity, op string) bool {
 	return restricted
 }
 
+// GuardedEntitiesFromRoles возвращает множество имён сущностей (lower-case), для
+// которых хотя бы одна роль объявляет строковую политику (catalogs/documents).
+// Используется strict-RLS чокпоинтом (план 79F) как guard для storage.List:
+// список такой сущности без вычисленного строкового доступа — обход RLS.
+func GuardedEntitiesFromRoles(roles []*auth.Role) map[string]bool {
+	guarded := map[string]bool{}
+	for _, role := range roles {
+		if role == nil {
+			continue
+		}
+		for name := range role.Permissions.RowAccess.Catalogs {
+			guarded[strings.ToLower(name)] = true
+		}
+		for name := range role.Permissions.RowAccess.Documents {
+			guarded[strings.ToLower(name)] = true
+		}
+	}
+	return guarded
+}
+
 // ValidatePolicy checks a row policy with the same compiler path used at
 // runtime. It is intended for diagnostics/lint: callers pass already resolved
 // same_as policies.

--- a/internal/api/row_access.go
+++ b/internal/api/row_access.go
@@ -31,6 +31,7 @@ func (h *handler) applyRowFilter(ctx context.Context, entity *metadata.Entity, o
 	if !dec.Unrestricted {
 		params.RowFilter = dec.Predicate
 	}
+	params.RowFilterEvaluated = true // план 79F: строковый доступ вычислен
 	return params, nil
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ivantit66/onebase/internal/access"
 	"github.com/ivantit66/onebase/internal/api"
 	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/backup"
@@ -191,6 +192,15 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		if err := authRepo.SyncRoles(ctx, roles); err != nil {
 			return fmt.Errorf("sync roles: %w", err)
 		}
+	}
+
+	// План 79F: strict-RLS чокпоинт (defense-in-depth). Под флагом
+	// ONEBASE_STRICT_RLS storage.List fail-closed отклоняет список сущности со
+	// строковой политикой, запрошенный без вычисленного доступа — чтобы обход
+	// RLS новым list-хендлером всплывал сразу. По умолчанию выключено.
+	if os.Getenv("ONEBASE_STRICT_RLS") != "" {
+		guarded := access.GuardedEntitiesFromRoles(roles)
+		db.SetStrictRLSGuard(func(name string) bool { return guarded[name] })
 	}
 
 	if err := db.EnsureAccountsTable(ctx); err != nil {

--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -17,6 +17,11 @@ import (
 type ListParams struct {
 	Filters           map[string]FilterValue
 	RowFilter         *Predicate            // additional SQL-side row-level access predicate
+	// RowFilterEvaluated — строковый доступ был вычислен для этого списка (план
+	// 79F): хендлер прошёл через applyRowFilter/rowFilterFor (даже если политика
+	// неограничивающая — RowFilter при этом nil). Используется strict-RLS
+	// чокпоинтом в List как признак «фильтр не забыли», иначе fail-closed.
+	RowFilterEvaluated bool
 	JournalRowFilters map[string]*Predicate // per document name row-level predicates for journal UNIONs
 	Sort              string                // field Name (empty = default sort by id)
 	Dir               string                // "asc" or "desc"
@@ -366,6 +371,13 @@ func folderScopeWhere(d Dialect, entity *metadata.Entity, onlyFolders, excludeFo
 }
 
 func (db *DB) List(ctx context.Context, entityName string, entity *metadata.Entity, params ListParams) ([]map[string]any, error) {
+	// План 79F (defense-in-depth, по умолчанию выключен): если у сущности есть
+	// строковая политика, но список запрошен без вычисления строкового доступа
+	// (хендлер не прошёл applyRowFilter/rowFilterFor), отклоняем fail-closed —
+	// чтобы обход RLS новым list-хендлером всплывал сразу, а не тихо.
+	if db.rlsGuard != nil && !params.RowFilterEvaluated && db.rlsGuard(strings.ToLower(entityName)) {
+		return nil, fmt.Errorf("strict RLS: список %q запрошен без вычисления строкового доступа (fail-closed, план 79F)", entityName)
+	}
 	d := db.dialect
 	table := metadata.TableName(entityName)
 	cols := []string{"id"}

--- a/internal/storage/pg.go
+++ b/internal/storage/pg.go
@@ -25,6 +25,20 @@ type DB struct {
 	blobStore  BlobObjectStore // non-nil when file_storage=s3 configured
 	blobPrefix string          // key prefix for blob objects in the bucket
 	blobStream bool            // s3 attachments: stream via Range instead of temp file
+	// rlsGuard — strict-RLS чокпоинт (план 79F). nil = выключен (по умолчанию).
+	// Когда задан, List для сущности, у которой guard возвращает true (есть
+	// строковая политика), но без вычисленного строкового доступа
+	// (ListParams.RowFilterEvaluated=false), отклоняется fail-closed. Инжектится
+	// из лаунчера/сервера в строгом режиме (ONEBASE_STRICT_RLS).
+	rlsGuard func(entityName string) bool
+}
+
+// SetStrictRLSGuard включает strict-RLS чокпоинт (план 79F, defense-in-depth).
+// guard(entityName) == true означает «у сущности есть строковая политика».
+// Передача nil выключает режим. Возвращает db для чейнинга при инициализации.
+func (db *DB) SetStrictRLSGuard(guard func(entityName string) bool) *DB {
+	db.rlsGuard = guard
+	return db
 }
 
 // BlobObjectStore is the S3-compatible backend used when file_storage=s3

--- a/internal/storage/strict_rls_test.go
+++ b/internal/storage/strict_rls_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Strict-RLS чокпоинт (план 79F): List для сущности с политикой, запрошенный без
+// вычисленного строкового доступа, отклоняется fail-closed. По умолчанию (guard
+// nil) режим выключен и поведение не меняется.
+func TestStrictRLSGuard_ListChokepoint(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	guarded := &metadata.Entity{Name: "Заказы", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}}}
+	open := &metadata.Entity{Name: "Валюты", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Код", Type: metadata.FieldTypeString}}}
+	if err := db.Migrate(ctx, []*metadata.Entity{guarded, open}); err != nil {
+		t.Fatal(err)
+	}
+
+	// По умолчанию (guard nil) чокпоинт выключен — список без флага проходит.
+	if _, err := db.List(ctx, guarded.Name, guarded, ListParams{}); err != nil {
+		t.Fatalf("guard nil: список должен проходить, получили %v", err)
+	}
+
+	// Строгий режим: политика есть только у «заказы».
+	db.SetStrictRLSGuard(func(name string) bool { return name == "заказы" })
+
+	// Guarded без вычисленного доступа → fail-closed.
+	_, err = db.List(ctx, guarded.Name, guarded, ListParams{})
+	if err == nil {
+		t.Fatal("strict RLS: ожидалась ошибка для guarded-сущности без RowFilterEvaluated")
+	}
+	if !strings.Contains(err.Error(), "strict RLS") {
+		t.Fatalf("неожиданная ошибка: %v", err)
+	}
+
+	// Guarded с вычисленным доступом → проходит (даже если фильтр nil — неограничивающая политика).
+	if _, err := db.List(ctx, guarded.Name, guarded, ListParams{RowFilterEvaluated: true}); err != nil {
+		t.Fatalf("guarded + RowFilterEvaluated: список должен проходить, получили %v", err)
+	}
+
+	// Non-guarded без флага → проходит (нет политики — нечего обходить).
+	if _, err := db.List(ctx, open.Name, open, ListParams{}); err != nil {
+		t.Fatalf("non-guarded: список должен проходить, получили %v", err)
+	}
+
+	// Выключение режима (nil) снова открывает.
+	db.SetStrictRLSGuard(nil)
+	if _, err := db.List(ctx, guarded.Name, guarded, ListParams{}); err != nil {
+		t.Fatalf("после выключения: список должен проходить, получили %v", err)
+	}
+}

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -94,10 +94,11 @@ func (s *Server) list(w http.ResponseWriter, r *http.Request) {
 	var treeRows []map[string]any
 	if treeView {
 		allRows, _ := s.store.List(r.Context(), entity.Name, entity, storage.ListParams{
-			ActivityScope: metadata.ActivityScopeAll,
-			ParentStr:     "root",
-			RowFilter:     params.RowFilter,
-			Limit:         storage.MaxListPageSize,
+			ActivityScope:      metadata.ActivityScopeAll,
+			ParentStr:          "root",
+			RowFilter:          params.RowFilter,
+			RowFilterEvaluated: params.RowFilterEvaluated,
+			Limit:              storage.MaxListPageSize,
 		})
 		s.maskRecords(r.Context(), entity, allRows)
 		s.resolveRefs(r.Context(), entity, allRows)

--- a/internal/ui/handlers_image.go
+++ b/internal/ui/handlers_image.go
@@ -181,7 +181,7 @@ func (s *Server) blobReferencedWithPolicy(ctx context.Context, entity *metadata.
 		if rowFilter != nil {
 			filter = &storage.Predicate{All: []storage.Predicate{imageFilter, *rowFilter}}
 		}
-		rows, err := s.store.List(ctx, entity.Name, entity, storage.ListParams{Limit: 1, RowFilter: filter})
+		rows, err := s.store.List(ctx, entity.Name, entity, storage.ListParams{Limit: 1, RowFilter: filter, RowFilterEvaluated: true})
 		if err == nil && len(rows) > 0 {
 			return true
 		}

--- a/internal/ui/row_access.go
+++ b/internal/ui/row_access.go
@@ -34,6 +34,7 @@ func (s *Server) applyRowFilter(w http.ResponseWriter, r *http.Request, entity *
 	if !dec.Unrestricted {
 		params.RowFilter = dec.Predicate
 	}
+	params.RowFilterEvaluated = true // план 79F: строковый доступ вычислен
 	return params, true
 }
 
@@ -177,6 +178,7 @@ func (s *Server) rowFilterFor(ctx context.Context, entity *metadata.Entity, op s
 	if !dec.Unrestricted {
 		params.RowFilter = dec.Predicate
 	}
+	params.RowFilterEvaluated = true // план 79F: строковый доступ вычислен
 	return params, nil
 }
 


### PR DESCRIPTION
Этап **79F** плана 79 — defense-in-depth для строкового доступа (RLS).

**Проблема:** query compiler fail-closed (`assertRowFiltersApplied`), но `store.List` полагается на дисциплину — каждый хендлер обязан позвать `applyRowFilter`. Новый хендлер, дёрнувший `store.List` напрямую, **тихо обойдёт RLS**, и регрессия не всплывёт.

**Решение (вариант B — рантайм-гейт, по умолчанию ВЫКЛЮЧЕН):**
- `ListParams.RowFilterEvaluated` — признак «строковый доступ вычислен»; ставится всеми хелперами (`ui`/`api` `applyRowFilter`, `rowFilterFor`) и явными gated-вызовами.
- `storage.List` fail-closed отклоняет список guarded-сущности без этого признака.
- `storage.DB.SetStrictRLSGuard(guard)` (nil = выкл.); `access.GuardedEntitiesFromRoles(roles)` строит множество сущностей с политиками.
- Активация: env `ONEBASE_STRICT_RLS` в `onebase run`.

По умолчанию поведение не меняется (guard nil → гейт не срабатывает, нулевая стоимость). Тест `storage/strict_rls_test.go`. `go test ./...` + golangci-lint — чисто.

**Осталось (опц.):** вариант A (статический сканер `store.GetByID`), распространение на регистры и на `run --id`/launcher/dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)