### PR TITLE
test(109): errcheck в тестах objstore и backup (план 109, класс 4)

### DIFF
--- a/internal/backup/s3_integration_test.go
+++ b/internal/backup/s3_integration_test.go
@@ -38,7 +38,9 @@ func TestCreateAutoBackup_S3EndToEnd(t *testing.T) {
 	got := make(chan captured, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(r.Body)
+		if _, err := buf.ReadFrom(r.Body); err != nil {
+			t.Errorf("read body: %v", err)
+		}
 		got <- captured{
 			method: r.Method,
 			path:   r.URL.Path,

--- a/internal/backup/universal_test.go
+++ b/internal/backup/universal_test.go
@@ -43,10 +43,16 @@ func buildLegacyOBZ(t *testing.T) []byte {
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
 	mf, _ := zw.Create("META.txt")
-	mf.Write([]byte("onebase_full_export\nversion=1.0\ndb_type=sqlite\n"))
+	if _, err := mf.Write([]byte("onebase_full_export\nversion=1.0\ndb_type=sqlite\n")); err != nil {
+		t.Fatal(err)
+	}
 	df, _ := zw.Create("database.db")
-	df.Write([]byte("not a real db"))
-	zw.Close()
+	if _, err := df.Write([]byte("not a real db")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
 	return buf.Bytes()
 }
 
@@ -59,22 +65,32 @@ func extractZip(data []byte, dir string) error {
 	for _, f := range zr.File {
 		outPath := filepath.Join(dir, filepath.FromSlash(f.Name))
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(outPath, 0o755)
+			if err := os.MkdirAll(outPath, 0o755); err != nil {
+				return err
+			}
 			continue
 		}
-		os.MkdirAll(filepath.Dir(outPath), 0o755)
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return err
+		}
 		rc, err := f.Open()
 		if err != nil {
 			return err
 		}
 		out, err := os.Create(outPath)
 		if err != nil {
-			rc.Close()
+			_ = rc.Close()
 			return err
 		}
-		io.Copy(out, rc)
-		out.Close()
-		rc.Close()
+		_, copyErr := io.Copy(out, rc)
+		closeErr := out.Close() // write-close: ошибка важна (файл мог не долететь)
+		_ = rc.Close()          // read-close: best-effort
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
 	}
 	return nil
 }
@@ -552,10 +568,14 @@ func TestAttachmentsExportRestore(t *testing.T) {
 	attDir := t.TempDir()
 	// Write a fake attachment file.
 	subDir := filepath.Join(attDir, "Реализация")
-	os.MkdirAll(subDir, 0o755)
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	attFile := filepath.Join(subDir, "abc123-uuid")
 	attContent := []byte("hello attachment content")
-	os.WriteFile(attFile, attContent, 0o644)
+	if err := os.WriteFile(attFile, attContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	var buf bytes.Buffer
 	if err := ExportUniversal(ctx, db, "file", t.TempDir(), attDir, "test", &buf); err != nil {
@@ -574,7 +594,7 @@ func TestAttachmentsExportRestore(t *testing.T) {
 			// Verify content.
 			rc, _ := f.Open()
 			got, _ := io.ReadAll(rc)
-			rc.Close()
+			_ = rc.Close()
 			if !bytes.Equal(got, attContent) {
 				t.Errorf("attachment content mismatch: got %q, want %q", got, attContent)
 			}
@@ -591,7 +611,9 @@ func TestAttachmentsExportRestore(t *testing.T) {
 	// Restore attachments.
 	dstAttDir := t.TempDir()
 	tmpDir := t.TempDir()
-	extractZip(buf.Bytes(), tmpDir)
+	if err := extractZip(buf.Bytes(), tmpDir); err != nil {
+		t.Fatal(err)
+	}
 	attSrc := filepath.Join(tmpDir, "attachments")
 	existing := filepath.Join(dstAttDir, "Реализация", "abc123-uuid")
 	if err := os.MkdirAll(filepath.Dir(existing), 0o755); err != nil {
@@ -612,12 +634,14 @@ func TestAttachmentsExportRestore(t *testing.T) {
 
 	// Verify the restored file exists with correct content.
 	var restoredContent []byte
-	filepath.WalkDir(dstAttDir, func(path string, d fs.DirEntry, _ error) error {
+	if err := filepath.WalkDir(dstAttDir, func(path string, d fs.DirEntry, _ error) error {
 		if !d.IsDir() {
 			restoredContent, _ = os.ReadFile(path)
 		}
 		return nil
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(restoredContent, attContent) {
 		t.Errorf("restored content mismatch: got %q, want %q", restoredContent, attContent)
 	}

--- a/internal/objstore/s3_test.go
+++ b/internal/objstore/s3_test.go
@@ -14,6 +14,22 @@ import (
 
 func ptrBool(b bool) *bool { return &b }
 
+// writeAll пишет тело фикстур-сервера; ошибку записи помечает как сбой теста.
+func writeAll(t *testing.T, w io.Writer, b []byte) {
+	t.Helper()
+	if _, err := w.Write(b); err != nil {
+		t.Errorf("write fixture response: %v", err)
+	}
+}
+
+// closeChecked закрывает ресурс; ошибку закрытия помечает как сбой теста.
+func closeChecked(t *testing.T, c io.Closer) {
+	t.Helper()
+	if err := c.Close(); err != nil {
+		t.Errorf("close: %v", err)
+	}
+}
+
 // TestSignV4AWSVector checks our signature against AWS's documented
 // "GET Object" Signature Version 4 example, so a regression in the signer is
 // caught deterministically. See the AWS docs' worked example for these values.
@@ -108,7 +124,7 @@ func TestPutObjectRoundTrip(t *testing.T) {
 func TestPutObjectServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
-		io.WriteString(w, `<Error><Code>AccessDenied</Code><Message>nope</Message></Error>`)
+		writeAll(t, w, []byte(`<Error><Code>AccessDenied</Code><Message>nope</Message></Error>`))
 	}))
 	defer srv.Close()
 
@@ -134,16 +150,16 @@ func TestListKeysPagination(t *testing.T) {
 		w.Header().Set("Content-Type", "application/xml")
 		if page == 0 && r.URL.Query().Get("continuation-token") == "" {
 			page++
-			fmt.Fprint(w, `<ListBucketResult><IsTruncated>true</IsTruncated>`+
+			writeAll(t, w, []byte(`<ListBucketResult><IsTruncated>true</IsTruncated>`+
 				`<NextContinuationToken>TOK</NextContinuationToken>`+
-				`<Contents><Key>prod/a</Key></Contents></ListBucketResult>`)
+				`<Contents><Key>prod/a</Key></Contents></ListBucketResult>`))
 			return
 		}
 		if r.URL.Query().Get("continuation-token") != "TOK" {
 			t.Errorf("expected continuation-token TOK, got %q", r.URL.Query().Get("continuation-token"))
 		}
-		fmt.Fprint(w, `<ListBucketResult><IsTruncated>false</IsTruncated>`+
-			`<Contents><Key>prod/b</Key></Contents></ListBucketResult>`)
+		writeAll(t, w, []byte(`<ListBucketResult><IsTruncated>false</IsTruncated>`+
+			`<Contents><Key>prod/b</Key></Contents></ListBucketResult>`))
 	}))
 	defer srv.Close()
 
@@ -165,7 +181,7 @@ func TestGetObjectRoundTrip(t *testing.T) {
 		gotAuth = r.Header.Get("Authorization")
 		w.Header().Set("Content-Length", fmt.Sprint(len(payload)))
 		w.WriteHeader(http.StatusOK)
-		w.Write(payload)
+		writeAll(t, w, payload)
 	}))
 	defer srv.Close()
 
@@ -174,7 +190,7 @@ func TestGetObjectRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetObject: %v", err)
 	}
-	defer rc.Close()
+	defer closeChecked(t, rc)
 	if gotPath != "/mybucket/blobs/abc" {
 		t.Errorf("path = %s", gotPath)
 	}
@@ -216,14 +232,14 @@ func TestOpenReadSeeker_FullAndRange(t *testing.T) {
 		t.Fatal(err)
 	}
 	full, _ := io.ReadAll(rs)
-	rs.Close()
+	closeChecked(t, rs)
 	if !bytes.Equal(full, payload) {
 		t.Fatalf("full read mismatch (%d bytes)", len(full))
 	}
 
 	// Seek then read a middle window.
 	rs2 := c.OpenReadSeeker(context.Background(), "blobs/x", int64(len(payload)))
-	defer rs2.Close()
+	defer closeChecked(t, rs2)
 	if _, err := rs2.Seek(400, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +265,7 @@ func TestOpenReadSeeker_ServeContent(t *testing.T) {
 
 	dl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rs := c.OpenReadSeeker(r.Context(), "blobs/x", int64(len(payload)))
-		defer rs.Close()
+		defer closeChecked(t, rs)
 		http.ServeContent(w, r, "file.bin", time.Time{}, rs)
 	}))
 	defer dl.Close()
@@ -260,7 +276,7 @@ func TestOpenReadSeeker_ServeContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close() // errcheck+bodyclose: явное закрытие тела ответа
 	if resp.StatusCode != 200 || !bytes.Equal(body, payload) {
 		t.Fatalf("full: status=%d len=%d", resp.StatusCode, len(body))
 	}
@@ -273,7 +289,7 @@ func TestOpenReadSeeker_ServeContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	part, _ := io.ReadAll(resp2.Body)
-	resp2.Body.Close()
+	_ = resp2.Body.Close() // errcheck+bodyclose: явное закрытие тела ответа
 	if resp2.StatusCode != http.StatusPartialContent {
 		t.Fatalf("range status = %d, want 206", resp2.StatusCode)
 	}
@@ -285,7 +301,7 @@ func TestOpenReadSeeker_ServeContent(t *testing.T) {
 func TestGetObjectNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		io.WriteString(w, `<Error><Code>NoSuchKey</Code><Message>missing</Message></Error>`)
+		writeAll(t, w, []byte(`<Error><Code>NoSuchKey</Code><Message>missing</Message></Error>`))
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
Первый заход по `errcheck` (после `bodyclose`/`unused`) — самый **безопасный класс 4: тесты**, поведение продукта не меняется.

Закрыты все errcheck-находки в `objstore/s3_test.go` и `backup`-тестах (~27):
- **setup-операции** (`MkdirAll`/`WriteFile`/`Write`/`io.Copy`/`WalkDir`/`ReadFrom`) → проверка через `t.Fatal`/`t.Errorf` (ловит битую подготовку теста);
- **фикстур-серверы и закрытия** → хелперы `writeAll`/`closeChecked` с диагностикой; в error-путях helper'а `extractZip` — `return err` (setup) / `_ =` для вторичного read-close;
- **тела HTTP-ответов** → `_ = resp.Body.Close()` — форма, совместимая и с `bodyclose` (распознаёт литеральный `.Body.Close()`), и с `errcheck` (явный `_ =`).

`go test` + полный golangci-lint (incl. bodyclose/unused) — чисто. **errcheck пока не включён в CI** (остаётся production-класс, ~750) — это снижение baseline; линтер включится, когда закрыты все классы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)