### PR TITLE
test(109): errcheck в остальных тестах equipment (план 109, класс 4)

### DIFF
--- a/internal/equipment/atol_test.go
+++ b/internal/equipment/atol_test.go
@@ -22,10 +22,10 @@ func atolEmulator(t *testing.T, fiscal string) (string, *atolTask) {
 		if err := json.Unmarshal(body, &got); err != nil {
 			t.Errorf("эмулятор: некорректное задание: %v", err)
 		}
-		w.Write([]byte(`{"isError":false}`))
+		_, _ = w.Write([]byte(`{"isError":false}`))
 	})
 	mux.HandleFunc("/api/v2/requests/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":` + fiscal + `}]}`))
+		_, _ = w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":` + fiscal + `}]}`))
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
@@ -50,7 +50,7 @@ func TestAtol_RegisterReceipt_Result(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	kkt, ok := dev.(FiscalRegistrar)
 	if !ok {
 		t.Fatal("устройство не реализует FiscalRegistrar")
@@ -81,7 +81,7 @@ func TestAtol_TaskMapping(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	if _, err := dev.(FiscalRegistrar).RegisterReceipt(sampleFiscalReceipt()); err != nil {
 		t.Fatalf("RegisterReceipt: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestAtol_TaskMapping(t *testing.T) {
 func TestAtol_ReturnAndDefaults(t *testing.T) {
 	url, got := atolEmulator(t, `{"fnNumber":"1","fiscalDocumentNumber":1,"fiscalDocumentSign":"1"}`)
 	dev, _ := Open("atol_kkt", map[string]string{"порт": url})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 
 	r := FiscalReceipt{
 		Type:     "возвратПрихода",
@@ -150,16 +150,16 @@ func TestAtol_ReturnAndDefaults(t *testing.T) {
 func TestAtol_ServiceError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v2/requests", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"isError":false}`))
+		_, _ = w.Write([]byte(`{"isError":false}`))
 	})
 	mux.HandleFunc("/api/v2/requests/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"ready":true,"isError":true,"results":[{"error":{"description":"нет бумаги"}}]}`))
+		_, _ = w.Write([]byte(`{"ready":true,"isError":true,"results":[{"error":{"description":"нет бумаги"}}]}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	dev, _ := Open("atol_kkt", map[string]string{"порт": srv.URL})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	_, err := dev.(FiscalRegistrar).RegisterReceipt(sampleFiscalReceipt())
 	if err == nil || !strings.Contains(err.Error(), "нет бумаги") {
 		t.Errorf("ожидалась ошибка с описанием от ККТ, получено: %v", err)
@@ -169,7 +169,7 @@ func TestAtol_ServiceError(t *testing.T) {
 func TestAtol_NoItems(t *testing.T) {
 	url, _ := atolEmulator(t, `{}`)
 	dev, _ := Open("atol_kkt", map[string]string{"порт": url})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	if _, err := dev.(FiscalRegistrar).RegisterReceipt(FiscalReceipt{Type: "приход"}); err == nil {
 		t.Error("ожидалась ошибка для чека без позиций")
 	}
@@ -181,7 +181,7 @@ func TestAtol_NoItems(t *testing.T) {
 func TestAtol_StateUnknownOnPollFailure(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v2/requests", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"isError":false}`)) // задание принято — чек ушёл в ФН
+		_, _ = w.Write([]byte(`{"isError":false}`)) // задание принято — чек ушёл в ФН
 	})
 	mux.HandleFunc("/api/v2/requests/", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "сервис недоступен", http.StatusInternalServerError) // опрос падает
@@ -190,7 +190,7 @@ func TestAtol_StateUnknownOnPollFailure(t *testing.T) {
 	defer srv.Close()
 
 	dev, _ := Open("atol_kkt", map[string]string{"порт": srv.URL})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	_, err := dev.(FiscalRegistrar).RegisterReceipt(sampleFiscalReceipt())
 	var unknown *FiscalStateUnknownError
 	if !errors.As(err, &unknown) {
@@ -208,7 +208,7 @@ func TestAtol_StateUnknownOnPollFailure(t *testing.T) {
 func TestAtol_RoundsMoneyToKopecks(t *testing.T) {
 	url, got := atolEmulator(t, `{"fnNumber":"9999078900012345","fiscalDocumentNumber":7,"fiscalDocumentSign":"111","receiptDatetime":"2026-06-19T10:00:00+03:00","total":87.15}`)
 	dev, _ := Open("atol_kkt", map[string]string{"порт": url})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 
 	r := FiscalReceipt{
 		Type:     "приход",
@@ -249,16 +249,16 @@ func TestAtol_RejectsUnbalancedReceipt(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v2/requests", func(w http.ResponseWriter, r *http.Request) {
 		posted = true
-		w.Write([]byte(`{"isError":false}`))
+		_, _ = w.Write([]byte(`{"isError":false}`))
 	})
 	mux.HandleFunc("/api/v2/requests/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":{}}]}`))
+		_, _ = w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":{}}]}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	dev, _ := Open("atol_kkt", map[string]string{"порт": srv.URL})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 
 	// Позиции на 100, оплата на 90 — расхождение должно отсекаться валидацией.
 	r := FiscalReceipt{
@@ -280,7 +280,7 @@ func TestAtol_RejectsUnbalancedReceipt(t *testing.T) {
 func TestAtol_IdempotencyKeyReusesUUID(t *testing.T) {
 	url, got := atolEmulator(t, `{"fnNumber":"1","fiscalDocumentNumber":1,"fiscalDocumentSign":"1"}`)
 	dev, _ := Open("atol_kkt", map[string]string{"порт": url})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	kkt := dev.(FiscalRegistrar)
 
 	r := sampleFiscalReceipt()
@@ -308,7 +308,7 @@ func TestAtol_IdempotencyKeyReusesUUID(t *testing.T) {
 func TestAtol_ResolveByUUID(t *testing.T) {
 	url, _ := atolEmulator(t, `{"fnNumber":"9999078900012345","fiscalDocumentNumber":42,"fiscalDocumentSign":"222","receiptDatetime":"2026-06-19T10:00:00+03:00","total":60}`)
 	dev, _ := Open("atol_kkt", map[string]string{"порт": url})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	kkt := dev.(FiscalRegistrar)
 
 	res, err := kkt.ResolveByUUID("some-saved-uuid")
@@ -328,7 +328,7 @@ func TestAtol_ResolveByUUID(t *testing.T) {
 func TestAtol_RejectsInvalidReceipt(t *testing.T) {
 	url, _ := atolEmulator(t, `{}`)
 	dev, _ := Open("atol_kkt", map[string]string{"порт": url})
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	kkt := dev.(FiscalRegistrar)
 
 	if _, err := kkt.RegisterReceipt(FiscalReceipt{Type: "приход", Items: []FiscalItem{{Name: "X", Qty: 1, Price: 0}}}); err == nil {

--- a/internal/equipment/display_test.go
+++ b/internal/equipment/display_test.go
@@ -19,7 +19,7 @@ func TestDisplay_ShowLines(t *testing.T) {
 	if err := disp.ShowLines([]string{"Молоко 3 шт", "ИТОГО: 150"}); err != nil {
 		t.Fatalf("ShowLines: %v", err)
 	}
-	dev.Disconnect()
+	disconnect(dev)
 
 	got := <-received
 	if !bytes.HasPrefix(got, dispInit) {
@@ -46,7 +46,7 @@ func TestDisplay_IsNotPrinter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	if _, ok := dev.(ReceiptPrinter); ok {
 		t.Error("дисплей покупателя не должен быть ReceiptPrinter")
 	}

--- a/internal/equipment/scripted_display_test.go
+++ b/internal/equipment/scripted_display_test.go
@@ -32,7 +32,7 @@ func TestScriptedDisplay_ShowLines_CP866(t *testing.T) {
 	if err := disp.ShowLines([]string{"Молоко", "ИТОГО 150"}); err != nil {
 		t.Fatalf("ShowLines: %v", err)
 	}
-	dev.Disconnect()
+	disconnect(dev)
 
 	got := <-received
 	if !bytes.HasPrefix(got, []byte{0x1B, 0x40}) {
@@ -67,8 +67,10 @@ func TestScriptedDisplay_UTF8Override(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	dev.(CustomerDisplay).ShowLines([]string{"Чай"})
-	dev.Disconnect()
+	if err := dev.(CustomerDisplay).ShowLines([]string{"Чай"}); err != nil {
+		t.Fatalf("ShowLines: %v", err)
+	}
+	disconnect(dev)
 
 	got := <-received
 	if !bytes.Contains(got, []byte("Чай")) {
@@ -92,8 +94,10 @@ func TestEscpos_CP866Opt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	dev.(ReceiptPrinter).PrintReceipt(Receipt{Header: []string{"Хлеб"}, Items: []ReceiptItem{{Name: "Батон", Qty: 1, Price: 30, Sum: 30}}, Total: 30})
-	dev.Disconnect()
+	if err := dev.(ReceiptPrinter).PrintReceipt(Receipt{Header: []string{"Хлеб"}, Items: []ReceiptItem{{Name: "Батон", Qty: 1, Price: 30, Sum: 30}}, Total: 30}); err != nil {
+		t.Fatalf("PrintReceipt: %v", err)
+	}
+	disconnect(dev)
 
 	got := <-received
 	if !bytes.Contains(got, encodeCP866("Хлеб")) || !bytes.Contains(got, encodeCP866("ИТОГО:")) {

--- a/internal/equipment/scripted_pay_test.go
+++ b/internal/equipment/scripted_pay_test.go
@@ -19,7 +19,7 @@ func TestScriptedPay_Approved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	term, ok := dev.(PaymentTerminal)
 	if !ok {
 		t.Fatal("scripted_pay не реализует PaymentTerminal")
@@ -45,7 +45,7 @@ func TestScriptedPay_Declined(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer dev.Disconnect()
+	defer disconnect(dev)
 	res, err := dev.(PaymentTerminal).Pay(100)
 	if err != nil {
 		t.Fatalf("Pay: %v", err)

--- a/internal/equipment/scripted_test.go
+++ b/internal/equipment/scripted_test.go
@@ -17,7 +17,7 @@ func TestScripted_Weight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer dev.Disconnect()
+	defer disconnect(dev)
 
 	if dev.Kind() != "весы" {
 		t.Errorf("Kind = %q, ожидался «весы» (из параметра)", dev.Kind())

--- a/internal/equipment/transport_test.go
+++ b/internal/equipment/transport_test.go
@@ -75,7 +75,9 @@ func TestOpenWriteTransport_TCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openWriteTransport TCP: %v", err)
 	}
-	wc.Close()
+	if err := wc.Close(); err != nil {
+		t.Errorf("close transport: %v", err)
+	}
 }
 
 // serial-путь выбирается по адресу без двоеточия; несуществующий порт даёт ошибку


### PR DESCRIPTION
Батч-3 errcheck (класс 4). Завершает пакет `equipment`: `atol` (HTTP-эмулятор ККТ), `display`/`scripted*`/`transport`.

- `dev.Disconnect` → best-effort хелпер `disconnect()` (из батча-2);
- `w.Write` эмулятора → `_, _ =`;
- операции под тестом (`ShowLines`/`PrintReceipt`/`wc.Close`) → проверка `t.Fatal`/`t.Errorf`.

**Все тест-файлы `equipment` теперь errcheck-clean.** 6/6 прогонов зелёные, полный golangci-lint — 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)