### PR TITLE
test(109): errcheck в тестах dsl/interpreter (план 109, класс 4)

### DIFF
--- a/internal/dsl/interpreter/builtins_stage_c_test.go
+++ b/internal/dsl/interpreter/builtins_stage_c_test.go
@@ -62,7 +62,9 @@ func TestFillPropertyValues_All(t *testing.T) {
 func TestFillPropertyValues_IncludeList(t *testing.T) {
 	src := newStruct([]any{"Имя, Возраст, Город", "Иван", float64(30), "Москва"})
 	dst := newStruct([]any{"Имя, Возраст, Город"})
-	fillPropertyValuesFn([]any{dst, src, "Имя, Город"}, "", 0)
+	if _, err := fillPropertyValuesFn([]any{dst, src, "Имя, Город"}, "", 0); err != nil {
+		t.Fatal(err)
+	}
 	if dst.Get("Имя") != "Иван" || dst.Get("Город") != "Москва" {
 		t.Errorf("включённые свойства не скопированы: %v", dst.vals)
 	}
@@ -75,7 +77,9 @@ func TestFillPropertyValues_ExcludeList(t *testing.T) {
 	src := newStruct([]any{"Имя, Возраст, Город", "Иван", float64(30), "Москва"})
 	dst := newStruct([]any{"Имя, Возраст, Город"})
 	// 3-й аргумент пустой → «все свойства», 4-й — исключаемые.
-	fillPropertyValuesFn([]any{dst, src, "", "Город"}, "", 0)
+	if _, err := fillPropertyValuesFn([]any{dst, src, "", "Город"}, "", 0); err != nil {
+		t.Fatal(err)
+	}
 	if dst.Get("Имя") != "Иван" || dst.Get("Возраст") != float64(30) {
 		t.Errorf("неисключённые свойства не скопированы: %v", dst.vals)
 	}

--- a/internal/dsl/interpreter/equipment_test.go
+++ b/internal/dsl/interpreter/equipment_test.go
@@ -38,14 +38,14 @@ func captureTCP(t *testing.T) (string, <-chan []byte) {
 	require.NoError(t, err)
 	out := make(chan []byte, 1)
 	go func() {
-		defer ln.Close()
+		defer func() { _ = ln.Close() }()
 		conn, err := ln.Accept()
 		if err != nil {
 			out <- nil
 			return
 		}
-		defer conn.Close()
-		conn.SetReadDeadline(time.Now().Add(time.Second))
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
 		data, _ := io.ReadAll(conn)
 		out <- data
 	}()
@@ -136,16 +136,16 @@ func scaleTCP(t *testing.T, reply string) string {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() {
-		defer ln.Close()
+		defer func() { _ = ln.Close() }()
 		conn, err := ln.Accept()
 		if err != nil {
 			return
 		}
-		defer conn.Close()
-		conn.SetReadDeadline(time.Now().Add(time.Second))
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
 		buf := make([]byte, 16)
-		conn.Read(buf)
-		conn.Write([]byte(reply))
+		_, _ = conn.Read(buf)
+		_, _ = conn.Write([]byte(reply))
 	}()
 	return ln.Addr().String()
 }
@@ -231,10 +231,10 @@ func atolEmulatorHTTP(t *testing.T) string {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v2/requests", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"isError":false}`))
+		_, _ = w.Write([]byte(`{"isError":false}`))
 	})
 	mux.HandleFunc("/api/v2/requests/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":` +
+		_, _ = w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":` +
 			`{"fnNumber":"9999078900012345","fiscalDocumentNumber":40,"fiscalDocumentSign":"2143256432"}}]}`))
 	})
 	srv := httptest.NewServer(mux)
@@ -281,10 +281,10 @@ func atolEmulatorCapturingHTTP(t *testing.T) (string, *atolCapturedTask) {
 		if err := json.Unmarshal(body, &got); err != nil {
 			t.Errorf("эмулятор: некорректное задание: %v", err)
 		}
-		w.Write([]byte(`{"isError":false}`))
+		_, _ = w.Write([]byte(`{"isError":false}`))
 	})
 	mux.HandleFunc("/api/v2/requests/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":` +
+		_, _ = w.Write([]byte(`{"ready":true,"isError":false,"results":[{"result":` +
 			`{"fnNumber":"9999078900012345","fiscalDocumentNumber":40,"fiscalDocumentSign":"2143256432"}}]}`))
 	})
 	srv := httptest.NewServer(mux)

--- a/internal/dsl/interpreter/filesandbox_test.go
+++ b/internal/dsl/interpreter/filesandbox_test.go
@@ -52,7 +52,7 @@ func TestFileBuiltins_RespectSandbox(t *testing.T) {
 	// копирование за пределы корня — должно прерваться
 	outside := filepath.Join(filepath.Dir(root), "evil.txt")
 	assertRaises(t, func() {
-		builtins["копироватьфайл"]([]any{inside, outside}, "", 0)
+		_, _ = builtins["копироватьфайл"]([]any{inside, outside}, "", 0)
 	})
 	if _, err := os.Stat(outside); !os.IsNotExist(err) {
 		t.Error("файл за пределами sandbox не должен быть создан")

--- a/internal/dsl/interpreter/http_test.go
+++ b/internal/dsl/interpreter/http_test.go
@@ -32,7 +32,7 @@ func TestHTTPGet_Shorthand(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		fmt.Fprint(w, `{"ok":true}`)
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
 	}))
 	defer srv.Close()
 
@@ -49,7 +49,7 @@ func TestHTTPConnection_Get(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/rates", r.URL.Path)
 		assert.Equal(t, "GET", r.Method)
-		fmt.Fprint(w, "hello")
+		_, _ = fmt.Fprint(w, "hello")
 	}))
 	defer srv.Close()
 
@@ -75,7 +75,7 @@ func TestHTTPConnection_Post(t *testing.T) {
 		gotBody = string(buf[:n])
 		gotHeader = r.Header.Get("Content-Type")
 		w.WriteHeader(201)
-		fmt.Fprint(w, `{"created":true}`)
+		_, _ = fmt.Fprint(w, `{"created":true}`)
 	}))
 	defer srv.Close()
 
@@ -113,7 +113,7 @@ func TestHTTPResponse_GetHeader(t *testing.T) {
 
 func TestHTTPGet_WithJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"rate":75}`)
+		_, _ = fmt.Fprint(w, `{"rate":75}`)
 	}))
 	defer srv.Close()
 

--- a/internal/dsl/interpreter/notify_test.go
+++ b/internal/dsl/interpreter/notify_test.go
@@ -38,7 +38,9 @@ func TestNewNotifyFunctions_NilNotifierIsNoop(t *testing.T) {
 func TestNewNotifyFunctions_ConvertsStructData(t *testing.T) {
 	fn := &fakeNotifier{}
 	pub := NewNotifyFunctions(fn)["ОтправитьУведомление"].(BuiltinFunc)
-	pub([]any{"ivan", "ui.обновитьСписок", NewStructFromMap(map[string]any{"сущность": "Заявка"})}, "", 0)
+	if _, err := pub([]any{"ivan", "ui.обновитьСписок", NewStructFromMap(map[string]any{"сущность": "Заявка"})}, "", 0); err != nil {
+		t.Fatal(err)
+	}
 	m, ok := fn.data.(map[string]any)
 	if !ok {
 		t.Fatalf("DSL-структуру нужно конвертировать в map (иначе на клиент придёт {}): %T", fn.data)
@@ -74,7 +76,9 @@ func TestShowUserNotification_PublishesUINotice(t *testing.T) {
 	}
 	// Важность по умолчанию — «обычное»; алиас ShowUserNotification работает.
 	fn2 := &fakeNotifier{}
-	NewNotifyFunctions(fn2)["ShowUserNotification"].(BuiltinFunc)([]any{"ivan", "T", "X"}, "", 0)
+	if _, err := NewNotifyFunctions(fn2)["ShowUserNotification"].(BuiltinFunc)([]any{"ivan", "T", "X"}, "", 0); err != nil {
+		t.Fatal(err)
+	}
 	if m2 := fn2.data.(map[string]any); m2["важность"] != "обычное" {
 		t.Fatalf("важность по умолчанию должна быть обычное: %+v", m2)
 	}


### PR DESCRIPTION
Батч-5 errcheck (класс 4). Пакет `dsl/interpreter`:
- `equipment_test` — socket-серверы в горутинах → best-effort `_ =`;
- `http_test` — `fmt.Fprint` эмулятора → `_, _ =`;
- `builtins`/`notify` — вызовы builtin-функций `(any,error)` под тестом → проверка `t.Fatal`;
- `filesandbox` — вызов, ожидающий панику внутри `assertRaises` → `_, _ =`.

errcheck-clean, полный golangci-lint 0, 6/6 прогонов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)