### PR TITLE
test(109): errcheck в тестах gengen (план 109, класс 4)

### DIFF
--- a/internal/gengen/generator_test.go
+++ b/internal/gengen/generator_test.go
@@ -9,9 +9,15 @@ import (
 func TestCopyDir(t *testing.T) {
 	// Create a temporary source directory with files
 	src := t.TempDir()
-	os.MkdirAll(filepath.Join(src, "config"), 0o755)
-	os.WriteFile(filepath.Join(src, "config", "app.yaml"), []byte("name: test\n"), 0o644)
-	os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0o644)
+	if err := os.MkdirAll(filepath.Join(src, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "config", "app.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	dst := t.TempDir()
 
@@ -30,11 +36,15 @@ func TestCopyDir(t *testing.T) {
 
 func TestCopyDir_NoOverwrite(t *testing.T) {
 	src := t.TempDir()
-	os.WriteFile(filepath.Join(src, "existing.txt"), []byte("original\n"), 0o644)
+	if err := os.WriteFile(filepath.Join(src, "existing.txt"), []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	dst := t.TempDir()
 	existingContent := []byte("do not overwrite\n")
-	os.WriteFile(filepath.Join(dst, "existing.txt"), existingContent, 0o644)
+	if err := os.WriteFile(filepath.Join(dst, "existing.txt"), existingContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := copyDir(src, dst); err != nil {
 		t.Fatalf("copyDir() error: %v", err)
@@ -77,8 +87,12 @@ func TestGenerator_Generate_NoTemplate(t *testing.T) {
 func TestGenerator_Generate_WithTemplate(t *testing.T) {
 	// Create a mock template
 	src := t.TempDir()
-	os.MkdirAll(filepath.Join(src, "config"), 0o755)
-	os.WriteFile(filepath.Join(src, "config", "app.yaml"), []byte("name: test\n"), 0o644)
+	if err := os.MkdirAll(filepath.Join(src, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "config", "app.yaml"), []byte("name: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	dst := t.TempDir()
 	g := &Generator{OutputDir: dst}

--- a/internal/gengen/merge_generator_test.go
+++ b/internal/gengen/merge_generator_test.go
@@ -8,7 +8,9 @@ import (
 
 func TestMergeGenerator_CreateNewCatalog(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	delta := &DeltaManifest{
 		NewCatalogs: []EntitySpec{
@@ -44,7 +46,9 @@ func TestMergeGenerator_CreateNewCatalog(t *testing.T) {
 
 func TestMergeGenerator_CreateNewDocument(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "documents"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	delta := &DeltaManifest{
 		NewDocuments: []EntitySpec{
@@ -83,7 +87,9 @@ func TestMergeGenerator_CreateNewDocument(t *testing.T) {
 
 func TestMergeGenerator_AddFieldsToExisting(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create existing catalog
 	existingYAML := `name: Контрагент
@@ -93,7 +99,9 @@ fields:
   - name: ИНН
     type: string
 `
-	os.WriteFile(filepath.Join(dir, "catalogs", "контрагент.yaml"), []byte(existingYAML), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "catalogs", "контрагент.yaml"), []byte(existingYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	delta := &DeltaManifest{
 		NewFields: map[string][]FieldSpec{

--- a/internal/gengen/scanner_test.go
+++ b/internal/gengen/scanner_test.go
@@ -22,7 +22,9 @@ func TestScanProjectFromFiles_Empty(t *testing.T) {
 
 func TestScanProjectFromFiles_Catalogs(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a catalog YAML file
 	yamlContent := `name: Контрагент
@@ -32,7 +34,9 @@ fields:
   - name: ИНН
     type: string
 `
-	os.WriteFile(filepath.Join(dir, "catalogs", "контрагент.yaml"), []byte(yamlContent), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "catalogs", "контрагент.yaml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	manifest, err := ScanProjectFromFiles(dir)
 	if err != nil {
@@ -54,7 +58,9 @@ fields:
 
 func TestScanProjectFromFiles_Documents(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "documents"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	yamlContent := `name: РеализацияТоваров
 fields:
@@ -70,7 +76,9 @@ tableparts:
       - name: Количество
         type: number
 `
-	os.WriteFile(filepath.Join(dir, "documents", "реализация_товаров.yaml"), []byte(yamlContent), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "documents", "реализация_товаров.yaml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	manifest, err := ScanProjectFromFiles(dir)
 	if err != nil {
@@ -95,7 +103,9 @@ tableparts:
 
 func TestScanProjectFromFiles_Enums(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "enums"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "enums"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	yamlContent := `name: СтавкиНДС
 values:
@@ -104,7 +114,9 @@ values:
   - "10%"
   - "20%"
 `
-	os.WriteFile(filepath.Join(dir, "enums", "ставки_ндс.yaml"), []byte(yamlContent), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "enums", "ставки_ндс.yaml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	manifest, err := ScanProjectFromFiles(dir)
 	if err != nil {
@@ -125,7 +137,9 @@ values:
 // читает перечисления нового формата ({name, titles}) и не теряет имена значений.
 func TestScanProjectFromFiles_EnumsNewFormat(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "enums"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "enums"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	yamlContent := `name: Приоритет
 values:
@@ -138,7 +152,9 @@ values:
       en: Medium
   - Низкий
 `
-	os.WriteFile(filepath.Join(dir, "enums", "приоритет.yaml"), []byte(yamlContent), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "enums", "приоритет.yaml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	manifest, err := ScanProjectFromFiles(dir)
 	if err != nil {
@@ -165,9 +181,13 @@ values:
 
 func TestScanProjectFromFiles_DSL(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
-	os.WriteFile(filepath.Join(dir, "src", "отчёт_продажи.os"), []byte("Процедура Сформировать()\nКонецПроцедуры\n"), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "src", "отчёт_продажи.os"), []byte("Процедура Сформировать()\nКонецПроцедуры\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	manifest, err := ScanProjectFromFiles(dir)
 	if err != nil {


### PR DESCRIPTION
Батч-6 errcheck (класс 4). Пакет `gengen` (генератор конфигураций): все находки — setup `os.MkdirAll`/`os.WriteFile`, обёрнуты в проверку с `t.Fatal` (сбой подготовки = невалидный тест). errcheck-clean, полный golangci-lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)