### PR TITLE
test(109): errcheck в тестах storage и intake (план 109, класс 4)

### DIFF
--- a/internal/intake/intake_test.go
+++ b/internal/intake/intake_test.go
@@ -151,7 +151,9 @@ func TestIngest_Mismatch(t *testing.T) {
 	var calls int64
 	h := creatingHandler(db, &calls)
 
-	eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "111"}))
+	if _, err := eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "111"})); err != nil {
+		t.Fatal(err)
+	}
 	// Тот же event_id, другое тело → несовпадение → карантин.
 	res, err := eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "222"}))
 	if err != nil {
@@ -253,7 +255,9 @@ func TestReplay(t *testing.T) {
 	in := sampleIntake()
 
 	// Сначала загоняем в карантин сбойным обработчиком.
-	eng.Ingest(ctx, in, failingHandler(db), env(t, "E1", map[string]any{"phone": "111"}))
+	if _, err := eng.Ingest(ctx, in, failingHandler(db), env(t, "E1", map[string]any{"phone": "111"})); err != nil {
+		t.Fatal(err)
+	}
 	open, err := db.ListIntakeDLQ(ctx, "SiteLead", true, 0)
 	if err != nil || len(open) != 1 {
 		t.Fatalf("получить карантин: len=%d err=%v", len(open), err)
@@ -282,7 +286,9 @@ func TestReplay(t *testing.T) {
 func TestReplay_IsIdempotent(t *testing.T) {
 	eng, db, ctx := setup(t)
 	in := sampleIntake()
-	eng.Ingest(ctx, in, failingHandler(db), env(t, "E1", map[string]any{"phone": "111"}))
+	if _, err := eng.Ingest(ctx, in, failingHandler(db), env(t, "E1", map[string]any{"phone": "111"})); err != nil {
+		t.Fatal(err)
+	}
 	open, _ := db.ListIntakeDLQ(ctx, "SiteLead", true, 0)
 
 	var calls int64
@@ -306,7 +312,9 @@ func TestReplay_IsIdempotent(t *testing.T) {
 func TestReplay_StateTransitionFailureRollsBackBusinessObject(t *testing.T) {
 	eng, db, ctx := setup(t)
 	in := sampleIntake()
-	eng.Ingest(ctx, in, failingHandler(db), env(t, "E1", map[string]any{"phone": "111"}))
+	if _, err := eng.Ingest(ctx, in, failingHandler(db), env(t, "E1", map[string]any{"phone": "111"})); err != nil {
+		t.Fatal(err)
+	}
 	open, _ := db.ListIntakeDLQ(ctx, "SiteLead", true, 0)
 
 	// Имитируем сбой записи replay_state. Закрытие DLQ должно быть в той же
@@ -343,8 +351,12 @@ func TestReplay_RejectsSchemaMismatch(t *testing.T) {
 	var calls int64
 	h := creatingHandler(db, &calls)
 
-	eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "111"}))
-	eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "222"}))
+	if _, err := eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "111"})); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := eng.Ingest(ctx, in, h, env(t, "E1", map[string]any{"phone": "222"})); err != nil {
+		t.Fatal(err)
+	}
 	open, _ := db.ListIntakeDLQ(ctx, "SiteLead", true, 0)
 	if len(open) != 1 || open[0].Reason != metadata.DLQSchemaMismatch {
 		t.Fatalf("ожидался schema_mismatch в карантине: %+v", open)

--- a/internal/storage/attachments_s3_test.go
+++ b/internal/storage/attachments_s3_test.go
@@ -67,7 +67,7 @@ func TestAttachmentRoundtrip_S3(t *testing.T) {
 	if _, err := rsc.Seek(0, io.SeekStart); err != nil {
 		t.Errorf("reader must be seekable: %v", err)
 	}
-	rsc.Close()
+	_ = rsc.Close()
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("OpenAttachment содержимое не совпало: %q", got)
 	}
@@ -115,7 +115,7 @@ func TestAttachment_S3Streaming(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenAttachment(stream): %v", err)
 	}
-	defer rsc.Close()
+	defer func() { _ = rsc.Close() }()
 	// Seekable (ServeContent так делает): в конец за размером, потом в начало.
 	if sz, err := rsc.Seek(0, io.SeekEnd); err != nil || sz != int64(len(payload)) {
 		t.Fatalf("Seek end = %d, %v; want %d", sz, err, len(payload))
@@ -158,7 +158,7 @@ func TestAttachment_S3ModeSwitchKeepsDisk(t *testing.T) {
 		t.Fatalf("OpenAttachment(disk after switch): %v", err)
 	}
 	got, _ := io.ReadAll(rsc)
-	rsc.Close()
+	_ = rsc.Close()
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("disk-вложение после переключения не прочиталось: %q", got)
 	}

--- a/internal/storage/blobs_gc_test.go
+++ b/internal/storage/blobs_gc_test.go
@@ -28,7 +28,7 @@ func openClosed(t *testing.T, db *DB, id uuid.UUID) error {
 	t.Helper()
 	_, rc, err := db.OpenBlob(context.Background(), id)
 	if rc != nil {
-		rc.Close()
+		_ = rc.Close()
 	}
 	return err
 }

--- a/internal/storage/blobs_test.go
+++ b/internal/storage/blobs_test.go
@@ -105,7 +105,7 @@ func TestBlobOwnerRoundtrip(t *testing.T) {
 		t.Fatalf("OpenBlob: %v", err)
 	}
 	if rc != nil {
-		rc.Close()
+		_ = rc.Close()
 	}
 	if got.OwnerKind != "catalog" || got.OwnerEntity != "Контрагенты" {
 		t.Fatalf("OpenBlob потерял владельца: kind=%q entity=%q", got.OwnerKind, got.OwnerEntity)
@@ -121,7 +121,7 @@ func TestBlobOwnerRoundtrip(t *testing.T) {
 		t.Fatalf("OpenBlob(без владельца): %v", err)
 	}
 	if rc2 != nil {
-		rc2.Close()
+		_ = rc2.Close()
 	}
 	if got2.OwnerKind != "" || got2.OwnerEntity != "" {
 		t.Fatalf("ожидался пустой владелец, получено kind=%q entity=%q", got2.OwnerKind, got2.OwnerEntity)
@@ -160,7 +160,7 @@ func readBlobBytes(t *testing.T, db *DB, id uuid.UUID) []byte {
 	if err != nil {
 		t.Fatalf("OpenBlob: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	data, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("ReadAll: %v", err)

--- a/internal/storage/catalog_write_test.go
+++ b/internal/storage/catalog_write_test.go
@@ -87,7 +87,9 @@ func TestWriteCatalogRecord_Multiple(t *testing.T) {
 	}
 
 	var count int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM контрагент").Scan(&count)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM контрагент").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
 	if count != 6 {
 		t.Errorf("ожидалось 6 записей, получили %d", count)
 	}

--- a/internal/storage/register_totals_test.go
+++ b/internal/storage/register_totals_test.go
@@ -27,11 +27,11 @@ func toF(v any) float64 {
 		return 0
 	case []byte:
 		var f float64
-		fmt.Sscanf(string(x), "%g", &f)
+		_, _ = fmt.Sscanf(string(x), "%g", &f)
 		return f
 	case string:
 		var f float64
-		fmt.Sscanf(x, "%g", &f)
+		_, _ = fmt.Sscanf(x, "%g", &f)
 		return f
 	default:
 		return 0

--- a/internal/storage/rollup_test.go
+++ b/internal/storage/rollup_test.go
@@ -117,9 +117,15 @@ func TestRollup_FoldsAccumulationRegister(t *testing.T) {
 
 	table := metadata.RegisterTableName(reg.Name)
 	var total, foldedLeft, opening int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total)
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE period < ?", cutoff).Scan(&foldedLeft)
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE recorder_type = ?", RollupRecorderType).Scan(&opening)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE period < ?", cutoff).Scan(&foldedLeft); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE recorder_type = ?", RollupRecorderType).Scan(&opening); err != nil {
+		t.Fatal(err)
+	}
 	if total != 3 {
 		t.Errorf("строк в регистре=%d, ждали 3 (2 опорных + 1 после даты)", total)
 	}
@@ -151,7 +157,9 @@ func TestRollup_FoldsAccumulationRegister(t *testing.T) {
 		t.Fatalf("после повторной свёртки остаток изменился: %v", after2)
 	}
 	var total2 int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total2)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total2); err != nil {
+		t.Fatal(err)
+	}
 	if total2 != 3 {
 		t.Errorf("после повторной свёртки строк=%d, ждали 3", total2)
 	}
@@ -183,7 +191,9 @@ func TestRollup_RejectsTurnoverRegister(t *testing.T) {
 	}
 
 	var total int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.RegisterTableName(reg.Name)).Scan(&total)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.RegisterTableName(reg.Name)).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
 	if total != 1 {
 		t.Fatalf("turnover movements changed: rows=%d, want 1", total)
 	}
@@ -300,7 +310,9 @@ func TestRollup_DeleteDocuments(t *testing.T) {
 		t.Errorf("delete hook calls=%d, ждали 2", len(tombstones))
 	}
 	var left int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(doc.Name)).Scan(&left)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(doc.Name)).Scan(&left); err != nil {
+		t.Fatal(err)
+	}
 	if left != 1 {
 		t.Errorf("осталось документов=%d, ждали 1", left)
 	}
@@ -325,7 +337,9 @@ func TestRollup_RejectsUnknownRegisterBeforeDocumentPolicy(t *testing.T) {
 	}
 
 	var left int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(doc.Name)).Scan(&left)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(doc.Name)).Scan(&left); err != nil {
+		t.Fatal(err)
+	}
 	if left != 1 {
 		t.Fatalf("document policy ran after invalid selection: documents left=%d, want 1", left)
 	}
@@ -443,8 +457,12 @@ func TestRollup_FoldsAccountRegister(t *testing.T) {
 
 	table := metadata.AccountRegTableName(ar.Name)
 	var foldedLeft, opening int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE period < ?", cutoff).Scan(&foldedLeft)
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE регистратор_тип = ?", RollupRecorderType).Scan(&opening)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE period < ?", cutoff).Scan(&foldedLeft); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE регистратор_тип = ?", RollupRecorderType).Scan(&opening); err != nil {
+		t.Fatal(err)
+	}
 	if foldedLeft != 0 {
 		t.Errorf("проводки до даты остались: %d", foldedLeft)
 	}
@@ -487,7 +505,9 @@ func TestRollup_AccountRegister_NoAuxAccount(t *testing.T) {
 		t.Fatalf("ожидалась пометка о пропуске: %+v", rep.AccountRegisters)
 	}
 	var left int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.AccountRegTableName(ar.Name)).Scan(&left)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.AccountRegTableName(ar.Name)).Scan(&left); err != nil {
+		t.Fatal(err)
+	}
 	if left != 1 {
 		t.Errorf("движения тронуты при пропуске: осталось %d, ждали 1", left)
 	}
@@ -553,8 +573,12 @@ func TestRollup_TrimInfoRegister(t *testing.T) {
 	}
 
 	var total, beforeCut int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total)
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE period < ?", cutoff).Scan(&beforeCut)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table+" WHERE period < ?", cutoff).Scan(&beforeCut); err != nil {
+		t.Fatal(err)
+	}
 	if beforeCut != 2 {
 		t.Errorf("до cutoff осталось строк=%d, ждали 2 (по последнему срезу на товар)", beforeCut)
 	}
@@ -578,7 +602,9 @@ func TestRollup_TrimInfoRegister(t *testing.T) {
 		t.Fatalf("повторная обрезка: %v", err)
 	}
 	var total2 int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total2)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+table).Scan(&total2); err != nil {
+		t.Fatal(err)
+	}
 	if total2 != 3 {
 		t.Errorf("после повторной обрезки строк=%d, ждали 3", total2)
 	}
@@ -609,7 +635,9 @@ func TestRollup_InfoRegister_NonPeriodicSkipped(t *testing.T) {
 		t.Fatalf("ожидалась пометка о пропуске непериодического: %+v", rep.InfoRegisters)
 	}
 	var left int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.InfoRegTableName(ir.Name)).Scan(&left)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.InfoRegTableName(ir.Name)).Scan(&left); err != nil {
+		t.Fatal(err)
+	}
 	if left != 1 {
 		t.Errorf("данные непериодического регистра тронуты: осталось %d, ждали 1", left)
 	}
@@ -644,7 +672,9 @@ func TestRollup_DanglingRefsGate(t *testing.T) {
 		t.Fatalf("ожидался отказ свёртки из-за повисшей ссылки")
 	}
 	var orders int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(order.Name)).Scan(&orders)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.TableName(order.Name)).Scan(&orders); err != nil {
+		t.Fatal(err)
+	}
 	if orders != 1 {
 		t.Errorf("документ удалён вопреки гейту: осталось %d, ждали 1", orders)
 	}

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -54,7 +54,7 @@ func TestSQLiteInMemory(t *testing.T) {
 	}
 	// Файл с именем «:memory:» не должен появиться в рабочей папке.
 	if _, err := os.Stat(":memory:"); err == nil {
-		os.Remove(":memory:")
+		_ = os.Remove(":memory:")
 		t.Fatal("in-memory подключение создало файл «:memory:» на диске")
 	}
 }


### PR DESCRIPTION
Батч-7 errcheck (класс 4).
- **storage**: `Row.Scan` в `rollup`/`catalog_write` (чтение COUNT для ассертов) → проверка `t.Fatal`; read-side `Close` (blobs/attachments) → best-effort; `Sscanf`/`os.Remove` → best-effort.
- **intake**: `eng.Ingest` (setup-проводка события) → проверка `t.Fatal`.

errcheck-clean по этим тест-файлам, полный golangci-lint 0, тесты зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)