### PR TITLE
test(109): errcheck в тестах launcher (план 109, класс 4)

### DIFF
--- a/internal/launcher/ai_generate_guides_test.go
+++ b/internal/launcher/ai_generate_guides_test.go
@@ -62,15 +62,15 @@ func TestShowObject_AllDirs(t *testing.T) {
 // самых промахоопасных типов и false для неизвестного.
 func TestExampleForType(t *testing.T) {
 	cases := map[string]string{
-		"форма":      "form:\n  name: ФормаОбъекта",              // обёртка form:, не верхний уровень
-		"проведение": "Движения.ОстаткиТоваров.Добавить()",        // верный API движений
-		"отчёт":      "query: |",                                  // отчёт = params + query
-		"виджет":     "type: kpi",                                 // виджет с обязательным type
-		"план счетов": "kind: active",                             // счета
-		"журнал":     "documents: [РеализацияТоваров",             // journals
-		"обработка":  ".proc.os",                                  // код отдельным модулем
-		"константы":  "constants:",                                // список, не по-объектно
-		"печатная форма": "binding:",                              // areas + binding/repeat
+		"форма":          "form:\n  name: ФормаОбъекта",        // обёртка form:, не верхний уровень
+		"проведение":     "Движения.ОстаткиТоваров.Добавить()", // верный API движений
+		"отчёт":          "query: |",                           // отчёт = params + query
+		"виджет":         "type: kpi",                          // виджет с обязательным type
+		"план счетов":    "kind: active",                       // счета
+		"журнал":         "documents: [РеализацияТоваров",      // journals
+		"обработка":      ".proc.os",                           // код отдельным модулем
+		"константы":      "constants:",                         // список, не по-объектно
+		"печатная форма": "binding:",                           // areas + binding/repeat
 	}
 	for kind, needle := range cases {
 		ex, ok := exampleForType(kind)

--- a/internal/launcher/config_history_test.go
+++ b/internal/launcher/config_history_test.go
@@ -164,7 +164,7 @@ func TestCfgAdminConfigHistoryExportZip(t *testing.T) {
 			t.Fatalf("open zip file %s: %v", f.Name, err)
 		}
 		data, _ := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		got[f.Name] = string(data)
 	}
 	if got["config/app.yaml"] != "name: zip\n" || !strings.Contains(got["src/main.os"], "Процедура X") {
@@ -193,7 +193,7 @@ func TestCfgAdminConfigHistoryExportZip(t *testing.T) {
 			t.Fatalf("open obz file %s: %v", f.Name, err)
 		}
 		data, _ := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		got[f.Name] = string(data)
 	}
 	if got["config/config/app.yaml"] != "name: zip\n" || !strings.Contains(got["config/src/main.os"], "Процедура X") {

--- a/internal/launcher/configurator_titles_test.go
+++ b/internal/launcher/configurator_titles_test.go
@@ -18,9 +18,9 @@ func TestParseMapForm(t *testing.T) {
 	r := formReq(url.Values{
 		"titles.en":         {"Counterparty"},
 		"titles.de":         {"  Geschäftspartner  "}, // trimmed
-		"titles.fr":         {"   "},                   // empty after trim → skip
-		"titles.ru":         {"Контрагент"},            // base lang → skip
-		"field.0.titles.en": {"Name"},                  // другой префикс → не попадает
+		"titles.fr":         {"   "},                  // empty after trim → skip
+		"titles.ru":         {"Контрагент"},           // base lang → skip
+		"field.0.titles.en": {"Name"},                 // другой префикс → не попадает
 	})
 
 	got := parseMapForm(r, "titles")

--- a/internal/launcher/forms_handlers_test.go
+++ b/internal/launcher/forms_handlers_test.go
@@ -45,8 +45,12 @@ form:
 elements: []
 `
 	osBody := "// модуль формы"
-	os.WriteFile(filepath.Join(dir, "forms", "контрагент", "объекта.form.yaml"), []byte(yamlBody), 0o644)
-	os.WriteFile(filepath.Join(dir, "forms", "контрагент", "объекта.form.os"), []byte(osBody), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "forms", "контрагент", "объекта.form.yaml"), []byte(yamlBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "forms", "контрагент", "объекта.form.os"), []byte(osBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	listYAML := `schema: onebase.form/v1
 form:
@@ -54,7 +58,9 @@ form:
   kind: list
   entity: Контрагент
 `
-	os.WriteFile(filepath.Join(dir, "forms", "контрагент", "списка.form.yaml"), []byte(listYAML), 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "forms", "контрагент", "списка.form.yaml"), []byte(listYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	b := &Base{Path: dir, ConfigSource: "file"}
 	forms, err := listManagedFormsFromFS(b)

--- a/internal/launcher/isolated_browser_test.go
+++ b/internal/launcher/isolated_browser_test.go
@@ -50,13 +50,13 @@ func makeProfileBusy(t *testing.T, dir string) func() {
 		if err != nil {
 			t.Fatalf("open lockfile: %v", err)
 		}
-		return func() { f.Close() }
+		return func() { _ = f.Close() }
 	}
 	lock := filepath.Join(dir, "SingletonLock")
 	if err := os.Symlink(fmt.Sprintf("host-%d", os.Getpid()), lock); err != nil {
 		t.Skipf("symlink недоступен: %v", err)
 	}
-	return func() { os.Remove(lock) }
+	return func() { _ = os.Remove(lock) }
 }
 
 func TestPickProfileDir_ReusesFreeSkipsBusy(t *testing.T) {

--- a/internal/launcher/journals_handlers_test.go
+++ b/internal/launcher/journals_handlers_test.go
@@ -98,8 +98,12 @@ func TestReadJournalSources(t *testing.T) {
 		t.Fatal(err)
 	}
 	body := "name: РасписаниеДокладов\ntitle: Расписание\ndocuments: [Доклад]\n"
-	os.WriteFile(filepath.Join(jDir, "РасписаниеДокладов.yaml"), []byte(body), 0o644)
-	os.WriteFile(filepath.Join(jDir, "readme.txt"), []byte("не yaml"), 0o644)
+	if err := os.WriteFile(filepath.Join(jDir, "РасписаниеДокладов.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jDir, "readme.txt"), []byte("не yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got := readJournalSources(dir)
 	if len(got) != 1 {
@@ -256,7 +260,9 @@ func TestConfiguratorSubsystem_PersistsJournalsKeepsPages(t *testing.T) {
 		t.Fatal(err)
 	}
 	subFile := filepath.Join(subDir, nameToFilename("Конференция")+".yaml")
-	os.WriteFile(subFile, []byte("name: Конференция\ntitle: Конференция\ncontents:\n  pages: [ПанельОрганизатора]\n"), 0o644)
+	if err := os.WriteFile(subFile, []byte("name: Конференция\ntitle: Конференция\ncontents:\n  pages: [ПанельОрганизатора]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", b.ID)

--- a/internal/launcher/layout_import_pdf_test.go
+++ b/internal/launcher/layout_import_pdf_test.go
@@ -86,9 +86,13 @@ func postImportPDF(t *testing.T, h *handler, b *Base, name, doc, page string, pd
 		if err != nil {
 			t.Fatal(err)
 		}
-		fw.Write(pdfBytes)
+		if _, err := fw.Write(pdfBytes); err != nil {
+			t.Fatal(err)
+		}
 	}
-	mw.Close()
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", b.ID)

--- a/internal/launcher/layout_new_test.go
+++ b/internal/launcher/layout_new_test.go
@@ -137,7 +137,9 @@ func newLayoutTestBase(t *testing.T) (*handler, *Base, string) {
 	s := newTestStore(t)
 	dir := t.TempDir()
 	// минимальный проект: документ с табличной частью.
-	os.MkdirAll(filepath.Join(dir, "documents"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	doc := "name: Реализация\nfields:\n  - name: Номер\n    type: string\n  - name: Дата\n    type: date\ntableparts:\n  - name: Товары\n    fields:\n      - name: Номенклатура\n        type: string\n      - name: Сумма\n        type: number\n"
 	if err := os.WriteFile(filepath.Join(dir, "documents", "реализация.yaml"), []byte(doc), 0o644); err != nil {
 		t.Fatal(err)
@@ -194,9 +196,13 @@ func TestNewLayout_EntityHappyPath(t *testing.T) {
 // Отказ на дубликат.
 func TestNewLayout_DuplicateRejected(t *testing.T) {
 	h, b, dir := newLayoutTestBase(t)
-	os.MkdirAll(filepath.Join(dir, "printforms"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "printforms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	existing := filepath.Join(dir, "printforms", "Дубль.layout.yaml")
-	os.WriteFile(existing, []byte("areas: []\n"), 0o644)
+	if err := os.WriteFile(existing, []byte("areas: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	orig, _ := os.ReadFile(existing)
 
 	rec := postNewLayout(t, h, b, url.Values{
@@ -244,7 +250,9 @@ func newLayoutTestBaseDB(t *testing.T) (*handler, *Base) {
 	dbPath := filepath.Join(t.TempDir(), "cfg.db")
 
 	// исходный каталог конфигурации для импорта в БД.
-	os.MkdirAll(filepath.Join(dir, "documents"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, "documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	doc := "name: Реализация\nfields:\n  - name: Номер\n    type: string\ntableparts:\n  - name: Товары\n    fields:\n      - name: Номенклатура\n        type: string\n      - name: Сумма\n        type: number\n"
 	if err := os.WriteFile(filepath.Join(dir, "documents", "реализация.yaml"), []byte(doc), 0o644); err != nil {
 		t.Fatal(err)
@@ -345,8 +353,12 @@ func TestNewLayout_DBDuplicateRejected(t *testing.T) {
 // .os-форма: создаётся пустой парный макет 3×3.
 func TestNewLayout_OSForm(t *testing.T) {
 	h, b, dir := newLayoutTestBase(t)
-	os.MkdirAll(filepath.Join(dir, "printforms"), 0o755)
-	os.WriteFile(filepath.Join(dir, "printforms", "ПечатьЧека.os"), []byte("// форма\n"), 0o644)
+	if err := os.MkdirAll(filepath.Join(dir, "printforms"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "printforms", "ПечатьЧека.os"), []byte("// форма\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	rec := postNewLayout(t, h, b, url.Values{"osform": {"ПечатьЧека"}})
 	if rec.Code != http.StatusOK {

--- a/internal/launcher/pages_handlers_test.go
+++ b/internal/launcher/pages_handlers_test.go
@@ -118,10 +118,16 @@ func TestReadPageSources(t *testing.T) {
 		t.Fatal(err)
 	}
 	body := "Процедура ПриФормировании(Страница, Параметры) Экспорт\nКонецПроцедуры\n"
-	os.WriteFile(filepath.Join(srcDir, "Панель.page.os"), []byte(body), 0o644)
+	if err := os.WriteFile(filepath.Join(srcDir, "Панель.page.os"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	// Постороннее: модуль и обработка не должны попасть в карту страниц.
-	os.WriteFile(filepath.Join(srcDir, "общий.module.os"), []byte("// модуль"), 0o644)
-	os.WriteFile(filepath.Join(srcDir, "отчёт.proc.os"), []byte("// обработка"), 0o644)
+	if err := os.WriteFile(filepath.Join(srcDir, "общий.module.os"), []byte("// модуль"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "отчёт.proc.os"), []byte("// обработка"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got := readPageSources(dir)
 	if len(got) != 1 {

--- a/internal/launcher/report_builder_render_test.go
+++ b/internal/launcher/report_builder_render_test.go
@@ -71,8 +71,8 @@ func TestReportBuilderAppearance(t *testing.T) {
 	for _, want := range []string{
 		"Оформление вывода",
 		`name="comp.appearance.lines"`,
-		`value="both" selected`,                  // линии both выбраны
-		`name="comp.appearance.zebra" checked`,   // зебра включена
+		`value="both" selected`,                // линии both выбраны
+		`name="comp.appearance.zebra" checked`, // зебра включена
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("нет %q", want)

--- a/internal/launcher/runner_waitready_test.go
+++ b/internal/launcher/runner_waitready_test.go
@@ -44,7 +44,7 @@ func waitReadyFreePort(t *testing.T) int {
 		t.Fatalf("free port: %v", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
+	_ = ln.Close()
 	return port
 }
 
@@ -59,7 +59,9 @@ func TestTailFile(t *testing.T) {
 	}
 
 	p := filepath.Join(dir, "base.log")
-	os.WriteFile(p, []byte("строка1\r\nстрока2\r\nстрока3\r\nстрока4\r\n"), 0o644)
+	if err := os.WriteFile(p, []byte("строка1\r\nстрока2\r\nстрока3\r\nстрока4\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	got := tailFile(p, 2)
 	if got != "строка3\nстрока4" {
 		t.Errorf("последние 2 строки: получено %q", got)
@@ -70,7 +72,9 @@ func TestTailFile(t *testing.T) {
 	for i := 0; i < 2000; i++ {
 		fmt.Fprintf(&b, "line %04d\n", i)
 	}
-	os.WriteFile(p, []byte(b.String()), 0o644)
+	if err := os.WriteFile(p, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	got = tailFile(p, 3)
 	if got != "line 1997\nline 1998\nline 1999" {
 		t.Errorf("хвост большого файла: получено %q", got)
@@ -85,7 +89,9 @@ func TestWaitReady_ProcessDiedShowsLogTail(t *testing.T) {
 
 	base := &Base{ID: "died", Name: "died", Port: waitReadyFreePort(t)}
 	logText := "запуск...\nload project: нет каталога documents\n"
-	os.WriteFile(filepath.Join(logsDirOverride, base.ID+".log"), []byte(logText), 0o644)
+	if err := os.WriteFile(filepath.Join(logsDirOverride, base.ID+".log"), []byte(logText), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	r := NewRunner()
 	r.exits[base.ID] = true // процесс успел упасть ещё до входа в WaitReady

--- a/internal/launcher/store_test.go
+++ b/internal/launcher/store_test.go
@@ -54,7 +54,9 @@ func TestStore_AddAndList(t *testing.T) {
 func TestStore_Get(t *testing.T) {
 	s := newTestStore(t)
 	b := &Base{Name: "ERP", DB: "postgres://localhost/erp"}
-	s.Add(b)
+	if err := s.Add(b); err != nil {
+		t.Fatal(err)
+	}
 
 	got, err := s.Get(b.ID)
 	if err != nil {
@@ -73,7 +75,9 @@ func TestStore_Get(t *testing.T) {
 func TestStore_Update(t *testing.T) {
 	s := newTestStore(t)
 	b := &Base{Name: "Old", DB: "postgres://localhost/old"}
-	s.Add(b)
+	if err := s.Add(b); err != nil {
+		t.Fatal(err)
+	}
 
 	b.Name = "New"
 	b.Port = 9090
@@ -94,8 +98,12 @@ func TestStore_Remove(t *testing.T) {
 	s := newTestStore(t)
 	b1 := &Base{Name: "A", DB: "postgres://localhost/a"}
 	b2 := &Base{Name: "B", DB: "postgres://localhost/b"}
-	s.Add(b1)
-	s.Add(b2)
+	if err := s.Add(b1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Add(b2); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Remove(b1.ID); err != nil {
 		t.Fatalf("Remove: %v", err)
@@ -115,9 +123,15 @@ func TestStore_Move(t *testing.T) {
 	a := &Base{Name: "A", DB: "postgres://localhost/a"}
 	b := &Base{Name: "B", DB: "postgres://localhost/b"}
 	c := &Base{Name: "C", DB: "postgres://localhost/c"}
-	s.Add(a)
-	s.Add(b)
-	s.Add(c)
+	if err := s.Add(a); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Add(b); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Add(c); err != nil {
+		t.Fatal(err)
+	}
 
 	order := func() []string {
 		bases, _ := s.List()
@@ -137,8 +151,12 @@ func TestStore_Move(t *testing.T) {
 	}
 
 	// Move B down twice: A,C,B
-	s.Move(b.ID, 1)
-	s.Move(b.ID, 1)
+	if err := s.Move(b.ID, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Move(b.ID, 1); err != nil {
+		t.Fatal(err)
+	}
 	if got := order(); got[0] != "A" || got[1] != "C" || got[2] != "B" {
 		t.Fatalf("after move down want A,C,B got %v", got)
 	}
@@ -180,10 +198,12 @@ func TestStore_MultipleOps_Persistence(t *testing.T) {
 	s := newTestStore(t)
 
 	for i := range 3 {
-		s.Add(&Base{
+		if err := s.Add(&Base{
 			Name: []string{"Alpha", "Beta", "Gamma"}[i],
 			DB:   "postgres://localhost/db",
-		})
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	bases, _ := s.List()


### PR DESCRIPTION
Батч-8 errcheck (класс 4). Пакет `launcher` (35 находок):
- setup (`os.WriteFile`/`MkdirAll`), операции ibases-store (`s.Add`/`s.Move`), запись multipart-формы (`fw.Write`/`mw.Close`) → проверка `t.Fatal`;
- закрытия в cleanup-замыканиях (`f.Close`/`os.Remove`/`rc.Close`/`ln.Close`) → best-effort.

errcheck-clean, полный golangci-lint 0, тесты зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)