### PR TITLE
test(109): errcheck в тестах ui (план 109, класс 4)

### DIFF
--- a/internal/ui/deletion_posting_test.go
+++ b/internal/ui/deletion_posting_test.go
@@ -124,12 +124,16 @@ func TestDocWriterPost_BlockedWhenMarked(t *testing.T) {
 
 	// Ранний guard сработал ДО хука/saveMovements ⇒ движений нет и posted=false.
 	var mov int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov); err != nil {
+		t.Fatal(err)
+	}
 	if mov != 0 {
 		t.Fatalf("guard должен сработать до saveMovements: движений %d, ожидалось 0", mov)
 	}
 	var posted bool
-	db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted)
+	if err := db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted); err != nil {
+		t.Fatal(err)
+	}
 	if posted {
 		t.Error("помеченный документ не должен быть проведён")
 	}
@@ -142,7 +146,9 @@ func TestServerMarkForDeletion_AutoUnposts(t *testing.T) {
 	w := postOne(t, dp)
 
 	var mov int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov); err != nil {
+		t.Fatal(err)
+	}
 	if mov != 1 {
 		t.Fatalf("до пометки ожидалось 1 движение, получили %d", mov)
 	}
@@ -150,12 +156,16 @@ func TestServerMarkForDeletion_AutoUnposts(t *testing.T) {
 	if err := s.markForDeletion(ctx, doc, w.obj.ID, true); err != nil {
 		t.Fatal(err)
 	}
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov); err != nil {
+		t.Fatal(err)
+	}
 	if mov != 0 {
 		t.Errorf("после пометки движений должно быть 0, получили %d", mov)
 	}
 	var posted, marked bool
-	db.QueryRow(ctx, "SELECT posted, deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&posted, &marked)
+	if err := db.QueryRow(ctx, "SELECT posted, deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&posted, &marked); err != nil {
+		t.Fatal(err)
+	}
 	if posted {
 		t.Error("проведение должно быть снято при пометке")
 	}
@@ -167,7 +177,9 @@ func TestServerMarkForDeletion_AutoUnposts(t *testing.T) {
 	if err := s.markForDeletion(ctx, doc, w.obj.ID, false); err != nil {
 		t.Fatal(err)
 	}
-	db.QueryRow(ctx, "SELECT posted, deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&posted, &marked)
+	if err := db.QueryRow(ctx, "SELECT posted, deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&posted, &marked); err != nil {
+		t.Fatal(err)
+	}
 	if posted {
 		t.Error("снятие пометки не должно проводить документ")
 	}
@@ -185,12 +197,16 @@ func TestDocsRoot_UnpostAndMarkMethods(t *testing.T) {
 	// ОтменитьПроведение → движения 0, posted false.
 	dp.CallMethod("отменитьпроведение", []any{ref})
 	var mov int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov); err != nil {
+		t.Fatal(err)
+	}
 	if mov != 0 {
 		t.Errorf("после ОтменитьПроведение движений 0 ожидалось, получили %d", mov)
 	}
 	var posted bool
-	db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted)
+	if err := db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted); err != nil {
+		t.Fatal(err)
+	}
 	if posted {
 		t.Error("posted=false ожидался после ОтменитьПроведение")
 	}
@@ -198,14 +214,18 @@ func TestDocsRoot_UnpostAndMarkMethods(t *testing.T) {
 	// ПометитьНаУдаление → deletion_mark true.
 	dp.CallMethod("пометитьнаудаление", []any{ref})
 	var marked bool
-	db.QueryRow(ctx, "SELECT deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&marked)
+	if err := db.QueryRow(ctx, "SELECT deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&marked); err != nil {
+		t.Fatal(err)
+	}
 	if !marked {
 		t.Error("документ должен быть помечен после ПометитьНаУдаление")
 	}
 
 	// СнятьПометку → deletion_mark false.
 	dp.CallMethod("снятьпометку", []any{ref})
-	db.QueryRow(ctx, "SELECT deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&marked)
+	if err := db.QueryRow(ctx, "SELECT deletion_mark FROM поступлениетоваров LIMIT 1").Scan(&marked); err != nil {
+		t.Fatal(err)
+	}
 	if marked {
 		t.Error("пометка должна быть снята после СнятьПометку")
 	}
@@ -408,7 +428,9 @@ func TestDocWriterPost_DSL_PersistsOnPostFieldEdits(t *testing.T) {
 		t.Fatalf("СуммаДокумента из OnPost не персистилась: в БД %v, ожидалось 1000", total)
 	}
 	var posted bool
-	db.QueryRow(ctx, "SELECT posted FROM расходтоваров LIMIT 1").Scan(&posted)
+	if err := db.QueryRow(ctx, "SELECT posted FROM расходтоваров LIMIT 1").Scan(&posted); err != nil {
+		t.Fatal(err)
+	}
 	if !posted {
 		t.Error("документ должен быть проведён после Провести()")
 	}

--- a/internal/ui/dsl_catalogs_test.go
+++ b/internal/ui/dsl_catalogs_test.go
@@ -113,13 +113,17 @@ func TestCatWriter_CreateWithTableParts(t *testing.T) {
 	}
 
 	var tpCount int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты_контакты").Scan(&tpCount)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты_контакты").Scan(&tpCount); err != nil {
+		t.Fatal(err)
+	}
 	if tpCount != 2 {
 		t.Fatalf("строк ТЧ в БД = %d, ожидалось 2", tpCount)
 	}
 	// Хук ПриЗаписи собрал Сводку из строк ТЧ.
 	var summary string
-	db.QueryRow(ctx, "SELECT сводка FROM клиенты").Scan(&summary)
+	if err := db.QueryRow(ctx, "SELECT сводка FROM клиенты").Scan(&summary); err != nil {
+		t.Fatal(err)
+	}
 	if summary != "a@b.ru;79001112233;" {
 		t.Fatalf("хук ПриЗаписи не отработал: Сводка = %q", summary)
 	}
@@ -146,12 +150,16 @@ func TestCatWriter_CreateWithTableParts(t *testing.T) {
 	if res := w2.CallMethod("записать", nil); res == nil {
 		t.Fatal("повторная запись вернула nil")
 	}
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты_контакты").Scan(&tpCount)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты_контакты").Scan(&tpCount); err != nil {
+		t.Fatal(err)
+	}
 	if tpCount != 1 {
 		t.Fatalf("после обновления строк ТЧ = %d, ожидалась 1", tpCount)
 	}
 	var cnt int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты").Scan(&cnt)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM клиенты").Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
 	if cnt != 1 {
 		t.Fatalf("записей справочника = %d, ожидалась 1 (обновление, не дубль)", cnt)
 	}

--- a/internal/ui/dsl_documents_test.go
+++ b/internal/ui/dsl_documents_test.go
@@ -141,25 +141,33 @@ func TestDocsRoot_CreateWritePost(t *testing.T) {
 
 	// Проверки: документ записан
 	var docCount int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров").Scan(&docCount)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров").Scan(&docCount); err != nil {
+		t.Fatal(err)
+	}
 	if docCount != 1 {
 		t.Errorf("ожидался 1 документ, получили %d", docCount)
 	}
 	// ТЧ записана
 	var tpCount int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров_товары").Scan(&tpCount)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров_товары").Scan(&tpCount); err != nil {
+		t.Fatal(err)
+	}
 	if tpCount != 2 {
 		t.Errorf("ожидалось 2 строки ТЧ, получили %d", tpCount)
 	}
 	// движения регистра записаны
 	var movCount int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&movCount)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&movCount); err != nil {
+		t.Fatal(err)
+	}
 	if movCount != 2 {
 		t.Errorf("ожидалось 2 движения, получили %d", movCount)
 	}
 	// posted = true
 	var posted bool
-	db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted)
+	if err := db.QueryRow(ctx, "SELECT posted FROM поступлениетоваров LIMIT 1").Scan(&posted); err != nil {
+		t.Fatal(err)
+	}
 	if !posted {
 		t.Error("документ не помечен проведённым")
 	}
@@ -410,7 +418,9 @@ func TestDocsRoot_DeleteClearsMovements(t *testing.T) {
 	w.CallMethod("провести", nil)
 
 	var mov int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov); err != nil {
+		t.Fatal(err)
+	}
 	if mov != 1 {
 		t.Fatalf("до удаления ожидалось 1 движение, получили %d", mov)
 	}
@@ -419,12 +429,16 @@ func TestDocsRoot_DeleteClearsMovements(t *testing.T) {
 	ref := dp.CallMethod("найтипономеру", []any{"ПОС-001"}).(*interpreter.Ref)
 	dp.CallMethod("удалить", []any{ref})
 
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM рег_остаткитоваров").Scan(&mov); err != nil {
+		t.Fatal(err)
+	}
 	if mov != 0 {
 		t.Errorf("после удаления документа движений должно быть 0, получили %d (осиротевшие)", mov)
 	}
 	var docCnt int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров").Scan(&docCnt)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM поступлениетоваров").Scan(&docCnt); err != nil {
+		t.Fatal(err)
+	}
 	if docCnt != 0 {
 		t.Errorf("документ не удалён: осталось %d", docCnt)
 	}
@@ -482,7 +496,9 @@ func TestDocsRoot_FindByNumberAndDelete(t *testing.T) {
 	// Ссылка.Удалить() — удаление через привязанный менеджер.
 	ref.CallMethod("удалить", nil)
 	var cnt int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM заказпокупателя").Scan(&cnt)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM заказпокупателя").Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
 	if cnt != 1 {
 		t.Errorf("после Ссылка.Удалить() ожидался 1 документ, получили %d", cnt)
 	}
@@ -490,7 +506,9 @@ func TestDocsRoot_FindByNumberAndDelete(t *testing.T) {
 	// Менеджерный вариант: Документы.X.Удалить(Ссылка).
 	ref2 := dp.CallMethod("найтипономеру", []any{"ЗП-002"}).(*interpreter.Ref)
 	dp.CallMethod("удалить", []any{ref2})
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM заказпокупателя").Scan(&cnt)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM заказпокупателя").Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
 	if cnt != 0 {
 		t.Errorf("после Документы.X.Удалить() ожидалось 0 документов, получили %d", cnt)
 	}
@@ -675,7 +693,9 @@ func TestDocsRoot_GetObject_UpdateExisting(t *testing.T) {
 
 	// Запись не плодит дублей — это UPDATE, не INSERT.
 	var cnt int
-	db.QueryRow(ctx, "SELECT COUNT(*) FROM входящееписьмо").Scan(&cnt)
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM входящееписьмо").Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
 	if cnt != 1 {
 		t.Errorf("после Записать() через ПолучитьОбъект — записей %d, want 1", cnt)
 	}
@@ -838,7 +858,9 @@ func TestDocsRoot_OnWriteRunsOnSave(t *testing.T) {
 	w.CallMethod("записать", nil)
 
 	var total float64
-	db.QueryRow(ctx, "SELECT суммадокумента FROM счёт LIMIT 1").Scan(&total)
+	if err := db.QueryRow(ctx, "SELECT суммадокумента FROM счёт LIMIT 1").Scan(&total); err != nil {
+		t.Fatal(err)
+	}
 	if total != 400 {
 		t.Errorf("СуммаДокумента = %v, ожидалось 400 (ПриЗаписи не отработала)", total)
 	}

--- a/internal/ui/handlers_events_test.go
+++ b/internal/ui/handlers_events_test.go
@@ -39,7 +39,7 @@ func TestEventsStream_StreamsBroadcastFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("запрос /ui/events: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
 		t.Fatalf("Content-Type = %q, ожидался text/event-stream", ct)
@@ -87,7 +87,7 @@ func TestEventsStream_ReplaysRecentFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /ui/events: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	frameJSON := readDataFrame(t, resp.Body)
 	var frame struct {
@@ -157,7 +157,7 @@ func TestProcessorRun_PublishesRealtimeToast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /ui/events: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	waitSubscriber(t, hub)
 
 	postResp, err := http.PostForm(srv.URL+"/ui/processor/%d1%82%d0%b5%d1%81%d1%82%d0%bf%d1%83%d1%88", url.Values{
@@ -166,7 +166,7 @@ func TestProcessorRun_PublishesRealtimeToast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST processor: %v", err)
 	}
-	postResp.Body.Close()
+	_ = postResp.Body.Close()
 	if postResp.StatusCode != http.StatusOK {
 		t.Fatalf("POST processor status = %d", postResp.StatusCode)
 	}

--- a/internal/ui/picker_test.go
+++ b/internal/ui/picker_test.go
@@ -171,7 +171,9 @@ func TestSelectedTPRows(t *testing.T) {
 	form2.Set("_tp", "Товары")
 	req2 := httptest.NewRequest("POST", "/x", strings.NewReader(form2.Encode()))
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req2.ParseForm()
+	if err := req2.ParseForm(); err != nil {
+		t.Fatal(err)
+	}
 	if selectedTPRows(req2, obj) != nil {
 		t.Error("без _tp_selected ждали nil")
 	}


### PR DESCRIPTION
Батч-9 errcheck (класс 4). Пакет `ui` (31 находка): `Row.Scan` (чтение COUNT для ассертов) → `t.Fatal`; HTTP-тела ответов → `defer func(){ _ = resp.Body.Close() }()` (bodyclose-compat); `req2.ParseForm` → check. errcheck-clean, полный golangci-lint 0, тесты зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)