### PR TITLE
test(109): errcheck в тестах — финал класса 4 (план 109)

### DIFF
--- a/internal/api/debug_auth_test.go
+++ b/internal/api/debug_auth_test.go
@@ -33,7 +33,7 @@ func newDebugTestServer(t *testing.T) *Server {
 // Без ONEBASE_DEBUG_TOKEN debug-маршруты не регистрируются вовсе —
 // опубликованная база (`onebase run`) не имеет debug-поверхности.
 func TestDebugAPI_AbsentWithoutToken(t *testing.T) {
-	os.Unsetenv("ONEBASE_DEBUG_TOKEN")
+	_ = os.Unsetenv("ONEBASE_DEBUG_TOKEN")
 	srv := newDebugTestServer(t)
 	req := httptest.NewRequest(http.MethodPost, "/debug/global/enable", nil)
 	rec := httptest.NewRecorder()
@@ -45,8 +45,8 @@ func TestDebugAPI_AbsentWithoutToken(t *testing.T) {
 
 // С заданным токеном debug-эндпоинт требует совпадающий X-OneBase-Debug-Token.
 func TestDebugAPI_TokenEnforced(t *testing.T) {
-	os.Setenv("ONEBASE_DEBUG_TOKEN", "s3cr3t")
-	t.Cleanup(func() { os.Unsetenv("ONEBASE_DEBUG_TOKEN") })
+	_ = os.Setenv("ONEBASE_DEBUG_TOKEN", "s3cr3t")
+	t.Cleanup(func() { _ = os.Unsetenv("ONEBASE_DEBUG_TOKEN") })
 	srv := newDebugTestServer(t)
 
 	cases := []struct {

--- a/internal/api/h2c_test.go
+++ b/internal/api/h2c_test.go
@@ -73,7 +73,7 @@ func TestH2CUpstreamEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("h2c GET /health: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.ProtoMajor != 2 {
 		t.Fatalf("proto = %q, ожидали HTTP/2", resp.Proto)
 	}
@@ -90,7 +90,7 @@ func TestH2CUpstreamDisabledByDefault(t *testing.T) {
 
 	resp, err := h2cClient().Get("http://" + addr + "/health")
 	if err == nil {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.ProtoMajor == 2 {
 			t.Fatal("сервер отдал HTTP/2, хотя h2c выключен")
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1320,7 +1320,9 @@ func TestAPI_Create_WithTableParts(t *testing.T) {
 	var resp struct {
 		ID string `json:"id"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
 	docID, _ := uuid.Parse(resp.ID)
 
 	tpRows, err := h.store.GetTablePartRows(ctx, "Поступление", "Товары", docID, doc.TableParts[0])

--- a/internal/api/server_shutdown_test.go
+++ b/internal/api/server_shutdown_test.go
@@ -43,7 +43,7 @@ func TestShutdownClosesSSEAndOwnedBackgroundResources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("events status = %d", resp.StatusCode)
 	}

--- a/internal/auth/repo_sqlite_test.go
+++ b/internal/auth/repo_sqlite_test.go
@@ -740,7 +740,9 @@ func TestSyncRolesUpsert(t *testing.T) {
 func TestListForSelectionFiltersByShowInList(t *testing.T) {
 	repo, ctx := newTestRepo(t)
 	visible, _ := repo.Create(ctx, "visible", "password", "", false)
-	repo.Create(ctx, "hidden", "password", "", false)
+	if _, err := repo.Create(ctx, "hidden", "password", "", false); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := repo.SetShowInList(ctx, visible.ID, true); err != nil {
 		t.Fatalf("SetShowInList: %v", err)

--- a/internal/cli/app_file_storage_test.go
+++ b/internal/cli/app_file_storage_test.go
@@ -38,7 +38,7 @@ func fakeS3Server(objects map[string][]byte, mu *sync.Mutex) *httptest.Server {
 			}
 			w.Header().Set("Content-Length", strconv.Itoa(len(b)))
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write(b)
 		case http.MethodDelete:
 			delete(objects, r.URL.Path)
 			w.WriteHeader(http.StatusNoContent)
@@ -101,7 +101,7 @@ func TestApplyFileStorageS3_EndToEnd(t *testing.T) {
 		t.Fatalf("OpenBlob: %v", err)
 	}
 	got, _ := io.ReadAll(rc)
-	rc.Close()
+	_ = rc.Close()
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("OpenBlob content mismatch: %q", got)
 	}
@@ -165,7 +165,7 @@ func TestApplyFileStorageS3_AttachmentEndToEnd(t *testing.T) {
 		t.Fatalf("OpenAttachment: %v", err)
 	}
 	got, _ := io.ReadAll(rsc)
-	rsc.Close()
+	_ = rsc.Close()
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("OpenAttachment content mismatch: %q", got)
 	}

--- a/internal/cli/describe_test.go
+++ b/internal/cli/describe_test.go
@@ -55,10 +55,10 @@ func TestRunDescribe_V2Contract(t *testing.T) {
 		done <- err
 	}()
 	if err := runDescribe(cmd, nil); err != nil {
-		w.Close()
+		_ = w.Close()
 		t.Fatalf("runDescribe: %v", err)
 	}
-	w.Close()
+	_ = w.Close()
 	if err := <-done; err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/errors_test.go
+++ b/internal/cli/errors_test.go
@@ -12,15 +12,15 @@ func TestGUIErrorsDisabled(t *testing.T) {
 	t.Cleanup(func() {
 		noGUI = false
 		if had {
-			os.Setenv("ONEBASE_NO_GUI", old)
+			_ = os.Setenv("ONEBASE_NO_GUI", old)
 		} else {
-			os.Unsetenv("ONEBASE_NO_GUI")
+			_ = os.Unsetenv("ONEBASE_NO_GUI")
 		}
 	})
 
 	// По умолчанию модалки разрешены.
 	noGUI = false
-	os.Unsetenv("ONEBASE_NO_GUI")
+	_ = os.Unsetenv("ONEBASE_NO_GUI")
 	if guiErrorsDisabled() {
 		t.Error("по умолчанию модальные окна должны быть разрешены")
 	}
@@ -33,13 +33,13 @@ func TestGUIErrorsDisabled(t *testing.T) {
 
 	// Переменная окружения отключает.
 	noGUI = false
-	os.Setenv("ONEBASE_NO_GUI", "1")
+	_ = os.Setenv("ONEBASE_NO_GUI", "1")
 	if !guiErrorsDisabled() {
 		t.Error("ONEBASE_NO_GUI=1 должен отключать модальные окна")
 	}
 
 	// Пустое значение переменной не считается включённым.
-	os.Setenv("ONEBASE_NO_GUI", "")
+	_ = os.Setenv("ONEBASE_NO_GUI", "")
 	if guiErrorsDisabled() {
 		t.Error("пустой ONEBASE_NO_GUI не должен отключать окна")
 	}

--- a/internal/configcheck/module_queries_test.go
+++ b/internal/configcheck/module_queries_test.go
@@ -40,7 +40,7 @@ fields:
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
-	defer func() { db.Close(); os.Remove(dbPath) }()
+	defer func() { db.Close(); _ = os.Remove(dbPath) }()
 	if err := db.Migrate(ctx, proj.Entities); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/devserver/watcher_test.go
+++ b/internal/devserver/watcher_test.go
@@ -141,7 +141,9 @@ func TestWatchContext_Debounces(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	// Несколько правок подряд должны схлопнуться в один onChange.
 	for i := 0; i < 5; i++ {
-		os.WriteFile(file, []byte("// edited"+string(rune('A'+i))), 0o644)
+		if err := os.WriteFile(file, []byte("// edited"+string(rune('A'+i))), 0o644); err != nil {
+			t.Fatal(err)
+		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	// Ждём debounce + запас.

--- a/internal/entityservice/posting_mark_test.go
+++ b/internal/entityservice/posting_mark_test.go
@@ -52,7 +52,9 @@ func TestSave_PostingBlockedWhenMarked(t *testing.T) {
 		t.Fatal("ожидался res.DSLError != \"\" (проведение помеченного запрещено)")
 	}
 	var posted bool
-	db.QueryRow(ctx, "SELECT posted FROM расходник LIMIT 1").Scan(&posted)
+	if err := db.QueryRow(ctx, "SELECT posted FROM расходник LIMIT 1").Scan(&posted); err != nil {
+		t.Fatal(err)
+	}
 	if posted {
 		t.Error("документ не должен быть проведён")
 	}

--- a/internal/mailer/mailer_test.go
+++ b/internal/mailer/mailer_test.go
@@ -36,11 +36,11 @@ func (f *fakeSMTP) serve() {
 	if err != nil {
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	w := bufio.NewWriter(conn)
 	r := bufio.NewReader(conn)
-	send := func(s string) { w.WriteString(s + "\r\n"); w.Flush() }
+	send := func(s string) { _, _ = w.WriteString(s + "\r\n"); _ = w.Flush() }
 	recv := func() string { line, _ := r.ReadString('\n'); return strings.TrimSpace(line) }
 
 	send("220 fakesmtp ESMTP")
@@ -78,7 +78,7 @@ func (f *fakeSMTP) Payload() string {
 
 func TestSend_PlainText(t *testing.T) {
 	srv := startFakeSMTP(t)
-	defer srv.ln.Close()
+	defer func() { _ = srv.ln.Close() }()
 
 	host, portStr, _ := net.SplitHostPort(srv.Addr())
 	port := 0
@@ -109,7 +109,7 @@ func TestSend_PlainText(t *testing.T) {
 
 func TestSend_HTML(t *testing.T) {
 	srv := startFakeSMTP(t)
-	defer srv.ln.Close()
+	defer func() { _ = srv.ln.Close() }()
 
 	_, portStr, _ := net.SplitHostPort(srv.Addr())
 	var p int

--- a/internal/metadata/journal_test.go
+++ b/internal/metadata/journal_test.go
@@ -86,7 +86,9 @@ columns:
   - field: Дата
 `
 	path := filepath.Join(dir, "тест.yaml")
-	os.WriteFile(path, []byte(yaml), 0644)
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
 	j, err := LoadJournalFile(path)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/onec_forms/export_test.go
+++ b/internal/onec_forms/export_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 // TestExport_FullRoundTrip — полный конвейер:
-//   Form.xml (фикстура) → IR → нормализация-импорт → YAML на диск →
-//   YAML → IR → нормализация-экспорт → Form.xml' → IR' → диффы по
-//   ключевым семантическим полям.
+//
+//	Form.xml (фикстура) → IR → нормализация-импорт → YAML на диск →
+//	YAML → IR → нормализация-экспорт → Form.xml' → IR' → диффы по
+//	ключевым семантическим полям.
 //
 // Этот тест ловит регрессии в любой из 4 точек конвертера (reader_xml /
 // writer_yaml / reader_yaml / writer_xml). Он не делает побайтового
@@ -249,11 +250,13 @@ func TestExportToOneC_Smoke(t *testing.T) {
 	// Импортируем фикстуру, чтобы получить валидный YAML/OS.
 	xmlPath := writeFixture(t, "Form.xml", minForm)
 	bslPath := filepath.Join(t.TempDir(), "Module.bsl")
-	os.WriteFile(bslPath, []byte(`// @directive=&НаСервере
+	if err := os.WriteFile(bslPath, []byte(`// @directive=&НаСервере
 Процедура ПриСозданииНаСервере(Отмена, СтандартнаяОбработка)
 	ЭтаФорма.Заголовок = "test";
 КонецПроцедуры
-`), 0o644)
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := ImportFromOneC(ImportOptions{
 		XMLPath:     xmlPath,

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -18,7 +18,7 @@ func writeZip(t *testing.T, path string, entries map[string]string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	zw := zip.NewWriter(f)
 	for name, body := range entries {
 		w, err := zw.Create(name)


### PR DESCRIPTION
Батч-10 — **финал класса 4 (тесты)** плана 109. Закрыт хвост из ~28 находок в 13 пакетах (api/auth/cli/configcheck/devserver/entityservice/mailer/metadata/onec_forms/selfupdate):
- env (`Setenv`/`Unsetenv`) и read-closes → best-effort;
- setup (`WriteFile`/`Create`/`Scan`/`Unmarshal`) → `t.Fatal`;
- HTTP-тела ответов → `defer func(){ _ = resp.Body.Close() }()` (bodyclose-compat).

**Итог: весь класс «тесты» errcheck-clean по всему репо (0 находок в `_test.go`).** Осталось только production (~750, поведенческий класс). Полный golangci-lint 0, тесты зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)