### PR TITLE
fix: три дефекта корректности, найденные аудитом роадмапа (Д1–Д3)

### DIFF
--- a/internal/storage/accountreg.go
+++ b/internal/storage/accountreg.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/i18n/i18nerr"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/shopspring/decimal"
 )
 
 // EnsureAccountsTable creates the _accounts table for storing chart of accounts data.
@@ -344,8 +345,16 @@ ORDER BY a.code`, selectCols, table, d.Placeholder(1), d.Placeholder(2), groupBy
 	for rows.Next() {
 		var code, name, kind string
 		dests := []any{&code, &name, &kind}
+		// Деньги читаем в any и нормализуем в decimal (план 42): раньше здесь
+		// стоял float64, из-за чего PostgreSQL терял точность NUMERIC уже на
+		// стороне Go — сумма приходила округлённой в отчёт и, что хуже, в опорные
+		// проводки свёртки (accountOpeningRows).
+		// Оговорка: на SQLite точность всё равно ограничена движком — SUM() над
+		// TEXT-колонкой возвращает float64 при любом CAST (NUMERIC/DECIMAL), так
+		// что там decimal лишь сохраняет то, что отдал SQL, без второго
+		// округления. Точный агрегат на SQLite потребовал бы суммирования в Go.
 		for range resourceCols {
-			var v float64
+			var v any
 			dests = append(dests, &v)
 		}
 		subVals := make([]sql.NullString, len(subconto))
@@ -360,19 +369,19 @@ ORDER BY a.code`, selectCols, table, d.Placeholder(1), d.Placeholder(2), groupBy
 		ei := 0
 		for _, r := range resources {
 			col := metadata.ColumnName(r)
-			dtVal := *dests[3+ei*2].(*float64)
-			ktVal := *dests[3+ei*2+1].(*float64)
+			dtVal := scanDecimal(dests[3+ei*2])
+			ktVal := scanDecimal(dests[3+ei*2+1])
 			row[col+"_дт"] = dtVal
 			row[col+"_кт"] = ktVal
 			switch kind {
 			case "active":
-				row[col] = dtVal - ktVal
+				row[col] = dtVal.Sub(ktVal)
 			case "passive":
-				row[col] = ktVal - dtVal
+				row[col] = ktVal.Sub(dtVal)
 			default: // active_passive
-				row[col+"_сальдо_дт"] = max0(dtVal - ktVal)
-				row[col+"_сальдо_кт"] = max0(ktVal - dtVal)
-				row[col] = dtVal - ktVal
+				row[col+"_сальдо_дт"] = max0Dec(dtVal.Sub(ktVal))
+				row[col+"_сальдо_кт"] = max0Dec(ktVal.Sub(dtVal))
+				row[col] = dtVal.Sub(ktVal)
 			}
 			ei++
 		}
@@ -429,7 +438,7 @@ ORDER BY a.code`, selectCols, table, d.Placeholder(1), d.Placeholder(2), d.Place
 		var code, name, kind string
 		dests := []any{&code, &name, &kind}
 		for range resourceCols {
-			var v float64
+			var v any
 			dests = append(dests, &v)
 		}
 		if err := rows.Scan(dests...); err != nil {
@@ -439,8 +448,8 @@ ORDER BY a.code`, selectCols, table, d.Placeholder(1), d.Placeholder(2), d.Place
 		ei := 0
 		for _, r := range resources {
 			col := metadata.ColumnName(r)
-			row[col+"_дт"] = *dests[3+ei*2].(*float64)
-			row[col+"_кт"] = *dests[3+ei*2+1].(*float64)
+			row[col+"_дт"] = scanDecimal(dests[3+ei*2])
+			row[col+"_кт"] = scanDecimal(dests[3+ei*2+1])
 			ei++
 		}
 		result = append(result, row)
@@ -507,9 +516,25 @@ func nullStr(s string) any {
 	return s
 }
 
-func max0(v float64) float64 {
-	if v < 0 {
-		return 0
+// scanDecimal достаёт денежное значение из приёмника Scan (*any) и приводит его
+// к decimal.Decimal: PG отдаёт pgtype.Numeric, SQLite — строку. NULL/непонятный
+// тип → 0, как и COALESCE(...,0) в самом запросе.
+func scanDecimal(dest any) decimal.Decimal {
+	p, ok := dest.(*any)
+	if !ok || p == nil {
+		return decimal.Zero
+	}
+	if d, ok := normalizeNumber(*p).(decimal.Decimal); ok {
+		return d
+	}
+	return decimal.Zero
+}
+
+// max0Dec схлопывает отрицательное сальдо в ноль (развёрнутое сальдо
+// активно-пассивного счёта).
+func max0Dec(v decimal.Decimal) decimal.Decimal {
+	if v.IsNegative() {
+		return decimal.Zero
 	}
 	return v
 }

--- a/internal/storage/accountreg_decimal_test.go
+++ b/internal/storage/accountreg_decimal_test.go
@@ -1,0 +1,205 @@
+package storage
+
+// Регрессия (план 47 п. 4.2): AccountBalances/AccountTurnovers сканировали
+// денежные ресурсы в float64, хотя план 42 перевёл деньги на decimal. Это било
+// не только по виду отчёта: accountOpeningRows строит из этих остатков опорные
+// проводки свёртки, то есть округление осело бы в базе навсегда.
+//
+// Тесты фиксируют ТИП (decimal.Decimal во всех денежных ключах) и сквозную
+// согласованность остатка до/после свёртки. Точность самого агрегата проверить
+// на SQLite нельзя: SUM() над TEXT-колонкой возвращает float64 при любом CAST,
+// поэтому 0.1×3 там равно 0.30000000000000004 на уровне SQL. На PostgreSQL
+// NUMERIC суммируется точно, и именно там фикс убирает потерю копеек.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/shopspring/decimal"
+)
+
+func decimalAcctReg() *metadata.AccountRegister {
+	return &metadata.AccountRegister{
+		Name:      "БухТочность",
+		Accounts:  "Основной",
+		Resources: []metadata.Field{{Name: "Сумма", Type: "number"}},
+	}
+}
+
+// Денежные ключи остатков и оборотов приходят как decimal.Decimal, а не float64.
+func TestAccountBalances_KeepsDecimalPrecision(t *testing.T) {
+	ar := decimalAcctReg()
+	db, ctx := newAccountTestDB(t, ar)
+	if err := db.EnsureAccountsTable(ctx); err != nil {
+		t.Fatal(err)
+	}
+	chart := &metadata.ChartOfAccounts{Name: "Основной", Accounts: []metadata.Account{
+		{Code: "41", Name: "Товары", Kind: "active"},
+		{Code: "60", Name: "Поставщики", Kind: "passive"},
+	}}
+	if err := db.SyncAccounts(ctx, []*metadata.ChartOfAccounts{chart}); err != nil {
+		t.Fatal(err)
+	}
+
+	period := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 20; i++ {
+		rows := []map[string]any{{"счётдт": "41", "счёткт": "60", "Сумма": "0.1"}}
+		if err := db.WriteAccountMovements(ctx, ar.Name, "Док", uuid.New(), rows, ar, &period); err != nil {
+			t.Fatalf("WriteAccountMovements: %v", err)
+		}
+	}
+
+	asOf := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+	balances, err := db.AccountBalances(ctx, ar.Name, "Основной", asOf, ar.Resources, nil)
+	if err != nil {
+		t.Fatalf("AccountBalances: %v", err)
+	}
+
+	var got41 decimal.Decimal
+	var found bool
+	for _, b := range balances {
+		if code, _ := b["code"].(string); code == "41" {
+			d, ok := b["сумма"].(decimal.Decimal)
+			if !ok {
+				t.Fatalf("сальдо счёта 41: тип %T, ожидался decimal.Decimal", b["сумма"])
+			}
+			got41, found = d, true
+		}
+	}
+	if !found {
+		t.Fatal("счёт 41 не найден в остатках")
+	}
+	if diff := got41.Sub(decimal.RequireFromString("2")).Abs(); diff.GreaterThan(decimal.RequireFromString("0.000001")) {
+		t.Errorf("сальдо счёта 41 = %s, ожидалось ≈2", got41)
+	}
+
+	// Обороты — тем же типом и той же точностью.
+	turn, err := db.AccountTurnovers(ctx, ar.Name, "Основной", period.AddDate(0, 0, -1), asOf, ar.Resources)
+	if err != nil {
+		t.Fatalf("AccountTurnovers: %v", err)
+	}
+	for _, r := range turn {
+		if code, _ := r["code"].(string); code != "41" {
+			continue
+		}
+		d, ok := r["сумма_дт"].(decimal.Decimal)
+		if !ok {
+			t.Fatalf("оборот Дт: тип %T, ожидался decimal.Decimal", r["сумма_дт"])
+		}
+		if diff := d.Sub(decimal.RequireFromString("2")).Abs(); diff.GreaterThan(decimal.RequireFromString("0.000001")) {
+			t.Errorf("оборот Дт счёта 41 = %s, ожидалось ≈2", d)
+		}
+	}
+}
+
+// Опорные проводки свёртки наследуют точность остатков: сумма, которую нельзя
+// представить в float64, должна лечь в базу без искажения.
+func TestRollup_OpeningRowsKeepDecimalPrecision(t *testing.T) {
+	ar := decimalAcctReg()
+	db, ctx := newAccountTestDB(t, ar)
+	if err := db.EnsureAccountsTable(ctx); err != nil {
+		t.Fatal(err)
+	}
+	chart := &metadata.ChartOfAccounts{Name: "Основной", Accounts: []metadata.Account{
+		{Code: "000", Name: "Вспомогательный", Kind: "active_passive"},
+		{Code: "41", Name: "Товары", Kind: "active"},
+		{Code: "60", Name: "Поставщики", Kind: "passive"},
+	}}
+	if err := db.SyncAccounts(ctx, []*metadata.ChartOfAccounts{chart}); err != nil {
+		t.Fatal(err)
+	}
+
+	period := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		rows := []map[string]any{{"счётдт": "41", "счёткт": "60", "Сумма": "0.1"}}
+		if err := db.WriteAccountMovements(ctx, ar.Name, "Док", uuid.New(), rows, ar, &period); err != nil {
+			t.Fatalf("WriteAccountMovements: %v", err)
+		}
+	}
+
+	cutoff := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	aux, _ := db.resolveAuxAccount(ctx, ar.Accounts)
+	rows, err := db.accountOpeningRows(ctx, ar, aux, cutoff)
+	if err != nil {
+		t.Fatalf("accountOpeningRows: %v", err)
+	}
+	var seen bool
+	for _, r := range rows {
+		if code, _ := r["счётдт"].(string); code != "41" {
+			continue
+		}
+		seen = true
+		d, ok := r["Сумма"].(decimal.Decimal)
+		if !ok {
+			t.Fatalf("опорная проводка: тип суммы %T, ожидался decimal.Decimal", r["Сумма"])
+		}
+		// Значение сверяем с допуском: на SQLite агрегат пришёл из float-SUM.
+		// Главное здесь — что сумма доехала как decimal, а не через float64 в Go.
+		if diff := d.Sub(decimal.RequireFromString("0.3")).Abs(); diff.GreaterThan(decimal.RequireFromString("0.000001")) {
+			t.Errorf("опорная сумма = %s, ожидалось ≈0.3", d)
+		}
+	}
+	if !seen {
+		t.Fatal("опорная проводка по счёту 41 не построена")
+	}
+}
+
+// Свёртка целиком проходит на «неудобных» суммах и сохраняет остаток.
+func TestRollup_AccountRegisterDecimalRoundTrip(t *testing.T) {
+	ar := decimalAcctReg()
+	db, ctx := newAccountTestDB(t, ar)
+	if err := db.EnsureAccountsTable(ctx); err != nil {
+		t.Fatal(err)
+	}
+	chart := &metadata.ChartOfAccounts{Name: "Основной", Accounts: []metadata.Account{
+		{Code: "000", Name: "Вспомогательный", Kind: "active_passive"},
+		{Code: "41", Name: "Товары", Kind: "active"},
+		{Code: "60", Name: "Поставщики", Kind: "passive"},
+	}}
+	if err := db.SyncAccounts(ctx, []*metadata.ChartOfAccounts{chart}); err != nil {
+		t.Fatal(err)
+	}
+
+	before := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	after := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	for _, p := range []time.Time{before, before, before, after} {
+		period := p
+		rows := []map[string]any{{"счётдт": "41", "счёткт": "60", "Сумма": "0.1"}}
+		if err := db.WriteAccountMovements(ctx, ar.Name, "Док", uuid.New(), rows, ar, &period); err != nil {
+			t.Fatalf("WriteAccountMovements: %v", err)
+		}
+	}
+
+	asOf := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+	bal41 := func() decimal.Decimal {
+		rows, err := db.AccountBalances(ctx, ar.Name, "Основной", asOf, ar.Resources, nil)
+		if err != nil {
+			t.Fatalf("AccountBalances: %v", err)
+		}
+		for _, b := range rows {
+			if code, _ := b["code"].(string); code == "41" {
+				d, _ := b["сумма"].(decimal.Decimal)
+				return d
+			}
+		}
+		return decimal.Zero
+	}
+
+	want := decimal.RequireFromString("0.4")
+	approx := func(got decimal.Decimal) bool {
+		return got.Sub(want).Abs().LessThanOrEqual(decimal.RequireFromString("0.000001"))
+	}
+	if got := bal41(); !approx(got) {
+		t.Fatalf("до свёртки сальдо 41 = %s, ожидалось ≈%s", got, want)
+	}
+	if _, err := db.Rollup(ctx, nil, nil, []*metadata.AccountRegister{ar}, nil,
+		RollupOptions{Date: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			AccountRegisters: []string{ar.Name}}); err != nil {
+		t.Fatalf("Rollup: %v", err)
+	}
+	if got := bal41(); !approx(got) {
+		t.Errorf("после свёртки сальдо 41 = %s, ожидалось ≈%s", got, want)
+	}
+}

--- a/internal/storage/accountreg_subconto_test.go
+++ b/internal/storage/accountreg_subconto_test.go
@@ -159,10 +159,10 @@ func TestAccountBalances_BySubconto(t *testing.T) {
 		switch code {
 		case "41":
 			товар, _ := b["субконто2"].(string)
-			saldo41[товар] = b["сумма"].(float64)
+			saldo41[товар] = toFloat(b["сумма"]) // AccountBalances отдаёт decimal (план 42)
 		case "19.3":
 			count193++
-			saldo193 = b["сумма"].(float64)
+			saldo193 = toFloat(b["сумма"])
 		}
 	}
 

--- a/internal/storage/rollup.go
+++ b/internal/storage/rollup.go
@@ -347,6 +347,14 @@ func (db *DB) Rollup(ctx context.Context, regs []*metadata.Register, ents []*met
 				metadata.RegisterTableName(reg.Name), db.dialect.Placeholder(1)), cutoff); err != nil {
 				return err
 			}
+			// Итоги (план 80) считаются из движений и поддерживаются только через
+			// WriteMovements. Массовое удаление свёрнутых строк идёт мимо него, поэтому
+			// помесячные строки итогов за периоды до cutoff остались бы на месте, а
+			// опорные остатки легли бы сверху — быстрый путь query отдал бы задвоенные
+			// остатки. Пересчитываем в той же транзакции, уже после удаления.
+			if err := db.RecalcRegisterTotals(ctx, reg); err != nil {
+				return fmt.Errorf("свёртка регистра %s: пересчёт итогов: %w", reg.Name, err)
+			}
 			rep.Registers = append(rep.Registers, RollupRegReport{
 				Name: reg.Name, FoldedMovements: folded, OpeningRows: len(open),
 			})
@@ -823,6 +831,11 @@ func (db *DB) foldAccountReg(ctx context.Context, ar *metadata.AccountRegister, 
 	if _, err := db.Exec(ctx, fmt.Sprintf("DELETE FROM %s WHERE period < %s",
 		metadata.AccountRegTableName(ar.Name), db.dialect.Placeholder(1)), cutoff); err != nil {
 		return rep, err
+	}
+	// См. комментарий в Rollup: удаление свёрнутых проводок идёт мимо
+	// WriteAccountMovements, поэтому итоги бухрегистра пересчитываем явно.
+	if err := db.RecalcAccountRegisterTotals(ctx, ar); err != nil {
+		return rep, fmt.Errorf("свёртка бухрегистра %s: пересчёт итогов: %w", ar.Name, err)
 	}
 	after, err := db.AccountBalances(ctx, ar.Name, ar.Accounts, cutoff, ar.Resources, ar.Subconto)
 	if err != nil {

--- a/internal/storage/rollup.go
+++ b/internal/storage/rollup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/shopspring/decimal"
 )
 
 // RollupRecorderType — синтетический тип регистратора опорных движений, которые
@@ -768,13 +769,16 @@ func (db *DB) accountOpeningRows(ctx context.Context, ar *metadata.AccountRegist
 			col := metadata.ColumnName(r)
 			// Сырой дебет минус кредит (НЕ b[col]: тот скорректирован по виду
 			// счёта — для пассивного это Кт−Дт, что исказило бы сторону проводки).
-			net := toFloat(b[col+"_дт"]) - toFloat(b[col+"_кт"])
+			// Считаем в decimal: опорные проводки — это денежные суммы, которые
+			// становятся входящим остатком, и округление float64 осело бы в базе
+			// навсегда.
+			net := toDecimal(b[col+"_дт"]).Sub(toDecimal(b[col+"_кт"]))
 			switch {
-			case net > 1e-9:
+			case net.IsPositive():
 				dtRow[r.Name] = net
 				dtHas = true
-			case net < -1e-9:
-				ktRow[r.Name] = -net
+			case net.IsNegative():
+				ktRow[r.Name] = net.Neg()
 				ktHas = true
 			}
 		}
@@ -1126,11 +1130,25 @@ func absFloat(f float64) float64 {
 	return f
 }
 
-// toFloat приводит значение остатка (float64/строка/json.Number/…) к float64.
+// toDecimal приводит значение остатка к decimal.Decimal (деньги считаем точно).
+// Непонятный тип/NULL → 0, как COALESCE в запросах остатков.
+func toDecimal(v any) decimal.Decimal {
+	if d, ok := normalizeNumber(v).(decimal.Decimal); ok {
+		return d
+	}
+	return decimal.Zero
+}
+
+// toFloat приводит значение остатка (decimal/float64/строка/json.Number/…) к
+// float64. Годится для сравнений с допуском, но не для денежной арифметики —
+// для неё toDecimal.
 func toFloat(v any) float64 {
 	switch n := v.(type) {
 	case nil:
 		return 0
+	case decimal.Decimal:
+		f, _ := n.Float64()
+		return f
 	case float64:
 		return n
 	case float32:

--- a/internal/storage/rollup_test.go
+++ b/internal/storage/rollup_test.go
@@ -471,6 +471,159 @@ func TestRollup_FoldsAccountRegister(t *testing.T) {
 	}
 }
 
+// TestRollup_KeepsRegisterTotalsInSync — регрессия: свёртка удаляет свёрнутые
+// движения массовым DELETE мимо WriteMovements, поэтому итоги (план 80) надо
+// пересчитывать явно. Без пересчёта помесячные строки итогов за периоды до
+// cutoff остаются на месте, а опорные остатки ложатся сверху — быстрый путь
+// query отдаёт задвоенный остаток при верных данных в самом регистре.
+func TestRollup_KeepsRegisterTotalsInSync(t *testing.T) {
+	ctx, db := rollupTestDB(t)
+	reg := &metadata.Register{
+		Name:       "ОстаткиТоваров",
+		Dimensions: []metadata.Field{{Name: "Товар", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+		Totals:     metadata.RegisterTotals{Enabled: true},
+	}
+	if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatalf("MigrateRegisters: %v", err)
+	}
+	if !reg.TotalsUsable() {
+		t.Fatal("итоги регистра выключены — тест ничего не проверит")
+	}
+
+	mk := func(date, vid, tovar string, kol float64) {
+		d := mustDate(t, date)
+		rows := []map[string]any{{"Товар": tovar, "Количество": kol, "ВидДвижения": vid}}
+		if err := db.WriteMovements(ctx, reg.Name, "ПоступлениеТоваров", uuid.New(), rows, reg, &d); err != nil {
+			t.Fatalf("WriteMovements: %v", err)
+		}
+	}
+	// Три разных месяца до даты свёртки — каждый даёт свою строку в итогах.
+	mk("2025-01-10", "Приход", "Молоко", 10)
+	mk("2025-02-15", "Расход", "Молоко", 3)
+	mk("2025-01-05", "Приход", "Хлеб", 7)
+	mk("2025-06-20", "Приход", "Молоко", 5) // >= cutoff, не сворачивается
+
+	assertTotalsMatch(ctx, t, db, reg, "до свёртки")
+	before := balMap(t, ctx, db, reg, "Товар", "Количество")
+
+	cutoff := mustDate(t, "2025-03-01")
+	if _, err := db.Rollup(ctx, []*metadata.Register{reg}, nil, nil, nil,
+		RollupOptions{Date: cutoff, Registers: []string{"ОстаткиТоваров"}}); err != nil {
+		t.Fatalf("Rollup: %v", err)
+	}
+
+	// Сами движения свёрнуты верно (это проверял и старый пост-чек)...
+	after := balMap(t, ctx, db, reg, "Товар", "Количество")
+	if !sameBal(before, after) {
+		t.Fatalf("остаток по движениям изменился: до=%v после=%v", before, after)
+	}
+	// ...и итоги согласованы с ними — то, что ломалось до фикса.
+	assertTotalsMatch(ctx, t, db, reg, "после свёртки")
+
+	// Строк итогов за свёрнутые месяцы не осталось: всё схлопнуто в месяц cutoff.
+	var stale int
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+metadata.RegisterTotalsTableName(reg.Name)+
+		" WHERE "+totalsMonthCol+" < ?", cutoff.Format("2006-01")).Scan(&stale); err != nil {
+		t.Fatal(err)
+	}
+	if stale != 0 {
+		t.Errorf("в итогах остались строки за свёрнутые месяцы: %d", stale)
+	}
+
+	// Повторная свёртка на ту же дату не должна разъезжать итоги.
+	if _, err := db.Rollup(ctx, []*metadata.Register{reg}, nil, nil, nil,
+		RollupOptions{Date: cutoff, Registers: []string{"ОстаткиТоваров"}}); err != nil {
+		t.Fatalf("повторная свёртка: %v", err)
+	}
+	assertTotalsMatch(ctx, t, db, reg, "после повторной свёртки")
+}
+
+// TestRollup_KeepsAccountTotalsInSync — то же для бухрегистра: foldAccountReg
+// удаляет свёрнутые проводки мимо WriteAccountMovements.
+func TestRollup_KeepsAccountTotalsInSync(t *testing.T) {
+	ctx, db := rollupTestDB(t)
+	if err := db.EnsureAccountsTable(ctx); err != nil {
+		t.Fatalf("EnsureAccountsTable: %v", err)
+	}
+	chart := &metadata.ChartOfAccounts{Name: "Основной", Accounts: []metadata.Account{
+		{Code: "000", Name: "Вспомогательный", Kind: "active_passive"},
+		{Code: "41", Name: "Товары", Kind: "active"},
+		{Code: "60", Name: "Поставщики", Kind: "passive"},
+	}}
+	if err := db.SyncAccounts(ctx, []*metadata.ChartOfAccounts{chart}); err != nil {
+		t.Fatalf("SyncAccounts: %v", err)
+	}
+	ar := &metadata.AccountRegister{
+		Name: "Хозрасчетный", Accounts: "Основной",
+		Resources: []metadata.Field{{Name: "Сумма", Type: metadata.FieldTypeNumber}},
+		Totals:    metadata.RegisterTotals{Enabled: true},
+	}
+	if err := db.MigrateAccountRegisters(ctx, []*metadata.AccountRegister{ar}); err != nil {
+		t.Fatalf("MigrateAccountRegisters: %v", err)
+	}
+	if !ar.TotalsUsable() {
+		t.Fatal("итоги бухрегистра выключены — тест ничего не проверит")
+	}
+
+	post := func(date string, sum float64) {
+		d := mustDate(t, date)
+		rows := []map[string]any{{"счётдт": "41", "счёткт": "60", "Сумма": sum}}
+		if err := db.WriteAccountMovements(ctx, ar.Name, "Поступление", uuid.New(), rows, ar, &d); err != nil {
+			t.Fatalf("WriteAccountMovements: %v", err)
+		}
+	}
+	post("2025-01-10", 1000)
+	post("2025-02-15", 500)
+	post("2025-06-20", 200)
+	cutoff := mustDate(t, "2025-03-01")
+
+	totalsTable := metadata.AccountRegTotalsTableName(ar.Name)
+	movTable := metadata.AccountRegTableName(ar.Name)
+	// Инвариант: помесячные обороты Дт/Кт из итогов == обороты по проводкам.
+	assertAcctTotalsMatch := func(stage string) {
+		t.Helper()
+		fromTotals := scanAcctDtKt(t, db, ctx,
+			"SELECT счёт, COALESCE(SUM(сумма_дт),0), COALESCE(SUM(сумма_кт),0) FROM "+totalsTable+" GROUP BY счёт")
+		onTheFlyDt := scanCodeSum(t, db, ctx, "SELECT счётдт, SUM(сумма) FROM "+movTable+" GROUP BY счётдт")
+		onTheFlyKt := scanCodeSum(t, db, ctx, "SELECT счёткт, SUM(сумма) FROM "+movTable+" GROUP BY счёткт")
+		codes := map[string]bool{}
+		for c := range onTheFlyDt {
+			codes[c] = true
+		}
+		for c := range onTheFlyKt {
+			codes[c] = true
+		}
+		if len(codes) == 0 {
+			t.Fatalf("[%s] нет проводок — тест ничего не проверил", stage)
+		}
+		for c := range codes {
+			if absFloat(fromTotals[c].dt-onTheFlyDt[c]) > 1e-6 {
+				t.Errorf("[%s] счёт %s: оборот Дт итогов=%v, на лету=%v", stage, c, fromTotals[c].dt, onTheFlyDt[c])
+			}
+			if absFloat(fromTotals[c].kt-onTheFlyKt[c]) > 1e-6 {
+				t.Errorf("[%s] счёт %s: оборот Кт итогов=%v, на лету=%v", stage, c, fromTotals[c].kt, onTheFlyKt[c])
+			}
+		}
+	}
+
+	assertAcctTotalsMatch("до свёртки")
+	if _, err := db.Rollup(ctx, nil, nil, []*metadata.AccountRegister{ar}, nil,
+		RollupOptions{Date: cutoff, AccountRegisters: []string{"Хозрасчетный"}}); err != nil {
+		t.Fatalf("Rollup: %v", err)
+	}
+	assertAcctTotalsMatch("после свёртки")
+
+	var stale int
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+totalsTable+
+		" WHERE месяц < ?", cutoff.Format("2006-01")).Scan(&stale); err != nil {
+		t.Fatal(err)
+	}
+	if stale != 0 {
+		t.Errorf("в итогах бухрегистра остались строки за свёрнутые месяцы: %d", stale)
+	}
+}
+
 // TestRollup_AccountRegister_NoAuxAccount — нет вспомогательного счёта → бухрегистр
 // пропускается с пометкой, движения не трогаются.
 func TestRollup_AccountRegister_NoAuxAccount(t *testing.T) {

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -13,7 +13,51 @@ import (
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/ivantit66/onebase/internal/webhook"
 )
+
+// dispatchDocWebhook публикует исходящий веб-хук (план 29) с DSL-пути документов.
+// Путь Документы.X (docWriter/docProxy) не проходит через entityservice.Save, где
+// живёт dispatchSaved, поэтому документы, записанные обработкой, HTTP-сервисом или
+// регламентным заданием, событий не порождали — интеграции их не видели.
+// Справочников это не касалось: catWriter сохраняется через entityservice.Save.
+//
+// Как и в entityservice: если запись идёт внутри явной DSL-транзакции, публикация
+// откладывается до коммита — не сообщаем наружу о данных, которые ещё могут
+// откатиться. record передаётся только там, где поля записи под рукой.
+func (s *Server) dispatchDocWebhook(ctx context.Context, name string, entity *metadata.Entity, id uuid.UUID, fields map[string]any) {
+	if !s.cfg.Webhooks.Enabled() {
+		return
+	}
+	event := webhook.Event{
+		Name:   name,
+		Entity: entity.Name,
+		ID:     id.String(),
+		User:   storage.AuditUserLogin(ctx),
+	}
+	if fields != nil {
+		event.Record = webhookDSLRecord(fields)
+	}
+	dispatch := func() { s.cfg.Webhooks.Dispatch(event) }
+	if storage.DeferUntilTxCommit(ctx, dispatch) {
+		return
+	}
+	dispatch()
+}
+
+// webhookDSLRecord — копия полей для тела хука без служебного псевдо-реквизита
+// «Ссылка» (*interpreter.Ref в шаблоне бесполезен). Зеркалит
+// entityservice.webhookRecord.
+func webhookDSLRecord(fields map[string]any) map[string]any {
+	rec := make(map[string]any, len(fields))
+	for k, v := range fields {
+		if low := strings.ToLower(k); low == "ссылка" || low == "reference" {
+			continue
+		}
+		rec[k] = v
+	}
+	return rec
+}
 
 // docsCtxSource предоставляет «живой» контекст (с открытой DSL-транзакцией,
 // если она есть). Реализуется *interpreter.TxState.
@@ -352,6 +396,9 @@ func (p *docProxy) DeleteRef(uuidStr string) error {
 			return err
 		}
 		p.s.publishDocChange(ctx, p.entity, id, "удалён", delBefore)
+		// Веб-хук <kind>.delete (план 29) — как в UI-обработчике физического
+		// удаления. Пометка на удаление обратима и событием не считается (markRef).
+		p.s.dispatchDocWebhook(ctx, string(p.entity.Kind)+".delete", p.entity, id, nil)
 		return nil
 	})
 }
@@ -378,6 +425,9 @@ func (p *docProxy) unpostRef(uuidStr string) error {
 	if result.DSLError != "" {
 		return fmt.Errorf("%s", result.DSLError)
 	}
+	// Веб-хук document.unpost (план 29) — как в UI-обработчике «Отменить проведение»
+	// (entityservice.Unpost хуки не диспетчеризует, это делает вызывающий).
+	p.s.dispatchDocWebhook(ctx, "document.unpost", p.entity, id, nil)
 	return nil
 }
 
@@ -718,6 +768,9 @@ func (w *docWriter) writeInContext(ctx context.Context) error {
 	})
 	// Живой список (план 87): отложенная до commit публикация «данные.<сущность>».
 	w.s.publishDocChange(ctx, w.entity, w.obj.ID, "записан", changeBefore)
+	// Веб-хук document.save (план 29) — Провести() зовёт write(), поэтому событие
+	// записи приходит и перед document.post, как на пути entityservice.Save.
+	w.s.dispatchDocWebhook(ctx, "document.save", w.entity, w.obj.ID, w.obj.Fields)
 	return nil
 }
 
@@ -787,6 +840,8 @@ func (w *docWriter) postInContext(ctx context.Context) error {
 	}
 	// Живой список (план 87): «проведён» после успешного проведения из DSL.
 	w.s.publishDocChange(ctx, w.entity, w.obj.ID, "проведён", nil)
+	// Веб-хук document.post (план 29).
+	w.s.dispatchDocWebhook(ctx, "document.post", w.entity, w.obj.ID, w.obj.Fields)
 	return nil
 }
 

--- a/internal/ui/dsl_webhooks_test.go
+++ b/internal/ui/dsl_webhooks_test.go
@@ -1,0 +1,193 @@
+package ui
+
+// Регрессия (план 29): путь Документы.X из DSL не проходит через
+// entityservice.Save, где живёт диспетчеризация веб-хуков, поэтому документы,
+// записанные обработкой / HTTP-сервисом / регламентным заданием, событий не
+// порождали — интеграции их не видели. Справочников это не касалось: catWriter
+// сохраняется через entityservice.Save.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/ivantit66/onebase/internal/webhook"
+)
+
+// errRollbackDSLWebhook — маркер намеренного отката транзакции в тесте.
+var errRollbackDSLWebhook = errors.New("намеренный откат")
+
+type dslHookSink struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (h *dslHookSink) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		h.mu.Lock()
+		if s, ok := body["event"].(string); ok {
+			h.events = append(h.events, s)
+		}
+		h.mu.Unlock()
+		w.WriteHeader(200)
+	}
+}
+
+func (h *dslHookSink) sorted() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := append([]string(nil), h.events...)
+	sort.Strings(out)
+	return out
+}
+
+// dslWebhookServer поднимает Server с подключённым диспетчером хуков на все
+// четыре события документа.
+func dslWebhookServer(t *testing.T, url string, doc *metadata.Entity, progs map[string]*ast.Program) (*Server, *webhook.Dispatcher, *storage.DB, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "wh.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+	if err := db.Migrate(ctx, []*metadata.Entity{doc}); err != nil {
+		t.Fatal(err)
+	}
+	registry := runtime.NewRegistry()
+	registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{doc}, Programs: progs})
+	interp := interpreter.New()
+	interp.LookupProc = registry.GetModuleProc
+
+	var hooks []webhook.Config
+	for _, ev := range []string{"document.save", "document.post", "document.unpost", "document.delete"} {
+		hooks = append(hooks, webhook.Config{
+			Name: ev, On: ev, URL: url,
+			Body: `{"event":"` + ev + `","id":"{{id}}","number":"{{Номер}}"}`,
+		})
+	}
+	d := webhook.New(hooks, nil)
+	t.Cleanup(func() {
+		c, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = d.Close(c)
+	})
+
+	s := &Server{
+		store: db, reg: registry, interp: interp,
+		lockMgr: runtime.NewLockManager(), messages: NewMessageStore(),
+		cfg: Config{Webhooks: d},
+	}
+	s.entitySvc = s.newEntityService(d)
+	return s, d, db, ctx
+}
+
+func dslWebhookDoc() *metadata.Entity {
+	return &metadata.Entity{
+		Name:    "ПоступлениеТоваров",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields:  []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+	}
+}
+
+// Записать/Провести/ОтменитьПроведение/Удалить из DSL публикуют события.
+func TestDSLDocuments_DispatchWebhooks(t *testing.T) {
+	sink := &dslHookSink{}
+	srv := httptest.NewServer(sink.handler())
+	defer srv.Close()
+
+	s, d, _, ctx := dslWebhookServer(t, srv.URL, dslWebhookDoc(), nil)
+
+	root := newDocsRoot(s, interpreter.NewTxState(ctx))
+	dp := root.Get("ПоступлениеТоваров").(*docProxy)
+
+	w := dp.CallMethod("создать", nil).(*docWriter)
+	w.Set("Номер", "ПОС-001")
+	w.CallMethod("записать", nil)
+	d.Wait()
+	if got := sink.sorted(); len(got) != 1 || got[0] != "document.save" {
+		t.Fatalf("после Записать ожидался document.save, получено %v", got)
+	}
+
+	// Провести() делает неявную запись, поэтому добавляет save + post.
+	w.CallMethod("провести", nil)
+	d.Wait()
+	if got := sink.sorted(); len(got) != 3 {
+		t.Fatalf("после Провести ожидалось 3 события (save, save, post), получено %v", got)
+	}
+
+	ref := dp.CallMethod("найтипономеру", []any{"ПОС-001"}).(*interpreter.Ref)
+	dp.CallMethod("отменитьпроведение", []any{ref})
+	d.Wait()
+	dp.CallMethod("удалить", []any{ref})
+	d.Wait()
+
+	got := sink.sorted()
+	want := []string{"document.delete", "document.post", "document.save", "document.save", "document.unpost"}
+	if len(got) != len(want) {
+		t.Fatalf("событий %d, ждали %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("события: получили %v, ждали %v", got, want)
+		}
+	}
+}
+
+// В явной DSL-транзакции событие уходит только после коммита: откат не должен
+// сообщать наружу о данных, которых в базе нет.
+func TestDSLDocuments_WebhookDeferredUntilCommit(t *testing.T) {
+	sink := &dslHookSink{}
+	srv := httptest.NewServer(sink.handler())
+	defer srv.Close()
+
+	s, d, db, ctx := dslWebhookServer(t, srv.URL, dslWebhookDoc(), nil)
+
+	// Откат: событие не публикуется.
+	err := db.WithTxScope(ctx, func(txCtx context.Context) error {
+		root := newDocsRoot(s, interpreter.NewTxState(txCtx))
+		dp := root.Get("ПоступлениеТоваров").(*docProxy)
+		w := dp.CallMethod("создать", nil).(*docWriter)
+		w.Set("Номер", "ОТКАТ-1")
+		w.CallMethod("записать", nil)
+		return errRollbackDSLWebhook
+	})
+	if err == nil {
+		t.Fatal("ожидалась ошибка отката транзакции")
+	}
+	d.Wait()
+	if got := sink.sorted(); len(got) != 0 {
+		t.Fatalf("после отката событий быть не должно, получено %v", got)
+	}
+
+	// Коммит: событие уходит.
+	if err := db.WithTxScope(ctx, func(txCtx context.Context) error {
+		root := newDocsRoot(s, interpreter.NewTxState(txCtx))
+		dp := root.Get("ПоступлениеТоваров").(*docProxy)
+		w := dp.CallMethod("создать", nil).(*docWriter)
+		w.Set("Номер", "КОММИТ-1")
+		w.CallMethod("записать", nil)
+		return nil
+	}); err != nil {
+		t.Fatalf("запись в транзакции: %v", err)
+	}
+	d.Wait()
+	if got := sink.sorted(); len(got) != 1 || got[0] != "document.save" {
+		t.Fatalf("после коммита ожидался document.save, получено %v", got)
+	}
+}


### PR DESCRIPTION
Дефекты найдены сплошной сверкой планов с кодом (аудит 2026-08-02). Ни один не числился в планах и не имел владельца. У каждого фикса — регрессионный тест, **проверенный на падение без фикса**.

### Д1 — свёртка не пересчитывала итоги регистров

Итоги (план 80) считаются из движений и поддерживаются только через `WriteMovements`/`WriteAccountMovements`. Свёртка удаляет свёрнутые движения массовым `DELETE` мимо них (`rollup.go:346,823`), поэтому помесячные строки итогов за периоды до даты свёртки оставались на месте, а опорные остатки ложились сверху.

Сами регистры сворачивались верно — пост-чек `GetBalances` читает движения напрямую и проходил. Ломался быстрый путь `query`: на тестовом наборе **19 вместо 12** по регистру накопления и оборот **3200 вместо 1700** по бухрегистру.

`RecalcRegisterTotals`/`RecalcAccountRegisterTotals` теперь вызываются в той же транзакции сразу после удаления. Регистры без итогов не затрагиваются (вызов no-op).

### Д2 — деньги бухотчётности во float64

`AccountBalances`/`AccountTurnovers` сканировали денежные ресурсы в `float64`, хотя план 42 перевёл деньги на `decimal`. На PostgreSQL это теряло точность `NUMERIC` уже на стороне Go, причём не только в отчёте: `accountOpeningRows` строит из этих остатков **опорные проводки свёртки**, то есть округление осело бы в базе навсегда как входящий остаток.

**Оговорка по SQLite:** там точность ограничена движком — `SUM()` над TEXT-колонкой возвращает `float64` при любом `CAST` (проверено на `NUMERIC` и `DECIMAL(38,10)`). `decimal` лишь сохраняет то, что отдал SQL, без второго округления. Точный агрегат на SQLite потребовал бы суммирования в Go — отдельное решение с влиянием на производительность.

Смена типа в map (`float64` → `decimal.Decimal`) затронула `accountreg_subconto_test.go`; шаблон ОСВ печатает значение через `{{str}}` (`%v`), то есть Stringer у decimal.

### Д3 — веб-хуки не срабатывали на DSL-пути документов

Путь `Документы.X` (`docWriter`/`docProxy`) не проходит через `entityservice.Save`, где живёт `dispatchSaved`, поэтому документы, записанные обработкой, HTTP-сервисом или регламентным заданием, событий не порождали — интеграции их не видели. Справочников это не касалось: `catWriter` сохраняется через `entityservice.Save`.

Добавлена единая точка `dispatchDocWebhook`: `document.save`, `document.post`, `document.unpost` и `<kind>.delete` (только физическое удаление — пометка обратима и событием не считается). Внутри явной DSL-транзакции публикация откладывается до коммита, как в `entityservice`.

### Проверка

```
go build ./...   # ok
go test ./...    # 66 пакетов, всё зелёное
```

Каждый тест прогнан с временно отключённым фиксом и падает: итоги 19≠12 / 3200≠1700, тип `float64` вместо `decimal.Decimal`, 0 событий вместо 5.

Отдельно: **Д4 из аудита оказался не дефектом** — исключение регистров с реквизитами из итогов задокументировано в `metadata/types.go:293` как осознанное (итоги не хранят `MIN(attr)` из проекции остатков). Это развитие плана 80, а не ошибка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)