### PR TITLE
fix(git): убрать случайный gitlink рабочей копии агента

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Thumbs.db
 # Claude Code skills
 .claude/commands/
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 .codex/
 .superpowers/
 


### PR DESCRIPTION
В `be913dc4` в индекс попал `.claude/worktrees/agent-a77fe3a29610021ee` — запись режима `160000` (gitlink на вложенный репозиторий), при том что `.gitmodules` в проекте нет вообще.

Из-за этого **каждый** прогон CI на шаге очистки `actions/checkout` сыплет:

```
fatal: No url found for submodule path '.claude/worktrees/agent-a77fe3a29610021ee' in .gitmodules
##[warning]The process '/usr/bin/git' failed with exit code 128
```

Запись удалена из индекса; `.claude/worktrees/` добавлен в `.gitignore` рядом с уже игнорируемыми `.claude/commands/` и `.claude/scheduled_tasks.lock`, чтобы временные рабочие копии агентов больше не попадали в коммиты.

Кода не касается: `git ls-files -s | grep ^160000` теперь пусто, `go build ./...` проходит.

Найдено попутно при ревью #521/#522.

Generated-with: Claude Code