### PR TITLE
fix(ui): не подменять опции поля сущности и не глушить команды автопанели

### DIFF
--- a/internal/ui/form_attr_regressions_test.go
+++ b/internal/ui/form_attr_regressions_test.go
@@ -1,0 +1,191 @@
+package ui
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// collisionServer поднимает сервер с РЕАЛЬНОЙ базой и справочником
+// «СовсемДругойСправочник» в реестре: без этого GetEntity вернул бы nil,
+// mergeFormLocalRefOptions вышла бы раньше подмены ключа, и тест коллизии
+// проверял бы пустоту.
+func collisionServer(t *testing.T) *Server {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "c.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	other := &metadata.Entity{
+		Name: "СовсемДругойСправочник", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{other}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Upsert(ctx, other.Name, uuid.New(),
+		map[string]any{"Наименование": "ЧужойВариант"}, other); err != nil {
+		t.Fatal(err)
+	}
+	reg := runtime.NewRegistry()
+	reg.Load(runtime.LoadOptions{Entities: []*metadata.Entity{other}})
+	return &Server{reg: reg, store: db}
+}
+
+// Реквизит формы, совпадающий по имени с полем сущности, не должен подменять
+// собранные для этого поля варианты: шаблон рисует поле сущности, и подмена
+// отдала бы ему опции чужого справочника, а текущее значение выпало бы из
+// списка — при следующем сохранении ссылка молча очищается.
+func TestMergeFormLocalRefOptions_KeepsEntityFieldOptions(t *testing.T) {
+	entity := &metadata.Entity{
+		Name: "Заявка", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Статус", Type: metadata.FieldType("reference:СтатусЗаявки"), RefEntity: "СтатусЗаявки"}},
+	}
+	form := &metadata.FormModule{Attributes: []*metadata.FormAttribute{
+		// Одноимённый полю сущности реквизит формы, но ссылается на другой справочник.
+		{Name: "Статус", TypeRef: "CatalogRef.СовсемДругойСправочник", Save: false},
+	}}
+	entityRows := []map[string]any{{"id": "st-1", "_label": "Новая"}}
+	data := map[string]any{
+		"Entity":     entity,
+		"RefOptions": map[string][]map[string]any{"Статус": entityRows},
+	}
+
+	collisionServer(t).mergeFormLocalRefOptions(context.Background(), form, data)
+
+	got, _ := data["RefOptions"].(map[string][]map[string]any)
+	if len(got["Статус"]) != 1 || got["Статус"][0]["_label"] != "Новая" {
+		t.Fatalf("опции поля сущности подменены реквизитом формы: %+v", got["Статус"])
+	}
+}
+
+// Реквизит формы с уникальным именем по-прежнему получает свои опции.
+func TestMergeFormLocalRefOptions_KeepsDistinctAttrKey(t *testing.T) {
+	entity := &metadata.Entity{Name: "Заявка", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}}}
+	form := &metadata.FormModule{Attributes: []*metadata.FormAttribute{
+		{Name: "Причина", TypeRef: "CatalogRef.ПричинаОтказа", Save: false},
+	}}
+	data := map[string]any{
+		"Entity":     entity,
+		"RefOptions": map[string][]map[string]any{"Номер": {{"id": "x"}}},
+	}
+	s := &Server{reg: runtime.NewRegistry()}
+	s.mergeFormLocalRefOptions(context.Background(), form, data)
+
+	got, _ := data["RefOptions"].(map[string][]map[string]any)
+	if len(got["Номер"]) != 1 {
+		t.Errorf("чужой ключ затёрт: %+v", got)
+	}
+	// Реестр пуст, поэтому сущность не резолвится и опции не добавляются —
+	// важно, что ключ не создан пустым и ничего не сломано.
+	if _, exists := got["Причина"]; exists {
+		t.Errorf("для нерезолвящейся сущности ключ создаваться не должен: %+v", got)
+	}
+}
+
+// Элемент с обработчиками, среди которых нет нужного события, не должен глушить
+// фолбэк на одноимённую команду: раньше кнопка автопанели оказывалась мёртвой.
+func TestResolveHandlerProc_ElementWithoutEventFallsBackToCommand(t *testing.T) {
+	form := &metadata.FormModule{
+		Commands: []*metadata.FormCommand{{Name: "Классифицировать", Action: "КлассифицироватьНажатие"}},
+		Elements: []*metadata.FormElement{{
+			Kind: metadata.FormElementField, Name: "Классифицировать",
+			Handlers: map[metadata.FormEventType]string{metadata.FormEventOnChange: "ЧтоТоПриИзменении"},
+		}},
+	}
+	if proc := resolveHandlerProc(form, "Классифицировать", "Нажатие"); proc != "КлассифицироватьНажатие" {
+		t.Fatalf("ожидалась КлассифицироватьНажатие, получено %q", proc)
+	}
+	// Собственный обработчик элемента по своему событию по-прежнему в приоритете.
+	if proc := resolveHandlerProc(form, "Классифицировать", "ПриИзменении"); proc != "ЧтоТоПриИзменении" {
+		t.Fatalf("обработчик элемента должен быть приоритетнее, получено %q", proc)
+	}
+}
+
+// Фолбэк на команду ограничен событиями, которые автопанель реально шлёт:
+// иначе команда выполнялась бы на любом событии, включая мусорное имя.
+func TestResolveHandlerProc_CommandFallbackOnlyForClickAndChoice(t *testing.T) {
+	form := &metadata.FormModule{
+		Commands: []*metadata.FormCommand{{Name: "Провести", Action: "ПровестиКоманда"}},
+	}
+	for _, evt := range []string{"Нажатие", "Выбор"} {
+		if proc := resolveHandlerProc(form, "Провести", evt); proc != "ПровестиКоманда" {
+			t.Errorf("событие %s: ожидалась ПровестиКоманда, получено %q", evt, proc)
+		}
+	}
+	for _, evt := range []string{"ПриИзменении", "НачалоВыбора", "ЧтоУгодно"} {
+		if proc := resolveHandlerProc(form, "Провести", evt); proc != "" {
+			t.Errorf("событие %s не должно резолвиться на команду, получено %q", evt, proc)
+		}
+	}
+}
+
+// Автопанель шлёт имя команды как есть; сравнение регистронезависимое, чтобы
+// расхождение регистра в конфигурации не давало молча мёртвую кнопку.
+func TestResolveHandlerProc_CommandNameCaseInsensitive(t *testing.T) {
+	form := &metadata.FormModule{
+		Commands: []*metadata.FormCommand{{Name: "Провести", Action: "ПровестиКоманда"}},
+	}
+	if proc := resolveHandlerProc(form, "провести", "Нажатие"); proc != "ПровестиКоманда" {
+		t.Fatalf("ожидалась ПровестиКоманда при другом регистре, получено %q", proc)
+	}
+}
+
+// Сквозная проверка: при коллизии имён форма рендерит поле сущности с ЕГО
+// вариантами, а не с вариантами одноимённого реквизита формы.
+func TestManagedFormRendersEntityOptionsOnNameCollision(t *testing.T) {
+	form := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: "Заявка",
+		LayoutKind: metadata.FormLayoutManaged,
+		Attributes: []*metadata.FormAttribute{
+			{Name: "Статус", TypeRef: "CatalogRef.СовсемДругойСправочник", Save: false},
+		},
+		Elements: []*metadata.FormElement{
+			{Kind: metadata.FormElementField, Name: "ПолеСтатус", DataPath: "Объект.Статус"},
+		},
+	}
+	entity := &metadata.Entity{
+		Name: "Заявка", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Статус", Type: metadata.FieldType("reference:СтатусЗаявки"), RefEntity: "СтатусЗаявки"}},
+		Forms:  []*metadata.FormModule{form},
+	}
+	data := map[string]any{
+		"Entity": entity, "Form": form, "IsNew": true,
+		"Values":        map[string]string{"Статус": "st-1"},
+		"RefOptions":    map[string][]map[string]any{"Статус": {{"id": "st-1", "_label": "Новая"}}},
+		"EnumOptions":   map[string]any{},
+		"ChoiceOptions": loadChoiceOptions(form, "ru"),
+		"TPRefOptions":  map[string]any{},
+		"TPEnumLabels":  map[string]map[string]map[string]string{},
+		"TPEnumOrder":   map[string]map[string][]string{},
+		"TPRefMeta":     map[string]any{},
+		"TablePartRows": map[string][]map[string]any{},
+		"User":          nil, "Lang": "ru",
+	}
+	collisionServer(t).mergeFormLocalRefOptions(context.Background(), form, data)
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "page-managed-form", data); err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+	html := buf.String()
+	if !strings.Contains(html, "Новая") {
+		t.Error("вариант поля сущности не отрисован")
+	}
+	if !strings.Contains(html, `value="st-1" selected`) {
+		t.Error("текущее значение поля сущности потеряно")
+	}
+	if strings.Contains(html, "СовсемДругойСправочник") {
+		t.Error("в разметку просочился справочник одноимённого реквизита формы")
+	}
+}

--- a/internal/ui/handlers_managed.go
+++ b/internal/ui/handlers_managed.go
@@ -150,8 +150,21 @@ func (s *Server) mergeFormLocalRefOptions(ctx context.Context, form *metadata.Fo
 	if ref == nil {
 		ref = map[string][]map[string]any{}
 	}
+	entity, _ := data["Entity"].(*metadata.Entity)
 	for _, a := range form.Attributes {
 		if a == nil || a.Save {
+			continue
+		}
+		// Имя реквизита формы ничем не связано с именами полей сущности и вполне
+		// может совпасть (в 1С неглавный реквизит формы по умолчанию SaveData=false
+		// и часто называется как реквизит объекта). Шаблон в таком случае рисует
+		// поле сущности, и подмена ключа отдала бы ему варианты чужого справочника,
+		// а текущее значение выпало бы из списка — при следующем сохранении ссылка
+		// молча очищается. Поле сущности всегда важнее: свои опции оно уже собрало.
+		if _, isEntityField := entityFieldByName(entity, a.Name); isEntityField {
+			continue
+		}
+		if _, busy := ref[a.Name]; busy {
 			continue
 		}
 		refEntityName := attrRefEntityName(a.TypeRef)

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -442,21 +442,29 @@ func resolveHandlerProc(form *metadata.FormModule, elementName, eventName string
 		}
 		return ""
 	}
-	el := form.GetElementByName(elementName)
-	if el == nil || el.Handlers == nil {
-		// Фикс A: команда, размещённая автоматической командной панелью (не вручную
-		// элементом kind: Кнопка), не имеет элемента в дереве — резолвим по имени
-		// команды на её процедуру-Action.
-		if elementName != "" {
-			for _, c := range form.Commands {
-				if c != nil && c.Name == elementName && c.Action != "" {
-					return c.Action
-				}
-			}
+	// Обработчик самого элемента имеет приоритет — но именно по нужному событию.
+	// Ветвление по «есть ли у элемента вообще Handlers» глушило фолбэк: элемент с
+	// непустой картой без ключа этого события возвращал пустую строку, и кнопка
+	// автопанели с тем же именем оказывалась мёртвой без всякой диагностики.
+	if el := form.GetElementByName(elementName); el != nil && el.Handlers != nil {
+		if proc := el.Handlers[evt]; proc != "" {
+			return proc
 		}
+	}
+	// Команда, размещённая автоматической командной панелью (не вручную элементом
+	// kind: Кнопка), не имеет элемента в дереве — резолвим по имени команды на её
+	// процедуру-Action. Фолбэк ограничен событиями, которые автопанель реально
+	// шлёт: без этого команда выполнялась бы на любом событии, включая ПриИзменении
+	// и мусорные имена.
+	if evt != metadata.FormEventOnClick && evt != metadata.FormEventOnChoice {
 		return ""
 	}
-	return el.Handlers[evt]
+	for _, c := range form.Commands {
+		if c != nil && c.Action != "" && strings.EqualFold(c.Name, elementName) {
+			return c.Action
+		}
+	}
+	return ""
 }
 
 // buildObjectFromForm восстанавливает *runtime.Object из POST-формы.


### PR DESCRIPTION
Два регресса, привнесённых #522. Оба воспроизведены до правки; четыре из шести новых тестов падают без этого коммита.

## 1. Подмена опций одноимённого поля сущности

`mergeFormLocalRefOptions` писала `ref[a.Name]` без проверки занятости ключа (`internal/ui/handlers_managed.go`). Имя реквизита формы ничем не связано с именами полей сущности и вполне может совпасть — в 1С неглавный реквизит формы по умолчанию `SaveData=false` и часто называется как реквизит объекта.

Шаблон в такой ситуации рисует **поле сущности** (ветка `fieldByName` идёт раньше `attrByName`), поэтому оно получало варианты чужого справочника, а его текущее значение выпадало из списка. Дальше — тихая потеря данных: при следующем сохранении `formToFields` пишет `nil`, и ссылка очищается.

Тест без правки показывает подмену буквально:
```
опции поля сущности подменены реквизитом формы:
  [map[_label:ЧужойВариант ... Наименование:ЧужойВариант]]
```

Теперь имена, совпадающие с полями сущности, пропускаются, а занятые ключи не перетираются.

## 2. Мёртвые кнопки командной панели

`resolveHandlerProc` ветвился по «есть ли у элемента вообще `Handlers`». Элемент с непустой картой, но без ключа нужного события, возвращал пустую строку и глушил фолбэк — кнопка автопанели с тем же именем оказывалась мёртвой без всякой диагностики.

Теперь сперва ищется обработчик элемента **именно по нужному событию**, и только затем фолбэк на одноимённую команду.

Заодно фолбэк ограничен событиями, которые автопанель реально шлёт (`Нажатие`, `Выбор`): раньше команда резолвилась на **любое** событие, включая `ПриИзменении` и несуществующее имя. Сравнение имён сделано регистронезависимым.

## Проверка

`go build`, `go vet ./...`, `go test ./...`, `golangci-lint run` (v2.11.4) — всё зелёное, `0 issues`.

Найдено при разборе хвостов ревью #522.

Generated-with: Claude Code