### PR TITLE
test(devserver): убрать таймингозависимость TestWatchContext_Debounces

### DIFF
--- a/internal/devserver/watcher.go
+++ b/internal/devserver/watcher.go
@@ -58,6 +58,13 @@ func WatchProjectContext(ctx context.Context, dir string, onChange func()) (<-ch
 	}, onChange)
 }
 
+// debounceWindow — сколько тишины ждать после правки, прежде чем звать onChange.
+// Переменная, а не константа, чтобы тест мог задать заведомо широкое окно:
+// проверка схлопывания серии правок иначе зависит от планировщика раннера, и на
+// нагруженном CI пауза между записями растягивалась за окно, разбивая серию на
+// два вызова (флейк TestWatchContext_Debounces).
+var debounceWindow = 300 * time.Millisecond
+
 func watchContext(ctx context.Context, dir string, accept func(string, bool) bool, onChange func()) (<-chan struct{}, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -100,7 +107,7 @@ func watchContext(ctx context.Context, dir string, accept func(string, bool) boo
 			default:
 			}
 		}
-		debounce.Reset(300 * time.Millisecond)
+		debounce.Reset(debounceWindow)
 	}
 
 	done := make(chan struct{})

--- a/internal/devserver/watcher_test.go
+++ b/internal/devserver/watcher_test.go
@@ -129,6 +129,15 @@ func TestWatchContext_TriggersOnNewSubdir(t *testing.T) {
 }
 
 func TestWatchContext_Debounces(t *testing.T) {
+	// Раньше серия правок растягивалась на 250 мс при штатном окне 300 мс —
+	// запас всего шестикратный, и на нагруженном раннере одна пауза выходила за
+	// окно: таймер срабатывал посреди серии, тест видел два вызова вместо одного.
+	// Теперь окно шире, а правки плотнее: 80 мс серии против 1 с окна.
+	// Проверяемое поведение (N правок → один onChange) не меняется.
+	prev := debounceWindow
+	debounceWindow = time.Second
+	t.Cleanup(func() { debounceWindow = prev })
+
 	dir := t.TempDir()
 	file := filepath.Join(dir, "y.os")
 	if err := os.WriteFile(file, []byte("// initial"), 0o644); err != nil {
@@ -144,10 +153,17 @@ func TestWatchContext_Debounces(t *testing.T) {
 		if err := os.WriteFile(file, []byte("// edited"+string(rune('A'+i))), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 	}
-	// Ждём debounce + запас.
-	time.Sleep(700 * time.Millisecond)
+	// Ждём срабатывания, а не фиксированной паузы: так тест не зависит от того,
+	// насколько быстро раннер донёс события fsnotify.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&changes) == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Дать шанс лишним вызовам проявиться — иначе тест не отличит «схлопнулось»
+	// от «второй вызов ещё не пришёл».
+	time.Sleep(debounceWindow)
 
 	got := atomic.LoadInt32(&changes)
 	if got != 1 {


### PR DESCRIPTION
Тест уронил CI на `main` — прогон [30756822374](https://github.com/ivanarama/onebase/actions/runs/30756822374), коммит `74e5be8a`:

```
--- FAIL: TestWatchContext_Debounces (1.55s)
    watcher_test.go:154: ожидался 1 onChange (debounce), получили 2
```

К содержанию мерджа отношения не имеет: PR #529 менял только `internal/ui`, `internal/devserver` не трогали 20+ коммитов.

## Причина

Запас по времени. Серия из пяти правок писалась с паузой 50 мс, то есть растягивалась на **250 мс при окне debounce 300 мс** — запас всего шестикратный. Каждая правка сдвигает таймер, поэтому достаточно одной паузы, вышедшей за 300 мс (планировщик нагруженного раннера, задержка доставки события fsnotify), чтобы таймер сработал посреди серии и вызовов стало два.

## Что сделано

- Окно debounce вынесено в пакетную переменную `debounceWindow` — публичный API не меняется; тест поднимает её до 1 с и возвращает через `t.Cleanup`.
- Правки идут плотнее: 20 мс вместо 50, серия укладывается в 80 мс. Запас стал **двенадцатикратным** вместо шестикратного.
- Фиксированное ожидание заменено опросом до первого срабатывания — тест больше не зависит от скорости доставки событий. После этого пауза длиной в окно, чтобы лишний вызов успел проявиться и «схлопнулось» не спуталось с «второй ещё не пришёл».

Проверяемое поведение не изменилось: N правок подряд → один `onChange`.

## Честная оговорка

Локально флейк воспроизвести **не удалось**: старый тест выдержал 15 прогонов под шестикратной CPU-нагрузкой на 4 ядрах. Обоснование правки — лог CI и арифметика запаса, а не локальное воспроизведение. Новый вариант прогнан 20 раз подряд и 8 раз под нагрузкой.

Generated-with: Claude Code