### PR TITLE
fix(backup,storage): закрыть errcheck в критичных путях записи (план 109D)

### DIFF
--- a/internal/backup/universal.go
+++ b/internal/backup/universal.go
@@ -86,13 +86,20 @@ func ExportUniversal(
 	attachmentsDir string,
 	baseName string,
 	w io.Writer,
-) error {
+) (err error) {
 	zw := zip.NewWriter(w)
+	// Close дописывает центральный каталог zip — без него архив нечитаем.
+	// На успешном пути эта ошибка основная, на пути ошибки — вторичная, но
+	// терять её нельзя: молча «успешный» бэкап хуже явно неудавшегося.
+	defer func() {
+		if cerr := zw.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+	}()
 
 	// --- 1. DATA tables -------------------------------------------------------
 	appTables, err := listAppTables(ctx, db)
 	if err != nil {
-		zw.Close()
 		return fmt.Errorf("export: list tables: %w", err)
 	}
 	manifest := make(map[string]int)
@@ -100,12 +107,10 @@ func ExportUniversal(
 		entryName := "data/" + tbl + ".jsonl"
 		fw, err := zw.Create(entryName)
 		if err != nil {
-			zw.Close()
 			return err
 		}
 		n, err := dumpTableJSONL(ctx, db, tbl, fw)
 		if err != nil {
-			zw.Close()
 			return fmt.Errorf("export table %s: %w", tbl, err)
 		}
 		manifest[entryName] = n
@@ -116,7 +121,6 @@ func ExportUniversal(
 		entryName := "system/" + tbl + ".jsonl"
 		fw, err := zw.Create(entryName)
 		if err != nil {
-			zw.Close()
 			return err
 		}
 		n, err := dumpTableJSONL(ctx, db, tbl, fw)
@@ -134,7 +138,6 @@ func ExportUniversal(
 		entryName := "exchange/" + tbl + ".jsonl"
 		fw, err := zw.Create(entryName)
 		if err != nil {
-			zw.Close()
 			return err
 		}
 		n, err := dumpTableJSONL(ctx, db, tbl, fw)
@@ -146,7 +149,6 @@ func ExportUniversal(
 
 	// --- 3. SAFE SETTINGS -----------------------------------------------------
 	if n, err := exportSafeSettings(ctx, db, zw); err != nil {
-		zw.Close()
 		return fmt.Errorf("export settings: %w", err)
 	} else if n > 0 {
 		manifest["settings/safe.jsonl"] = n
@@ -154,7 +156,6 @@ func ExportUniversal(
 
 	// --- 4. CONFIG ------------------------------------------------------------
 	if err := exportConfig(ctx, db, configSource, configDir, zw); err != nil {
-		zw.Close()
 		return fmt.Errorf("export config: %w", err)
 	}
 
@@ -171,9 +172,21 @@ func ExportUniversal(
 	}
 
 	// --- 6. manifest.json ----------------------------------------------------
-	manifestJSON, _ := json.MarshalIndent(manifest, "", "  ")
-	mf, _ := zw.Create("manifest.json")
-	mf.Write(manifestJSON)
+	// Манифест — не украшение: восстановление сверяет по нему число строк.
+	// Раньше ошибка zw.Create игнорировалась, а возвращаемый ею nil сделал бы
+	// mf.Write паникой. Перебор 858 сценариев обрыва записи такую комбинацию не
+	// воспроизвёл, но полагаться на недостижимость nil-указателя незачем.
+	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("export: манифест: %w", err)
+	}
+	mf, err := zw.Create("manifest.json")
+	if err != nil {
+		return fmt.Errorf("export: манифест: %w", err)
+	}
+	if _, err := mf.Write(manifestJSON); err != nil {
+		return fmt.Errorf("export: манифест: %w", err)
+	}
 
 	// --- 7. META.txt ----------------------------------------------------------
 	dbType := db.Dialect().Name()
@@ -181,10 +194,15 @@ func ExportUniversal(
 		"onebase_full_export\nversion=2\nformat=universal\nsource_db_type=%s\nsource_base=%s\ndate=%s\nhas_attachments=%v\nhas_exchange_state=%v\n",
 		dbType, baseName, time.Now().UTC().Format(time.RFC3339), hasAttachments, hasExchangeState,
 	)
-	mfw, _ := zw.Create("META.txt")
-	mfw.Write([]byte(meta))
+	mfw, err := zw.Create("META.txt")
+	if err != nil {
+		return fmt.Errorf("export: META.txt: %w", err)
+	}
+	if _, err := mfw.Write([]byte(meta)); err != nil {
+		return fmt.Errorf("export: META.txt: %w", err)
+	}
 
-	return zw.Close()
+	return nil
 }
 
 // listAppTables returns all non-system table names in the database, sorted.
@@ -216,8 +234,12 @@ func listAppTables(ctx context.Context, db *storage.DB) ([]string, error) {
 // Lines 2+: data rows as JSON objects.
 // Returns the number of data rows written.
 func dumpTableJSONL(ctx context.Context, db *storage.DB, tableName string, w io.Writer) (int, error) {
+	// Flush — финализация записи, а не уборка. Раньше ошибка уходила в
+	// `defer bw.Flush()` и терялась здесь; наружу она всё же попадала, потому что
+	// zip.Writer запоминает ошибку нижележащего писателя и отдаёт её на Close.
+	// Полагаться на это не стоит: ошибка приходила без указания таблицы и на
+	// другом этапе. Теперь сбой сброса виден там, где произошёл.
 	bw := bufio.NewWriterSize(w, 256*1024)
-	defer bw.Flush()
 
 	// Detect byte columns.
 	byCols, err := detectByteCols(ctx, db, tableName)
@@ -234,9 +256,13 @@ func dumpTableJSONL(ctx context.Context, db *storage.DB, tableName string, w io.
 		}
 		schemaObj["btypes"] = list
 	}
-	sl, _ := json.Marshal(schemaObj)
-	bw.Write(sl)
-	bw.WriteByte('\n')
+	sl, err := json.Marshal(schemaObj)
+	if err != nil {
+		return 0, fmt.Errorf("dump %s: заголовок схемы: %w", tableName, err)
+	}
+	if err := writeJSONLine(bw, sl); err != nil {
+		return 0, fmt.Errorf("dump %s: заголовок схемы: %w", tableName, err)
+	}
 
 	// Stream rows.
 	rows, err := db.Query(ctx, "SELECT * FROM "+quotedIdent(db, tableName))
@@ -265,11 +291,30 @@ func dumpTableJSONL(ctx context.Context, db *storage.DB, tableName string, w io.
 		if err != nil {
 			return n, err
 		}
-		bw.Write(line)
-		bw.WriteByte('\n')
+		if err := writeJSONLine(bw, line); err != nil {
+			return n, fmt.Errorf("dump %s: строка %d: %w", tableName, n+1, err)
+		}
 		n++
 	}
-	return n, rows.Err()
+	if err := rows.Err(); err != nil {
+		return n, err
+	}
+	// Сброс буфера — часть записи: без него хвост таблицы не попадёт в архив.
+	if err := bw.Flush(); err != nil {
+		return n, fmt.Errorf("dump %s: сброс буфера: %w", tableName, err)
+	}
+	return n, nil
+}
+
+// writeJSONLine пишет одну строку JSONL вместе с переводом строки. Ошибки
+// bufio.Writer «залипают»: после первой все последующие записи возвращают её же,
+// поэтому достаточно проверять результат — но проверять обязательно, иначе
+// обрыв записи останется незамеченным до восстановления.
+func writeJSONLine(bw *bufio.Writer, line []byte) error {
+	if _, err := bw.Write(line); err != nil {
+		return err
+	}
+	return bw.WriteByte('\n')
 }
 
 // detectByteCols returns the set of columns in tableName that store binary data.
@@ -570,7 +615,11 @@ func exportConfig(ctx context.Context, db *storage.DB, configSource, configDir s
 			if err != nil {
 				return err
 			}
-			fw.Write(content)
+			// Ошибку записи конфигурации сообщаем с именем файла: без этого она
+			// всплывала бы позже и безадресно — на Close всего архива.
+			if _, err := fw.Write(content); err != nil {
+				return fmt.Errorf("export config %s: %w", entryPath, err)
+			}
 		}
 		return rows.Err()
 	}
@@ -599,7 +648,9 @@ func exportConfig(ctx context.Context, db *storage.DB, configSource, configDir s
 		if err != nil {
 			return err
 		}
-		fw.Write(content)
+		if _, err := fw.Write(content); err != nil {
+			return fmt.Errorf("export config %s: %w", rel, err)
+		}
 		return nil
 	})
 }
@@ -1581,16 +1632,23 @@ func getTableCols(ctx context.Context, db *storage.DB, tableName string) (map[st
 }
 
 // tableExists reports whether tableName exists in the target DB.
+// Ошибка запроса трактуется как «таблицы нет» — так же, как было до проверки
+// (Scan при ошибке оставлял exists=false), но теперь это записано явно, а не
+// получается само собой из проигнорированного возврата.
 func tableExists(ctx context.Context, db *storage.DB, tableName string) bool {
 	var exists bool
+	var err error
 	if db.IsSQLite() {
-		db.QueryRow(ctx,
+		err = db.QueryRow(ctx,
 			`SELECT COUNT(*)>0 FROM sqlite_master WHERE type='table' AND name=?`, tableName,
 		).Scan(&exists)
 	} else {
-		db.QueryRow(ctx,
+		err = db.QueryRow(ctx,
 			`SELECT EXISTS(SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename=$1)`, tableName,
 		).Scan(&exists)
+	}
+	if err != nil {
+		return false
 	}
 	return exists
 }

--- a/internal/backup/universal_writeerr_test.go
+++ b/internal/backup/universal_writeerr_test.go
@@ -1,0 +1,121 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// errAfterWriter отдаёт ошибку после того, как через него прошло limit байт, —
+// так ведёт себя диск, на котором кончилось место, или оборванный поток.
+type errAfterWriter struct {
+	limit   int
+	written int
+}
+
+var errDiskFull = errors.New("устройство переполнено (тест)")
+
+func (w *errAfterWriter) Write(p []byte) (int, error) {
+	if w.written >= w.limit {
+		return 0, errDiskFull
+	}
+	n := len(p)
+	if w.written+n > w.limit {
+		n = w.limit - w.written
+		w.written += n
+		return n, errDiskFull
+	}
+	w.written += n
+	return n, nil
+}
+
+// Ошибка записи в архив обязана дойти до вызывающего кода. Тест проходит и на
+// коде до правки: zip.Writer запоминает ошибку нижележащего писателя и отдаёт её
+// на Close, так что молчаливой потери не было — это проверено перебором 858
+// сценариев обрыва (паник и ложных «успехов» не найдено). Тест закрепляет само
+// свойство: ни один путь выгрузки не должен возвращать nil при сбое записи,
+// включая те, где ошибка теперь сообщается раньше и адресно.
+func TestExportUniversal_WriteErrorIsReported(t *testing.T) {
+	ctx := context.Background()
+	db := newSQLite(t, "exporterr")
+
+	if _, err := db.Exec(ctx, `CREATE TABLE товары (id TEXT PRIMARY KEY, наименование TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	// ~400 КБ полезных данных — больше 256-килобайтного буфера выгрузки, чтобы
+	// сброс происходил не только в самом конце.
+	big := strings.Repeat("я", 2000)
+	for i := 0; i < 200; i++ {
+		if _, err := db.Exec(ctx,
+			`INSERT INTO товары (id, наименование) VALUES (?, ?)`,
+			"id-"+strings.Repeat("0", 3)+itoa(i), big); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Калибруемся по реальному размеру архива: zip сжимает повторяющиеся данные
+	// в разы, поэтому фиксированные лимиты вроде 64 КБ могут оказаться БОЛЬШЕ
+	// всего архива — тогда обрыва не происходит и nil корректен. Лимиты берём
+	// долями от измеренного размера.
+	var probe countingWriter
+	if err := ExportUniversal(ctx, db, "file", t.TempDir(), "", "test", &probe); err != nil {
+		t.Fatalf("контрольная выгрузка не удалась: %v", err)
+	}
+	if probe.n < 100 {
+		t.Fatalf("архив подозрительно мал (%d байт) — тест ничего не проверит", probe.n)
+	}
+	t.Logf("размер эталонного архива: %d байт", probe.n)
+
+	for _, limit := range []int{0, probe.n / 4, probe.n / 2, probe.n - 1} {
+		w := &errAfterWriter{limit: limit}
+		err := ExportUniversal(ctx, db, "file", t.TempDir(), "", "test", w)
+		if err == nil {
+			t.Errorf("limit=%d из %d: выгрузка вернула nil при сбое записи — бэкап молча обрезан",
+				limit, probe.n)
+			continue
+		}
+		if !errors.Is(err, errDiskFull) {
+			t.Logf("limit=%d: ошибка сообщена, но не разворачивается до исходной: %v", limit, err)
+		}
+	}
+}
+
+// Успешная выгрузка по-прежнему проходит и даёт читаемый архив — guard, чтобы
+// добавленные проверки не сломали happy path.
+func TestExportUniversal_SuccessStillWorks(t *testing.T) {
+	ctx := context.Background()
+	db := newSQLite(t, "exportok")
+	if _, err := db.Exec(ctx, `CREATE TABLE товары (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `INSERT INTO товары (id) VALUES ('x')`); err != nil {
+		t.Fatal(err)
+	}
+	var buf countingWriter
+	if err := ExportUniversal(ctx, db, "file", t.TempDir(), "", "test", &buf); err != nil {
+		t.Fatalf("успешная выгрузка вернула ошибку: %v", err)
+	}
+	if buf.n == 0 {
+		t.Fatal("архив пуст")
+	}
+}
+
+type countingWriter struct{ n int }
+
+func (w *countingWriter) Write(p []byte) (int, error) { w.n += len(p); return len(p), nil }
+
+var _ io.Writer = (*countingWriter)(nil)
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -27,9 +27,9 @@ func toSnakeCase(s string) string {
 // renameSnakeCols renames old snake_case columns (e.g. тип_контрагента)
 // to the current lowercase style (типконтрагента) if they exist in the table.
 // PG-only: uses information_schema. No-op on SQLite (legacy data isn't a concern there).
-func (db *DB) renameSnakeCols(ctx context.Context, table string, fields []metadata.Field) {
+func (db *DB) renameSnakeCols(ctx context.Context, table string, fields []metadata.Field) error {
 	if db.IsSQLite() {
-		return
+		return nil
 	}
 	for _, f := range fields {
 		newCol := metadata.ColumnName(f)
@@ -37,26 +37,41 @@ func (db *DB) renameSnakeCols(ctx context.Context, table string, fields []metada
 		if oldCol == newCol {
 			continue
 		}
+		// Сбой пробы наличия колонки трактуем как «её нет» и пропускаем поле:
+		// разрушительных действий при этом не выполняется.
 		var oldExists bool
-		db.QueryRow(ctx,
+		if err := db.QueryRow(ctx,
 			`SELECT EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name=$1 AND column_name=$2)`,
-			table, oldCol).Scan(&oldExists)
-		if !oldExists {
+			table, oldCol).Scan(&oldExists); err != nil || !oldExists {
 			continue
 		}
 		var newExists bool
-		db.QueryRow(ctx,
+		if err := db.QueryRow(ctx,
 			`SELECT EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name=$1 AND column_name=$2)`,
-			table, newCol).Scan(&newExists)
+			table, newCol).Scan(&newExists); err != nil {
+			continue
+		}
 		if newExists {
-			db.Exec(ctx, fmt.Sprintf(
+			// Перенос данных и удаление старой колонки — одна операция по смыслу.
+			// Раньше обе ошибки игнорировались: неудачный UPDATE с последующим
+			// успешным DROP COLUMN уничтожал единственную копию данных молча.
+			// Теперь сбой переноса прерывает миграцию до удаления.
+			if _, err := db.Exec(ctx, fmt.Sprintf(
 				"UPDATE %s SET %s = %s WHERE %s IS NOT NULL AND %s IS NULL",
-				table, newCol, oldCol, oldCol, newCol))
-			db.Exec(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", table, oldCol))
+				table, newCol, oldCol, oldCol, newCol)); err != nil {
+				return fmt.Errorf("перенос данных %s.%s → %s: %w", table, oldCol, newCol, err)
+			}
+			if _, err := db.Exec(ctx, fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", table, oldCol)); err != nil {
+				return fmt.Errorf("удаление устаревшей колонки %s.%s: %w", table, oldCol, err)
+			}
 		} else {
-			db.Exec(ctx, fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s", table, oldCol, newCol))
+			if _, err := db.Exec(ctx, fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s",
+				table, oldCol, newCol)); err != nil {
+				return fmt.Errorf("переименование %s.%s → %s: %w", table, oldCol, newCol, err)
+			}
 		}
 	}
+	return nil
 }
 
 // MigrateRegisters creates register tables.
@@ -71,7 +86,9 @@ func (db *DB) MigrateRegisters(ctx context.Context, registers []*metadata.Regist
 			return fmt.Errorf("migrate register %s.period: %w", reg.Name, err)
 		}
 		allFields := append(append([]metadata.Field{}, reg.Dimensions...), append(reg.Resources, reg.Attributes...)...)
-		db.renameSnakeCols(ctx, table, allFields)
+		if err := db.renameSnakeCols(ctx, table, allFields); err != nil {
+			return fmt.Errorf("migrate register %s: %w", reg.Name, err)
+		}
 		for _, f := range allFields {
 			if err := db.AddColumnIfMissing(ctx, table, metadata.ColumnName(f), fieldType(d, f)); err != nil {
 				return fmt.Errorf("migrate register %s.%s: %w", reg.Name, f.Name, err)
@@ -437,7 +454,9 @@ func (db *DB) Migrate(ctx context.Context, entities []*metadata.Entity) error {
 				return fmt.Errorf("migrate %s.posted: %w", e.Name, err)
 			}
 		}
-		db.renameSnakeCols(ctx, table, e.Fields)
+		if err := db.renameSnakeCols(ctx, table, e.Fields); err != nil {
+			return fmt.Errorf("migrate %s: %w", e.Name, err)
+		}
 		for _, f := range e.Fields {
 			if err := db.AddColumnIfMissing(ctx, table, metadata.ColumnName(f), fieldType(d, f)); err != nil {
 				return fmt.Errorf("migrate %s.%s: %w", e.Name, f.Name, err)


### PR DESCRIPTION
Первый PR класса 1 из плана 109D — транзакции, `Exec`/`Scan`, запись файлов. `errcheck` 753 → 730.

## Реальный риск потери данных — один, в миграции схемы

`storage/migrate.go`, `renameSnakeCols`: переносит данные из устаревшей snake_case-колонки в текущую и **удаляет старую**, не проверяя ни одной ошибки.

```go
db.Exec(ctx, "UPDATE ... SET newCol = oldCol WHERE ...")   // ошибка игнорируется
db.Exec(ctx, "ALTER TABLE ... DROP COLUMN oldCol")          // и здесь тоже
```

Неудачный `UPDATE` с последующим успешным `DROP COLUMN` уничтожал единственную копию данных молча. Теперь сбой переноса прерывает миграцию **до** удаления, функция возвращает ошибку, оба вызова её пробрасывают. Сбой пробы наличия колонки трактуется как «колонки нет» — разрушительных действий при этом не выполняется.

Путь только для PostgreSQL (на SQLite функция сразу выходит), поэтому покрывается integration-прогоном CI, а не юнит-тестом.

## В бэкапе потери данных не было — и это проверено

Честно: я начал с гипотезы, что `defer bw.Flush()` и непроверенные `Write` дают молча обрезанный архив. **Гипотеза не подтвердилась.** Написанный регрессионный тест прошёл и на коде до правки: `zip.Writer` запоминает ошибку нижележащего писателя и отдаёт её на `Close`, а `ExportUniversal` делал `return zw.Close()`. Перебор **858 сценариев** обрыва записи на исходном коде дал ноль паник и ноль ложных «успехов».

Поэтому правки в `backup/universal.go` — не исправление дефекта, а качество обработки ошибок:

- двенадцать ручных `zw.Close()` заменены **одним** `defer` с `errors.Join`: ошибка финализации архива сохраняется и на успешном пути, и поверх основной;
- ошибки записи манифеста, `META.txt` и файлов конфигурации сообщаются адресно (с именем таблицы/файла) и сразу, а не безадресно на финальном `Close`;
- ошибка `Flush` больше не теряется в `defer`, а привязана к своей таблице;
- `zw.Create` для манифеста и META проверяется: возвращаемый им `nil` сделал бы `Write` паникой — перебор такую комбинацию не воспроизвёл, но полагаться на недостижимость nil-указателя незачем;
- `tableExists`: ошибка запроса явно означает «таблицы нет» — прежнее поведение, но записанное, а не получающееся из проигнорированного возврата.

## Тесты

`errAfterWriter` отдаёт ошибку после N байт (диск кончился / поток оборван). Лимиты **калибруются по реальному размеру архива**: фиксированные значения вроде 64 КБ оказывались больше всего архива — zip сжимает повторяющиеся данные примерно в 100 раз, и проверка вырождалась в тишину. Плюс guard на успешный путь.

## Что дальше

Оставшиеся в `internal/backup` 13 находок — класс 3 (закрытие читателей, удаление временных файлов). По плану он идёт отдельным PR: там ошибки действительно вторичны, и смешивать их с классом 1 нельзя.

`go vet ./...`, `go test ./...`, `golangci-lint run` — зелёные, `0 issues`.

Generated-with: Claude Code