### PR TITLE
fix(auth,storage): доделать errcheck в критичных путях (план 109D)

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"html/template"
+	"log/slog"
 	"net/http"
 	"strconv"
+
+	oblog "github.com/ivantit66/onebase/internal/logging"
 )
+
+func authLog() *slog.Logger { return oblog.Component("auth") }
 
 var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 <html lang="ru">
@@ -218,7 +223,15 @@ func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
 				h.Auditor.LogAction(r.Context(), "logout", "", "", "", user.ID, user.Login, r.RemoteAddr)
 			}
 		}
-		h.Repo.DeleteSession(r.Context(), cookie.Value)
+		// Сбой удаления — вопрос безопасности, а не уборки: cookie у клиента мы
+		// сотрём в любом случае, но серверная сессия останется валидной, и
+		// перехваченный токен продолжит работать до истечения TTL. Отказать в
+		// выходе нельзя (пользователь останется залогинен), поэтому громко пишем
+		// в лог — это единственное, что отличает такой случай от штатного выхода.
+		if err := h.Repo.DeleteSession(r.Context(), cookie.Value); err != nil {
+			authLog().Error("не удалось удалить сессию при выходе — токен остаётся валидным до истечения TTL",
+				"err", err)
+		}
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     "onebase_session",

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -57,9 +57,14 @@ func (r *Repo) serveWithSession(next http.Handler, w http.ResponseWriter, req *h
 		return
 	}
 
-	// last_seen_at для админки сессий (план 78); троттлится внутри,
-	// ошибка не критична.
-	r.TouchSession(ctx, token, time.Now())
+	// last_seen_at для админки сессий (план 78); троттлится внутри. Ошибка не
+	// влияет на доступ — пользователь уже аутентифицирован, устареет лишь
+	// отметка «последняя активность». Отказывать в запросе из-за неё нельзя,
+	// поэтому пишем в лог на уровне Debug: это горячий путь каждого запроса,
+	// и Warn залил бы журнал при недоступной БД.
+	if err := r.TouchSession(ctx, token, time.Now()); err != nil {
+		authLog().Debug("не удалось обновить last_seen_at сессии", "err", err)
+	}
 
 	next.ServeHTTP(w, req.WithContext(r.contextWithUser(ctx, user)))
 }

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -444,7 +444,13 @@ type SessionMeta struct {
 // (п. 1.6) может вытеснить старейшую enterprise-сессию.
 func (r *Repo) CreateSession(ctx context.Context, userID string, meta SessionMeta) (string, error) {
 	d := r.db.Dialect()
-	r.DeleteExpiredSessions(ctx)
+	// Уборка истёкших — попутная housekeeping-операция перед выдачей новой
+	// сессии. Её сбой не должен мешать входу: пользователь войдёт, а таблица
+	// подчистится при следующей попытке. Но молчать нельзя — постоянные сбои
+	// означают неограниченный рост _sessions.
+	if err := r.DeleteExpiredSessions(ctx); err != nil {
+		authLog().Warn("не удалось подчистить истёкшие сессии", "err", err)
+	}
 	if meta.Kind == SessionKindEnterprise {
 		r.enforceSessionLimit(ctx, userID, meta)
 	}
@@ -542,9 +548,14 @@ func (r *Repo) enforceSessionLimit(ctx context.Context, userID string, meta Sess
 	if _, err := r.db.Exec(ctx, delQ, userID, SessionKindEnterprise, excess); err != nil {
 		return
 	}
-	// Аудит вытеснения — актор сам пользователь: это его новый вход.
+	// Аудит вытеснения — актор сам пользователь: это его новый вход. Логин нужен
+	// лишь для читаемости записи: если прочитать не удалось, пишем аудит с
+	// пустым логином, но по user_id событие всё равно найдётся.
 	login := ""
-	r.db.QueryRow(ctx, fmt.Sprintf(`SELECT login FROM _users WHERE id = %s`, d.Placeholder(1)), userID).Scan(&login)
+	if err := r.db.QueryRow(ctx, fmt.Sprintf(`SELECT login FROM _users WHERE id = %s`,
+		d.Placeholder(1)), userID).Scan(&login); err != nil {
+		authLog().Debug("не удалось прочитать логин для аудита вытеснения сессии", "err", err)
+	}
 	r.db.LogAction(ctx, "session_displaced", "", login, userID, userID, login, meta.IP)
 }
 

--- a/internal/backup/universal_writeerr_test.go
+++ b/internal/backup/universal_writeerr_test.go
@@ -68,7 +68,12 @@ func TestExportUniversal_WriteErrorIsReported(t *testing.T) {
 	}
 	t.Logf("размер эталонного архива: %d байт", probe.n)
 
-	for _, limit := range []int{0, probe.n / 4, probe.n / 2, probe.n - 1} {
+	// Лимиты берём с запасом ниже измеренного размера. Побайтовой
+	// воспроизводимости у архива нет: META.txt содержит `date=` с текущим
+	// временем, и прогоны по разные стороны границы секунды сжимаются в разное
+	// число байт. Из-за limit = probe.n-1 тест упал на CI (эталон 4212, а
+	// следующая выгрузка уложилась в 4211 и завершилась успешно).
+	for _, limit := range []int{0, probe.n / 4, probe.n / 2, probe.n * 3 / 4} {
 		w := &errAfterWriter{limit: limit}
 		err := ExportUniversal(ctx, db, "file", t.TempDir(), "", "test", w)
 		if err == nil {

--- a/internal/storage/deletion.go
+++ b/internal/storage/deletion.go
@@ -80,7 +80,12 @@ type RefInfo struct {
 }
 
 // CheckRefs returns all entities/fields that reference the given object.
-func (db *DB) CheckRefs(ctx context.Context, entityName string, id uuid.UUID, allEntities []*metadata.Entity) []RefInfo {
+//
+// Это предохранитель перед удалением, поэтому он обязан быть fail-closed.
+// Раньше ошибки Scan игнорировались: count оставался нулём, функция отвечала
+// «ссылок нет», и объект удалялся, ломая ссылочную целостность. Теперь сбой
+// любого подсчёта возвращается вызывающему коду, а тот отказывается удалять.
+func (db *DB) CheckRefs(ctx context.Context, entityName string, id uuid.UUID, allEntities []*metadata.Entity) ([]RefInfo, error) {
 	d := db.dialect
 	idA := idArg(d, id)
 	var refs []RefInfo
@@ -91,10 +96,12 @@ func (db *DB) CheckRefs(ctx context.Context, entityName string, id uuid.UUID, al
 			}
 			col := metadata.ColumnName(f)
 			var count int
-			db.QueryRow(ctx,
+			if err := db.QueryRow(ctx,
 				fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = %s",
 					metadata.TableName(e.Name), col, d.Placeholder(1)),
-				idA).Scan(&count)
+				idA).Scan(&count); err != nil {
+				return nil, fmt.Errorf("проверка ссылок %s.%s: %w", e.Name, f.Name, err)
+			}
 			if count > 0 {
 				refs = append(refs, RefInfo{EntityName: e.Name, FieldName: f.Name, Count: count})
 			}
@@ -107,9 +114,11 @@ func (db *DB) CheckRefs(ctx context.Context, entityName string, id uuid.UUID, al
 				col := metadata.ColumnName(f)
 				table := metadata.TablePartTableName(e.Name, tp.Name)
 				var count int
-				db.QueryRow(ctx,
+				if err := db.QueryRow(ctx,
 					fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = %s", table, col, d.Placeholder(1)),
-					idA).Scan(&count)
+					idA).Scan(&count); err != nil {
+					return nil, fmt.Errorf("проверка ссылок %s.%s.%s: %w", e.Name, tp.Name, f.Name, err)
+				}
 				if count > 0 {
 					refs = append(refs, RefInfo{
 						EntityName: e.Name + "." + tp.Name,
@@ -120,7 +129,7 @@ func (db *DB) CheckRefs(ctx context.Context, entityName string, id uuid.UUID, al
 			}
 		}
 	}
-	return refs
+	return refs, nil
 }
 
 // ListMarked returns all records with deletion_mark=true for the given entity.

--- a/internal/storage/deletion_failclosed_test.go
+++ b/internal/storage/deletion_failclosed_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// CheckRefs — предохранитель перед удалением, поэтому он обязан быть
+// fail-closed: при невозможности пересчитать ссылки он возвращает ошибку, а не
+// пустой список. Раньше ошибки Scan игнорировались, count оставался нулём, и
+// вызывающий код видел «ссылок нет» — объект удалялся, ломая целостность.
+//
+// Ошибку воспроизводим отсутствующей таблицей: сущность объявлена в метаданных,
+// но в схеме её нет — ровно то, что бывает при неполной миграции.
+func TestCheckRefs_FailsClosedOnQueryError(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "refs.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	target := &metadata.Entity{
+		Name: "Контрагент", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	// Ссылающаяся сущность НЕ мигрируется — её таблицы в базе нет.
+	referrer := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Клиент", Type: metadata.FieldType("reference:Контрагент"), RefEntity: "Контрагент"},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{target}); err != nil {
+		t.Fatal(err)
+	}
+
+	refs, err := db.CheckRefs(ctx, "Контрагент", uuid.New(),
+		[]*metadata.Entity{target, referrer})
+	if err == nil {
+		t.Fatalf("проверка ссылок скрыла сбой запроса и вернула %v — "+
+			"вызывающий код принял бы это за «ссылок нет» и удалил объект", refs)
+	}
+	if refs != nil {
+		t.Errorf("при ошибке список ссылок должен быть nil, получено %v", refs)
+	}
+}
+
+// На исправной схеме поведение прежнее: реальные ссылки находятся, ошибки нет.
+func TestCheckRefs_FindsRealReferences(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "refs2.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	target := &metadata.Entity{
+		Name: "Контрагент", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	referrer := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Клиент", Type: metadata.FieldType("reference:Контрагент"), RefEntity: "Контрагент"},
+		},
+	}
+	all := []*metadata.Entity{target, referrer}
+	if err := db.Migrate(ctx, all); err != nil {
+		t.Fatal(err)
+	}
+
+	clientID := uuid.New()
+	if err := db.Upsert(ctx, target.Name, clientID,
+		map[string]any{"Наименование": "Ромашка"}, target); err != nil {
+		t.Fatal(err)
+	}
+
+	// Пока ссылок нет — пусто и без ошибки.
+	refs, err := db.CheckRefs(ctx, "Контрагент", clientID, all)
+	if err != nil {
+		t.Fatalf("неожиданная ошибка на исправной схеме: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("ссылок быть не должно, получено %v", refs)
+	}
+
+	// Появилась ссылка — она найдена.
+	if err := db.Upsert(ctx, referrer.Name, uuid.New(),
+		map[string]any{"Клиент": clientID.String()}, referrer); err != nil {
+		t.Fatal(err)
+	}
+	refs, err = db.CheckRefs(ctx, "Контрагент", clientID, all)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].EntityName != "Заказ" || refs[0].Count != 1 {
+		t.Fatalf("ожидалась одна ссылка из Заказ, получено %+v", refs)
+	}
+}

--- a/internal/storage/register.go
+++ b/internal/storage/register.go
@@ -95,7 +95,11 @@ func (db *DB) OrphanMovements(ctx context.Context, registers []*metadata.Registe
 		var recTypes []recTotal
 		for rows.Next() {
 			var rt recTotal
-			rows.Scan(&rt.recType, &rt.total)
+			// Сбойную строку пропускаем: нулевой recTotal дал бы статистику
+			// по несуществующему типу регистратора.
+			if err := rows.Scan(&rt.recType, &rt.total); err != nil {
+				continue
+			}
 			recTypes = append(recTypes, rt)
 		}
 		rows.Close()
@@ -112,9 +116,13 @@ func (db *DB) OrphanMovements(ctx context.Context, registers []*metadata.Registe
 			if !exists {
 				count = rt.total
 			} else {
-				db.QueryRow(ctx, fmt.Sprintf(
+				// Не смогли посчитать — не сообщаем о сиротах: лучше
+				// недосказать, чем предложить удалить неизвестно что.
+				if err := db.QueryRow(ctx, fmt.Sprintf(
 					"SELECT COUNT(*) FROM %s WHERE recorder_type = %s AND recorder NOT IN (SELECT id FROM %s)",
-					table, d.Placeholder(1), tbl), rt.recType).Scan(&count)
+					table, d.Placeholder(1), tbl), rt.recType).Scan(&count); err != nil {
+					continue
+				}
 			}
 			if count > 0 {
 				stats = append(stats, OrphanStat{RegisterName: reg.Name, RecorderType: rt.recType, Count: count})
@@ -142,7 +150,12 @@ func (db *DB) DeleteOrphanMovements(ctx context.Context, registers []*metadata.R
 		var types []string
 		for rows.Next() {
 			var t string
-			rows.Scan(&t)
+			// КРИТИЧНО: при сбое Scan строка t осталась бы пустой, и ниже
+			// выполнился бы DELETE ... WHERE recorder_type = '' — удаление,
+			// вызванное непрочитанной строкой. Пропускаем.
+			if err := rows.Scan(&t); err != nil {
+				continue
+			}
 			types = append(types, t)
 		}
 		rows.Close()

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -1547,8 +1547,13 @@ func (s *Server) deleteRecord(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Admin: check references before permanent delete
-	refs := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
+	// Admin: check references before permanent delete.
+	// Сбой проверки — отказ: удалять, не зная о ссылках, нельзя.
+	refs, refErr := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
+	if refErr != nil {
+		http.Error(w, s.errText(r, refErr), 500)
+		return
+	}
 	if len(refs) > 0 {
 		var msg strings.Builder
 		lang := s.resolveLang(r)
@@ -1626,8 +1631,10 @@ func (s *Server) deleteMarkedAll(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					continue
 				}
-				refs := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
-				if len(refs) > 0 {
+				// Сбой проверки трактуем как «ссылки есть»: пропускаем запись,
+				// а не удаляем вслепую.
+				refs, refErr := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
+				if refErr != nil || len(refs) > 0 {
 					skipped++
 					continue
 				}
@@ -1668,13 +1675,16 @@ func (s *Server) deleteMarkedAll(w http.ResponseWriter, r *http.Request) {
 		for _, row := range rows {
 			idStr, _ := row["id"].(string)
 			id, _ := uuid.Parse(idStr)
-			refs := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
+			// При сбое проверки показываем запись как «есть ссылки»: так
+			// пользователь не примет её за безопасную к удалению.
+			refs, refErr := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
+			hasRefs := refErr != nil || len(refs) > 0
 			entries = append(entries, markedEntry{
 				EntityName: entity.Name,
 				Kind:       string(entity.Kind),
 				ID:         idStr,
 				Label:      s.maskedRecordLabel(r.Context(), entity, row),
-				HasRefs:    len(refs) > 0,
+				HasRefs:    hasRefs,
 			})
 		}
 	}
@@ -1714,8 +1724,9 @@ func (s *Server) deleteMarked(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
-		refs := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
-		if len(refs) > 0 {
+		// Сбой проверки трактуем как «ссылки есть»: пропускаем запись.
+		refs, refErr := s.store.CheckRefs(r.Context(), entity.Name, id, s.reg.Entities())
+		if refErr != nil || len(refs) > 0 {
 			skipped++
 			continue
 		}


### PR DESCRIPTION
Второй PR класса 1 — сессии и `Scan` в защитных проверках. `errcheck` 730 → 721. Класс 1 на этом закрыт.

## `CheckRefs` работал fail-open в предохранителе удаления

Функция проверяет, ссылается ли кто-то на объект, **перед удалением**. Ошибки `Scan` игнорировались: `count` оставался нулём, функция отвечала «ссылок нет», и объект удалялся, ломая ссылочную целостность.

Сигнатура сменена на `([]RefInfo, error)`, все четыре вызова трактуют сбой как **запрет** удаления:

| Место | Поведение при сбое |
|---|---|
| одиночное удаление | отказ с ошибкой |
| два пакетных удаления | запись пропускается, как при наличии ссылок |
| список помеченных | запись показывается как «есть ссылки» |

Регрессионный тест воспроизводит сбой отсутствующей таблицей (сущность в метаданных есть, в схеме нет — неполная миграция) и **падает без правки**:

```
проверка ссылок скрыла сбой запроса и вернула [] —
вызывающий код принял бы это за «ссылок нет» и удалил объект
```

## `DeleteOrphanMovements` мог удалять по непрочитанной строке

При сбое `rows.Scan(&t)` имя типа регистратора оставалось пустым, и ниже выполнялся

```sql
DELETE FROM рег_X WHERE recorder_type = 
```

— удаление, вызванное строкой, которую не удалось прочитать. Теперь сбойная строка пропускается. То же в `OrphanMovements`: нулевой `recTotal` давал статистику по несуществующему типу регистратора.

## Сессии — по фактическим последствиям, а не единообразно

- **`DeleteSession` при выходе** — сбой оставляет серверную сессию валидной, тогда как cookie у клиента уже стёрт: перехваченный токен продолжит работать до истечения TTL. Отказать в выходе нельзя (пользователь останется залогинен), поэтому `Error` в лог — это единственное, что отличает такой случай от штатного выхода.
- **`TouchSession`** — доступ не затрагивает, устаревает лишь отметка активности. `Debug`: это горячий путь каждого запроса, и `Warn` залил бы журнал при недоступной БД.
- **`DeleteExpiredSessions`** перед выдачей сессии — попутная уборка, вход ломать не должна, но постоянные сбои означают неограниченный рост `_sessions`. `Warn`.
- **Чтение логина для аудита вытеснения** — событие найдётся по `user_id` и с пустым логином. `Debug`.

Логирование через `oblog.Component("auth")` — тот же приём, что уже применён в `devserver`.

`go vet ./...`, `go test ./...`, `golangci-lint run` — зелёные, `0 issues`.

Дальше по плану: класс 2 (HTTP/UI/CLI-вывод — `Fprintf`/`Encode`/`ExecuteTemplate`, ~325 находок) и класс 3 (уборка — `Close`/`Remove`, ~175).

Generated-with: Claude Code