### PR TITLE
fix(ui): ограниченный разбор формы вместо игнорируемого ParseForm (план 109)

### DIFF
--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -230,7 +230,19 @@ func (s *Server) adminUserCard(w http.ResponseWriter, r *http.Request) {
 	s.addPasswordPolicyData(data)
 
 	if r.Method == http.MethodPost {
-		r.ParseForm()
+		// Сбой разбора формы игнорировать нельзя: дальше все FormValue вернут
+		// пустые строки, и обработчик воспримет это как осознанный ввод —
+		// сотрёт полное имя и снимет флаги (is_admin, show_in_list). То есть
+		// битый запрос молча понижал бы права пользователя. Отказываем явно.
+		//
+		// Разбор ограниченный (limitMultipartRequest + parseBoundedForm) — тот
+		// же приём, что на пути событий управляемых форм. Голый r.ParseForm()
+		// читает тело целиком без предела: gosec помечает это как G120.
+		s.limitMultipartRequest(w, r)
+		if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+			http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+			return
+		}
 		switch r.FormValue("action") {
 		case "update":
 			fullName := r.FormValue("full_name")
@@ -300,7 +312,11 @@ func (s *Server) adminUserCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := s.resolveLang(r)
-	r.ParseForm()
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 	login := r.FormValue("login")
 	password := r.FormValue("password")
 	fullName := r.FormValue("full_name")
@@ -376,7 +392,11 @@ func (s *Server) adminUserPasswd(w http.ResponseWriter, r *http.Request) {
 	}
 	s.addPasswordPolicyData(data)
 	if r.Method == http.MethodPost {
-		r.ParseForm()
+		s.limitMultipartRequest(w, r)
+		if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+			http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+			return
+		}
 		newPwd := r.FormValue("new_password")
 		confirm := r.FormValue("confirm_password")
 		if newPwd != confirm {
@@ -437,7 +457,11 @@ func (s *Server) selfPasswd(w http.ResponseWriter, r *http.Request) {
 	}
 	s.addPasswordPolicyData(data)
 	if r.Method == http.MethodPost {
-		r.ParseForm()
+		s.limitMultipartRequest(w, r)
+		if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+			http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+			return
+		}
 		oldPwd := r.FormValue("old_password")
 		newPwd := r.FormValue("new_password")
 		confirm := r.FormValue("confirm_password")
@@ -523,7 +547,11 @@ func (s *Server) adminSessionLimit(w http.ResponseWriter, r *http.Request) {
 		s.renderForbidden(w, r)
 		return
 	}
-	r.ParseForm()
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 	n, err := strconv.Atoi(strings.TrimSpace(r.FormValue("limit")))
 	if err != nil || n < 0 {
 		n = 0
@@ -614,7 +642,11 @@ func (s *Server) adminKickSession(w http.ResponseWriter, r *http.Request) {
 		s.renderForbidden(w, r)
 		return
 	}
-	r.ParseForm()
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 	publicID := r.FormValue("public_id")
 	if publicID != "" && s.authRepo != nil {
 		if err := s.authRepo.KickSession(r.Context(), publicID); err == nil {
@@ -793,7 +825,11 @@ func (s *Server) adminUserRolesUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	userID := chi.URLParam(r, "id")
-	r.ParseForm()
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 	selectedRoleIDs := r.Form["role_id"]
 	selectedSet := make(map[string]bool, len(selectedRoleIDs))
 	for _, id := range selectedRoleIDs {

--- a/internal/ui/handlers_registers.go
+++ b/internal/ui/handlers_registers.go
@@ -289,7 +289,11 @@ func (s *Server) infoRegSubmit(w http.ResponseWriter, r *http.Request) {
 	if !s.requirePerm(w, r, "inforeg", ir.Name, "write") {
 		return
 	}
-	r.ParseForm()
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 
 	var periodPtr *time.Time
 	if ir.Periodic {
@@ -361,7 +365,11 @@ func (s *Server) infoRegDelete(w http.ResponseWriter, r *http.Request) {
 	if !s.requirePerm(w, r, "inforeg", ir.Name, "delete") {
 		return
 	}
-	r.ParseForm()
+	s.limitMultipartRequest(w, r)
+	if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
+		http.Error(w, s.errText(r, err), uploadErrorStatus(err))
+		return
+	}
 
 	var periodPtr *time.Time
 	if ir.Periodic {

--- a/internal/ui/parseform_test.go
+++ b/internal/ui/parseform_test.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+// Сбой разбора формы обязан приводить к отказу, а не к продолжению с пустыми
+// значениями. Раньше r.ParseForm() вызывался без проверки: при битом теле все
+// FormValue возвращали "", и обработчик воспринимал это как осознанный ввод —
+// в админке это стирало полное имя и снимало флаги is_admin/show_in_list, то
+// есть битый запрос молча понижал права пользователя.
+//
+// Проверяем на infoRegSubmit: у него самые скромные предусловия из девяти
+// затронутых обработчиков, а код разбора формы там тот же.
+func TestParseFormError_RejectsRequest(t *testing.T) {
+	ir := &metadata.InfoRegister{
+		Name:       "КурсыВалют",
+		Dimensions: []metadata.Field{{Name: "Валюта", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Курс", Type: metadata.FieldTypeNumber}},
+	}
+	reg := runtime.NewRegistry()
+	reg.Load(runtime.LoadOptions{InfoRegs: []*metadata.InfoRegister{ir}})
+	s := &Server{reg: reg}
+
+	// «%zz» — некорректная процентная последовательность: ParseForm вернёт
+	// ошибку, а FormValue после неё отдаст пустые строки.
+	body := "Валюта=%zz&Курс=100"
+	r := httptest.NewRequest(http.MethodPost, "/ui/inforeg/КурсыВалют/submit", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "КурсыВалют")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	s.infoRegSubmit(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("при битом теле формы ожидался 400, получен %d: %s",
+			w.Code, strings.TrimSpace(w.Body.String()))
+	}
+}
+
+// Корректное тело по-прежнему проходит разбор формы: guard, чтобы проверка не
+// начала отклонять нормальные запросы. Дальше обработчик уйдёт в запись и
+// упрётся в отсутствующее хранилище — нас интересует только то, что до 400 по
+// причине разбора формы дело не дошло.
+func TestParseFormOK_NotRejected(t *testing.T) {
+	ir := &metadata.InfoRegister{
+		Name:       "КурсыВалют",
+		Dimensions: []metadata.Field{{Name: "Валюта", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Курс", Type: metadata.FieldTypeNumber}},
+	}
+	reg := runtime.NewRegistry()
+	reg.Load(runtime.LoadOptions{InfoRegs: []*metadata.InfoRegister{ir}})
+	s := &Server{reg: reg}
+
+	r := httptest.NewRequest(http.MethodPost, "/ui/inforeg/КурсыВалют/submit",
+		strings.NewReader("Валюта=USD&Курс=100"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", "КурсыВалют")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	defer func() {
+		// Хранилища нет — паника ниже по пути записи ожидаема и означает, что
+		// разбор формы прошёл. Важно лишь, что мы не получили 400.
+		_ = recover()
+	}()
+	w := httptest.NewRecorder()
+	s.infoRegSubmit(w, r)
+	if w.Code == http.StatusBadRequest {
+		t.Fatalf("корректное тело формы отклонено как битое: %s",
+			strings.TrimSpace(w.Body.String()))
+	}
+}

--- a/internal/ui/upload_limits.go
+++ b/internal/ui/upload_limits.go
@@ -63,3 +63,8 @@ func uploadErrorStatus(err error) int {
 func (s *Server) uploadTooLargeText(lang string, limit int64) string {
 	return fmt.Sprintf(s.tr(lang, "файл превышает максимальный размер %d МБ"), limit>>20)
 }
+
+// defaultFormMemoryBytes — сколько памяти отводится под разбор обычной формы
+// (не загрузки файла). Админские и справочные формы состоят из коротких полей,
+// поэтому мегабайта достаточно; превышение вернёт 413, а не съест память.
+const defaultFormMemoryBytes = int64(1 << 20)


### PR DESCRIPTION
Продолжение серии 109. `errcheck` 536 → 527.

## Что было

Девять обработчиков мутаций вызывали `r.ParseForm()` без проверки. При битом теле разбор падает, но выполнение продолжается — и все `FormValue` возвращают пустые строки, которые обработчик принимает за осознанный ввод.

В `adminUserCard` это означало:

```go
fullName   := r.FormValue("full_name")        // ""
isAdmin    := r.FormValue("is_admin") == "1"  // false
showInList := r.FormValue("show_in_list") == "1" // false
```

Некорректный запрос **молча понижал права пользователя**: стирал полное имя, снимал `is_admin` и `show_in_list`. Со стороны это выглядело как намеренное изменение.

## Как gate поправил моё решение

Сначала я просто добавил проверку ошибки. Локальный прогон gate из 109C показал на тех же строках **девять `G120`**: голый `ParseForm` читает тело целиком без ограничения размера.

Поэтому взят приём, уже принятый в проекте на пути событий управляемых форм:

```go
s.limitMultipartRequest(w, r)
if err := parseBoundedForm(r, defaultFormMemoryBytes); err != nil {
    http.Error(w, s.errText(r, err), uploadErrorStatus(err))
    return
}
```

Он закрывает и `errcheck`, и `G120`, и попутно добавляет этим обработчикам ограничение размера тела, которого у них не было. Превышение отвечает `413`, битое тело — `400`.

`defaultFormMemoryBytes` = 1 МБ: административные и справочные формы состоят из коротких полей, файлы через них не грузятся.

## Тесты

Битое тело (`%zz` — некорректная процентная последовательность) даёт `400`; **падает без правки**. Корректное тело проходит разбор — guard, чтобы проверка не начала отклонять нормальные запросы.

Проверяются на `infoRegSubmit`: у него самые скромные предусловия из девяти затронутых обработчиков, а код разбора там тот же.

## Проверка

Перед пушем прогнан **весь** набор шагов CI локально: BOM, `i18ncheck`, линт поставляемых конфигураций, `vet`, тесты, обычный линт и gate — всё чисто. Два предыдущих PR серии падали именно из-за выборочной проверки.

Generated-with: Claude Code