### PR TITLE
refactor(ui): запись HTTP-ответов через respondJSON/renderTemplate (план 109)

### DIFF
--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -211,7 +211,7 @@ func (s *Server) adminUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-users", map[string]any{"Users": users})
+	renderAdminTemplate(w, "admin-users", map[string]any{"Users": users})
 }
 
 func (s *Server) adminUserCard(w http.ResponseWriter, r *http.Request) {
@@ -275,7 +275,7 @@ func (s *Server) adminUserCard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-user-card", data)
+	renderAdminTemplate(w, "admin-user-card", data)
 }
 
 func (s *Server) adminUserNew(w http.ResponseWriter, r *http.Request) {
@@ -284,7 +284,7 @@ func (s *Server) adminUserNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-user-form", s.adminUserFormData(r, "", "", "", false))
+	renderAdminTemplate(w, "admin-user-form", s.adminUserFormData(r, "", "", "", false))
 }
 
 func (s *Server) adminUserFormData(r *http.Request, errMsg, login, fullName string, adminChecked bool) map[string]any {
@@ -328,7 +328,7 @@ func (s *Server) adminUserCreate(w http.ResponseWriter, r *http.Request) {
 	if login == "" {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		data := s.adminUserFormData(r, s.tr(lang, "Логин обязателен"), login, fullName, isAdmin)
-		adminTmpl.ExecuteTemplate(w, "admin-user-form", data)
+		renderAdminTemplate(w, "admin-user-form", data)
 		return
 	}
 
@@ -336,7 +336,7 @@ func (s *Server) adminUserCreate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		data := s.adminUserFormData(r, s.errText(r, err), login, fullName, isAdmin)
-		adminTmpl.ExecuteTemplate(w, "admin-user-form", data)
+		renderAdminTemplate(w, "admin-user-form", data)
 		return
 	}
 	if denyPasswd || showInList || aiData {
@@ -345,7 +345,7 @@ func (s *Server) adminUserCreate(w http.ResponseWriter, r *http.Request) {
 		if err := s.authRepo.Update(r.Context(), u.ID, fullName, isAdmin, denyPasswd, showInList, aiData); err != nil {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			data := s.adminUserFormData(r, s.errText(r, err), login, fullName, isAdmin)
-			adminTmpl.ExecuteTemplate(w, "admin-user-form", data)
+			renderAdminTemplate(w, "admin-user-form", data)
 			return
 		}
 	}
@@ -402,20 +402,20 @@ func (s *Server) adminUserPasswd(w http.ResponseWriter, r *http.Request) {
 		if newPwd != confirm {
 			data["Error"] = s.tr(lang, "Пароли не совпадают")
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
 		if err := s.authRepo.UpdatePassword(r.Context(), userID, newPwd); err != nil {
 			data["Error"] = s.errText(r, err)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
 		s.revokeSessionsOnPasswordChange(r, userID, userLogin)
 		data["Success"] = true
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+	renderAdminTemplate(w, "admin-passwd", data)
 }
 
 // revokeSessionsOnPasswordChange — политика плана 78: смена пароля админом
@@ -469,26 +469,26 @@ func (s *Server) selfPasswd(w http.ResponseWriter, r *http.Request) {
 		if _, err := s.authRepo.Authenticate(r.Context(), u.Login, oldPwd); err != nil {
 			data["Error"] = s.tr(lang, "Неверный текущий пароль")
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
 		if newPwd != confirm {
 			data["Error"] = s.tr(lang, "Пароли не совпадают")
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
 		if err := s.authRepo.UpdatePassword(r.Context(), u.ID, newPwd); err != nil {
 			data["Error"] = s.errText(r, err)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
 		s.revokeSessionsOnPasswordChange(r, u.ID, u.Login)
 		data["Success"] = true
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-passwd", data)
+	renderAdminTemplate(w, "admin-passwd", data)
 }
 
 func (s *Server) addPasswordPolicyData(data map[string]any) {
@@ -525,7 +525,7 @@ func (s *Server) adminSessions(w http.ResponseWriter, r *http.Request) {
 	}
 	if !hasUsers {
 		users, _ := s.store.ActiveUsersFromAudit(r.Context())
-		adminTmpl.ExecuteTemplate(w, "admin-sessions", map[string]any{"AuditUsers": users})
+		renderAdminTemplate(w, "admin-sessions", map[string]any{"AuditUsers": users})
 		return
 	}
 	sessions, _ := s.authRepo.ActiveSessions(r.Context())
@@ -533,7 +533,7 @@ func (s *Server) adminSessions(w http.ResponseWriter, r *http.Request) {
 	if s.store != nil {
 		limit = s.store.GetMaxSessionsPerUser(r.Context())
 	}
-	adminTmpl.ExecuteTemplate(w, "admin-sessions", map[string]any{
+	renderAdminTemplate(w, "admin-sessions", map[string]any{
 		"Sessions":   sessionVMs(sessions),
 		"Limit":      limit,
 		"LimitSaved": r.URL.Query().Get("limit_saved") == "1",
@@ -737,7 +737,7 @@ func (s *Server) renderAdminAPITokens(w http.ResponseWriter, r *http.Request, ex
 		data[k] = v
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-api-tokens", data)
+	renderAdminTemplate(w, "admin-api-tokens", data)
 }
 
 func parseAPITokenExpiresAt(raw string) (*time.Time, error) {
@@ -770,7 +770,7 @@ func (s *Server) adminCleanup(w http.ResponseWriter, r *http.Request) {
 	stats := s.store.OrphanMovements(r.Context(), registers, entities)
 	deletedStr := r.URL.Query().Get("deleted")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-cleanup", map[string]any{
+	renderAdminTemplate(w, "admin-cleanup", map[string]any{
 		"Stats":   stats,
 		"Deleted": deletedStr,
 	})
@@ -791,7 +791,7 @@ func (s *Server) adminRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-roles", map[string]any{"Roles": roles})
+	renderAdminTemplate(w, "admin-roles", map[string]any{"Roles": roles})
 }
 
 func (s *Server) adminUserRoles(w http.ResponseWriter, r *http.Request) {
@@ -811,7 +811,7 @@ func (s *Server) adminUserRoles(w http.ResponseWriter, r *http.Request) {
 	allRoles, _ := s.authRepo.ListRoles(r.Context())
 	userRoleIDs, _ := s.authRepo.GetUserRoleIDs(r.Context(), userID)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-user-roles", map[string]any{
+	renderAdminTemplate(w, "admin-user-roles", map[string]any{
 		"UserID":      userID,
 		"UserLogin":   userLogin,
 		"AllRoles":    allRoles,
@@ -924,7 +924,7 @@ func (s *Server) adminAudit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-audit", map[string]any{
+	renderAdminTemplate(w, "admin-audit", map[string]any{
 		"Filter":    fv,
 		"Entries":   entries,
 		"Page":      page,
@@ -1432,5 +1432,5 @@ func (s *Server) adminWebhooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-webhooks", map[string]any{"Entries": entries})
+	renderAdminTemplate(w, "admin-webhooks", map[string]any{"Entries": entries})
 }

--- a/internal/ui/admin_rls.go
+++ b/internal/ui/admin_rls.go
@@ -55,7 +55,7 @@ func (s *Server) adminRLSDiagnostics(w http.ResponseWriter, r *http.Request) {
 	}
 	rows := s.buildRLSDiagnosticRows(roles)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	adminTmpl.ExecuteTemplate(w, "admin-rls", map[string]any{
+	renderAdminTemplate(w, "admin-rls", map[string]any{
 		"Rows":     rows,
 		"DSLPaths": rlsDSLPathRows(),
 	})

--- a/internal/ui/content_disposition_test.go
+++ b/internal/ui/content_disposition_test.go
@@ -7,7 +7,7 @@ import (
 
 // Issue #46: сырой UTF-8 в filename="..." декодируется браузером как latin-1 —
 // имя файла превращается в кракозябры. RFC 6266: ASCII-фолбэк в filename= и
-// полное имя в filename*=UTF-8''.
+// полное имя в filename*=UTF-8”.
 func TestContentDisposition(t *testing.T) {
 	got := contentDisposition("Контрагенты.xlsx")
 	if !strings.Contains(got, "filename*=UTF-8''") {

--- a/internal/ui/debug_handlers.go
+++ b/internal/ui/debug_handlers.go
@@ -17,7 +17,7 @@ import (
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	respondJSONTo(w, v)
 }
 
 func readJSON(r *http.Request, v any) error {

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -456,7 +456,7 @@ func stripQueryQuotes(q string) string {
 func jsonResp(w http.ResponseWriter, status int, data map[string]any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	respondJSONTo(w, data)
 }
 
 // coerceParams converts string values to appropriate types for query parameters:

--- a/internal/ui/exchange_http.go
+++ b/internal/ui/exchange_http.go
@@ -12,7 +12,6 @@ package ui
 import (
 	"context"
 	"crypto/subtle"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -140,7 +139,7 @@ func (s *Server) exchangePush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(res)
+	respondJSONTo(w, res)
 }
 
 func (s *Server) exchangePull(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/exchange_monitor.go
+++ b/internal/ui/exchange_monitor.go
@@ -59,7 +59,7 @@ func (s *Server) exchangeMonitor(w http.ResponseWriter, r *http.Request) {
 		plans = append(plans, pv)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	exchangeMonitorTmpl.ExecuteTemplate(w, "exchange-monitor", map[string]any{
+	renderTemplate(w, exchangeMonitorTmpl, "exchange-monitor", map[string]any{
 		"Plans": plans,
 		"Msg":   r.URL.Query().Get("msg"),
 		"Err":   r.URL.Query().Get("err"),

--- a/internal/ui/extforms.go
+++ b/internal/ui/extforms.go
@@ -28,7 +28,7 @@ func (s *Server) adminExtForms(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	extFormTmpl.ExecuteTemplate(w, "admin-extforms", map[string]any{
+	renderTemplate(w, extFormTmpl, "admin-extforms", map[string]any{
 		"Forms": recs,
 		"Msg":   r.URL.Query().Get("msg"),
 		"Err":   r.URL.Query().Get("err"),

--- a/internal/ui/extprocessors.go
+++ b/internal/ui/extprocessors.go
@@ -28,7 +28,7 @@ func (s *Server) adminExtProcessors(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	extProcTmpl.ExecuteTemplate(w, "admin-extprocessors", map[string]any{
+	renderTemplate(w, extProcTmpl, "admin-extprocessors", map[string]any{
 		"Procs": recs,
 		"Msg":   r.URL.Query().Get("msg"),
 		"Err":   r.URL.Query().Get("err"),

--- a/internal/ui/extreports.go
+++ b/internal/ui/extreports.go
@@ -29,7 +29,7 @@ func (s *Server) adminExtReports(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	extReportTmpl.ExecuteTemplate(w, "admin-extreports", map[string]any{
+	renderTemplate(w, extReportTmpl, "admin-extreports", map[string]any{
 		"Reports": recs,
 		"Msg":     r.URL.Query().Get("msg"),
 		"Err":     r.URL.Query().Get("err"),

--- a/internal/ui/feed_render_test.go
+++ b/internal/ui/feed_render_test.go
@@ -80,7 +80,7 @@ func TestPageList_FeedMode(t *testing.T) {
 		`data-item="tr"`,
 		"Показать ещё",
 		"page=2", "lm=feed", // ссылка догрузки (& экранируется в &amp;, проверяем по частям)
-		"lm=pages",          // тумблер предлагает вернуться к страницам
+		"lm=pages", // тумблер предлагает вернуться к страницам
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("feed: нет %q", want)

--- a/internal/ui/form_commands_test.go
+++ b/internal/ui/form_commands_test.go
@@ -49,11 +49,11 @@ func TestResolveHandlerProc_CommandFallback(t *testing.T) {
 // attrRefEntityName извлекает сущность из ссылочного типа реквизита формы (фикс B).
 func TestAttrRefEntityName(t *testing.T) {
 	cases := map[string]string{
-		"CatalogRef.Клиент":   "Клиент",
-		"DocumentRef.Заявка":  "Заявка",
-		"string(40)":          "",
+		"CatalogRef.Клиент":    "Клиент",
+		"DocumentRef.Заявка":   "Заявка",
+		"string(40)":           "",
 		"enum:СостояниеЗвонка": "",
-		"":                    "",
+		"":                     "",
 	}
 	for in, want := range cases {
 		if got := attrRefEntityName(in); got != want {

--- a/internal/ui/handlers_attachments.go
+++ b/internal/ui/handlers_attachments.go
@@ -4,7 +4,6 @@ package ui
 // Выделено из handlers.go (план 55, этап 1) — перенос as-is.
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -42,7 +41,7 @@ func (s *Server) attachmentsList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(atts)
+	respondJSONTo(w, atts)
 }
 
 // attachmentUpload handles file upload for a record.

--- a/internal/ui/handlers_export.go
+++ b/internal/ui/handlers_export.go
@@ -64,7 +64,7 @@ func (s *Server) listExcel(w http.ResponseWriter, r *http.Request) {
 
 // contentDisposition собирает заголовок Content-Disposition по RFC 6266:
 // ASCII-фолбэк в filename= (для старых клиентов) и полное имя в
-// filename*=UTF-8'' (issue #46 — сырой UTF-8 в quoted-string браузеры
+// filename*=UTF-8” (issue #46 — сырой UTF-8 в quoted-string браузеры
 // декодируют как latin-1, имя файла превращается в кракозябры).
 func contentDisposition(filename string) string {
 	fallback := make([]rune, 0, len(filename))
@@ -78,7 +78,7 @@ func contentDisposition(filename string) string {
 	return "attachment; filename=\"" + string(fallback) + "\"; filename*=UTF-8''" + encodeRFC5987(filename)
 }
 
-// encodeRFC5987 кодирует строку для filename*=UTF-8'' — percent-кодируется
+// encodeRFC5987 кодирует строку для filename*=UTF-8” — percent-кодируется
 // всё, кроме attr-char по RFC 5987 (url.PathEscape оставляет «=», «@», «:»,
 // которые ломают разбор заголовка).
 func encodeRFC5987(s string) string {

--- a/internal/ui/handlers_image.go
+++ b/internal/ui/handlers_image.go
@@ -7,7 +7,6 @@ package ui
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -78,7 +77,7 @@ func (s *Server) imageUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"ref": b.ID.String()})
+	respondJSONTo(w, map[string]string{"ref": b.ID.String()})
 }
 
 // imageServe отдаёт бинарник по UUID (значение поля image). Бинарник

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -63,18 +63,18 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	s.limitMultipartRequest(w, r)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		w.WriteHeader(uploadErrorStatus(err))
-		enc.Encode(formEventResponse{Error: "bad form: " + err.Error()})
+		respondJSON(enc, formEventResponse{Error: "bad form: " + err.Error()})
 		return
 	}
 
 	entityName := chi.URLParam(r, "entity")
 	if entityName == "" {
-		enc.Encode(formEventResponse{Error: "entity required"})
+		respondJSON(enc, formEventResponse{Error: "entity required"})
 		return
 	}
 	entity := s.reg.GetEntity(entityName)
 	if entity == nil {
-		enc.Encode(formEventResponse{Error: "entity not found: " + entityName})
+		respondJSON(enc, formEventResponse{Error: "entity not found: " + entityName})
 		return
 	}
 
@@ -84,25 +84,25 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	}
 	form := pickManagedForm(entity, formKind)
 	if form == nil {
-		enc.Encode(formEventResponse{Error: "managed form not found for " + entityName})
+		respondJSON(enc, formEventResponse{Error: "managed form not found for " + entityName})
 		return
 	}
 	progAny := form.ProgramAST
 	if progAny == nil {
 		// .form.os не загружен или не распарсен — обработчики недоступны.
-		enc.Encode(formEventResponse{OK: true})
+		respondJSON(enc, formEventResponse{OK: true})
 		return
 	}
 	program, ok := progAny.(*ast.Program)
 	if !ok || program == nil {
-		enc.Encode(formEventResponse{Error: "form AST type mismatch"})
+		respondJSON(enc, formEventResponse{Error: "form AST type mismatch"})
 		return
 	}
 
 	elementName := strings.TrimSpace(r.FormValue("_element"))
 	eventName := strings.TrimSpace(r.FormValue("_event"))
 	if eventName == "" {
-		enc.Encode(formEventResponse{Error: "_event required"})
+		respondJSON(enc, formEventResponse{Error: "_event required"})
 		return
 	}
 
@@ -110,7 +110,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	procName := resolveHandlerProc(form, elementName, eventName)
 	if procName == "" {
 		// Нет привязки — это не ошибка, просто событие декларативное.
-		enc.Encode(formEventResponse{OK: true})
+		respondJSON(enc, formEventResponse{OK: true})
 		return
 	}
 
@@ -133,7 +133,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	// parseSubmitForm/handlers_entity — иначе мега-blob обходит лимит через
 	// событийный путь managed-формы (DoS/раздувание БД), XSS при этом нет.
 	if err := checkRichTextLimits(r, entity); err != nil {
-		enc.Encode(formEventResponse{Error: s.errText(r, err)})
+		respondJSON(enc, formEventResponse{Error: s.errText(r, err)})
 		return
 	}
 
@@ -693,22 +693,22 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 	s.limitMultipartRequest(w, r)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		w.WriteHeader(uploadErrorStatus(err))
-		enc.Encode(formEventResponse{Error: "bad form: " + err.Error()})
+		respondJSON(enc, formEventResponse{Error: "bad form: " + err.Error()})
 		return
 	}
 
 	procName := chi.URLParam(r, "name")
 	if procName == "" {
-		enc.Encode(formEventResponse{Error: "processor name required"})
+		respondJSON(enc, formEventResponse{Error: "processor name required"})
 		return
 	}
 	proc := s.reg.GetProcessor(procName)
 	if proc == nil {
-		enc.Encode(formEventResponse{Error: "processor not found: " + procName})
+		respondJSON(enc, formEventResponse{Error: "processor not found: " + procName})
 		return
 	}
 	if !s.can(r, "processor", proc.Name, "run") {
-		enc.Encode(formEventResponse{Error: "доступ запрещён"})
+		respondJSON(enc, formEventResponse{Error: "доступ запрещён"})
 		return
 	}
 	// Тот же trust-гейт, что и у processorRun: form-event исполняет DSL
@@ -716,20 +716,20 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 	// внешнюю обработку здесь тоже может запускать только администратор —
 	// иначе неадмин обходил бы проверку через /form-event.
 	if !s.canRunExternalProc(r, proc) {
-		enc.Encode(formEventResponse{Error: "доступ запрещён"})
+		respondJSON(enc, formEventResponse{Error: "доступ запрещён"})
 		return
 	}
 
 	form := proc.ManagedForm()
 	if form == nil {
-		enc.Encode(formEventResponse{Error: "managed form not found for " + procName})
+		respondJSON(enc, formEventResponse{Error: "managed form not found for " + procName})
 		return
 	}
 
 	elementName := strings.TrimSpace(r.FormValue("_element"))
 	eventName := strings.TrimSpace(r.FormValue("_event"))
 	if eventName == "" {
-		enc.Encode(formEventResponse{Error: "_event required"})
+		respondJSON(enc, formEventResponse{Error: "_event required"})
 		return
 	}
 
@@ -830,7 +830,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 
 		procDecl := s.reg.GetProcedure(proc.Name, "Выполнить")
 		if procDecl == nil {
-			enc.Encode(formEventResponse{OK: true})
+			respondJSON(enc, formEventResponse{OK: true})
 			return
 		}
 
@@ -858,7 +858,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	enc.Encode(formEventResponse{OK: true})
+	respondJSON(enc, formEventResponse{OK: true})
 }
 
 func formTablesFromRows(rows map[string][]map[string]any, form *metadata.FormModule) map[string][]map[string]any {

--- a/internal/ui/intake_http.go
+++ b/internal/ui/intake_http.go
@@ -210,7 +210,7 @@ func (s *Server) writeIntakeResult(w http.ResponseWriter, res intake.Result) {
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(body)
+	respondJSONTo(w, body)
 }
 
 // dslIntakeHandler запускает DSL-процедуру Обработать(Конверт) как обработчик

--- a/internal/ui/intake_monitor.go
+++ b/internal/ui/intake_monitor.go
@@ -65,7 +65,7 @@ func (s *Server) intakeMonitor(w http.ResponseWriter, r *http.Request) {
 		views = append(views, v)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	intakeMonitorTmpl.ExecuteTemplate(w, "intake-monitor", map[string]any{
+	renderTemplate(w, intakeMonitorTmpl, "intake-monitor", map[string]any{
 		"Intakes": views,
 		"Msg":     r.URL.Query().Get("msg"),
 		"Err":     r.URL.Query().Get("err"),

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"sync"
 	"time"
@@ -81,7 +80,7 @@ func userKeyFromCtx(ctx context.Context) string {
 func (s *Server) messagesList(w http.ResponseWriter, r *http.Request) {
 	msgs := s.messages.List(userKeyFromRequest(r))
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	json.NewEncoder(w).Encode(map[string]any{"messages": msgs})
+	respondJSONTo(w, map[string]any{"messages": msgs})
 }
 
 func (s *Server) messagesClear(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/report_compose_excel_test.go
+++ b/internal/ui/report_compose_excel_test.go
@@ -178,7 +178,7 @@ func TestComposedRowsNilMeasure(t *testing.T) {
 	res := &compose.Result{
 		Groups: []*compose.Group{
 			{
-				Key:      "Группа1",
+				Key:       "Группа1",
 				Subtotals: map[string]any{"Кол": nil},
 			},
 		},

--- a/internal/ui/report_cross_render_test.go
+++ b/internal/ui/report_cross_render_test.go
@@ -105,7 +105,7 @@ func TestCrossSheetRowsDuplicateField(t *testing.T) {
 		Groupings: []string{"Товар"},
 		Columns:   []string{"Месяц"},
 		Measures: []report.Measure{
-			{Field: "Сумма", Agg: "sum", Title: "Сумма"},                          // без формата → float64
+			{Field: "Сумма", Agg: "sum", Title: "Сумма"},                           // без формата → float64
 			{Field: "Сумма", Agg: "sum", Title: "Сумма с НДС", Format: "#,##0.00"}, // с форматом → строка
 		},
 	}

--- a/internal/ui/respond.go
+++ b/internal/ui/respond.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"encoding/json"
+	"html/template"
+	"log/slog"
+	"net/http"
+
+	oblog "github.com/ivantit66/onebase/internal/logging"
+)
+
+// Запись в уже начатый HTTP-ответ.
+//
+// К моменту этих вызовов заголовки отправлены (а иногда и часть тела), поэтому
+// вернуть пользователю другой статус нельзя — план 109 предписывает для такого
+// случая зафиксировать сбой структурным логом и прекратить запись. Решение
+// принято здесь один раз, вместо того чтобы повторяться в каждом обработчике.
+//
+// Уровни разные не для красоты, а по природе сбоя:
+//   - JSON-ответ обычно не дописывается, потому что клиент отсоединился —
+//     штатная ситуация, Debug, иначе журнал зальёт при каждом закрытии вкладки;
+//   - сбой шаблона чаще означает ошибку в самом шаблоне (нет поля, nil-карта),
+//     и пользователь получает обрезанную страницу — это Warn, такое надо видеть.
+
+func uiLog() *slog.Logger { return oblog.Component("ui") }
+
+// respondJSON дописывает значение в ответ через уже созданный энкодер.
+func respondJSON(enc *json.Encoder, v any) {
+	if err := enc.Encode(v); err != nil {
+		uiLog().Debug("не удалось записать JSON-ответ", "err", err)
+	}
+}
+
+// respondJSONTo кодирует значение прямо в ответ (когда энкодер не переиспользуется).
+func respondJSONTo(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		uiLog().Debug("не удалось записать JSON-ответ", "err", err)
+	}
+}
+
+// renderTemplate отрисовывает именованный шаблон в уже начатый ответ.
+func renderTemplate(w http.ResponseWriter, t *template.Template, name string, data any) {
+	if err := t.ExecuteTemplate(w, name, data); err != nil {
+		uiLog().Warn("не удалось отрисовать шаблон", "template", name, "err", err)
+	}
+}
+
+// renderAdminTemplate отрисовывает шаблон админки в уже начатый ответ.
+func renderAdminTemplate(w http.ResponseWriter, name string, data any) {
+	renderTemplate(w, adminTmpl, name, data)
+}

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -12,7 +12,6 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"io"
 	"net"
@@ -104,7 +103,7 @@ func (s *Server) serviceIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].RootURL < out[j].RootURL })
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	_ = json.NewEncoder(w).Encode(map[string]any{"services": out})
+	respondJSONTo(w, map[string]any{"services": out})
 }
 
 // serviceDispatch разбирает /hs/<корень>/<путь>, находит сервис и шаблон,
@@ -408,7 +407,7 @@ func (s *Server) writeServiceResult(w http.ResponseWriter, result any) {
 func writeServiceError(w http.ResponseWriter, code int, msg string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(map[string]any{"error": msg})
+	respondJSONTo(w, map[string]any{"error": msg})
 }
 
 // sessionToken читает токен сессии ТОЛЬКО из cookie onebase_session. Приём из

--- a/internal/ui/services_openapi.go
+++ b/internal/ui/services_openapi.go
@@ -5,7 +5,6 @@ package ui
 // достаточно для импорта в Swagger UI / Postman / кодогенераторы клиентов.
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -16,7 +15,7 @@ import (
 func (s *Server) serviceOpenAPI(w http.ResponseWriter, r *http.Request) {
 	doc := buildOpenAPI(s.reg.HTTPServices(), s.cfg.AppName, s.cfg.AppVersion)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	_ = json.NewEncoder(w).Encode(doc)
+	respondJSONTo(w, doc)
 }
 
 func buildOpenAPI(services []*httpservice.Service, title, version string) map[string]any {

--- a/internal/ui/tp_json_test.go
+++ b/internal/ui/tp_json_test.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"context"
+
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/storage"
-	"context"
 )
 
 // TestParseTablePartRows_TpJSON проверяет ветку tp_json.{TPName} (план 48):


### PR DESCRIPTION
Продолжение серии 109. `errcheck` 527 → **477**; `internal/ui` — 114 → 32.

## Что было

Пятьдесят вызовов `enc.Encode`, `json.NewEncoder(w).Encode` и `<tmpl>.ExecuteTemplate` писали в **уже начатый** ответ, игнорируя ошибку. К этому моменту заголовки отправлены, а иногда и часть тела, поэтому вернуть другой статус нельзя — план предписывает зафиксировать сбой структурным логом и прекратить запись.

Решение принято один раз в `internal/ui/respond.go`, а не повторяется в каждом обработчике.

## Уровни логирования — по природе сбоя, а не для единообразия

| Что | Уровень | Почему |
|---|---|---|
| JSON-ответ | `Debug` | обычно не дописывается из-за отсоединившегося клиента — штатная ситуация; `Warn` залил бы журнал при каждом закрытии вкладки |
| шаблон | `Warn` | чаще означает ошибку в самом шаблоне (нет поля, nil-карта), и пользователь получает обрезанную страницу — такое надо видеть |

## Грабли

Шаблон замены задел четыре места, где результат `Encode` **использовался**:

```go
_ = json.NewEncoder(w).Encode(res)   // стало: _ = respondJSONTo(w, res)
```

а `respondJSONTo` ничего не возвращает. Сборка отвалилась сразу, поправлено точечно.

## Проверка

Перед пушем прогнан **весь** набор шагов CI локально: BOM, `i18ncheck`, линт поставляемых конфигураций, `vet`, тесты, обычный линт и gate — всё чисто.

Generated-with: Claude Code