### PR TITLE
fix(launcher): ограниченный разбор формы вместо игнорируемого ParseForm (план 109)

### DIFF
--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -302,7 +302,9 @@ func (h *handler) backupSettings(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	type backupCfg struct {
 		Enabled   bool   `yaml:"enabled"`
 		Schedule  string `yaml:"schedule"`

--- a/internal/launcher/cfgauth.go
+++ b/internal/launcher/cfgauth.go
@@ -156,7 +156,9 @@ func (h *handler) cfgLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		renderTemplate(w, cfgLoginTmpl, data)
 	}
 
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	login := r.FormValue("login")
 	password := r.FormValue("password")
 	limiter := h.configuratorLoginLimiter()

--- a/internal/launcher/configurator.go
+++ b/internal/launcher/configurator.go
@@ -39,7 +39,9 @@ func (h *handler) configuratorConvert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	srcDir := strings.TrimSpace(r.FormValue("src_dir"))
 	apply := r.FormValue("apply") == "1"
 

--- a/internal/launcher/configurator_entity.go
+++ b/internal/launcher/configurator_entity.go
@@ -24,7 +24,9 @@ func (h *handler) configuratorSaveModule(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	entityName := r.FormValue("entity")
 	moduleType := r.FormValue("module_type")
 	source := r.FormValue("source")

--- a/internal/launcher/configurator_enum_constant.go
+++ b/internal/launcher/configurator_enum_constant.go
@@ -18,7 +18,9 @@ func (h *handler) configuratorSaveEnum(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	enumName := r.FormValue("enum_name")
 
 	type enumValueOut struct {
@@ -97,7 +99,9 @@ func (h *handler) configuratorSaveConstant(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	constName := r.FormValue("const_name")
 	label := strings.TrimSpace(r.FormValue("label"))
 	typ := strings.TrimSpace(r.FormValue("type"))

--- a/internal/launcher/configurator_printforms.go
+++ b/internal/launcher/configurator_printforms.go
@@ -20,7 +20,9 @@ func (h *handler) configuratorSavePrintForm(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	filename := strings.TrimSpace(r.FormValue("printform_filename"))
 	source := r.FormValue("source")
 	relPath := "printforms/" + filename
@@ -80,7 +82,9 @@ func (h *handler) configuratorNewPrintForm(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	name := strings.TrimSpace(r.FormValue("name"))
 	document := strings.TrimSpace(r.FormValue("document"))
 
@@ -139,7 +143,9 @@ func (h *handler) configuratorSaveLayout(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	layoutName := strings.TrimSpace(r.FormValue("layout_name"))
 	source := r.FormValue("source")
 

--- a/internal/launcher/configurator_processor.go
+++ b/internal/launcher/configurator_processor.go
@@ -18,7 +18,9 @@ func (h *handler) configuratorSaveProcessor(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	procName := r.FormValue("processor_name")
 	title := strings.TrimSpace(r.FormValue("title"))
 	source := r.FormValue("source")

--- a/internal/launcher/configurator_report_module.go
+++ b/internal/launcher/configurator_report_module.go
@@ -20,7 +20,9 @@ func (h *handler) configuratorSaveReport(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	repName := r.FormValue("report_name")
 	query := r.FormValue("query")
 	title := strings.TrimSpace(r.FormValue("title"))
@@ -194,7 +196,9 @@ func (h *handler) configuratorSaveCommonModule(w http.ResponseWriter, r *http.Re
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	moduleName := r.FormValue("module_name")
 	source := r.FormValue("source")
 	if !validObjectName(moduleName) {

--- a/internal/launcher/form_limits.go
+++ b/internal/launcher/form_limits.go
@@ -1,0 +1,79 @@
+package launcher
+
+import (
+	"errors"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// Разбор формы запроса в обработчиках лаунчера.
+//
+// Игнорировать ошибку r.ParseForm() нельзя, и дело не в аккуратности. При сбое
+// разбора тела выполнение продолжается, а все FormValue возвращают пустые
+// строки — обработчик принимает пустоту за осознанный ввод пользователя.
+//
+// Причём «всё пустое» — не единственный сценарий. ParseForm разбирает и тело, и
+// строку запроса, а ошибку тела возвращает уже после того, как значения из query
+// попали в r.Form. То есть при битом теле часть полей приходит из URL, а
+// остальные оказываются пустыми — и обработчик видит правдоподобную, но
+// наполовину стёртую форму. В handler.update это означает: имя берётся из query
+// и проходит проверку, а Path, DBPath и Port обнуляются и сохраняются в
+// хранилище — регистрация базы теряет путь к конфигурации и к файлу БД.
+//
+// Разбор здесь ограниченный: голый ParseForm читает тело целиком, без предела
+// (gosec помечает это как G120). MaxBytesReader закрывает и это, и даёт
+// обработчикам конфигуратора предел размера тела, которого у них не было.
+
+const (
+	// maxFormBody — предел тела обычной формы лаунчера. Формы конфигуратора
+	// несут исходники модулей, отчётов и макетов, поэтому предел заметно выше
+	// административного: 8 МиБ — это заведомо больше любого реального модуля,
+	// но уже не «сколько пришлёт клиент».
+	maxFormBody = int64(8 << 20)
+
+	// formMemoryBytes — сколько multipart-формы держат в памяти; остаток
+	// уходит во временный файл силами ParseMultipartForm.
+	formMemoryBytes = int64(1 << 20)
+)
+
+// parseBoundedForm разбирает форму, не подменяя urlencoded-путь на multipart:
+// ParseMultipartForm на обычной форме возвращает сбивающий с толку
+// ErrNotMultipart, а для настоящего multipart нужно именно его ограниченное
+// поведение с временным файлом.
+func parseBoundedForm(r *http.Request, maxMemory int64) error {
+	contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if strings.EqualFold(contentType, "multipart/form-data") {
+		return r.ParseMultipartForm(maxMemory)
+	}
+	return r.ParseForm()
+}
+
+// parseFormLimited ограничивает тело запроса и разбирает форму. Возвращает
+// ошибку — вызывающий обязан прекратить обработку, а не работать с пустыми
+// FormValue.
+func parseFormLimited(w http.ResponseWriter, r *http.Request) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxFormBody)
+	return parseBoundedForm(r, formMemoryBytes)
+}
+
+// formErrorStatus отличает превышение размера (413) от прочих сбоев разбора (400).
+func formErrorStatus(err error) int {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return http.StatusRequestEntityTooLarge
+	}
+	return http.StatusBadRequest
+}
+
+// failForm отвечает на нечитаемую форму и сообщает вызывающему, что обработку
+// пора прекратить. Текст намеренно служебный и без перевода — как соседние
+// http.Error в этом пакете: до пользователя такой ответ доходит только при
+// сломанном или подделанном запросе, а не при обычной работе.
+func failForm(w http.ResponseWriter, r *http.Request) bool {
+	if err := parseFormLimited(w, r); err != nil {
+		http.Error(w, "bad form: "+err.Error(), formErrorStatus(err))
+		return true
+	}
+	return false
+}

--- a/internal/launcher/form_limits_test.go
+++ b/internal/launcher/form_limits_test.go
@@ -1,0 +1,146 @@
+package launcher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// postForm собирает POST /bases/{id} с заданными query и телом.
+func postForm(t *testing.T, id, rawQuery, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/bases/"+id+"?"+rawQuery, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func storedBase(t *testing.T, st *Store, id string) *Base {
+	t.Helper()
+	b, err := st.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", id, err)
+	}
+	return b
+}
+
+func baseFixture(t *testing.T) (*handler, *Store) {
+	t.Helper()
+	st := newTestStore(t)
+	if err := st.Add(&Base{
+		ID: "base", Name: "Рабочая", ConfigSource: "file",
+		Path: "/srv/onebase/cfg", DB: "postgres://localhost/onebase",
+		DBType: "postgres", Port: 9090,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &handler{store: st}, st
+}
+
+// Главный случай, ради которого правка и делалась.
+//
+// ParseForm разбирает и тело, и строку запроса, а ошибку тела возвращает уже
+// после того, как значения из query попали в r.Form. Поэтому битое тело — это не
+// «все поля пустые»: имя приходит из URL и проходит проверку, а Path и DBPath
+// оказываются пустыми и уходят в хранилище. Без проверки ошибки регистрация базы
+// теряла путь к конфигурации — по журналу неотличимо от правки администратора.
+func TestUpdateRejectsMalformedFormBodyAndKeepsBase(t *testing.T) {
+	h, st := baseFixture(t)
+	before := storedBase(t, st, "base")
+
+	// %zz — некорректная escape-последовательность: url.ParseQuery на теле
+	// вернёт ошибку, а значения из query при этом уже разобраны.
+	req := postForm(t, "base", "name=Рабочая&db_type=postgres&db=postgres://localhost/onebase", "path=%zz")
+	rec := httptest.NewRecorder()
+
+	h.update(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("код = %d, ожидался 400: битую форму нельзя принимать за ввод", rec.Code)
+	}
+	after := storedBase(t, st, "base")
+	if after.Path != before.Path {
+		t.Errorf("Path затёрт: было %q, стало %q", before.Path, after.Path)
+	}
+	if after.ConfigSource != before.ConfigSource {
+		t.Errorf("ConfigSource затёрт: было %q, стало %q", before.ConfigSource, after.ConfigSource)
+	}
+	if after.Port != before.Port {
+		t.Errorf("Port затёрт: было %d, стало %d", before.Port, after.Port)
+	}
+}
+
+// Тело сверх предела — 413, а не 400: клиенту важно различать «прислал мусор» и
+// «прислал слишком много».
+func TestUpdateRejectsOversizedFormBody(t *testing.T) {
+	h, st := baseFixture(t)
+
+	big := "path=" + url.QueryEscape(strings.Repeat("x", int(maxFormBody)+1))
+	req := postForm(t, "base", "", big)
+	rec := httptest.NewRecorder()
+
+	h.update(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("код = %d, ожидался 413", rec.Code)
+	}
+	if got := storedBase(t, st, "base").Path; got != "/srv/onebase/cfg" {
+		t.Errorf("Path изменён на переполнении: %q", got)
+	}
+}
+
+// Обычная форма по-прежнему проходит: ограничение не должно ломать штатный путь.
+func TestUpdateAcceptsWellFormedForm(t *testing.T) {
+	h, st := baseFixture(t)
+
+	body := url.Values{
+		"name":          {"Рабочая"},
+		"config_source": {"file"},
+		"path":          {"/srv/onebase/cfg2"},
+		"db":            {"postgres://localhost/onebase"},
+		"db_type":       {"postgres"},
+		"port":          {"9091"},
+	}.Encode()
+	req := postForm(t, "base", "", body)
+	rec := httptest.NewRecorder()
+
+	h.update(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("код = %d, ожидался 302; body=%q", rec.Code, rec.Body.String())
+	}
+	after := storedBase(t, st, "base")
+	if after.Path != "/srv/onebase/cfg2" || after.Port != 9091 {
+		t.Errorf("форма не применилась: Path=%q Port=%d", after.Path, after.Port)
+	}
+}
+
+// parseBoundedForm не должен подменять обычную форму multipart-разбором: на
+// urlencoded ParseMultipartForm вернул бы ErrNotMultipart, и обработчик отказал
+// бы в корректном запросе.
+func TestParseBoundedFormHandlesBothEncodings(t *testing.T) {
+	urlencoded := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("a=1"))
+	urlencoded.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if err := parseBoundedForm(urlencoded, formMemoryBytes); err != nil {
+		t.Fatalf("urlencoded: %v", err)
+	}
+	if got := urlencoded.FormValue("a"); got != "1" {
+		t.Errorf("urlencoded: FormValue(a) = %q", got)
+	}
+
+	body := "--b\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--b--\r\n"
+	multi := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	multi.Header.Set("Content-Type", `multipart/form-data; boundary=b`)
+	if err := parseBoundedForm(multi, formMemoryBytes); err != nil {
+		t.Fatalf("multipart: %v", err)
+	}
+	if got := multi.FormValue("a"); got != "1" {
+		t.Errorf("multipart: FormValue(a) = %q", got)
+	}
+}

--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -169,7 +169,9 @@ func (h *handler) newForm(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) create(w http.ResponseWriter, r *http.Request) {
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	lang := resolveLang(r)
 	dbType := r.FormValue("db_type")
 	if dbType == "" {
@@ -284,7 +286,9 @@ func (h *handler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	lang := resolveLang(r)
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	b.Name = r.FormValue("name")
 	b.ConfigSource = r.FormValue("config_source")
 	b.Path = r.FormValue("path")
@@ -698,7 +702,9 @@ func (h *handler) configImport(w http.ResponseWriter, r *http.Request) {
 	lang := resolveLang(r)
 	backURL := "/bases/" + b.ID + "/configurator?tab=files"
 
-	r.ParseForm()
+	if failForm(w, r) {
+		return
+	}
 	srcDir := strings.TrimSpace(r.FormValue("path"))
 	if srcDir == "" {
 		srcDir, err = workspacePath(b.ID)


### PR DESCRIPTION
Продолжение серии 109E. Зеркало PR #537, сделанного для `internal/ui`.

**errcheck 434 → 419**, `internal/launcher`: 132 → 117.

## Не «линтер придрался», а потеря данных

15 обработчиков вызывали `r.ParseForm()` без проверки. Важна не сама пропущенная ошибка, а то, **как именно** ведёт себя `ParseForm` при сбое:

> он разбирает и тело, и строку запроса, а ошибку тела возвращает **уже после** того, как значения из query попали в `r.Form`.

Значит битое тело — это не «все поля пустые». Часть полей приходит из URL, остальные пустые, и обработчик видит правдоподобную, но наполовину стёртую форму — которая проходит валидацию.

В `handler.update` это давало прямую потерю данных:

1. `name` берётся из query → проверка «Наименование обязательно» пройдена;
2. `Path`, `ConfigSource`, `Port` оказываются пустыми;
3. `store.Update` их сохраняет — регистрация базы теряет путь к конфигурации;
4. пользователь получает **302**, то есть ответ об успехе.

Новый `TestUpdateRejectsMalformedFormBodyAndKeepsBase` это фиксирует. Без правки:

```
--- FAIL: TestUpdateRejectsMalformedFormBodyAndKeepsBase
    код = 302, ожидался 400: битую форму нельзя принимать за ввод
    Path затёрт: было "/srv/onebase/cfg", стало ""
    ConfigSource затёрт: было "file", стало ""
    Port затёрт: было 9090, стало 8080
```

## Как починено

Приём, уже принятый в `internal/ui` (PR #537): `MaxBytesReader` + `parseBoundedForm`. Закрывает и `errcheck`, и `G120` (голый `ParseForm` читает тело целиком, без предела), и добавляет обработчикам конфигуратора ограничение размера тела, которого у них не было. Превышение → **413**, битое тело → **400**.

`maxFormBody` = 8 МиБ, а не 1 МБ как в ui: формы конфигуратора несут исходники модулей, отчётов и макетов. Заведомо больше любого реального модуля, но уже не «сколько пришлёт клиент». Штатный путь закрыт отдельным тестом, чтобы ограничение не сломало обычное сохранение.

`parseBoundedForm` не подменяет urlencoded-путь multipart-разбором: на обычной форме `ParseMultipartForm` вернул бы `ErrNotMultipart` и обработчик отказал бы в корректном запросе. Обе кодировки проверены тестом.

Текст ошибки служебный и без перевода — как соседние `http.Error` в этом пакете: такой ответ доходит до пользователя только при сломанном или подделанном запросе.

## Проверки

Локально прогнан весь набор шагов CI: BOM, `i18ncheck`, линт поставляемых конфигураций, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)