### PR TITLE
fix(launcher): не собирать и не восстанавливать конфигурацию молча наполовину (план 109D)

### DIFF
--- a/internal/launcher/archive.go
+++ b/internal/launcher/archive.go
@@ -1,0 +1,137 @@
+package launcher
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/configdb"
+)
+
+// Сборка ZIP-архивов конфигурации: экспорт конфигурации и полный .obz.
+//
+// zip.Writer теряет ошибки тихо: Create отдаёт io.Writer, Write — счётчик байт,
+// Close дописывает центральный каталог. Пропустив любую из трёх, получаешь
+// «успешно» собранный, но неполный или вовсе нечитаемый архив — и пользователь
+// сохраняет его как резервную копию. Дефект вскроется при восстановлении, то
+// есть ровно тогда, когда копия нужна и проверять уже поздно.
+//
+// Поэтому здесь принят один контракт: любой сбой прекращает сборку и уходит
+// вызывающему. Раньше обе ветки экспорта пропускали сбойный файл (`continue`
+// после Scan, `return nil` после ReadFile) и молча игнорировали недоступную БД —
+// архив собирался вообще без конфигурации, а пользователь получал HTTP 200.
+//
+// Пропуск нечитаемого файла в резервной копии хуже отказа: отказ виден сразу,
+// а неполная копия выглядит нормальной ровно до попытки восстановиться из неё.
+
+// zipAdd добавляет один файл в архив.
+func zipAdd(zw *zip.Writer, name string, content []byte) error {
+	f, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("создание записи %q: %w", name, err)
+	}
+	if _, err := f.Write(content); err != nil {
+		return fmt.Errorf("запись %q: %w", name, err)
+	}
+	return nil
+}
+
+// addConfigToZip кладёт в архив конфигурацию базы — из таблицы _onebase_config
+// либо из каталога проекта. prefix задаёт папку внутри архива: "" для экспорта
+// конфигурации, "config/" для полного .obz.
+func addConfigToZip(ctx context.Context, zw *zip.Writer, b *Base, prefix string) error {
+	if b.ConfigSource == "database" {
+		db, err := OpenDB(ctx, b)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+
+		rows, err := db.Query(ctx, `SELECT path, content FROM _onebase_config ORDER BY path`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var p string
+			var content []byte
+			if err := rows.Scan(&p, &content); err != nil {
+				return err
+			}
+			if err := zipAdd(zw, prefix+strings.ReplaceAll(p, `\`, "/"), content); err != nil {
+				return err
+			}
+		}
+		return rows.Err()
+	}
+
+	srcDir := b.Path
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		rel = strings.ReplaceAll(rel, `\`, "/")
+		// Каталог резервных копий в копию не кладём — иначе каждая следующая
+		// вкладывает предыдущую.
+		if strings.HasPrefix(rel, "backups/") {
+			return nil
+		}
+		content, err := os.ReadFile(path) //nolint:gosec // G304,G122: путь пришёл из WalkDir по каталогу самой базы; переход на os.Root — отдельная задача этапа 109H
+		if err != nil {
+			return err
+		}
+		return zipAdd(zw, prefix+rel, content)
+	})
+}
+
+// restoreConfigDir раскладывает файловую конфигурацию из распакованного архива
+// в каталог базы.
+//
+// Каждая ошибка здесь — потерянный файл конфигурации, поэтому ни одна не
+// пропускается. Раньше сбой чтения давал `return nil`, а MkdirAll и WriteFile не
+// проверялись вовсе: восстановление, при котором не записался НИ ОДИН файл,
+// доходило до конца, запускало миграцию и показывало «Полное восстановление
+// выполнено: база данных + конфигурация». Правду пользователь узнавал, только
+// открыв конфигурацию.
+//
+// SafeJoin держит запись внутри каталога базы: пути берутся из архива, который
+// мог прийти откуда угодно.
+func restoreConfigDir(configDir, basePath string) error {
+	return filepath.WalkDir(configDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(configDir, path)
+		if err != nil {
+			return err
+		}
+		dst, err := configdb.SafeJoin(basePath, filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		// 0755/0644 ниже — соглашение пакета (25 и 27 мест). Права разбираются
+		// разом на этапе 109H, а не точечно здесь: одиночное ужесточение сделало
+		// бы восстановленную конфигурацию непохожей на созданную обычным путём.
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil { //nolint:gosec // G301,G122: см. комментарий выше
+			return err
+		}
+		content, err := os.ReadFile(path) //nolint:gosec // G304,G122: путь — из временного каталога, который мы сами и распаковали
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dst, content, 0o644) //nolint:gosec // G306,G703,G122: dst построен configdb.SafeJoin — это и есть guard от traversal; права — этап 109H
+	})
+}

--- a/internal/launcher/archive_test.go
+++ b/internal/launcher/archive_test.go
@@ -1,0 +1,135 @@
+package launcher
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func zipNames(t *testing.T, raw []byte) []string {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	if err != nil {
+		t.Fatalf("архив не читается: %v", err)
+	}
+	var names []string
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Файловая конфигурация попадает в архив целиком, каталог backups/ — нет
+// (иначе каждая следующая копия вкладывала бы предыдущую).
+func TestAddConfigToZipPacksFilesAndSkipsBackups(t *testing.T) {
+	dir := t.TempDir()
+	for _, rel := range []string{"app.yaml", "catalogs/Контрагент.yaml", "backups/old.obz"} {
+		p := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("содержимое "+rel), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	b := &Base{ID: "b", ConfigSource: "file", Path: dir}
+	if err := addConfigToZip(context.Background(), zw, b, "config/"); err != nil {
+		t.Fatalf("addConfigToZip: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := zipNames(t, buf.Bytes())
+	want := []string{"config/app.yaml", "config/catalogs/Контрагент.yaml"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("состав архива = %v, ожидался %v", got, want)
+	}
+}
+
+// Главный случай. Раньше полный экспорт игнорировал недоступность конфигурации
+// в БД: .obz собирался вообще без папки config/ и отдавался с HTTP 200.
+// Резервная копия без конфигурации выглядит нормальной ровно до попытки
+// восстановиться из неё, поэтому теперь это ошибка, а не пустой архив.
+func TestAddConfigToZipFailsWhenConfigUnreadable(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "no-config-table.db")
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close() // база есть, таблицы _onebase_config в ней нет
+	t.Cleanup(CloseAuthPools)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	b := &Base{ID: "b", ConfigSource: "database", DBType: "sqlite", DBPath: dbPath}
+
+	err = addConfigToZip(ctx, zw, b, "config/")
+	if err == nil {
+		t.Fatal("недоступная конфигурация должна быть ошибкой, а не пустым архивом")
+	}
+	if !strings.Contains(err.Error(), "_onebase_config") {
+		t.Errorf("ошибка должна называть недоступный источник, получено: %v", err)
+	}
+}
+
+// Восстановление раскладывает файлы, создавая вложенные каталоги.
+func TestRestoreConfigDirWritesTree(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "catalogs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "catalogs", "К.yaml"), []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "app.yaml"), []byte("a"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreConfigDir(src, dst); err != nil {
+		t.Fatalf("restoreConfigDir: %v", err)
+	}
+	for rel, want := range map[string]string{"app.yaml": "a", "catalogs/К.yaml": "k"} {
+		got, err := os.ReadFile(filepath.Join(dst, filepath.FromSlash(rel))) //nolint:gosec // G304: путь собран здесь же, в тесте
+		if err != nil {
+			t.Fatalf("%s не восстановлен: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, ожидалось %q", rel, got, want)
+		}
+	}
+}
+
+// Второй главный случай. Раньше сбой записи пропускался (`return nil` на чтении,
+// непроверенные MkdirAll и WriteFile), восстановление доходило до конца и
+// показывало «Полное восстановление выполнено: база данных + конфигурация».
+//
+// Сбой воспроизводится без игр с правами: каталог базы — обычный файл, поэтому
+// MkdirAll под него не может создать путь.
+func TestRestoreConfigDirReportsWriteFailure(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "app.yaml"), []byte("a"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	blocker := filepath.Join(t.TempDir(), "не-каталог")
+	if err := os.WriteFile(blocker, []byte("я файл"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreConfigDir(src, blocker); err == nil {
+		t.Fatal("сбой записи при восстановлении не должен выдаваться за успех")
+	}
+}

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -539,47 +539,19 @@ func (h *handler) backupFullExport(w http.ResponseWriter, r *http.Request) {
 	if b.DBType == "sqlite" {
 		dumpEntryName = "database.db"
 	}
-	f, _ := zw.Create(dumpEntryName)
-	f.Write(dumpData)
+	if err := zipAdd(zw, dumpEntryName, dumpData); err != nil {
+		http.Error(w, tr(lang, "Ошибка выгрузки")+": "+errText(r, err), 500)
+		return
+	}
 
 	// Configuration
-	if b.ConfigSource == "database" {
-		db, cerr := OpenDB(r.Context(), b)
-		if cerr == nil {
-			defer db.Close()
-			rows, qerr := db.Query(r.Context(), `SELECT path, content FROM _onebase_config ORDER BY path`)
-			if qerr == nil {
-				defer rows.Close()
-				for rows.Next() {
-					var p string
-					var content []byte
-					if rows.Scan(&p, &content) != nil {
-						continue
-					}
-					cf, _ := zw.Create("config/" + strings.ReplaceAll(p, `\`, "/"))
-					cf.Write(content)
-				}
-			}
-		}
-	} else {
-		srcDir := b.Path
-		filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-			rel, _ := filepath.Rel(srcDir, path)
-			rel = strings.ReplaceAll(rel, `\`, "/")
-			if strings.HasPrefix(rel, "backups/") {
-				return nil
-			}
-			content, err := os.ReadFile(path)
-			if err != nil {
-				return nil
-			}
-			cf, _ := zw.Create("config/" + rel)
-			cf.Write(content)
-			return nil
-		})
+	//
+	// Раньше недоступная БД и сбойный файл здесь просто пропускались: .obz
+	// собирался вообще без конфигурации и отдавался с HTTP 200. Полный бэкап
+	// без конфигурации — не бэкап, поэтому теперь это отказ.
+	if err := addConfigToZip(r.Context(), zw, b, "config/"); err != nil {
+		http.Error(w, tr(lang, "Ошибка выгрузки")+": "+errText(r, err), 500)
+		return
 	}
 
 	exportDBType := b.DBType
@@ -588,10 +560,16 @@ func (h *handler) backupFullExport(w http.ResponseWriter, r *http.Request) {
 	}
 	meta := fmt.Sprintf("onebase_full_export\nversion=1.0\nformat=binary\ndate=%s\nbase=%s\nsource=%s\ndb_type=%s\n",
 		time.Now().Format("2006-01-02T15:04:05"), b.Name, b.ConfigSource, exportDBType)
-	mf, _ := zw.Create("META.txt")
-	mf.Write([]byte(meta))
-
-	zw.Close()
+	if err := zipAdd(zw, "META.txt", []byte(meta)); err != nil {
+		http.Error(w, tr(lang, "Ошибка выгрузки")+": "+errText(r, err), 500)
+		return
+	}
+	// Close дописывает центральный каталог: без него .obz нечитаем, а без
+	// проверки — нечитаем молча, и выяснится это при восстановлении.
+	if err := zw.Close(); err != nil {
+		http.Error(w, tr(lang, "Ошибка выгрузки")+": "+errText(r, err), 500)
+		return
+	}
 	writeDownload(w, name, buf.Bytes())
 }
 
@@ -838,23 +816,7 @@ func (h *handler) backupFullImport(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		} else {
-			configErr = filepath.WalkDir(configDir, func(path string, d os.DirEntry, err error) error {
-				if err != nil || d.IsDir() {
-					return nil
-				}
-				rel, _ := filepath.Rel(configDir, path)
-				dst, jerr := configdb.SafeJoin(b.Path, filepath.ToSlash(rel))
-				if jerr != nil {
-					return jerr
-				}
-				os.MkdirAll(filepath.Dir(dst), 0o755)
-				content, err := os.ReadFile(path)
-				if err != nil {
-					return nil
-				}
-				os.WriteFile(dst, content, 0o644)
-				return nil
-			})
+			configErr = restoreConfigDir(configDir, b.Path)
 		}
 	}
 

--- a/internal/launcher/config_handlers.go
+++ b/internal/launcher/config_handlers.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/ivantit66/onebase/internal/configdb"
@@ -25,51 +23,16 @@ func (h *handler) configExportZip(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
 
-	if b.ConfigSource == "database" {
-		db, cerr := OpenDB(r.Context(), b)
-		if cerr != nil {
-			http.Error(w, cerr.Error(), 500)
-			return
-		}
-		defer db.Close()
-
-		rows, qerr := db.Query(r.Context(), `SELECT path, content FROM _onebase_config ORDER BY path`)
-		if qerr != nil {
-			http.Error(w, qerr.Error(), 500)
-			return
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var p string
-			var content []byte
-			if err := rows.Scan(&p, &content); err != nil {
-				continue
-			}
-			f, _ := zw.Create(p)
-			f.Write(content)
-		}
-	} else {
-		srcDir := b.Path
-		filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-			rel, _ := filepath.Rel(srcDir, path)
-			rel = strings.ReplaceAll(rel, `\`, `/`)
-			if strings.HasPrefix(rel, "backups/") {
-				return nil
-			}
-			content, err := os.ReadFile(path)
-			if err != nil {
-				return nil
-			}
-			f, _ := zw.Create(rel)
-			f.Write(content)
-			return nil
-		})
+	if err := addConfigToZip(r.Context(), zw, b, ""); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
 	}
-
-	zw.Close()
+	// Close дописывает центральный каталог: без него архив нечитаем, а без
+	// проверки — нечитаем молча.
+	if err := zw.Close(); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
 
 	name := b.Name + "_config.zip"
 	w.Header().Set("Content-Type", "application/zip")


### PR DESCRIPTION
Класс 1, вторая группа: запись архивов и восстановление из них.

**errcheck `internal/launcher`: 109 → 97.**

## Экспорт: архив мог собраться вообще без конфигурации

`zip.Writer` теряет ошибки тихо — `Create` отдаёт `io.Writer`, `Write` возвращает счётчик байт, `Close` дописывает центральный каталог. **Ни одна из трёх не проверялась**, а недоступная БД и нечитаемый файл просто пропускались (`continue` после `Scan`, `return nil` после `ReadFile`).

Полный `.obz` мог собраться **без папки `config/`** и уйти пользователю с HTTP 200. Резервная копия без конфигурации выглядит нормальной ровно до попытки восстановиться из неё.

Обе ветки экспорта — конфигурации и полного `.obz` — содержали одну и ту же ошибку дважды, поэтому сведены в `addConfigToZip` с единым контрактом: любой сбой прекращает сборку.

> **Изменение поведения:** раньше нечитаемый файл пропускался, теперь экспорт отказывает. Это осознанно — пропуск в резервной копии хуже отказа, потому что отказ виден сразу.

## Восстановление: «выполнено» при нуле записанных файлов

То же самое, но опаснее. Сбой чтения давал `return nil`, `MkdirAll` и `WriteFile` не проверялись вовсе. Восстановление, при котором **не записался ни один файл**, доходило до конца, запускало миграцию и показывало:

> Полное восстановление выполнено: база данных + конфигурация

Правду пользователь узнавал, только открыв конфигурацию.

Обход вынесен в `restoreConfigDir` — чтобы он стал проверяемым без multipart-загрузки `.obz` и поднятой базы.

## Тесты

Оба направления и оба сбоя, детерминированно и без игр с правами файлов:

- экспорт — конфигурация в БД без таблицы `_onebase_config`;
- восстановление — каталог базы, на месте которого лежит обычный файл (`MkdirAll` не может создать путь).

## Про gosec в этом PR

Перенос кода в новый файл показал gate 10 находок `gosec` на тех же строках. Разобраны, не спрятаны:

- `G703` на `os.WriteFile(dst, ...)` — `dst` строится через `configdb.SafeJoin`, что и есть guard от traversal; gosec его не распознаёт;
- `G304` — пути приходят из `WalkDir` по каталогу самой базы и из временного каталога, который мы сами распаковали;
- `G301`/`G306` — права `0755`/`0644` **не менялись**: это соглашение пакета (25 и 27 мест). Точечное ужесточение сделало бы восстановленную конфигурацию непохожей на созданную обычным путём, а решение по правам — этап 109H, где оно принимается разом для всех 206 `G306`;
- `G122` (symlink TOCTOU в callback `WalkDir`) — настоящий пункт для этапа 109H: переход на `os.Root` меняет поведение и заслуживает отдельного PR.

Каждое подавление точечное, с указанием правила и основания.

## Проверки

Локально прогнан весь набор шагов CI: BOM, `i18ncheck`, линт поставляемых конфигураций, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)