### PR TITLE
fix(launcher): не терять сбои записи временных файлов и копий (план 109D)

### DIFF
--- a/internal/launcher/ai_generate.go
+++ b/internal/launcher/ai_generate.go
@@ -3,6 +3,7 @@ package launcher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -997,14 +998,13 @@ func copyTree(src, dst string) error {
 		if err != nil {
 			return err
 		}
-		defer in.Close()
+		defer closeRead("исходный файл", in)
 		out, err := os.Create(target)
 		if err != nil {
 			return err
 		}
 		if _, err := io.Copy(out, in); err != nil {
-			out.Close()
-			return err
+			return errors.Join(err, out.Close())
 		}
 		// Возвращаем ошибку Close — она ловит сбой сброса буфера (напр. диск
 		// заполнен), иначе усечённая копия молча сошла бы за успех.

--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -634,14 +635,12 @@ func (h *handler) configuratorFormsValidate(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Пишем во временный файл и пытаемся загрузить через managed_form_loader.
-	tmp, err := os.CreateTemp("", "obform-*.form.yaml")
+	tmpPath, cleanup, err := writeTempFile("obform-*.form.yaml", yamlBody)
 	if err != nil {
 		writeFormsJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString(yamlBody)
-	tmp.Close()
+	defer cleanup()
 
 	type item struct {
 		Severity string `json:"severity"`
@@ -653,7 +652,7 @@ func (h *handler) configuratorFormsValidate(w http.ResponseWriter, r *http.Reque
 		Items []item `json:"items"`
 	}{OK: true}
 
-	if _, err := loader.NewManagedFormLoader().LoadFormFile(tmp.Name(), entity); err != nil {
+	if _, err := loader.NewManagedFormLoader().LoadFormFile(tmpPath, entity); err != nil {
 		resp.OK = false
 		resp.Items = append(resp.Items, item{Severity: "error", Message: err.Error()})
 	}
@@ -680,16 +679,14 @@ func (h *handler) configuratorFormsPreview(w http.ResponseWriter, r *http.Reques
 		entity = "Объект"
 	}
 
-	tmp, err := os.CreateTemp("", "obpreview-*.form.yaml")
+	tmpPath, cleanup, err := writeTempFile("obpreview-*.form.yaml", yamlBody)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return
 	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString(yamlBody)
-	tmp.Close()
+	defer cleanup()
 
-	fm, err := loader.NewManagedFormLoader().LoadFormFile(tmp.Name(), entity)
+	fm, err := loader.NewManagedFormLoader().LoadFormFile(tmpPath, entity)
 	if err != nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		writeBody(w, []byte(previewErrorHTML(err.Error())))
@@ -792,7 +789,7 @@ func (h *handler) configuratorFormsImport1C(w http.ResponseWriter, r *http.Reque
 func extractImportSource(r *http.Request, tmpDir string) (string, string, string, error) {
 	// Вариант 1: одиночный ZIP в поле "zip"
 	if zipFile, _, err := r.FormFile("zip"); err == nil {
-		defer zipFile.Close()
+		defer closeRead("загруженный ZIP", zipFile)
 		data, err := io.ReadAll(io.LimitReader(zipFile, (64<<20)+1))
 		if err != nil {
 			return "", "", "", err
@@ -811,14 +808,17 @@ func extractImportSource(r *http.Request, tmpDir string) (string, string, string
 		if err != nil {
 			return nil // не обязательно
 		}
-		defer f.Close()
+		defer closeRead("загруженный файл "+field, f)
 		out, err := os.Create(dst)
 		if err != nil {
 			return err
 		}
-		defer out.Close()
-		_, err = io.Copy(out, f)
-		return err
+		if _, err := io.Copy(out, f); err != nil {
+			return errors.Join(err, out.Close())
+		}
+		// Close возвращаем: он ловит сбой сброса буфера, иначе усечённая копия
+		// сошла бы за успех (тот же приём уже применён в ai_generate).
+		return out.Close()
 	}
 	if err := saveFile("form_xml", filepath.Join(tmpDir, "Form.xml")); err != nil {
 		return "", "", "", err

--- a/internal/launcher/layout_preview.go
+++ b/internal/launcher/layout_preview.go
@@ -91,9 +91,14 @@ func (h *handler) configuratorLayoutPreview(w http.ResponseWriter, r *http.Reque
 					http.Error(w, "PDF temp error: "+werr.Error(), http.StatusInternalServerError)
 					return
 				}
-				tf.Write(pdfBytes)
+				// Файл остаётся на диске: его открывает внешний просмотрщик.
+				// Поэтому Write и Close проверяем — иначе просмотрщик получит
+				// усечённый PDF и покажет «файл повреждён» вместо макета.
+				if wErr := writePDFTemp(tf, pdfBytes); wErr != nil {
+					http.Error(w, "PDF temp error: "+wErr.Error(), http.StatusInternalServerError)
+					return
+				}
 				fp = tf.Name()
-				tf.Close()
 			}
 			if oerr := OpenPath(fp); oerr != nil {
 				http.Error(w, "open error: "+oerr.Error(), http.StatusInternalServerError)

--- a/internal/launcher/tempfile.go
+++ b/internal/launcher/tempfile.go
@@ -1,0 +1,78 @@
+package launcher
+
+import (
+	"errors"
+	"io"
+	"os"
+)
+
+// Временные файлы, которые сразу же читает кто-то другой.
+//
+// В конфигураторе это устойчивый приём: YAML из редактора пишется во временный
+// файл и скармливается загрузчику (виджета, управляемой формы) — чтобы разбор
+// шёл ровно тем же кодом, что и при обычной загрузке с диска, и кривой ввод не
+// заменил рабочее определение.
+//
+// Приём хороший, но в нём три ошибки подряд оставались непроверенными:
+// CreateTemp, WriteString и особенно Close. Close здесь не формальность — он
+// сбрасывает буфер, и без него загрузчик читает усечённый или пустой файл.
+// Дальше он честно сообщает о своей беде («missing name», «ошибка YAML»), и
+// пользователь видит сообщение о том, что его YAML плохой, хотя на самом деле
+// не записался временный файл. Диагностика уводит в сторону — а на диске в этот
+// момент, например, кончилось место.
+//
+// Поэтому запись и Close проверяются, а удаление — нет: файл к тому моменту уже
+// прочитан, и неудача удаления ничего не портит, кроме занятого места в TMP.
+
+// writeTempFile создаёт временный файл с содержимым content и возвращает его
+// путь вместе с функцией удаления. Вызывающий обязан отложить cleanup.
+// При любой ошибке файл удаляется, а cleanup — пустышка.
+func writeTempFile(pattern, content string) (path string, cleanup func(), err error) {
+	noop := func() {}
+
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", noop, err
+	}
+	name := f.Name()
+	remove := func() {
+		if rerr := os.Remove(name); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			respondLog().Debug("не удалось удалить временный файл", "path", name, "err", rerr)
+		}
+	}
+
+	if _, werr := f.WriteString(content); werr != nil {
+		// Close тут вторичен — основная ошибка уже есть; errors.Join
+		// сохраняет обе, не подменяя причину.
+		werr = errors.Join(werr, f.Close())
+		remove()
+		return "", noop, werr
+	}
+	if cerr := f.Close(); cerr != nil {
+		remove()
+		return "", noop, cerr
+	}
+	return name, remove, nil
+}
+
+// closeRead закрывает читающую сторону (загруженный файл, открытый исходник).
+// Ошибка тут вторична — данные уже прочитаны, и отказывать в операции из-за
+// неё было бы хуже самой ошибки. Но и глотать молча незачем: Debug.
+//
+// Для пишущей стороны это НЕ подходит: там Close сбрасывает буфер, и его
+// ошибка основная. Такие места возвращают её вызывающему (io.Copy → out.Close
+// в ai_generate и extractImportSource).
+func closeRead(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		respondLog().Debug("не удалось закрыть "+what, "err", err)
+	}
+}
+
+// writePDFTemp дописывает содержимое во временный файл, который останется на
+// диске (его открывает внешний просмотрщик), и закрывает его.
+func writePDFTemp(f *os.File, content []byte) error {
+	if _, err := f.Write(content); err != nil {
+		return errors.Join(err, f.Close())
+	}
+	return f.Close()
+}

--- a/internal/launcher/tempfile_test.go
+++ b/internal/launcher/tempfile_test.go
@@ -1,0 +1,72 @@
+package launcher
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteTempFileRoundTripAndCleanup(t *testing.T) {
+	path, cleanup, err := writeTempFile("probe-*.yaml", "имя: виджет\n")
+	if err != nil {
+		t.Fatalf("writeTempFile: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // G304: путь только что получен здесь же
+	if err != nil {
+		t.Fatalf("временный файл не читается: %v", err)
+	}
+	if string(got) != "имя: виджет\n" {
+		t.Errorf("содержимое = %q", got)
+	}
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("cleanup не удалил файл: %v", err)
+	}
+}
+
+// Сбой подготовки временного файла — не повод пропустить проверку.
+func TestWriteTempFileFailsWhenTempDirMissing(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "нет-такого-каталога"))
+
+	if _, _, err := writeTempFile("probe-*.yaml", "x"); err == nil {
+		t.Fatal("ожидалась ошибка при недоступном каталоге временных файлов")
+	}
+}
+
+// Главный случай чанка.
+//
+// Проверка виджета намеренно идёт через временный файл: YAML разбирается тем же
+// загрузчиком, что и при обычной загрузке с диска, чтобы кривой ввод не заменил
+// рабочее определение. Раньше весь блок стоял под `if err == nil` — сбой
+// создания временного файла молча ОТКЛЮЧАЛ проверку, и непроверенный YAML
+// уходил в конфигурацию. То есть guard исчезал ровно в тот момент, когда с
+// машиной что-то не так.
+//
+// TMPDIR в никуда воспроизводит это детерминированно и без прав доступа.
+func TestSaveWidgetDoesNotSaveWhenValidationCannotRun(t *testing.T) {
+	cfgDir := t.TempDir()
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	base := &Base{ID: "wdg", Name: "wdg", ConfigSource: "file", Path: cfgDir}
+	if err := store.save([]*Base{base}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "нет-такого-каталога"))
+
+	form := url.Values{"widget_name": {"Продажи"}, "yaml": {"это: не виджет\n"}}
+	req := httptest.NewRequest(http.MethodPost, "/bases/wdg/configurator/widget/save",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = requestWithBaseID(req, "wdg")
+	rec := httptest.NewRecorder()
+
+	(&handler{store: store, runner: NewRunner()}).configuratorSaveWidget(rec, req)
+
+	if entries, err := os.ReadDir(filepath.Join(cfgDir, "widgets")); err == nil && len(entries) > 0 {
+		t.Fatalf("виджет сохранён без проверки: %v", entries)
+	}
+}

--- a/internal/launcher/widget_handlers.go
+++ b/internal/launcher/widget_handlers.go
@@ -37,17 +37,24 @@ func (h *handler) configuratorSaveWidget(w http.ResponseWriter, r *http.Request)
 
 	// Validate: parse without writing to disk first so a malformed YAML never
 	// replaces a working widget definition.
-	tmp, err := os.CreateTemp("", "widget-*.yaml")
-	if err == nil {
-		tmp.WriteString(body)
-		tmp.Close()
-		defer os.Remove(tmp.Name())
-		if _, perr := metadata.LoadWidgetFile(tmp.Name()); perr != nil {
-			data := h.loadCfgData(r.Context(), b, "tree")
-			data.Error = tr(lang, "Ошибка YAML") + ": " + perr.Error()
-			renderCfg(w, r, data)
-			return
-		}
+	//
+	// Раньше весь блок стоял под `if err == nil`: сбой создания временного файла
+	// молча отключал проверку, и непроверенный YAML уходил в конфигурацию —
+	// ровно то, что этот блок и должен предотвращать. Теперь сбой подготовки
+	// отличается от сбоя разбора по тексту, но одинаково прекращает сохранение.
+	tmpPath, cleanup, err := writeTempFile("widget-*.yaml", body)
+	if err != nil {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Ошибка проверки") + ": " + err.Error()
+		renderCfg(w, r, data)
+		return
+	}
+	defer cleanup()
+	if _, perr := metadata.LoadWidgetFile(tmpPath); perr != nil {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Ошибка YAML") + ": " + perr.Error()
+		renderCfg(w, r, data)
+		return
 	}
 
 	relPath := "widgets/" + nameToFilename(name) + ".yaml"

--- a/internal/launcher/widget_preview.go
+++ b/internal/launcher/widget_preview.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -116,14 +115,12 @@ func (h *handler) configuratorWidgetPreview(w http.ResponseWriter, r *http.Reque
 // дефолты chart_kind/limit/scope) через временный файл — тот же путь, что и при
 // сохранении, чтобы предпросмотр и сохранение трактовали YAML одинаково.
 func parseWidgetYAML(body string) (*metadata.Widget, error) {
-	tmp, err := os.CreateTemp("", "widget-preview-*.yaml")
+	tmpPath, cleanup, err := writeTempFile("widget-preview-*.yaml", body)
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString(body)
-	tmp.Close()
-	return metadata.LoadWidgetFile(tmp.Name())
+	defer cleanup()
+	return metadata.LoadWidgetFile(tmpPath)
 }
 
 // buildWidgetPreview приводит widget.Result к плоскому render-ready виду.


### PR DESCRIPTION
Класс 1, третья группа. **errcheck `internal/launcher`: 97 → 78.**

## Приём хороший, реализация теряла три ошибки подряд

В конфигураторе YAML из редактора пишется во временный файл и скармливается штатному загрузчику — чтобы разбор шёл тем же кодом, что и при обычной загрузке с диска, и кривой ввод не заменил рабочее определение. Но `CreateTemp`, `WriteString` и `Close` не проверялись.

### Главное: проверка виджета молча отключалась

Весь блок валидации стоял под `if err == nil`:

```go
tmp, err := os.CreateTemp("", "widget-*.yaml")
if err == nil {
    ...проверка...
}
// сюда попадали и когда проверка не выполнялась
```

Сбой создания временного файла **отключал проверку**, и непроверенный YAML уходил в конфигурацию — ровно то, что этот блок должен предотвращать. Guard исчезал именно тогда, когда с машиной что-то не так.

Тест ставит `TMPDIR` в никуда и без правки падает:

```
--- FAIL: TestSaveWidgetDoesNotSaveWhenValidationCannotRun
    виджет сохранён без проверки: [- продажи.yaml]
```

### Close здесь не формальность

Он сбрасывает буфер: без него загрузчик читает усечённый файл и честно сообщает о своей беде («missing name», «ошибка YAML»). Пользователь видит претензию к своему YAML, хотя на самом деле не записался временный файл — например, кончилось место на диске.

Поведение загрузчика на пустом файле проверял отдельно: обхода проверки нет, но диагностика уводит в сторону.

## Разделение по сторонам потока, а не по имени вызова

| Сторона | Как обработано | Почему |
|---|---|---|
| Пишущая (`io.Copy` → `out.Close`) | Ошибка возвращается вызывающему | Иначе усечённая копия сойдёт за успех. Приём уже был в `ai_generate` — теперь и там, где его забыли (`extractImportSource`) |
| Читающая (загруженный ZIP, открытый исходник) | `closeRead`, Debug | Данные уже прочитаны; отказывать в операции из-за этого хуже самой ошибки |
| Удаление временного файла | Не проверяется | Файл уже прочитан, неудача не портит ничего, кроме места в TMP |

Предпросмотр макета — отдельный случай: временный PDF **остаётся** на диске для внешнего просмотрщика, поэтому `Write` и `Close` проверяются, иначе просмотрщик покажет «файл повреждён» вместо макета.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)