### PR TITLE
fix(launcher): не скрывать нечитаемый config/app.yaml (план 109D)

### DIFF
--- a/internal/launcher/admin_handlers.go
+++ b/internal/launcher/admin_handlers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/version"
-	"gopkg.in/yaml.v3"
 )
 
 // ── Admin panel handlers for configurator ────────────────────────────────────
@@ -978,20 +977,8 @@ func (h *handler) cfgAdminAbout(w http.ResponseWriter, r *http.Request) {
 		Logo    string `yaml:"logo"`
 	}
 	var cfg appCfg
-	if b.ConfigSource == "database" {
-		db, dbErr := OpenDB(r.Context(), b)
-		if dbErr == nil {
-			defer db.Close()
-			var content []byte
-			if qrErr := db.QueryRow(r.Context(), `SELECT content FROM _onebase_config WHERE path = $1`, "config/app.yaml").Scan(&content); qrErr == nil {
-				yaml.Unmarshal(content, &cfg)
-			}
-		}
-	} else if b.Path != "" {
-		data, err := os.ReadFile(filepath.Join(b.Path, "config", "app.yaml"))
-		if err == nil {
-			yaml.Unmarshal(data, &cfg)
-		}
+	if err := readAppYAML(r.Context(), b, &cfg); err != nil {
+		cfg = appCfg{}
 	}
 
 	// Load logo — use endpoint URL so it works for both file and database sources
@@ -1081,6 +1068,11 @@ func (h *handler) configuratorLogo(w http.ResponseWriter, r *http.Request) {
 	var cfg appCfg
 	var logoData []byte
 
+	if err := readAppYAML(r.Context(), b, &cfg); err != nil || cfg.Logo == "" {
+		http.NotFound(w, r)
+		return
+	}
+
 	if b.ConfigSource == "database" {
 		db, cerr := OpenDB(r.Context(), b)
 		if cerr != nil {
@@ -1088,42 +1080,17 @@ func (h *handler) configuratorLogo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer db.Close()
-		// Get app.yaml
-		var content []byte
-		if err := db.QueryRow(r.Context(), `SELECT content FROM _onebase_config WHERE path = $1`, "config/app.yaml").Scan(&content); err != nil {
-			http.NotFound(w, r)
-			return
-		}
-		yaml.Unmarshal(content, &cfg)
-		if cfg.Logo == "" {
-			http.NotFound(w, r)
-			return
-		}
-		// Get logo file
 		if err := db.QueryRow(r.Context(), `SELECT content FROM _onebase_config WHERE path = $1`, cfg.Logo).Scan(&logoData); err != nil {
 			http.NotFound(w, r)
 			return
 		}
 	} else {
-		if b.Path == "" {
-			http.NotFound(w, r)
-			return
-		}
-		data, err := os.ReadFile(filepath.Join(b.Path, "config", "app.yaml"))
+		data, err := os.ReadFile(filepath.Join(b.Path, cfg.Logo)) //nolint:gosec // G304: путь берётся из config/app.yaml базы, который правит её же администратор
 		if err != nil {
 			http.NotFound(w, r)
 			return
 		}
-		yaml.Unmarshal(data, &cfg)
-		if cfg.Logo == "" {
-			http.NotFound(w, r)
-			return
-		}
-		logoData, err = os.ReadFile(filepath.Join(b.Path, cfg.Logo))
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
+		logoData = data
 	}
 
 	ext := strings.ToLower(filepath.Ext(cfg.Logo))

--- a/internal/launcher/appconfig.go
+++ b/internal/launcher/appconfig.go
@@ -1,0 +1,70 @@
+package launcher
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Чтение config/app.yaml базы.
+//
+// Этот блок был продублирован пятью копиями (список баз, страница входа, панель
+// «О программе», отдача логотипа, каталог резервных копий) — и во всех пяти
+// ошибка разбора игнорировалась одинаково. Последствие мягкое, но неприятное
+// именно тем, что уводит в сторону: при битом app.yaml структура остаётся
+// нулевой, и интерфейс показывает не «конфигурация не читается», а «имя не
+// задано, логотипа нет». Пользователь ищет несуществующую проблему в настройках.
+//
+// Отдельный случай — каталог резервных копий: пустое значение там означает
+// «класть в каталог по умолчанию», то есть битый app.yaml молча меняет место
+// хранения копий.
+//
+// Поведение вызывающих сохранено: это пути только для показа, и ронять список
+// баз из-за одной сломанной конфигурации было бы хуже. Изменилось то, что
+// причина теперь попадает в журнал, а не исчезает.
+
+// errAppConfigAbsent — конфигурации нет: не задан путь, нет записи или файла.
+// Это штатная ситуация (база ещё не наполнена), в отличие от битого YAML.
+var errAppConfigAbsent = errors.New("config/app.yaml отсутствует")
+
+const appConfigPath = "config/app.yaml"
+
+// readAppYAML разбирает config/app.yaml базы в v — из таблицы _onebase_config
+// либо из каталога проекта.
+func readAppYAML(ctx context.Context, b *Base, v any) error {
+	var content []byte
+
+	if b.ConfigSource == "database" {
+		db, err := OpenDB(ctx, b)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		if err := db.QueryRow(ctx,
+			`SELECT content FROM _onebase_config WHERE path = $1`, appConfigPath).Scan(&content); err != nil {
+			return errors.Join(errAppConfigAbsent, err)
+		}
+	} else {
+		if b.Path == "" {
+			return errAppConfigAbsent
+		}
+		data, err := os.ReadFile(filepath.Join(b.Path, "config", "app.yaml"))
+		if err != nil {
+			return errors.Join(errAppConfigAbsent, err)
+		}
+		content = data
+	}
+
+	if err := yaml.Unmarshal(content, v); err != nil {
+		// Логируем здесь, а не у вызывающих: именно эта ошибка раньше пропадала
+		// молча, и во всех пяти местах реакция на неё одинаковая — показать
+		// пустые значения. Дублировать Warn по местам вызова незачем.
+		respondLog().Warn("config/app.yaml не разобран — значения показаны пустыми",
+			"base", b.Name, "baseID", b.ID, "err", err)
+		return err
+	}
+	return nil
+}

--- a/internal/launcher/appconfig_test.go
+++ b/internal/launcher/appconfig_test.go
@@ -1,0 +1,93 @@
+package launcher
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// baseWithAppYAML создаёт файловую базу с заданным содержимым config/app.yaml.
+func baseWithAppYAML(t *testing.T, content string) *Base {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "app.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &Base{ID: "b", Name: "Проверка", ConfigSource: "file", Path: dir}
+}
+
+type appCfgProbe struct {
+	Name string `yaml:"name"`
+	Logo string `yaml:"logo"`
+}
+
+func TestReadAppYAMLParses(t *testing.T) {
+	b := baseWithAppYAML(t, "name: Торговля\nlogo: images/logo.png\n")
+	var cfg appCfgProbe
+	if err := readAppYAML(context.Background(), b, &cfg); err != nil {
+		t.Fatalf("readAppYAML: %v", err)
+	}
+	if cfg.Name != "Торговля" || cfg.Logo != "images/logo.png" {
+		t.Errorf("разобрано неверно: %+v", cfg)
+	}
+}
+
+// Отсутствие конфигурации — штатная ситуация (база ещё не наполнена) и должно
+// отличаться от битого YAML: на неё нет смысла ругаться в журнале.
+func TestReadAppYAMLAbsentIsDistinctFromBroken(t *testing.T) {
+	records := captureLog(t)
+
+	var cfg appCfgProbe
+	err := readAppYAML(context.Background(), &Base{ID: "b", ConfigSource: "file"}, &cfg)
+	if !errors.Is(err, errAppConfigAbsent) {
+		t.Fatalf("ожидался errAppConfigAbsent, получено %v", err)
+	}
+	if recs := records(); len(recs) != 0 {
+		t.Errorf("отсутствие конфигурации не должно писать в журнал: %v", recs)
+	}
+}
+
+// Главное. Раньше битый app.yaml давал нулевую структуру без единого следа:
+// интерфейс показывал не «конфигурация не читается», а «имя не задано,
+// логотипа нет», и пользователь искал несуществующую проблему в настройках.
+func TestReadAppYAMLBrokenReportsAndLogs(t *testing.T) {
+	records := captureLog(t)
+	b := baseWithAppYAML(t, "name: [не закрыт\n")
+
+	var cfg appCfgProbe
+	if err := readAppYAML(context.Background(), b, &cfg); err == nil {
+		t.Fatal("битый YAML должен возвращать ошибку")
+	}
+
+	rec := onlyRecord(t, records())
+	if rec["level"] != "WARN" {
+		t.Errorf("уровень = %v, ожидался WARN", rec["level"])
+	}
+	if rec["base"] != "Проверка" {
+		t.Errorf("в записи должна быть база: %v", rec)
+	}
+}
+
+// Пустой backup.directory означает «каталог по умолчанию», поэтому битый
+// app.yaml молча менял место хранения резервных копий. Поведение сохранено
+// (падать нельзя — каталог нужен и для показа настроек), но теперь это видно.
+func TestBackupDirFallsBackAndLogsOnBrokenConfig(t *testing.T) {
+	records := captureLog(t)
+	b := baseWithAppYAML(t, "backup: [не закрыт\n")
+
+	h := &handler{}
+	if got := h.loadBackupDirSetting(b); got != "" {
+		t.Errorf("ожидалась пустая настройка, получено %q", got)
+	}
+	if want := filepath.Join(b.Path, "backups"); h.backupDir(b) != want {
+		t.Errorf("каталог по умолчанию = %q, ожидался %q", h.backupDir(b), want)
+	}
+	if len(records()) == 0 {
+		t.Error("подмена каталога резервных копий должна попадать в журнал")
+	}
+}

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -173,38 +173,23 @@ func extractValidatedArchive(dir string, files []*zip.File) error {
 	return nil
 }
 
+// loadBackupDirSetting читает backup.directory из config/app.yaml базы.
+//
+// Пустая строка означает «класть копии в каталог по умолчанию», поэтому
+// нечитаемый app.yaml здесь молча менял место хранения резервных копий:
+// пользователь настроил отдельный диск, а копии уходили в каталог базы.
+// Само поведение оставлено прежним — падать из-за этого нельзя, каталог нужен и
+// для показа настроек, — но причина теперь видна в журнале (внутри readAppYAML).
 func (h *handler) loadBackupDirSetting(b *Base) string {
-	if b.ConfigSource == "database" {
-		db, err := OpenDB(context.Background(), b)
-		if err != nil {
-			return ""
-		}
-		defer db.Close()
-		var content []byte
-		if err := db.QueryRow(context.Background(),
-			"SELECT content FROM _onebase_config WHERE path='config/app.yaml'").Scan(&content); err != nil {
-			return ""
-		}
-		var tmp struct {
-			Backup struct {
-				Directory string `yaml:"directory"`
-			} `yaml:"backup"`
-		}
-		yaml.Unmarshal(content, &tmp)
-		return tmp.Backup.Directory
-	}
-	cfgPath := filepath.Join(b.Path, "config", "app.yaml")
-	raw, err := os.ReadFile(cfgPath)
-	if err != nil {
-		return ""
-	}
-	var tmp struct {
+	var cfg struct {
 		Backup struct {
 			Directory string `yaml:"directory"`
 		} `yaml:"backup"`
 	}
-	yaml.Unmarshal(raw, &tmp)
-	return tmp.Backup.Directory
+	if err := readAppYAML(context.Background(), b, &cfg); err != nil {
+		return ""
+	}
+	return cfg.Backup.Directory
 }
 
 // dumpForBase chooses the right backup mechanism based on b.DBType.

--- a/internal/launcher/cfgauth.go
+++ b/internal/launcher/cfgauth.go
@@ -5,13 +5,9 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-chi/chi/v5"
 
@@ -99,18 +95,10 @@ func (h *handler) cfgLoginData(r *http.Request, b *Base) map[string]any {
 		Logo string `yaml:"logo"`
 	}
 	var cfg appCfg
-	if b.ConfigSource == "database" {
-		if db, dbErr := OpenDB(r.Context(), b); dbErr == nil {
-			defer db.Close()
-			var content []byte
-			if qErr := db.QueryRow(r.Context(), "SELECT content FROM _onebase_config WHERE path = $1", "config/app.yaml").Scan(&content); qErr == nil {
-				yaml.Unmarshal(content, &cfg)
-			}
-		}
-	} else if b.Path != "" {
-		if raw, rErr := os.ReadFile(filepath.Join(b.Path, "config", "app.yaml")); rErr == nil {
-			yaml.Unmarshal(raw, &cfg)
-		}
+	// Логотип — украшение страницы входа: нечитаемый app.yaml не повод не
+	// пустить администратора в конфигуратор.
+	if err := readAppYAML(r.Context(), b, &cfg); err != nil {
+		cfg.Logo = ""
 	}
 	if cfg.Logo != "" {
 		data["LogoURL"] = "/bases/" + b.ID + "/configurator/logo"

--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ivantit66/onebase/internal/i18n/i18nerr"
 	"github.com/ivantit66/onebase/internal/project"
 	"github.com/ivantit66/onebase/internal/storage"
-	"gopkg.in/yaml.v3"
 )
 
 // normalizeSQLitePath приводит ввод пути к файлу SQLite к одному виду:
@@ -105,23 +104,10 @@ func (h *handler) index(w http.ResponseWriter, r *http.Request) {
 			Version string `yaml:"version"`
 			Logo    string `yaml:"logo"`
 		}
-		if b.ConfigSource == "database" {
-			db, err := OpenDB(context.Background(), b)
-			if err != nil {
-				return
-			}
-			defer db.Close()
-			var content []byte
-			if err := db.QueryRow(context.Background(), "SELECT content FROM _onebase_config WHERE path = $1", "config/app.yaml").Scan(&content); err != nil {
-				return
-			}
-			yaml.Unmarshal(content, &cfg)
-		} else if b.Path != "" {
-			data, err := os.ReadFile(filepath.Join(b.Path, "config", "app.yaml"))
-			if err != nil {
-				return
-			}
-			yaml.Unmarshal(data, &cfg)
+		// Одна сломанная конфигурация не должна ломать весь список баз:
+		// показываем эту строку пустой, причина уходит в журнал.
+		if err := readAppYAML(context.Background(), b, &cfg); err != nil {
+			return
 		}
 		vm.AppName = cfg.Name
 		vm.AppVersion = cfg.Version

--- a/internal/launcher/roles_handlers.go
+++ b/internal/launcher/roles_handlers.go
@@ -727,11 +727,20 @@ func (h *handler) deleteRoleConfigFiles(ctx context.Context, b *Base, relPaths [
 // roleConfigFiles returns map[configPath]roleName for every roles/*.yaml entry.
 func (h *handler) roleConfigFiles(ctx context.Context, b *Base) map[string]string {
 	out := map[string]string{}
-	readName := func(content []byte) string {
+	// Имя роли из её YAML. Битый файл даёт пустое имя, и роль выпадает из
+	// карты: при переименовании её старый файл не попадёт в stalePaths и
+	// останется в конфигурации рядом с новым — две записи одной роли.
+	// Пропустить такой файл всё равно приходится (имени в нём нет), но молчать
+	// об этом незачем.
+	readName := func(path string, content []byte) string {
 		var hdr struct {
 			Name string `yaml:"name"`
 		}
-		yaml.Unmarshal(content, &hdr)
+		if err := yaml.Unmarshal(content, &hdr); err != nil {
+			respondLog().Warn("роль пропущена: файл не разобран",
+				"path", path, "err", err)
+			return ""
+		}
 		return hdr.Name
 	}
 	if b.ConfigSource == "database" {
@@ -751,7 +760,7 @@ func (h *handler) roleConfigFiles(ctx context.Context, b *Base) map[string]strin
 			if rows.Scan(&path, &content) != nil {
 				continue
 			}
-			out[path] = readName(content)
+			out[path] = readName(path, content)
 		}
 		return out
 	}
@@ -764,8 +773,12 @@ func (h *handler) roleConfigFiles(ctx context.Context, b *Base) map[string]strin
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
 		}
-		content, _ := os.ReadFile(filepath.Join(dir, e.Name()))
-		out["roles/"+e.Name()] = readName(content)
+		content, rerr := os.ReadFile(filepath.Join(dir, e.Name())) //nolint:gosec // G304: имя из os.ReadDir по каталогу roles/ самой базы
+		if rerr != nil {
+			respondLog().Warn("роль пропущена: файл не прочитан", "path", e.Name(), "err", rerr)
+			continue
+		}
+		out["roles/"+e.Name()] = readName("roles/"+e.Name(), content)
 	}
 	return out
 }


### PR DESCRIPTION
**errcheck `internal/launcher`: 78 → 67.**

## Пять копий одного дефекта

Блок чтения `config/app.yaml` был продублирован пятью раз — список баз, страница входа, панель «О программе», отдача логотипа, каталог резервных копий — и во всех пяти ошибка разбора игнорировалась одинаково.

Последствие мягкое, но неприятное именно тем, что **уводит в сторону**: при битом `app.yaml` структура остаётся нулевой, и интерфейс показывает не «конфигурация не читается», а «имя не задано, логотипа нет». Пользователь идёт искать несуществующую проблему в настройках.

### Отдельный случай: место хранения резервных копий

Пустое значение `backup.directory` означает «класть копии в каталог по умолчанию». То есть нечитаемый `app.yaml` **молча менял место хранения копий**: администратор настроил отдельный диск, а копии уходили в каталог базы.

## Что сделано

Пять копий сведены в `readAppYAML`.

**Поведение вызывающих сохранено намеренно** — это пути только для показа, и ронять список баз из-за одной сломанной конфигурации было бы хуже самой поломки. Изменилось то, что причина попадает в журнал (Warn с именем базы), а не исчезает.

Отсутствие конфигурации отделено от битой: `errAppConfigAbsent` — штатная ситуация ненаполненной базы, в журнал не идёт. Тест это фиксирует, иначе Warn сыпался бы на каждой новой базе.

## Роли

`roleConfigFiles`: битый файл роли даёт пустое имя, и роль выпадает из карты путей. При переименовании её старый файл не попадает в `stalePaths` и остаётся в конфигурации рядом с новым — **две записи одной роли**. Пропустить такой файл всё равно приходится (имени в нём нет), но теперь об этом есть запись. Заодно перестал игнорироваться сбой чтения самого файла.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)