### PR TITLE
fix(ui): не терять сбои мутаций RBAC и удаления объекта (план 109D)

### DIFF
--- a/internal/ui/admin.go
+++ b/internal/ui/admin.go
@@ -267,8 +267,9 @@ func (s *Server) adminUserCard(w http.ResponseWriter, r *http.Request) {
 				data["Error"] = s.tr(lang, "Пароли не совпадают")
 			} else if err := s.authRepo.UpdatePassword(r.Context(), userID, newPwd); err != nil {
 				data["Error"] = s.errText(r, err)
+			} else if rerr := s.revokeSessionsOnPasswordChange(r, userID, u.Login); rerr != nil {
+				data["Error"] = s.tr(lang, "Пароль изменён, но сессии пользователя не завершены") + ": " + s.errText(r, rerr)
 			} else {
-				s.revokeSessionsOnPasswordChange(r, userID, u.Login)
 				data["Success"] = s.tr(lang, "Пароль изменён")
 			}
 		}
@@ -366,7 +367,12 @@ func (s *Server) adminUserDenyPasswd(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	s.authRepo.SetDenyPasswdChange(r.Context(), userID, !current)
+	// Флаг управляет тем, может ли пользователь сменить себе пароль. Молча не
+	// переключившийся запрет админ увидит только по неизменившейся галочке.
+	if err := s.authRepo.SetDenyPasswdChange(r.Context(), userID, !current); err != nil {
+		http.Error(w, s.errText(r, err), http.StatusInternalServerError)
+		return
+	}
 	http.Redirect(w, r, "/ui/admin/users", http.StatusFound)
 }
 
@@ -411,7 +417,12 @@ func (s *Server) adminUserPasswd(w http.ResponseWriter, r *http.Request) {
 			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
-		s.revokeSessionsOnPasswordChange(r, userID, userLogin)
+		if rerr := s.revokeSessionsOnPasswordChange(r, userID, userLogin); rerr != nil {
+			data["Error"] = s.tr(lang, "Пароль изменён, но сессии пользователя не завершены") + ": " + s.errText(r, rerr)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			renderAdminTemplate(w, "admin-passwd", data)
+			return
+		}
 		data["Success"] = true
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -421,19 +432,29 @@ func (s *Server) adminUserPasswd(w http.ResponseWriter, r *http.Request) {
 // revokeSessionsOnPasswordChange — политика плана 78: смена пароля админом
 // завершает все сессии пользователя; смена собственного пароля — все сессии,
 // кроме текущей (текущее окно продолжает работать). Событие пишется в аудит.
-func (s *Server) revokeSessionsOnPasswordChange(r *http.Request, targetUserID, targetLogin string) {
+// Ошибка отзыва возвращается вызывающему: пароль к этому моменту уже сменён,
+// откатить нельзя, но и молчать нельзя — сбой отзыва означает, что украденная
+// сессия пережила смену пароля, то есть ровно то, ради чего отзыв и делается.
+// Запись в аудит при этом НЕ пишется: «сессии отозваны» в журнале, когда они не
+// отозваны, хуже отсутствия записи — по ней инцидент закроют как отработанный.
+func (s *Server) revokeSessionsOnPasswordChange(r *http.Request, targetUserID, targetLogin string) error {
 	ctx := r.Context()
 	actor := auth.UserFromContext(ctx)
+	var err error
 	if actor != nil && actor.ID == targetUserID {
-		if cookie, err := r.Cookie("onebase_session"); err == nil && cookie.Value != "" {
-			s.authRepo.KickOtherSessions(ctx, targetUserID, cookie.Value)
+		if cookie, cerr := r.Cookie("onebase_session"); cerr == nil && cookie.Value != "" {
+			err = s.authRepo.KickOtherSessions(ctx, targetUserID, cookie.Value)
 		} else {
-			s.authRepo.KickUserSessions(ctx, targetUserID)
+			err = s.authRepo.KickUserSessions(ctx, targetUserID)
 		}
 	} else {
-		s.authRepo.KickUserSessions(ctx, targetUserID)
+		err = s.authRepo.KickUserSessions(ctx, targetUserID)
+	}
+	if err != nil {
+		return err
 	}
 	s.logSessionAudit(r, "password_change_sessions_revoked", targetLogin, targetUserID)
+	return nil
 }
 
 // selfPasswd lets any authenticated user change their own password.
@@ -484,7 +505,12 @@ func (s *Server) selfPasswd(w http.ResponseWriter, r *http.Request) {
 			renderAdminTemplate(w, "admin-passwd", data)
 			return
 		}
-		s.revokeSessionsOnPasswordChange(r, u.ID, u.Login)
+		if rerr := s.revokeSessionsOnPasswordChange(r, u.ID, u.Login); rerr != nil {
+			data["Error"] = s.tr(lang, "Пароль изменён, но сессии пользователя не завершены") + ": " + s.errText(r, rerr)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			renderAdminTemplate(w, "admin-passwd", data)
+			return
+		}
 		data["Success"] = true
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -557,7 +583,12 @@ func (s *Server) adminSessionLimit(w http.ResponseWriter, r *http.Request) {
 		n = 0
 	}
 	if s.store != nil {
-		s.store.SaveMaxSessionsPerUser(r.Context(), n)
+		// Редирект ниже прямо утверждает limit_saved=1 — нельзя утверждать это
+		// при неудавшейся записи.
+		if err := s.store.SaveMaxSessionsPerUser(r.Context(), n); err != nil {
+			http.Error(w, s.errText(r, err), http.StatusInternalServerError)
+			return
+		}
 	}
 	http.Redirect(w, r, "/ui/admin/sessions?limit_saved=1", http.StatusFound)
 }
@@ -836,14 +867,34 @@ func (s *Server) adminUserRolesUpdate(w http.ResponseWriter, r *http.Request) {
 		selectedSet[id] = true
 	}
 
-	allRoles, _ := s.authRepo.ListRoles(r.Context())
-	currentIDs, _ := s.authRepo.GetUserRoleIDs(r.Context(), userID)
+	// Диф считается от текущего состояния, поэтому сбой ЧТЕНИЯ опаснее сбоя
+	// записи: при пустом currentIDs ни одна роль не попадёт в ветку снятия,
+	// цикл отработает вхолостую, и админ получит редирект на список — то есть
+	// подтверждение — на запрос, где он снимал роль.
+	allRoles, err := s.authRepo.ListRoles(r.Context())
+	if err != nil {
+		http.Error(w, s.errText(r, err), http.StatusInternalServerError)
+		return
+	}
+	currentIDs, err := s.authRepo.GetUserRoleIDs(r.Context(), userID)
+	if err != nil {
+		http.Error(w, s.errText(r, err), http.StatusInternalServerError)
+		return
+	}
 
+	// Транзакции auth.Repo наружу не даёт: отказ на середине оставляет часть
+	// ролей применённой, поэтому в ошибке названа роль, на которой всё встало.
 	for _, role := range allRoles {
-		if selectedSet[role.ID] && !currentIDs[role.ID] {
-			s.authRepo.AssignRole(r.Context(), userID, role.ID)
-		} else if !selectedSet[role.ID] && currentIDs[role.ID] {
-			s.authRepo.UnassignRole(r.Context(), userID, role.ID)
+		var aerr error
+		switch {
+		case selectedSet[role.ID] && !currentIDs[role.ID]:
+			aerr = s.authRepo.AssignRole(r.Context(), userID, role.ID)
+		case !selectedSet[role.ID] && currentIDs[role.ID]:
+			aerr = s.authRepo.UnassignRole(r.Context(), userID, role.ID)
+		}
+		if aerr != nil {
+			http.Error(w, role.Name+": "+s.errText(r, aerr), http.StatusInternalServerError)
+			return
 		}
 	}
 	s.InvalidateWidgetCache()

--- a/internal/ui/admin_roles_failure_test.go
+++ b/internal/ui/admin_roles_failure_test.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// authRepoWithoutSchema даёт репозиторий поверх пустой базы: таблиц ролей в ней
+// нет, поэтому любое чтение ролей вернёт ошибку. Это воспроизводит недоступный
+// справочник ролей детерминированно, без подмены интерфейсов.
+func authRepoWithoutSchema(t *testing.T) *auth.Repo {
+	t.Helper()
+	db, err := storage.ConnectSQLite(context.Background(), filepath.Join(t.TempDir(), "empty.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return auth.NewRepo(db)
+}
+
+// Назначение ролей считает диф от текущего состояния, поэтому сбой ЧТЕНИЯ
+// опаснее сбоя записи: при пустом currentIDs ни одна роль не попадает в ветку
+// снятия, цикл отрабатывает вхолостую — и админ получает редирект на список
+// пользователей, то есть подтверждение, на запрос, где он СНИМАЛ роль.
+func TestAdminUserRolesUpdateReportsReadFailure(t *testing.T) {
+	s, _ := newSubmitTestServer(t, nil)
+	s.authRepo = authRepoWithoutSchema(t)
+
+	form := url.Values{"role_id": {}}
+	req := httptest.NewRequest(http.MethodPost, "/ui/admin/users/u1/roles",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "u1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	req = req.WithContext(auth.ContextWithUser(req.Context(), &auth.User{ID: "admin", IsAdmin: true}))
+	rec := httptest.NewRecorder()
+
+	s.adminUserRolesUpdate(rec, req)
+
+	if rec.Code == http.StatusFound {
+		t.Fatal("недоступный справочник ролей выдан за применённые изменения (редирект на список)")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("код = %d, ожидался 500; тело %q", rec.Code, rec.Body.String())
+	}
+}
+
+// Смена пароля отзывает сессии ради того, чтобы украденная сессия её не
+// пережила. Сбой отзыва раньше отбрасывался, и в аудит уходила запись
+// «password_change_sessions_revoked» — журнал утверждал ровно то, чего не
+// произошло. Теперь функция возвращает ошибку и записи не делает.
+func TestRevokeSessionsReturnsErrorAndSkipsAudit(t *testing.T) {
+	s, _ := newSubmitTestServer(t, nil)
+	s.authRepo = authRepoWithoutSchema(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/ui/admin/users/u1/passwd", nil)
+
+	if err := s.revokeSessionsOnPasswordChange(req, "u1", "petrov"); err == nil {
+		t.Fatal("сбой отзыва сессий должен возвращать ошибку")
+	}
+}

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -1644,8 +1644,14 @@ func (s *Server) deleteMarkedAll(w http.ResponseWriter, r *http.Request) {
 							return err
 						}
 					}
+					// Ошибку удаления ТЧ нельзя проглатывать внутри транзакции:
+					// дальше удаляется сам объект, транзакция коммитится, и
+					// строки табличной части остаются сиротами — ссылаются на
+					// несуществующего родителя. Возврат ошибки откатывает всё.
 					for _, tp := range entity.TableParts {
-						s.store.Exec(ctx, "DELETE FROM "+metadata.TablePartTableName(entity.Name, tp.Name)+" WHERE parent_id = "+s.store.Dialect().Placeholder(1), id)
+						if _, err := s.store.Exec(ctx, "DELETE FROM "+metadata.TablePartTableName(entity.Name, tp.Name)+" WHERE parent_id = "+s.store.Dialect().Placeholder(1), id); err != nil {
+							return err
+						}
 					}
 					if err := exchange.RegisterOnDelete(ctx, s.store, s.reg.ExchangePlans(), entity, id); err != nil {
 						return err


### PR DESCRIPTION
**errcheck `internal/ui`: 64 → 56.** Тот же класс fail-open, что закрыт в лаунчере (#541), плюс один случай хуже — порча данных внутри транзакции.

## Сироты в табличных частях

`handlers_entity.go`, групповое удаление. Ошибка `DELETE` табличной части игнорировалась **внутри транзакции**:

```go
for _, tp := range entity.TableParts {
    s.store.Exec(ctx, "DELETE FROM ... WHERE parent_id = ...", id)  // ошибка терялась
}
...
return s.store.Delete(ctx, entity.Name, id)   // объект удаляется
```

Дальше транзакция коммитится, и строки табличной части **остаются сиротами** — ссылаются на несуществующего родителя. Возврат ошибки откатывает всё, как и предполагалось замыслом `WithTx`.

## Роли: подтверждение на неприменённое снятие

`adminUserRolesUpdate` — тот же диф, что в конфигураторе: считается от текущего состояния, поэтому сбой **чтения** опаснее сбоя записи. При пустом `currentIDs` ни одна роль не попадает в ветку снятия, цикл отрабатывает вхолостую, и админ получает редирект на список — то есть подтверждение — на запрос, где он **снимал роль**.

Ошибки `ListRoles`/`GetUserRoleIDs` игнорировались через `_`, и errcheck их не показывал.

## Ложная запись в аудите

`revokeSessionsOnPasswordChange`: пароль сменён, сессии не отозваны — и в аудит всё равно уходила запись `password_change_sessions_revoked`. Ложная запись хуже отсутствия: по ней инцидент закроют как отработанный.

Функция теперь возвращает ошибку, записи при сбое не делает, а все три вызывающих показывают администратору, что пароль сменён, но сессии остались.

## Мельче, но той же природы

- `SetDenyPasswdChange` — молча не переключившийся запрет смены пароля админ увидел бы только по неизменившейся галочке;
- `SaveMaxSessionsPerUser` — редирект прямо утверждает `limit_saved=1`.

## Тесты

Недоступный справочник ролей (база без схемы) → обработчик обязан вернуть 500, а не редирект; отзыв сессий обязан вернуть ошибку.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)