### PR TITLE
refactor(ui): запись ответов, выгрузок и уборка по принятым решениям (план 109D)

### DIFF
--- a/internal/ui/debug_handlers.go
+++ b/internal/ui/debug_handlers.go
@@ -24,7 +24,7 @@ func readJSON(r *http.Request, v any) error {
 	if r.Body == nil {
 		return fmt.Errorf("empty body")
 	}
-	defer r.Body.Close()
+	defer closeRead("тело запроса", r.Body)
 	return json.NewDecoder(r.Body).Decode(v)
 }
 

--- a/internal/ui/dev_handlers.go
+++ b/internal/ui/dev_handlers.go
@@ -622,7 +622,7 @@ func (s *Server) gengenGenerate(w http.ResponseWriter, r *http.Request) {
 
 	// 5. Collect generated files for preview
 	files := make(map[string]string)
-	filepath.WalkDir(outDir, func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(outDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil
 		}
@@ -631,6 +631,7 @@ func (s *Server) gengenGenerate(w http.ResponseWriter, r *http.Request) {
 		files[rel] = string(data)
 		return nil
 	})
+	bestEffort("обойти каталог сгенерированных файлов", walkErr)
 
 	jsonResp(w, 200, map[string]any{
 		"domain":   result.Domain,

--- a/internal/ui/dsl_attachments.go
+++ b/internal/ui/dsl_attachments.go
@@ -151,7 +151,7 @@ func (s *Server) registerAttachmentBuiltins(vars map[string]any, ctxFn func() co
 		if err != nil {
 			return nil, fmt.Errorf("ПрисоединитьФайл: открытие файла: %w", err)
 		}
-		defer f.Close()
+		defer closeRead("вложение", f)
 		mimeType := mime.TypeByExtension(strings.ToLower(filepath.Ext(name)))
 		if mimeType == "" {
 			mimeType = "application/octet-stream"

--- a/internal/ui/export_jobs.go
+++ b/internal/ui/export_jobs.go
@@ -276,7 +276,7 @@ func (s *Server) exportJobDownload(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", job.ContentType)
 	w.Header().Set("Content-Disposition", contentDisposition(job.Filename))
-	w.Write(job.Data)
+	writeDownload(w, job.Filename, job.Data)
 }
 
 func (s *Server) exportJobForRequest(w http.ResponseWriter, r *http.Request) (exportJob, bool) {

--- a/internal/ui/extforms.go
+++ b/internal/ui/extforms.go
@@ -56,7 +56,7 @@ func (s *Server) adminExtFormUpload(w http.ResponseWriter, r *http.Request) {
 		s.extFormRedirect(w, r, "", s.tr(lang, "файл не выбран"))
 		return
 	}
-	defer file.Close()
+	defer closeRead("загруженный файл", file)
 	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
 		if errors.Is(err, errUploadTooLarge) {
@@ -168,7 +168,7 @@ func (s *Server) adminExtFormExport(w http.ResponseWriter, r *http.Request) {
 	fname := rec.Document + "." + rec.Name + ".obform"
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.Header().Set("Content-Disposition", contentDisposition(fname))
-	w.Write(bundle)
+	writeDownload(w, fname, bundle)
 }
 
 // reloadExtForms перечитывает включённые внешние формы из БД и обновляет

--- a/internal/ui/extprocessors.go
+++ b/internal/ui/extprocessors.go
@@ -55,7 +55,7 @@ func (s *Server) adminExtProcessorUpload(w http.ResponseWriter, r *http.Request)
 		s.extProcRedirect(w, r, "", s.tr(lang, "файл не выбран"))
 		return
 	}
-	defer file.Close()
+	defer closeRead("загруженный файл", file)
 	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
 		if errors.Is(err, errUploadTooLarge) {
@@ -183,7 +183,7 @@ func (s *Server) adminExtProcessorExport(w http.ResponseWriter, r *http.Request)
 	fname := rec.Name + ".obform"
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.Header().Set("Content-Disposition", contentDisposition(fname))
-	w.Write(bundle)
+	writeDownload(w, fname, bundle)
 }
 
 func (s *Server) reloadExtProcessors(ctx context.Context) {

--- a/internal/ui/extreports.go
+++ b/internal/ui/extreports.go
@@ -56,7 +56,7 @@ func (s *Server) adminExtReportUpload(w http.ResponseWriter, r *http.Request) {
 		s.extReportRedirect(w, r, "", s.tr(lang, "файл не выбран"))
 		return
 	}
-	defer file.Close()
+	defer closeRead("загруженный файл", file)
 	data, err := readUploadedBytes(file, maxSize)
 	if err != nil {
 		if errors.Is(err, errUploadTooLarge) {
@@ -163,7 +163,7 @@ func (s *Server) adminExtReportExport(w http.ResponseWriter, r *http.Request) {
 	fname := rec.Name + ".obform"
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.Header().Set("Content-Disposition", contentDisposition(fname))
-	w.Write(bundle)
+	writeDownload(w, fname, bundle)
 }
 
 // validateReportQuery компилирует запрос отчёта по схеме конфигурации и (на

--- a/internal/ui/handlers_attachments.go
+++ b/internal/ui/handlers_attachments.go
@@ -71,7 +71,7 @@ func (s *Server) attachmentUpload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.tr(lang, "Нет файла в форме"), 400)
 		return
 	}
-	defer file.Close()
+	defer closeRead("загруженный файл", file)
 
 	mimeType := header.Header.Get("Content-Type")
 	if mimeType == "" {
@@ -116,7 +116,7 @@ func (s *Server) attachmentDownload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.tr(s.resolveLang(r), "Файл не найден"), 404)
 		return
 	}
-	defer f.Close()
+	defer closeRead("загруженный файл", f)
 
 	// Авторизация (защита от IDOR): отдаём вложение только тем, у кого есть право
 	// чтения родителя (или записи — чтобы предпросмотр у загрузчика работал сразу).

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -892,11 +892,11 @@ func (s *Server) renderPopupSaved(w http.ResponseWriter, id, label string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	idJSON, _ := json.Marshal(id)
 	labelJSON, _ := json.Marshal(label)
-	fmt.Fprintf(w, `<!doctype html><html><body><script>
+	writeBody(w, fmt.Appendf(nil, `<!doctype html><html><body><script>
 try {
   window.parent.postMessage({source:"obRefCreate", id:%s, label:%s}, "*");
 } catch (e) {}
-</script>Готово.</body></html>`, idJSON, labelJSON)
+</script>Готово.</body></html>`, idJSON, labelJSON))
 }
 
 // pickObjectFormWithReadHook возвращает форму ОБЪЕКТА (Kind=="object"),

--- a/internal/ui/handlers_home.go
+++ b/internal/ui/handlers_home.go
@@ -99,7 +99,7 @@ func (s *Server) logo(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 	}
 	w.Header().Set("Cache-Control", "public, max-age=3600")
-	w.Write(data)
+	writeBody(w, data)
 }
 
 func (s *Server) index(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/handlers_image.go
+++ b/internal/ui/handlers_image.go
@@ -43,7 +43,7 @@ func (s *Server) imageUpload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.tr(lang, "Нет файла в форме"), 400)
 		return
 	}
-	defer file.Close()
+	defer closeRead("загруженную картинку", file)
 
 	// Тип определяем по СОДЕРЖИМОМУ файла, а не по Content-Type формы (он
 	// подделывается): читаем первые 512 байт для http.DetectContentType и
@@ -93,7 +93,7 @@ func (s *Server) imageServe(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, s.tr(s.resolveLang(r), "Файл не найден"), 404)
 		return
 	}
-	defer rc.Close()
+	defer closeRead("загруженную картинку", rc)
 
 	// Авторизация (защита от IDOR): если у блоба есть владелец-сущность, отдаём
 	// только тем, у кого есть право чтения видимой строки (или записи — чтобы
@@ -132,7 +132,11 @@ func (s *Server) imageServe(w http.ResponseWriter, r *http.Request) {
 	// открытии /image/{id} он будет инертен. На отрисовку через <img> не влияет.
 	w.Header().Set("Content-Disposition", "inline")
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
-	io.Copy(w, rc)
+	// Ответ уже начат — статус не поменять. Картинка, дописанная наполовину,
+	// видна пользователю сразу, а причина обрыва почти всегда внешняя.
+	if _, err := io.Copy(w, rc); err != nil {
+		uiLog().Debug("картинка не дописана в ответ", "err", err)
+	}
 }
 
 func (s *Server) blobAllowed(r *http.Request, b storage.Blob) bool {

--- a/internal/ui/handlers_journals.go
+++ b/internal/ui/handlers_journals.go
@@ -286,6 +286,7 @@ func (s *Server) journalExcel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	w.Header().Set("Content-Disposition", contentDisposition(j.Name+".xlsx"))
-	w.Write(data)
+	name := j.Name + ".xlsx"
+	w.Header().Set("Content-Disposition", contentDisposition(name))
+	writeDownload(w, name, data)
 }

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -123,7 +123,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	if decl == nil {
-		enc.Encode(formEventResponse{OK: true, Messages: []string{
+		respondJSON(enc, formEventResponse{OK: true, Messages: []string{
 			"⚠ Процедура «" + procName + "» не найдена в .form.os",
 		}})
 		return
@@ -234,7 +234,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	// клиент покажет красный баннер и не закроет форму.
 	if runErr := s.interp.Run(decl, thisObj, vars); runErr != nil {
 		values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, entity, obj, condRuntime.rules, msgs)
-		enc.Encode(formEventResponse{
+		respondJSON(enc, formEventResponse{
 			OK:             false,
 			Values:         values,
 			TableParts:     tableParts,
@@ -248,7 +248,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	}
 
 	values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, entity, obj, condRuntime.rules, msgs)
-	enc.Encode(formEventResponse{
+	respondJSON(enc, formEventResponse{
 		OK:             true,
 		Values:         values,
 		TableParts:     tableParts,
@@ -789,7 +789,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 
 				if runErr := s.interp.Run(decl, thisObj, vars); runErr != nil {
 					values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, virtEntity, obj, condRuntime.rules, msgs)
-					enc.Encode(formEventResponse{
+					respondJSON(enc, formEventResponse{
 						OK:             false,
 						Values:         values,
 						TableParts:     tableParts,
@@ -803,7 +803,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 				}
 
 				values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, virtEntity, obj, condRuntime.rules, msgs)
-				enc.Encode(formEventResponse{
+				respondJSON(enc, formEventResponse{
 					OK:             true,
 					Values:         values,
 					TableParts:     tableParts,
@@ -844,14 +844,14 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 
 		err := s.interp.Run(procDecl, paramsThis, dslVars)
 		if err != nil {
-			enc.Encode(formEventResponse{
+			respondJSON(enc, formEventResponse{
 				OK:       false,
 				Messages: msgs,
 				Error:    err.Error(),
 			})
 			return
 		}
-		enc.Encode(formEventResponse{
+		respondJSON(enc, formEventResponse{
 			OK:       true,
 			Messages: msgs,
 		})

--- a/internal/ui/handlers_print.go
+++ b/internal/ui/handlers_print.go
@@ -57,7 +57,7 @@ func (s *Server) printDocument(w http.ResponseWriter, r *http.Request) {
 		sd.SetBackURL(backPath)
 		html := sd.Doc.HTML(sheet.HTMLOptions{BackURL: sd.Doc.BackURL, PDFURL: r.URL.Path + "/pdf"})
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(html))
+		writeBody(w, []byte(html))
 		return
 	}
 
@@ -71,7 +71,7 @@ func (s *Server) printDocument(w http.ResponseWriter, r *http.Request) {
 		backPath := fmt.Sprintf("/ui/%s/%s/%s", strings.ToLower(string(entity.Kind)), strings.ToLower(entity.Name), id.String())
 		html := doc.HTML(sheet.HTMLOptions{BackURL: backPath, PDFURL: r.URL.Path + "/pdf"})
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(html))
+		writeBody(w, []byte(html))
 
 	case runtime.PrintFormDSL:
 		sd, ok := s.buildDSLPF(w, r, entity, id, ref.Name)
@@ -82,7 +82,7 @@ func (s *Server) printDocument(w http.ResponseWriter, r *http.Request) {
 		sd.SetBackURL(backPath)
 		html := sd.Doc.HTML(sheet.HTMLOptions{BackURL: sd.Doc.BackURL, PDFURL: r.URL.Path + "/pdf"})
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(html))
+		writeBody(w, []byte(html))
 
 	default: // Legacy — конвертируется в макет v2 при загрузке (ref.Decl) и
 		// рендерится тем же декларативным движком, что и Declarative (план 64, этап 4).
@@ -98,7 +98,7 @@ func (s *Server) printDocument(w http.ResponseWriter, r *http.Request) {
 		backPath := fmt.Sprintf("/ui/%s/%s/%s", strings.ToLower(string(entity.Kind)), strings.ToLower(entity.Name), id.String())
 		html := doc.HTML(sheet.HTMLOptions{BackURL: backPath, PDFURL: r.URL.Path + "/pdf"})
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(html))
+		writeBody(w, []byte(html))
 	}
 }
 
@@ -294,8 +294,9 @@ func (s *Server) printDocumentPDF(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/pdf")
-		w.Header().Set("Content-Disposition", contentDisposition(formName+".pdf"))
-		w.Write(pdfBytes)
+		name := formName + ".pdf"
+		w.Header().Set("Content-Disposition", contentDisposition(name))
+		writeDownload(w, name, pdfBytes)
 		return
 	}
 
@@ -354,7 +355,7 @@ func (s *Server) printDocumentPDF(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/pdf")
 	w.Header().Set("Content-Disposition", contentDisposition(fileName))
-	w.Write(pdfBytes)
+	writeDownload(w, fileName, pdfBytes)
 }
 
 // buildDSLPF выполняет общую часть DSL-печати: находит форму/процедуру,

--- a/internal/ui/handlers_processors.go
+++ b/internal/ui/handlers_processors.go
@@ -169,7 +169,7 @@ func (s *Server) processorRun(w http.ResponseWriter, r *http.Request) {
 			file, _, err := r.FormFile(p.Name)
 			if err == nil {
 				data, err := readUploadedBytes(file, maxSize)
-				file.Close()
+				closeRead("загруженный файл параметра", file)
 				if err != nil {
 					opStatus = "error"
 					http.Error(w, s.errText(r, err), uploadErrorStatus(err))

--- a/internal/ui/handlers_reports.go
+++ b/internal/ui/handlers_reports.go
@@ -639,6 +639,7 @@ func (s *Server) reportExcel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-	w.Header().Set("Content-Disposition", contentDisposition(rep.Name+".xlsx"))
-	w.Write(data)
+	name := rep.Name + ".xlsx"
+	w.Header().Set("Content-Disposition", contentDisposition(name))
+	writeDownload(w, name, data)
 }

--- a/internal/ui/intake_http.go
+++ b/internal/ui/intake_http.go
@@ -62,7 +62,7 @@ func (s *Server) dispatchIntake(w http.ResponseWriter, r *http.Request) bool {
 	if r.Body != nil {
 		var rerr error
 		body, rerr = io.ReadAll(http.MaxBytesReader(w, r.Body, s.maxFileSizeBytes))
-		r.Body.Close()
+		closeRead("тело запроса", r.Body)
 		if rerr != nil {
 			var maxErr *http.MaxBytesError
 			if errors.As(rerr, &maxErr) {

--- a/internal/ui/report_pdf.go
+++ b/internal/ui/report_pdf.go
@@ -32,8 +32,9 @@ func (s *Server) reportPDF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/pdf")
-	w.Header().Set("Content-Disposition", contentDisposition(rep.Name+".pdf"))
-	w.Write(pdfBytes)
+	name := rep.Name + ".pdf"
+	w.Header().Set("Content-Disposition", contentDisposition(name))
+	writeDownload(w, name, pdfBytes)
 }
 
 // buildReportSheet строит табличный документ из заголовков и строк отчёта:

--- a/internal/ui/respond.go
+++ b/internal/ui/respond.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"encoding/json"
 	"html/template"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -48,4 +49,53 @@ func renderTemplate(w http.ResponseWriter, t *template.Template, name string, da
 // renderAdminTemplate отрисовывает шаблон админки в уже начатый ответ.
 func renderAdminTemplate(w http.ResponseWriter, name string, data any) {
 	renderTemplate(w, adminTmpl, name, data)
+}
+
+// writeBody дописывает тело уже начатого ответа: страницу, фрагмент, картинку.
+// Обрыв виден пользователю сразу (пустая страница, битая картинка), причина
+// почти всегда внешняя — закрыли вкладку. Debug, иначе журнал зальёт.
+// G705 (taint-анализ gosec) видит здесь единый сток для HTML-ответов и не видит
+// санитизацию: путь, из-за которого правило срабатывает, — печатная форма
+// (проверено побайтовым отключением вызовов), а она экранируется внутри
+// internal/sheet собственными escapeHTML/richtext.Sanitize/csssafe и allowlist
+// classifyPicture. Стандартных html.EscapeString/template там нет, поэтому
+// gosec их не распознаёт. То же решение и по той же причине принято в
+// internal/launcher/respond.go.
+func writeBody(w http.ResponseWriter, b []byte) {
+	if _, err := w.Write(b); err != nil { //nolint:gosec // G705: HTML печатной формы санитизируется в internal/sheet — gosec этих санитайзеров не знает
+		uiLog().Debug("не удалось записать тело ответа", "err", err)
+	}
+}
+
+// writeDownload отдаёт содержимое, которое пользователь сохраняет файлом: PDF
+// печатной формы, выгрузку xlsx, бандл внешней формы.
+//
+// Уровень выше, чем у writeBody, по той же причине, что и в конфигураторе:
+// обрыв здесь НЕ виден. Получается внешне целый, но усечённый файл — отчёт,
+// который откроется с половиной строк, и это спишут на данные, а не на обрыв
+// загрузки.
+// G705 здесь ложное по контракту: все вызывающие отдают вложение
+// (Content-Disposition) с не-HTML типом — application/pdf, xlsx, x-yaml, а в
+// export_jobs — один из этих двух. HTML-страницу через эту функцию не отдают, и
+// браузер её содержимое не исполняет.
+func writeDownload(w http.ResponseWriter, name string, b []byte) {
+	if _, err := w.Write(b); err != nil { //nolint:gosec // G705: ответ не HTML-страница — вложение с типом pdf/xlsx/yaml
+		uiLog().Warn("ответ с файлом оборван — содержимое у пользователя усечено",
+			"file", name, "size", len(b), "err", err)
+	}
+}
+
+// closeRead закрывает читающую сторону: загруженный файл, тело запроса,
+// открытое вложение. Данные уже прочитаны, ошибка вторична — Debug.
+func closeRead(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		uiLog().Debug("не удалось закрыть "+what, "err", err)
+	}
+}
+
+// bestEffort фиксирует ошибку уборки, не меняя исход операции.
+func bestEffort(what string, err error) {
+	if err != nil {
+		uiLog().Debug("не удалось "+what, "err", err)
+	}
 }

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -198,7 +198,7 @@ func (s *Server) serviceDispatch(w http.ResponseWriter, r *http.Request) {
 	if r.Body != nil {
 		var rerr error
 		body, rerr = io.ReadAll(http.MaxBytesReader(w, r.Body, s.maxFileSizeBytes))
-		r.Body.Close()
+		closeRead("тело запроса", r.Body)
 		if rerr != nil {
 			// Тело больше лимита нельзя молча усекать: hmac посчитал бы подпись
 			// по огрызку (ложный 401), а обработчик обработал бы битые данные.

--- a/internal/ui/testreport.go
+++ b/internal/ui/testreport.go
@@ -31,6 +31,34 @@ func WriteReport(w io.Writer, res TestRunResult, format string) error {
 	return fmt.Errorf("неизвестный формат отчёта %q (доступны pretty, tap, junit)", format)
 }
 
+// errWriter копит первую ошибку записи, чтобы не превращать формирование отчёта
+// в лестницу проверок после каждой строки.
+//
+// Ошибка здесь не косметическая: WriteReport вызывается из `onebase test`, и
+// отчёт уходит либо в stdout, либо в файл (internal/cli/test.go). Записи не
+// проверялись вовсе, поэтому при заполненном диске команда сообщала об успехе, а
+// на диске оставался обрезанный отчёт. Для TAP и JUnit это опаснее, чем для
+// человекочитаемого вывода: CI разберёт усечённый файл как меньшее число тестов
+// и покажет зелёную сборку.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, a ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, a...)
+}
+
+func (e *errWriter) println(a ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintln(e.w, a...)
+}
+
 // caseStatus классифицирует тест: "pass" | "fail" | "error". Пустой тест (без
 // проверок и без ошибки) — это "fail".
 func caseStatus(c TestCaseResult) string {
@@ -47,31 +75,32 @@ func caseStatus(c TestCaseResult) string {
 // ─── pretty ───────────────────────────────────────────────────────────────────
 
 func writePretty(w io.Writer, res TestRunResult) error {
+	ew := &errWriter{w: w}
 	for _, c := range res.Cases {
-		fmt.Fprintf(w, "▶ %s\n", c.Name)
+		ew.printf("▶ %s\n", c.Name)
 		for _, o := range c.Asserts {
 			if o.Passed {
-				fmt.Fprintf(w, "  ok    — %s\n", o.Desc)
+				ew.printf("  ok    — %s\n", o.Desc)
 			} else if o.Detail != "" {
-				fmt.Fprintf(w, "  ПРОВАЛ — %s (%s)\n", o.Desc, o.Detail)
+				ew.printf("  ПРОВАЛ — %s (%s)\n", o.Desc, o.Detail)
 			} else {
-				fmt.Fprintf(w, "  ПРОВАЛ — %s\n", o.Desc)
+				ew.printf("  ПРОВАЛ — %s\n", o.Desc)
 			}
 		}
 		if c.Err != nil {
-			fmt.Fprintf(w, "  ОШИБКА — %s\n", c.Err.Error())
+			ew.printf("  ОШИБКА — %s\n", c.Err.Error())
 		}
 		if len(c.Asserts) == 0 && c.Err == nil {
-			fmt.Fprintln(w, "  (без единой проверки — тест считается неуспешным)")
+			ew.println("  (без единой проверки — тест считается неуспешным)")
 		}
-		fmt.Fprintf(w, "  %s  (%s)\n", caseSummary(c), fmtDuration(c.Duration))
+		ew.printf("  %s  (%s)\n", caseSummary(c), fmtDuration(c.Duration))
 	}
 
 	tests, passedTests, asserts, failedAsserts := res.Totals()
-	fmt.Fprintln(w, "── Итог ──")
-	fmt.Fprintf(w, "Тестов: %d, успешно: %d, провалено: %d\n", tests, passedTests, tests-passedTests)
-	fmt.Fprintf(w, "Проверок: %d, провалено: %d\n", asserts, failedAsserts)
-	return nil
+	ew.println("── Итог ──")
+	ew.printf("Тестов: %d, успешно: %d, провалено: %d\n", tests, passedTests, tests-passedTests)
+	ew.printf("Проверок: %d, провалено: %d\n", asserts, failedAsserts)
+	return ew.err
 }
 
 func caseSummary(c TestCaseResult) string {
@@ -95,21 +124,22 @@ func fmtDuration(d time.Duration) string {
 // ─── TAP (Test Anything Protocol v13) ─────────────────────────────────────────
 
 func writeTAP(w io.Writer, res TestRunResult) error {
-	fmt.Fprintln(w, "TAP version 13")
-	fmt.Fprintf(w, "1..%d\n", len(res.Cases))
+	ew := &errWriter{w: w}
+	ew.println("TAP version 13")
+	ew.printf("1..%d\n", len(res.Cases))
 	for i, c := range res.Cases {
 		status := "ok"
 		if caseStatus(c) != "pass" {
 			status = "not ok"
 		}
-		fmt.Fprintf(w, "%s %d - %s\n", status, i+1, c.Name)
+		ew.printf("%s %d - %s\n", status, i+1, c.Name)
 		// Диагностика проваленного/ошибочного теста — YAML-блок.
 		if caseStatus(c) == "pass" {
 			continue
 		}
-		fmt.Fprintln(w, "  ---")
+		ew.println("  ---")
 		if c.Err != nil {
-			fmt.Fprintf(w, "  error: %s\n", tapScalar(c.Err.Error()))
+			ew.printf("  error: %s\n", tapScalar(c.Err.Error()))
 		}
 		var failed []string
 		for _, o := range c.Asserts {
@@ -122,17 +152,17 @@ func writeTAP(w io.Writer, res TestRunResult) error {
 			}
 		}
 		if len(failed) > 0 {
-			fmt.Fprintln(w, "  failures:")
+			ew.println("  failures:")
 			for _, f := range failed {
-				fmt.Fprintf(w, "    - %s\n", tapScalar(f))
+				ew.printf("    - %s\n", tapScalar(f))
 			}
 		}
 		if len(c.Asserts) == 0 && c.Err == nil {
-			fmt.Fprintln(w, "  error: тест без единой проверки")
+			ew.println("  error: тест без единой проверки")
 		}
-		fmt.Fprintln(w, "  ...")
+		ew.println("  ...")
 	}
-	return nil
+	return ew.err
 }
 
 // tapScalar экранирует значение для YAML-скаляра TAP-диагностики: кавычит и

--- a/internal/ui/widget_helpers.go
+++ b/internal/ui/widget_helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -147,8 +148,13 @@ func toFloatForCell(v any) float64 {
 	case int64:
 		return float64(t)
 	case string:
-		var f float64
-		fmt.Sscanf(t, "%f", &f)
+		// Нечисловая строка даёт 0 — это и было прежним поведением, менять его
+		// здесь нельзя: функция приводит произвольное значение виджета к числу
+		// и вызывается на данных, где нечисловое значение штатно.
+		f, err := strconv.ParseFloat(strings.TrimSpace(t), 64)
+		if err != nil {
+			return 0
+		}
 		return f
 	}
 	return 0


### PR DESCRIPTION
**errcheck `internal/ui`: 56 → 0. Пакет закрыт** (было 64 в начале).

## Зелёная сборка на обрезанном отчёте

`WriteReport` объявлен возвращающим `error`, но **ни одна запись внутри не проверялась** — функция всегда возвращала `nil`. Отчёт уходит в stdout или в **файл** (`internal/cli/test.go`), поэтому при заполненном диске `onebase test` сообщал об успехе, а на диске оставался обрезанный отчёт.

Для TAP и JUnit это опаснее, чем для человекочитаемого вывода: **CI разберёт усечённый файл как меньшее число тестов и покажет зелёную сборку.**

Введён `errWriter`, копящий первую ошибку, — иначе формирование отчёта превратилось бы в лестницу проверок после каждой строки.

## Записи в ответ — по признаку «заметит ли пользователь обрыв»

Разделение то же, что в конфигураторе:

| Что пишем | Помощник | Уровень | Почему |
|---|---|---|---|
| Страница, фрагмент, картинка | `writeBody` | Debug | Обрыв виден сразу, причина внешняя — закрыли вкладку |
| То, что пользователь сохраняет файлом | `writeDownload` | **Warn** | Обрыв **не** виден: отчёт откроется с половиной строк, и это спишут на данные, а не на оборванную загрузку |

Все девять вызывающих `writeDownload` отдают вложение с не-HTML типом (`application/pdf`, xlsx, `application/x-yaml`) — проверено по вызовам; на этом же стоит обоснование подавления `G705`.

## G705 разобран, а не подавлен вслепую

Побайтовым отключением вызовов найдено: taint для `writeBody` приходит из **печатной формы**, а она экранируется внутри `internal/sheet` собственными `escapeHTML` / `richtext.Sanitize` / `csssafe` и allowlist `classifyPicture`. Стандартных `html.EscapeString`/`template` там нет, поэтому gosec их не распознаёт.

Ровно тот же вывод и то же обоснование, что в `internal/launcher/respond.go`.

## Остальное

Уборка (`closeRead`/`bestEffort`) — по решению, принятому в `internal/launcher`: читающая сторона и обходы каталогов на Debug, потому что эти сбои штатный фон.

`widget_helpers`: `fmt.Sscanf` → `strconv.ParseFloat`. Возврат 0 на нечисловой строке **сохранён намеренно** — функция приводит произвольное значение виджета к числу и вызывается на данных, где нечисловое штатно.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)