### PR TITLE
refactor(cli): вывод, флаги и уборка команд через явные решения (план 109D)

### DIFF
--- a/internal/cli/aiguide.go
+++ b/internal/cli/aiguide.go
@@ -40,7 +40,7 @@ func runAIGuide(cmd *cobra.Command, _ []string) error {
 	guide := generateAIGuide(environmentNote(proj))
 	out, _ := cmd.Flags().GetString("output")
 	if out == "" {
-		fmt.Fprint(os.Stdout, guide)
+		outf("%s", guide)
 		return nil
 	}
 	if err := os.WriteFile(out, []byte(guide), 0o644); err != nil {

--- a/internal/cli/backup_test.go
+++ b/internal/cli/backup_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/spf13/cobra"
 )
 
 func TestRequireOneDBTarget(t *testing.T) {

--- a/internal/cli/baseresolve.go
+++ b/internal/cli/baseresolve.go
@@ -98,8 +98,8 @@ func (bc *baseConfig) materializeDBConfig(ctx context.Context) (string, func(), 
 	}
 	if err := configdb.New(db).ExportToDir(ctx, tmp); err != nil {
 		db.Close()
-		os.RemoveAll(tmp)
+		removeTemp(tmp)
 		return "", nil, err
 	}
-	return tmp, func() { db.Close(); os.RemoveAll(tmp) }, nil
+	return tmp, func() { db.Close(); removeTemp(tmp) }, nil
 }

--- a/internal/cli/bench.go
+++ b/internal/cli/bench.go
@@ -70,7 +70,7 @@ func runBench(cmd *cobra.Command, _ []string) error {
 		tmp := filepath.Join(os.TempDir(), fmt.Sprintf("onebase-bench-%d.db", time.Now().UnixNano()))
 		db, err = storage.ConnectSQLite(ctx, tmp)
 		dbKind = "sqlite(temp)"
-		defer os.Remove(tmp)
+		defer removeTemp(tmp)
 	}
 	if err != nil {
 		return fmt.Errorf("bench: подключение к БД: %w", err)
@@ -150,21 +150,20 @@ func printBenchJSON(env benchEnvInfo, results []bench.Result) error {
 }
 
 func printBenchText(env benchEnvInfo, results []bench.Result) {
-	w := os.Stdout
-	fmt.Fprintf(w, "onebase bench — проведение документов (эталонная база)\n")
-	fmt.Fprintf(w, "  версия:  %s (go %s, %s/%s, CPU=%d)\n", env.OnebaseVersion, env.GoVersion, env.OS, env.Arch, env.NumCPU)
-	fmt.Fprintf(w, "  БД:      %s\n\n", env.DB)
+	outf("onebase bench — проведение документов (эталонная база)\n")
+	outf("  версия:  %s (go %s, %s/%s, CPU=%d)\n", env.OnebaseVersion, env.GoVersion, env.OS, env.Arch, env.NumCPU)
+	outf("  БД:      %s\n\n", env.DB)
 
-	fmt.Fprintf(w, "%-8s %10s %8s %9s %9s %9s %7s\n", "потоки", "док/сек", "ошибки", "p50", "p95", "p99", "APDEX")
-	fmt.Fprintf(w, "%s\n", "----------------------------------------------------------------------")
+	outf("%-8s %10s %8s %9s %9s %9s %7s\n", "потоки", "док/сек", "ошибки", "p50", "p95", "p99", "APDEX")
+	outf("%s\n", "----------------------------------------------------------------------")
 	for _, r := range results {
-		fmt.Fprintf(w, "%-8d %10.1f %8d %9s %9s %9s %7.2f\n",
+		outf("%-8d %10.1f %8d %9s %9s %9s %7.2f\n",
 			r.Threads, r.Throughput, r.Errors,
 			ms(r.P50), ms(r.P95), ms(r.P99), r.Apdex)
 	}
-	fmt.Fprintln(w)
+	outln()
 	for _, r := range results {
-		fmt.Fprintf(w, "  [%d поток(ов)] операций=%d, время=%s, min=%s, среднее=%s, max=%s\n",
+		outf("  [%d поток(ов)] операций=%d, время=%s, min=%s, среднее=%s, max=%s\n",
 			r.Threads, r.Ops, r.Elapsed.Round(time.Millisecond), ms(r.Min), ms(r.Mean), ms(r.Max))
 	}
 }

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -72,7 +72,12 @@ func runCheckWithOptions(cmd *cobra.Command, opts configcheck.Options) error {
 	if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		enc.Encode(res)
+		// В отличие от человекочитаемого вывода, этот JSON разбирает CI:
+		// недописанный отчёт там превратится в ошибку разбора на чужой
+		// стороне. Лучше упасть здесь, с понятной причиной.
+		if err := enc.Encode(res); err != nil {
+			return err
+		}
 	} else {
 		printIssuesText(res)
 	}

--- a/internal/cli/convert.go
+++ b/internal/cli/convert.go
@@ -24,8 +24,8 @@ func init() {
 	convertCmd.Flags().String("from", "1c-xml", "source format: 1c-xml")
 	convertCmd.Flags().String("dir", "", "path to the 1C:Enterprise XML export directory")
 	convertCmd.Flags().String("out", "", "output directory for the onebase project")
-	convertCmd.MarkFlagRequired("dir")
-	convertCmd.MarkFlagRequired("out")
+	mustMarkRequired(convertCmd, "dir")
+	mustMarkRequired(convertCmd, "out")
 }
 
 func runConvert(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/describe.go
+++ b/internal/cli/describe.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -313,7 +312,7 @@ func runDescribe(cmd *cobra.Command, _ []string) error {
 
 	compact, _ := cmd.Flags().GetBool("compact")
 	if compact {
-		fmt.Fprint(os.Stdout, projectAIContext(proj))
+		outf("%s", projectAIContext(proj))
 		return nil
 	}
 

--- a/internal/cli/examples.go
+++ b/internal/cli/examples.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -41,7 +40,7 @@ func runExamples(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("неизвестный вид примера %q\nдоступно:\n%s", args[0], strings.Join(exampleKinds(), "\n"))
 	}
-	fmt.Fprint(os.Stdout, text)
+	outf("%s", text)
 	if !strings.HasSuffix(text, "\n") {
 		outln()
 	}

--- a/internal/cli/exchange.go
+++ b/internal/cli/exchange.go
@@ -198,7 +198,7 @@ func exchangeInitToken(cmd *cobra.Command) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("чтение token-file: %w", err)
 		}
-		defer f.Close()
+		defer closeRead("файл обмена", f)
 		const maxTokenBytes = 64 << 10
 		data, err := io.ReadAll(io.LimitReader(f, maxTokenBytes+1))
 		if err != nil {
@@ -260,7 +260,7 @@ func readExchangePackage(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer closeRead("файл обмена", f)
 	data, err := io.ReadAll(io.LimitReader(f, exchange.MaxPackageBytes+1))
 	if err != nil {
 		return nil, err

--- a/internal/cli/forms.go
+++ b/internal/cli/forms.go
@@ -70,17 +70,17 @@ func init() {
 	formsConvertFromCmd.Flags().String("form-name", "", "имя создаваемой формы (по умолчанию из имени каталога)")
 	formsConvertFromCmd.Flags().String("form-kind", "custom", "тип формы: object|list|choice|folder|custom")
 	formsConvertFromCmd.Flags().String("dst", "", "корень проекта OneBase (внутри будет создан forms/<entity>/)")
-	formsConvertFromCmd.MarkFlagRequired("src")
-	formsConvertFromCmd.MarkFlagRequired("entity")
-	formsConvertFromCmd.MarkFlagRequired("dst")
+	mustMarkRequired(formsConvertFromCmd, "src")
+	mustMarkRequired(formsConvertFromCmd, "entity")
+	mustMarkRequired(formsConvertFromCmd, "dst")
 
 	formsConvertToCmd.Flags().String("src", "", "путь к .form.yaml в проекте OneBase")
 	formsConvertToCmd.Flags().String("dst", "", "целевой каталог Forms/<X>/Ext в выгрузке 1С")
-	formsConvertToCmd.MarkFlagRequired("src")
-	formsConvertToCmd.MarkFlagRequired("dst")
+	mustMarkRequired(formsConvertToCmd, "src")
+	mustMarkRequired(formsConvertToCmd, "dst")
 
 	formsValidateCmd.Flags().String("src", "", "путь к .form.yaml")
-	formsValidateCmd.MarkFlagRequired("src")
+	mustMarkRequired(formsValidateCmd, "src")
 
 	formsCmd.AddCommand(formsConvertFromCmd)
 	formsCmd.AddCommand(formsConvertToCmd)

--- a/internal/cli/gc_blobs.go
+++ b/internal/cli/gc_blobs.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -93,15 +92,14 @@ func runGcBlobs(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	out := os.Stdout
-	fmt.Fprintf(out, "Всего блобов:        %d\n", st.TotalBlobs)
-	fmt.Fprintf(out, "Живых ссылок:        %d\n", st.LiveRefs)
-	fmt.Fprintf(out, "Защищено grace-окном: %d (моложе %s)\n", st.Protected, minAge)
-	fmt.Fprintf(out, "Сирот:               %d\n", len(st.Orphans))
+	outf("Всего блобов:        %d\n", st.TotalBlobs)
+	outf("Живых ссылок:        %d\n", st.LiveRefs)
+	outf("Защищено grace-окном: %d (моложе %s)\n", st.Protected, minAge)
+	outf("Сирот:               %d\n", len(st.Orphans))
 	if doDelete {
-		fmt.Fprintf(out, "Удалено:             %d\n", st.Deleted)
+		outf("Удалено:             %d\n", st.Deleted)
 	} else if len(st.Orphans) > 0 {
-		fmt.Fprintln(out, "Режим предпросмотра — ничего не удалено. Для удаления добавьте --delete.")
+		outln("Режим предпросмотра — ничего не удалено. Для удаления добавьте --delete.")
 	}
 	return nil
 }

--- a/internal/cli/ibases.go
+++ b/internal/cli/ibases.go
@@ -32,13 +32,15 @@ var ibasesListCmd = &cobra.Command{
 			return nil
 		}
 		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(tw, "ID\tNAME\tSOURCE\tPORT\tDB")
+		// tabwriter копит строки в буфере и отдаёт ошибку записи из Flush,
+		// который проверяется ниже, — поэтому здесь ошибки нет по построению.
+		tabln(tw, "ID\tNAME\tSOURCE\tPORT\tDB")
 		for _, b := range bases {
 			dbLabel := b.DB
 			if b.DBType == "sqlite" {
 				dbLabel = b.DBPath
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n", b.ID[:8]+"…", b.Name, b.ConfigSource, b.Port, dbLabel)
+			tabf(tw, "%s\t%s\t%s\t%d\t%s\n", b.ID[:8]+"…", b.Name, b.ConfigSource, b.Port, dbLabel)
 		}
 		return tw.Flush()
 	},
@@ -80,8 +82,8 @@ var ibasesAddCmd = &cobra.Command{
 			b.DBPath = sqlitePath
 			b.DB = ""
 		}
-		warnMappedNetworkPath(os.Stderr, "файл SQLite", b.DBPath, detectMappedNetworkDrive)
-		warnMappedNetworkPath(os.Stderr, "каталог проекта", b.Path, detectMappedNetworkDrive)
+		warnMappedNetworkPath("файл SQLite", b.DBPath, detectMappedNetworkDrive)
+		warnMappedNetworkPath("каталог проекта", b.Path, detectMappedNetworkDrive)
 		if err := store.Add(b); err != nil {
 			return err
 		}

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -167,7 +167,7 @@ func scanImpactFile(root, path string, needles []impactNeedle) ([]impactMatch, e
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer closeRead("файл конфигурации", f)
 	rel, _ := filepath.Rel(root, path)
 	var out []impactMatch
 	sc := bufio.NewScanner(f)

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
 )
 
 // Вывод сообщений CLI в stdout.
@@ -39,4 +44,52 @@ func outf(format string, a ...any) {
 func outln(a ...any) {
 	// Ошибка не обрабатывается сознательно — обоснование в комментарии к файлу.
 	_, _ = fmt.Fprintln(os.Stdout, a...)
+}
+
+// errln печатает предупреждение в stderr. Обоснование то же, что у outf: если
+// запись в канал сообщений не удалась, сообщить об этом некуда.
+func errln(a ...any) {
+	// Ошибка не обрабатывается сознательно — обоснование в комментарии к файлу.
+	_, _ = fmt.Fprintln(os.Stderr, a...)
+}
+
+// Уборка в командах: удаление временных путей и закрытие читающей стороны.
+//
+// Здесь, в отличие от вывода, канал сообщений исправен — поэтому сбой уборки не
+// проглатывается, а печатается предупреждением. Команда при этом продолжает
+// работу: временный каталог, который не удалился, не повод считать выполненную
+// миграцию или собранный отчёт неудавшимися.
+
+// removeTemp удаляет временный файл или каталог.
+func removeTemp(path string) {
+	if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		errln("предупреждение: не удалён временный путь", path+":", err)
+	}
+}
+
+// closeRead закрывает читающую сторону: данные уже прочитаны.
+func closeRead(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		errln("предупреждение: не закрыт", what+":", err)
+	}
+}
+
+// mustMarkRequired помечает флаг обязательным. Ошибка тут означает опечатку в
+// имени флага, то есть дефект сборки, а не ситуацию времени выполнения:
+// команда молча теряла бы обязательность флага. Падаем сразу при инициализации.
+func mustMarkRequired(cmd *cobra.Command, name string) {
+	if err := cmd.MarkFlagRequired(name); err != nil {
+		panic("cli: MarkFlagRequired(" + name + "): " + err.Error())
+	}
+}
+
+// tabf/tabln печатают строку в tabwriter. Ошибки записи здесь нет по
+// построению: tabwriter копит строки в собственном буфере и отдаёт ошибку
+// только из Flush — а его вызывающий проверяет.
+func tabf(tw *tabwriter.Writer, format string, a ...any) {
+	_, _ = fmt.Fprintf(tw, format, a...)
+}
+
+func tabln(tw *tabwriter.Writer, a ...any) {
+	_, _ = fmt.Fprintln(tw, a...)
 }

--- a/internal/cli/rollup.go
+++ b/internal/cli/rollup.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -118,7 +116,7 @@ func runRollup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("предпросмотр свёртки: %w", err)
 	}
 	outln("Предпросмотр свёртки:")
-	printRollupReport(os.Stdout, prev, keepDocs)
+	printRollupReport(prev, keepDocs)
 
 	if dryRun {
 		outln("\n(--dry-run: изменения не внесены)")
@@ -128,8 +126,14 @@ func runRollup(cmd *cobra.Command, _ []string) error {
 	if !assumeYes {
 		outf("\nВНИМАНИЕ: операция необратима. Сделайте резервную копию (onebase backup).\nПродолжить свёртку на %s? [y/N]: ",
 			date.Format("02.01.2006"))
+		// Ошибку чтения обрабатываем тем же путём, что и любой ответ, кроме
+		// «y»: при закрытом stdin (запуск из скрипта без --yes) ans остаётся
+		// пустым, и необратимая свёртка отменяется. Это и есть нужное
+		// поведение — сомнение трактуется как отказ.
 		var ans string
-		fmt.Scanln(&ans)
+		if _, serr := fmt.Scanln(&ans); serr != nil {
+			ans = ""
+		}
 		if strings.ToLower(strings.TrimSpace(ans)) != "y" {
 			outln("Отменено.")
 			return nil
@@ -141,7 +145,7 @@ func runRollup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("свёртка: %w", err)
 	}
 	outln("\nГотово:")
-	printRollupReport(os.Stdout, rep, keepDocs)
+	printRollupReport(rep, keepDocs)
 	return nil
 }
 
@@ -167,34 +171,36 @@ func selectedRegisterNames(all []*metadata.Register, arg string) []string {
 	return out
 }
 
-func printRollupReport(w io.Writer, rep storage.RollupReport, keepDocs bool) {
-	fmt.Fprintf(w, "  Дата свёртки: %s\n", rep.Cutoff.Format("02.01.2006"))
+// Отчёт всегда идёт в stdout — печатаем через outf/outln, где решение об
+// ошибках записи принято один раз (см. output.go).
+func printRollupReport(rep storage.RollupReport, keepDocs bool) {
+	outf("  Дата свёртки: %s\n", rep.Cutoff.Format("02.01.2006"))
 	for _, r := range rep.Registers {
-		fmt.Fprintf(w, "  %-32s движений: %6d  опорных остатков: %5d\n",
+		outf("  %-32s движений: %6d  опорных остатков: %5d\n",
 			r.Name, r.FoldedMovements, r.OpeningRows)
 	}
 	for _, r := range rep.AccountRegisters {
 		if r.Note != "" {
-			fmt.Fprintf(w, "  %-32s движений: %6d  — %s\n", r.Name, r.FoldedMovements, r.Note)
+			outf("  %-32s движений: %6d  — %s\n", r.Name, r.FoldedMovements, r.Note)
 		} else {
-			fmt.Fprintf(w, "  %-32s движений: %6d  опорных проводок: %5d\n",
+			outf("  %-32s движений: %6d  опорных проводок: %5d\n",
 				r.Name, r.FoldedMovements, r.OpeningRows)
 		}
 	}
 	for _, r := range rep.InfoRegisters {
 		if r.Note != "" {
-			fmt.Fprintf(w, "  %-32s — %s\n", r.Name, r.Note)
+			outf("  %-32s — %s\n", r.Name, r.Note)
 		} else {
-			fmt.Fprintf(w, "  %-32s обрезано строк: %6d  срезов оставлено: %5d\n",
+			outf("  %-32s обрезано строк: %6d  срезов оставлено: %5d\n",
 				r.Name, r.FoldedMovements, r.OpeningRows)
 		}
 	}
 	if keepDocs {
-		fmt.Fprintln(w, "  Документы: снять проведение (не удалять)")
+		outln("  Документы: снять проведение (не удалять)")
 	} else {
-		fmt.Fprintf(w, "  Документы к удалению: %d\n", rep.DeletedDocs)
+		outf("  Документы к удалению: %d\n", rep.DeletedDocs)
 		if rep.DanglingRefs > 0 {
-			fmt.Fprintf(w, "  ⚠ на удаляемые документы ссылается сохраняемых записей: %d — свёртка будет отменена (используйте --keep-documents)\n", rep.DanglingRefs)
+			outf("  ⚠ на удаляемые документы ссылается сохраняемых записей: %d — свёртка будет отменена (используйте --keep-documents)\n", rep.DanglingRefs)
 		}
 	}
 }

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -279,7 +279,7 @@ func installSystemd(exe, svcName, displayName, dsn, sqlitePath, dbType, configSo
 		return fmt.Errorf("не удалось записать %s (запустите с sudo): %w", unitPath, err)
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+	defer removeTemp(tmpPath)
 	// The ExecStart line may contain a PostgreSQL DSN with credentials.
 	if err := tmp.Chmod(0o600); err != nil {
 		_ = tmp.Close()

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -174,7 +174,7 @@ func emitReport(cmd *cobra.Command, res ui.TestRunResult, format string) error {
 	if err != nil {
 		return fmt.Errorf("создать файл отчёта %q: %w", outPath, err)
 	}
-	defer f.Close()
+	defer closeRead("файл отчёта", f)
 	if err := ui.WriteReport(f, res, format); err != nil {
 		return err
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -62,7 +62,7 @@ func runUpdate(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(stageDir)
+	defer removeTemp(stageDir)
 
 	newBin, err := selfupdate.StageBinary(from, stageDir)
 	if err != nil {

--- a/internal/cli/windows_paths.go
+++ b/internal/cli/windows_paths.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"strings"
 )
 
@@ -40,12 +39,12 @@ func mappedDriveAdvice(paths []namedPath) string {
 	return fmt.Sprintf("%s находится на подключённом сетевом диске. Windows-сервис запускается от LocalSystem и не видит mapped drives. Используйте UNC-путь (\\\\server\\share\\...) или локальный диск.", strings.Join(items, ", "))
 }
 
-func warnMappedNetworkPath(w io.Writer, label, path string, detect networkDriveDetector) {
+func warnMappedNetworkPath(label, path string, detect networkDriveDetector) {
 	mapped, err := findMappedNetworkPaths([]namedPath{{Label: label, Path: path}}, detect)
 	if err != nil || len(mapped) == 0 {
 		return
 	}
-	fmt.Fprintln(w, "Предупреждение:", mappedDriveAdvice(mapped))
+	errln("Предупреждение:", mappedDriveAdvice(mapped))
 }
 
 // quoteWindowsCommandArg формирует один аргумент для команды, которую


### PR DESCRIPTION
**errcheck `internal/cli`: 48 → 0. Пакет закрыт.**

## Вывод (29 мест)

Писали в stdout напрямую через `fmt.Fprintf`/`Fprintln`, минуя `outf`/`outln` из `output.go`, где решение об ошибках записи в stdout уже принято и обосновано (#535). Все сведены к этим функциям.

Заодно ушло дублирование `w := os.Stdout` в `bench` и `gc_blobs`, а `printRollupReport` перестал принимать writer, который во всех вызовах был `os.Stdout` и ни разу не подменялся в тестах.

## `MarkFlagRequired` (9 мест) — дефект сборки, а не рантайма

Ошибка означает опечатку в имени флага. Команда молча теряла бы обязательность флага, и пользователь узнавал бы об этом по невнятному падению дальше. `mustMarkRequired` падает сразу при инициализации.

## Два противоположных решения по одному признаку

**`fmt.Scanln` в подтверждении свёртки** — единственное место, где прежнее поведение оказалось **верным**, и его нужно было сохранить, а не «починить». При закрытом stdin (запуск из скрипта без `--yes`) `ans` остаётся пустым, и необратимая свёртка отменяется: сомнение трактуется как отказ. Теперь это записано явно, а не держится на совпадении.

**`enc.Encode` в `onebase check --json`**, наоборот, стал ошибкой: этот JSON разбирает CI, и недописанный отчёт превратился бы в ошибку разбора на чужой стороне. Лучше упасть здесь, с понятной причиной.

## Уборка — уровень иной, чем в ui и лаунчере

`removeTemp`/`closeRead` вынесены в `output.go` рядом с `outf`. У команды канал сообщений **исправен**, поэтому сбой уборки печатается предупреждением в stderr, а не уходит в Debug-журнал. Сама команда продолжает работу: неудалённый временный каталог не повод считать выполненную миграцию неудавшейся.

## `tabf`/`tabln`

`tabwriter` копит строки в своём буфере и отдаёт ошибку только из `Flush`, который вызывающий уже проверяет. Ошибки записи там нет по построению — это записано в комментарии, а не спрятано.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)