### PR TITLE
fix(storage,auth): не регистрировать усечённый блоб и не терять причину входа (план 109D)

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -13,6 +13,10 @@ import (
 
 func authLog() *slog.Logger { return oblog.Component("auth") }
 
+// maxLoginFormBytes — предел тела формы входа. Логин и пароль — короткие поля;
+// запас на порядки больше любого разумного значения и при этом конечен.
+const maxLoginFormBytes = int64(64 << 10)
+
 var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 <html lang="ru">
 <head><meta charset="utf-8"><title>Вход — onebase</title>
@@ -109,7 +113,7 @@ func (h *Handlers) IssueOneTimeCode(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
 	}
-	json.NewEncoder(w).Encode(map[string]any{"code": code})
+	respondJSONTo(w, map[string]any{"code": code})
 }
 
 func (h *Handlers) LoginPage(w http.ResponseWriter, r *http.Request) {
@@ -118,7 +122,7 @@ func (h *Handlers) LoginPage(w http.ResponseWriter, r *http.Request) {
 	if h.Repo != nil {
 		users, _ = h.Repo.ListForSelection(r.Context())
 	}
-	loginTmpl.Execute(w, map[string]any{"Error": "", "Users": users})
+	renderTemplate(w, loginTmpl, map[string]any{"Error": "", "Users": users})
 }
 
 func (h *Handlers) LoginSubmit(w http.ResponseWriter, r *http.Request) {
@@ -129,10 +133,22 @@ func (h *Handlers) LoginSubmit(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(code)
-		loginTmpl.Execute(w, map[string]any{"Error": msg, "Users": users})
+		renderTemplate(w, loginTmpl, map[string]any{"Error": msg, "Users": users})
 	}
 
-	r.ParseForm()
+	// Сбой разбора формы нельзя пропускать: дальше login и password окажутся
+	// пустыми, и попытка входа уйдёт в общий путь «неверный логин или пароль».
+	// Пользователь будет искать ошибку в своих учётных данных, а дело в теле
+	// запроса.
+	//
+	// Тело ограничиваем здесь же: голый ParseForm читает его целиком, а форма
+	// входа доступна без аутентификации — то есть это единственная точка, куда
+	// неаутентифицированный клиент может слать сколько угодно данных.
+	r.Body = http.MaxBytesReader(w, r.Body, maxLoginFormBytes)
+	if err := r.ParseForm(); err != nil {
+		renderErr(w, r, http.StatusBadRequest, "некорректные данные формы")
+		return
+	}
 	login := r.FormValue("login")
 	password := r.FormValue("password")
 
@@ -210,7 +226,7 @@ func (h *Handlers) LoginJSON(w http.ResponseWriter, r *http.Request) {
 
 	h.setSessionCookie(w, r, token)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	respondJSONTo(w, map[string]any{
 		"ok":   true,
 		"user": map[string]any{"id": user.ID, "login": user.Login, "is_admin": user.IsAdmin},
 	})
@@ -250,10 +266,10 @@ func (h *Handlers) Status(w http.ResponseWriter, r *http.Request) {
 	hasUsers, err := h.Repo.HasUsers(r.Context())
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "authentication service unavailable"})
+		respondJSONTo(w, map[string]string{"error": "authentication service unavailable"})
 		return
 	}
-	_ = json.NewEncoder(w).Encode(map[string]any{"requires_auth": hasUsers})
+	respondJSONTo(w, map[string]any{"requires_auth": hasUsers})
 }
 
 // Bootstrap sets the session cookie from a one-time code and redirects.

--- a/internal/auth/respond.go
+++ b/internal/auth/respond.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+)
+
+// Запись в уже начатый ответ страницы входа.
+//
+// Заголовки к этому моменту отправлены, вернуть другой статус нельзя — как и в
+// internal/ui, остаётся зафиксировать сбой и прекратить запись. Уровни те же и
+// по той же причине: JSON обычно не дописывается из-за отсоединившегося
+// клиента (Debug), а сбой шаблона означает ошибку в самом шаблоне и обрезанную
+// страницу входа (Warn) — такое надо видеть, страница входа одна на всех.
+
+func respondJSONTo(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		authLog().Debug("не удалось записать JSON-ответ", "err", err)
+	}
+}
+
+func renderTemplate(w http.ResponseWriter, t *template.Template, data any) {
+	if err := t.Execute(w, data); err != nil {
+		authLog().Warn("не удалось отрисовать страницу входа", "err", err)
+	}
+}

--- a/internal/storage/attachments.go
+++ b/internal/storage/attachments.go
@@ -186,22 +186,19 @@ func (db *DB) UploadAttachment(ctx context.Context, ownerKind, ownerName string,
 		}
 		cnt, cpErr := io.Copy(f, io.LimitReader(r, maxSizeBytes+1))
 		if cpErr != nil {
-			f.Close()
-			os.Remove(filePath)
+			discardPartial(f, filePath)
 			return Attachment{}, cpErr
 		}
 		if cnt > maxSizeBytes {
-			f.Close()
-			os.Remove(filePath)
+			discardPartial(f, filePath)
 			return Attachment{}, attachmentTooLarge(maxSizeBytes)
 		}
 		if err := f.Sync(); err != nil {
-			f.Close()
-			os.Remove(filePath)
+			discardPartial(f, filePath)
 			return Attachment{}, err
 		}
 		if err := f.Close(); err != nil {
-			os.Remove(filePath)
+			removeFile(filePath)
 			return Attachment{}, err
 		}
 		n = cnt
@@ -255,9 +252,7 @@ func (db *DB) stagePutAttachmentS3(ctx context.Context, key, mime string, r io.R
 		return 0, err
 	}
 	defer func() {
-		name := tmp.Name()
-		tmp.Close()
-		os.Remove(name)
+		discardPartial(tmp, tmp.Name())
 	}()
 	n, err := io.Copy(tmp, io.LimitReader(r, maxSizeBytes+1))
 	if err != nil {
@@ -311,7 +306,7 @@ func (db *DB) OpenAttachment(ctx context.Context, id uuid.UUID) (io.ReadSeekClos
 		}
 		f, err := os.Open(filepath.Join(dir, a.ID.String()))
 		if err != nil {
-			os.RemoveAll(dir)
+			removeFile(dir)
 			return nil, nil, err
 		}
 		return &tempDirFile{File: f, dir: dir}, a, nil
@@ -339,7 +334,7 @@ func (db *DB) MaterializeAttachment(ctx context.Context, id uuid.UUID) (string, 
 		if err != nil {
 			return "", nil, nil, err
 		}
-		return filepath.Join(dir, a.ID.String()), func() { os.RemoveAll(dir) }, a, nil
+		return filepath.Join(dir, a.ID.String()), func() { removeFile(dir) }, a, nil
 	}
 	return filepath.Join(db.filesDir, a.OwnerName, id.String()), nil, a, nil
 }
@@ -354,7 +349,7 @@ func (db *DB) downloadAttachmentTemp(ctx context.Context, a *Attachment) (string
 	if err != nil {
 		return "", err
 	}
-	defer rc.Close()
+	defer closeRead("объект вложения в хранилище", rc)
 	base := filepath.Join(db.filesDir, "_attach_tmp")
 	if err := os.MkdirAll(base, 0o755); err != nil {
 		return "", err
@@ -365,16 +360,15 @@ func (db *DB) downloadAttachmentTemp(ctx context.Context, a *Attachment) (string
 	}
 	f, err := os.Create(filepath.Join(dir, a.ID.String()))
 	if err != nil {
-		os.RemoveAll(dir)
+		removeFile(dir)
 		return "", err
 	}
 	if _, err := io.Copy(f, rc); err != nil {
-		f.Close()
-		os.RemoveAll(dir)
+		discardPartial(f, dir)
 		return "", err
 	}
 	if err := f.Close(); err != nil {
-		os.RemoveAll(dir)
+		removeFile(dir)
 		return "", err
 	}
 	return dir, nil
@@ -398,7 +392,9 @@ type tempDirFile struct {
 
 func (t *tempDirFile) Close() error {
 	err := t.File.Close()
-	os.RemoveAll(t.dir)
+	// Каталог — временная материализация вложения из S3. Его неудалённость не
+	// повод подменять ошибку закрытия файла, но и терять её незачем.
+	removeFile(t.dir)
 	return err
 }
 

--- a/internal/storage/audit.go
+++ b/internal/storage/audit.go
@@ -392,11 +392,18 @@ func scanAuditRows(rows auditRowsScanner) ([]*AuditEntry, error) {
 		if recordID != nil {
 			e.RecordID = recordID.String()
 		}
+		// Неразобранное значение оставляло бы в журнале регистрации пустое
+		// «было/стало» — запись, по которой изменение выглядит как отсутствие
+		// изменения. Для журнала аудита это хуже шумной строки.
 		if len(oldVal) > 0 && string(oldVal) != "null" {
-			json.Unmarshal(oldVal, &e.OldValue)
+			if err := json.Unmarshal(oldVal, &e.OldValue); err != nil {
+				storageLog().Warn("значение «было» в журнале регистрации не разобрано", "err", err)
+			}
 		}
 		if len(newVal) > 0 && string(newVal) != "null" {
-			json.Unmarshal(newVal, &e.NewValue)
+			if err := json.Unmarshal(newVal, &e.NewValue); err != nil {
+				storageLog().Warn("значение «стало» в журнале регистрации не разобрано", "err", err)
+			}
 		}
 		entries = append(entries, e)
 	}

--- a/internal/storage/blobs.go
+++ b/internal/storage/blobs.go
@@ -182,17 +182,23 @@ func (db *DB) PutBlob(ctx context.Context, mime string, r io.Reader, maxSizeByte
 			return Blob{}, err
 		}
 		n, err := io.Copy(f, limited)
-		f.Close()
 		if err != nil {
-			os.Remove(fp)
+			discardPartial(f, fp)
 			return Blob{}, err
 		}
 		if n > maxSizeBytes {
-			os.Remove(fp)
+			discardPartial(f, fp)
 			return Blob{}, tooLarge()
 		}
+		// Close на успешном пути — не уборка: он сбрасывает буфер, и его сбой
+		// означает усечённый файл. Раньше ошибка терялась, и insertMeta ниже
+		// регистрировала огрызок как полноценный блоб.
+		if err := f.Close(); err != nil {
+			removeFile(fp)
+			return Blob{}, err
+		}
 		if err := insertMeta(n, FileStorageDisk); err != nil {
-			os.Remove(fp)
+			removeFile(fp)
 			return Blob{}, err
 		}
 		return result(n), nil
@@ -254,7 +260,7 @@ func (db *DB) DeleteBlob(ctx context.Context, id uuid.UUID) error {
 		}
 	} else {
 		// disk / db / легаси: файла на диске может не быть (db-режим) — это не ошибка.
-		os.Remove(filepath.Join(db.filesDir, blobsDirName, id.String()))
+		removeFile(filepath.Join(db.filesDir, blobsDirName, id.String()))
 	}
 	_, err := db.Exec(ctx,
 		fmt.Sprintf(`DELETE FROM _blobs WHERE id=%s`, d.Placeholder(1)), id.String())

--- a/internal/storage/cleanup.go
+++ b/internal/storage/cleanup.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+
+	oblog "github.com/ivantit66/onebase/internal/logging"
+)
+
+// Уборка недописанных файлов вложений и блобов.
+//
+// Хранилище пишет файл, а метаданные о нём — в БД. Если запись файла сорвалась,
+// на диске остаётся огрызок, и его надо убрать до возврата ошибки, иначе
+// следующая попытка упрётся в O_EXCL, а место утечёт. Ошибка самой уборки при
+// этом вторична: наверх идёт причина сбоя записи, подменять её «не удалось
+// удалить временный файл» значит потерять настоящую.
+//
+// Поэтому решение принято один раз здесь: уборка логируется на Debug. Отдельно
+// оговорено то, что уборкой НЕ является: Close пишущей стороны на успешном пути
+// сбрасывает буфер, и его ошибка означает усечённый файл — она обязана дойти до
+// вызывающего, иначе метаданные зарегистрируют огрызок как целый блоб.
+
+func storageLog() *slog.Logger { return oblog.Component("storage") }
+
+// discardPartial закрывает и удаляет недописанный файл на пути ошибки.
+func discardPartial(f *os.File, path string) {
+	if err := f.Close(); err != nil {
+		storageLog().Debug("не удалось закрыть недописанный файл", "path", path, "err", err)
+	}
+	removeFile(path)
+}
+
+// removeFile удаляет файл или каталог; отсутствие — не ошибка.
+func removeFile(path string) {
+	if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		storageLog().Debug("не удалось удалить временный путь", "path", path, "err", err)
+	}
+}
+
+// closeRead закрывает читающую сторону: данные уже прочитаны.
+func closeRead(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		storageLog().Debug("не удалось закрыть "+what, "err", err)
+	}
+}

--- a/internal/storage/crud.go
+++ b/internal/storage/crud.go
@@ -15,23 +15,23 @@ import (
 
 // ListParams controls filtering, search, sorting and pagination for List queries.
 type ListParams struct {
-	Filters           map[string]FilterValue
-	RowFilter         *Predicate            // additional SQL-side row-level access predicate
+	Filters   map[string]FilterValue
+	RowFilter *Predicate // additional SQL-side row-level access predicate
 	// RowFilterEvaluated — строковый доступ был вычислен для этого списка (план
 	// 79F): хендлер прошёл через applyRowFilter/rowFilterFor (даже если политика
 	// неограничивающая — RowFilter при этом nil). Используется strict-RLS
 	// чокпоинтом в List как признак «фильтр не забыли», иначе fail-closed.
 	RowFilterEvaluated bool
-	JournalRowFilters map[string]*Predicate // per document name row-level predicates for journal UNIONs
-	Sort              string                // field Name (empty = default sort by id)
-	Dir               string                // "asc" or "desc"
-	ParentStr         string                // "" = no filter; "root" = parent IS NULL; "<uuid>" = parent = uuid
-	Search            string                // full-text search: ILIKE across all string fields
-	ActivityScope     string                // "", "active", "inactive", "all"; applied only for opt-in catalogs
-	Limit             int                   // 0 = no limit
-	Offset            int                   // for pagination
-	ExcludeFolders    bool                  // for hierarchical catalogs: only non-folder elements
-	OnlyFolders       bool                  // for hierarchical catalogs: only folder elements
+	JournalRowFilters  map[string]*Predicate // per document name row-level predicates for journal UNIONs
+	Sort               string                // field Name (empty = default sort by id)
+	Dir                string                // "asc" or "desc"
+	ParentStr          string                // "" = no filter; "root" = parent IS NULL; "<uuid>" = parent = uuid
+	Search             string                // full-text search: ILIKE across all string fields
+	ActivityScope      string                // "", "active", "inactive", "all"; applied only for opt-in catalogs
+	Limit              int                   // 0 = no limit
+	Offset             int                   // for pagination
+	ExcludeFolders     bool                  // for hierarchical catalogs: only non-folder elements
+	OnlyFolders        bool                  // for hierarchical catalogs: only folder elements
 }
 
 // FilterValue holds a filter for one field.

--- a/internal/storage/dialect.go
+++ b/internal/storage/dialect.go
@@ -83,14 +83,14 @@ type Dialect interface {
 // PgDialect is the PostgreSQL implementation of Dialect.
 type PgDialect struct{}
 
-func (PgDialect) Name() string                       { return "postgres" }
-func (PgDialect) Placeholder(n int) string           { return fmt.Sprintf("$%d", n) }
-func (PgDialect) Now() string                        { return "now()" }
-func (PgDialect) CurrentTimestampTZ() string         { return "now()" }
-func (PgDialect) LowerLike(col string) string        { return "LOWER(" + col + "::text)" }
-func (PgDialect) CaseInsensitiveLikeOp() string      { return "ILIKE" }
-func (PgDialect) TypeBool() string                   { return "BOOLEAN" }
-func (PgDialect) TypeText() string                   { return "TEXT" }
+func (PgDialect) Name() string                  { return "postgres" }
+func (PgDialect) Placeholder(n int) string      { return fmt.Sprintf("$%d", n) }
+func (PgDialect) Now() string                   { return "now()" }
+func (PgDialect) CurrentTimestampTZ() string    { return "now()" }
+func (PgDialect) LowerLike(col string) string   { return "LOWER(" + col + "::text)" }
+func (PgDialect) CaseInsensitiveLikeOp() string { return "ILIKE" }
+func (PgDialect) TypeBool() string              { return "BOOLEAN" }
+func (PgDialect) TypeText() string              { return "TEXT" }
 func (PgDialect) TypeNumber(p, s int) string {
 	if p > 0 {
 		return fmt.Sprintf("NUMERIC(%d,%d)", p, s)
@@ -140,9 +140,9 @@ func (PgDialect) LatestPerKey(cols, partitionBy, orderBy []string, baseTable, al
 // SQLiteDialect is the SQLite implementation of Dialect.
 type SQLiteDialect struct{}
 
-func (SQLiteDialect) Name() string                  { return "sqlite" }
-func (SQLiteDialect) Placeholder(n int) string      { return "?" }
-func (SQLiteDialect) Now() string                   { return "datetime('now')" }
+func (SQLiteDialect) Name() string             { return "sqlite" }
+func (SQLiteDialect) Placeholder(n int) string { return "?" }
+func (SQLiteDialect) Now() string              { return "datetime('now')" }
 
 // CurrentTimestampTZ wraps datetime('now') in parens because SQLite requires
 // non-constant DEFAULT expressions to be parenthesised.
@@ -155,6 +155,7 @@ func (SQLiteDialect) LowerLike(col string) string {
 func (SQLiteDialect) CaseInsensitiveLikeOp() string { return "LIKE" }
 func (SQLiteDialect) TypeBool() string              { return "INTEGER" } // 0/1
 func (SQLiteDialect) TypeText() string              { return "TEXT" }
+
 // TEXT для денежной точности: shopspring/decimal на стороне Go. См. план.
 func (SQLiteDialect) TypeNumber(p, s int) string { return "TEXT" }
 func (SQLiteDialect) TypeTimestamp() string      { return "TEXT" } // ISO 8601

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -83,8 +83,7 @@ func ConnectSQLite(ctx context.Context, dbPath string) (*DB, error) {
 		if f, ferr := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY, 0o600); ferr != nil {
 			return nil, i18nerr.Wrapf(ferr, "storage: sqlite: нет прав на запись в папку %q", dir)
 		} else {
-			f.Close()
-			os.Remove(probe)
+			discardPartial(f, probe)
 		}
 
 		// modernc.org/sqlite uses "sqlite" driver name (not "sqlite3").

--- a/internal/storage/sqlite_adapter.go
+++ b/internal/storage/sqlite_adapter.go
@@ -10,10 +10,10 @@ type sqlRows struct {
 	r *sql.Rows
 }
 
-func (s *sqlRows) Next() bool          { return s.r.Next() }
+func (s *sqlRows) Next() bool            { return s.r.Next() }
 func (s *sqlRows) Scan(dst ...any) error { return s.r.Scan(dst...) }
-func (s *sqlRows) Err() error          { return s.r.Err() }
-func (s *sqlRows) Close()              { _ = s.r.Close() }
+func (s *sqlRows) Err() error            { return s.r.Err() }
+func (s *sqlRows) Close()                { _ = s.r.Close() }
 func (s *sqlRows) FieldNames() []string {
 	cols, _ := s.r.Columns()
 	return cols


### PR DESCRIPTION
**errcheck: `internal/storage` 26 → 0, `internal/auth` 5 → 0.**

## Главное: метаданные регистрировали огрызок как целый блоб

```go
n, err := io.Copy(f, limited)
f.Close()          // ошибка терялась
...
insertMeta(n, FileStorageDisk)
```

`Close` сбрасывает буфер, поэтому его сбой означает **усечённый файл** — а `insertMeta` следом регистрировала огрызок как полноценный блоб. Метаданные говорят «блоб есть, размер n», на диске лежит меньше.

Ровно та ситуация, о которой предупреждает план: *«Ошибка Close у writer/archive/database может быть основной, а не вторичной»*. Теперь ошибка удаляет файл и уходит вызывающему.

## Уборка недописанных файлов

Остальное в `storage` — уборка на путях ошибки. Наверх идёт причина сбоя записи, и подменять её на «не удалось удалить временный файл» значит потерять настоящую. Решение принято один раз в `cleanup.go` (`discardPartial`/`removeFile`/`closeRead`) **с явно очерченной границей**: успешный `Close` пишущей стороны сюда не относится.

## Журнал регистрации

`audit.go`: `json.Unmarshal` значений «было/стало». Сбой разбора оставлял бы пустой diff — запись, по которой изменение выглядит как **отсутствие изменения**. Для журнала аудита это хуже шумной строки → Warn.

## Страница входа

- `r.ParseForm` без проверки: при битом теле `login` и `password` пусты, и попытка уходит в общий путь «неверный логин или пароль». Пользователь ищет ошибку в своих учётных данных, а дело в запросе.
- Вместе с проверкой добавлен `MaxBytesReader`. **Изначально я написал в комментарии, что лимит стоит выше по стеку** — gate показал `G120`, проверка подтвердила, что лимита там нет. Форма входа доступна без аутентификации, то есть это единственная точка, куда неаутентифицированный клиент может слать сколько угодно данных.
- `Encode` и `Execute` шаблона — по решению из `internal/ui`: JSON на Debug (клиент отсоединился), шаблон на Warn (страница входа одна на всех).

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)