### PR TITLE
fix(metrics,excel,backup): не отдавать неполные метрики, выгрузки и копии (план 109D)

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/ui"
 	"github.com/ivantit66/onebase/internal/webhook"
+
+	oblog "github.com/ivantit66/onebase/internal/logging"
 )
 
 // mountMetrics вешает /metrics, отдающий HTTP-метрики (reg) и gauges пула
@@ -22,7 +25,13 @@ import (
 func mountMetrics(r chi.Router, token string, reg *metrics.Registry, store *storage.DB) {
 	r.With(pprofTokenMiddleware(token)).Get("/metrics", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-		reg.WritePrometheus(w)
+		// Заголовки отправлены — статус уже не поменять. Но обрыв экспозиции
+		// нельзя оставлять незамеченным: Prometheus разберёт то, что успело
+		// прийти, и недошедшие серии будут выглядеть как исчезнувшие.
+		if err := reg.WritePrometheus(w); err != nil {
+			oblog.Component("api").Warn("экспозиция метрик оборвана — Prometheus получил неполный набор", "err", err)
+			return
+		}
 		writePoolStats(w, store)
 	})
 }
@@ -72,8 +81,14 @@ func writePoolStats(w http.ResponseWriter, store *storage.DB) {
 	if st == nil {
 		return
 	}
+	// Заголовки отправлены; обрыв фиксируем один раз в конце, чтобы не
+	// повторять проверку у каждой серии.
+	var writeErr error
 	g := func(name, help string, val int64) {
-		fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, val)
+		if writeErr != nil {
+			return
+		}
+		_, writeErr = fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s gauge\n%s %d\n", name, help, name, name, val)
 	}
 	g("onebase_db_pool_acquired_conns", "Занятые соединения пула.", int64(st.AcquiredConns))
 	g("onebase_db_pool_constructing_conns", "Соединения в процессе установки.", int64(st.ConstructingConns))
@@ -82,10 +97,24 @@ func writePoolStats(w http.ResponseWriter, store *storage.DB) {
 	g("onebase_db_pool_max_conns", "Максимум соединений пула.", int64(st.MaxConns))
 
 	c := func(name, help string, val int64) {
-		fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n%s %d\n", name, help, name, name, val)
+		if writeErr != nil {
+			return
+		}
+		_, writeErr = fmt.Fprintf(w, "# HELP %s %s\n# TYPE %s counter\n%s %d\n", name, help, name, name, val)
 	}
 	c("onebase_db_pool_acquire_total", "Всего успешных Acquire.", st.AcquireCount)
 	c("onebase_db_pool_empty_acquire_total", "Acquire, ждавшие свободного соединения.", st.EmptyAcquireCount)
 	c("onebase_db_pool_canceled_acquire_total", "Acquire, отменённые контекстом.", st.CanceledAcquireCount)
 	c("onebase_db_pool_new_conns_total", "Всего созданных соединений.", st.NewConnsCount)
+	if writeErr != nil {
+		oblog.Component("api").Warn("метрики пула соединений не дописаны", "err", writeErr)
+	}
+}
+
+// closeReadAPI закрывает читающую сторону в обработчиках REST: данные уже
+// прочитаны, ошибка вторична и не должна подменять причину ответа.
+func closeReadAPI(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		oblog.Component("api").Debug("не удалось закрыть "+what, "err", err)
+	}
 }

--- a/internal/api/v2_attachments.go
+++ b/internal/api/v2_attachments.go
@@ -123,7 +123,7 @@ func (h *handler) uploadAttachmentV2(kind metadata.Kind) http.HandlerFunc {
 			writeError(w, http.StatusBadRequest, "missing file field", "", 0)
 			return
 		}
-		defer file.Close()
+		defer closeReadAPI("загруженный файл", file)
 
 		filename := storage.SanitizeAttachmentName(header.Filename)
 		if !storage.AttachmentExtAllowed(h.allowedAttachmentTypes, filename) {
@@ -191,7 +191,7 @@ func (h *handler) downloadAttachmentV2() http.HandlerFunc {
 			}
 			return
 		}
-		defer f.Close()
+		defer closeReadAPI("вложение", f)
 
 		w.Header().Set("Content-Type", att.MimeType)
 		w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/internal/backup/auto.go
+++ b/internal/backup/auto.go
@@ -113,7 +113,7 @@ func uploadToS3(ctx context.Context, cfg *project.S3Config, localPath string, mk
 	if err != nil {
 		return fmt.Errorf("auto backup: s3 open %s: %w", localPath, err)
 	}
-	defer f.Close()
+	defer closeRead("файл резервной копии", f)
 	info, err := f.Stat()
 	if err != nil {
 		return fmt.Errorf("auto backup: s3 stat: %w", err)

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -122,13 +122,13 @@ END $$;`
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer closeRead("файл резервной копии", f)
 
 	gz, err := gzip.NewReader(f)
 	if err != nil {
 		return fmt.Errorf("не удалось прочитать gzip-архив: %w", err)
 	}
-	defer gz.Close()
+	defer closeRead("gzip-поток дампа", gz)
 
 	cmd := exec.CommandContext(ctx, psql, "--no-password", connStr)
 	cmd.Stdin = gz

--- a/internal/backup/cleanup.go
+++ b/internal/backup/cleanup.go
@@ -1,0 +1,38 @@
+package backup
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+
+	oblog "github.com/ivantit66/onebase/internal/logging"
+)
+
+// Уборка на путях резервного копирования и восстановления.
+//
+// Здесь идут закрытия читающей стороны (открытый дамп, распакованный поток,
+// проверочное соединение с копией) и удаление временных путей. Наверх в этот
+// момент уходит либо успех, либо уже сформированная причина сбоя, и подменять
+// её ошибкой уборки значит потерять настоящую.
+//
+// Граница: Close ПИШУЩЕЙ стороны сюда не относится. Он сбрасывает буфер, и его
+// ошибка означает усечённый дамп — то есть неисправную резервную копию,
+// выглядящую исправной. Такие места (gzip-writer в Dump, tmp в restoreFile)
+// разбирают ошибку сами и уже это делают.
+
+func backupLog() *slog.Logger { return oblog.Component("backup") }
+
+// closeRead закрывает читающую сторону.
+func closeRead(what string, c io.Closer) {
+	if err := c.Close(); err != nil {
+		backupLog().Debug("не удалось закрыть "+what, "err", err)
+	}
+}
+
+// removeTemp удаляет временный файл или каталог.
+func removeTemp(path string) {
+	if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		backupLog().Debug("не удалось удалить временный путь", "path", path, "err", err)
+	}
+}

--- a/internal/backup/demo_reset.go
+++ b/internal/backup/demo_reset.go
@@ -41,7 +41,7 @@ func DemoReset(ctx context.Context, db *storage.DB, backupPath string) (*ImportR
 	if err != nil {
 		return nil, fmt.Errorf("demo reset: open backup %q: %w", backupPath, err)
 	}
-	defer f.Close()
+	defer closeRead("файл резервной копии", f)
 
 	fi, err := f.Stat()
 	if err != nil {
@@ -65,7 +65,7 @@ func DemoReset(ctx context.Context, db *storage.DB, backupPath string) (*ImportR
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer removeTemp(tmpDir)
 
 	for _, zf := range zr.File {
 		if zf.FileInfo().IsDir() {

--- a/internal/backup/sqlite.go
+++ b/internal/backup/sqlite.go
@@ -127,7 +127,7 @@ func validateSQLiteBackup(ctx context.Context, path string) error {
 	if err != nil {
 		return fmt.Errorf("sqlite restore: открыть подготовленную копию: %w", err)
 	}
-	defer db.Close()
+	defer closeRead("проверочное соединение с копией", db)
 	var result string
 	if err := db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&result); err != nil {
 		return fmt.Errorf("sqlite restore: integrity_check: %w", err)
@@ -143,7 +143,7 @@ func copyFileSynced(ctx context.Context, srcPath, dstPath string, perm os.FileMo
 	if err != nil {
 		return err
 	}
-	defer src.Close()
+	defer closeRead("исходный файл", src)
 	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
 	if err != nil {
 		return err

--- a/internal/backup/universal.go
+++ b/internal/backup/universal.go
@@ -822,7 +822,7 @@ func ImportUniversalWithOptions(
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(tmpDir)
+	defer removeTemp(tmpDir)
 
 	for _, f := range zr.File {
 		if f.FileInfo().IsDir() {
@@ -1002,7 +1002,7 @@ func importSafeSettings(ctx context.Context, db *storage.DB, filePath string, in
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer closeRead("файл резервной копии", f)
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
@@ -1111,7 +1111,7 @@ func extractFile(f *zip.File, outPath string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer closeRead("поток записи архива", rc)
 	out, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return err
@@ -1205,7 +1205,7 @@ func copyFilePublished(ctx context.Context, srcPath, dst string, perm os.FileMod
 	if err != nil {
 		return err
 	}
-	defer src.Close()
+	defer closeRead("исходный файл", src)
 	tmp, err := os.CreateTemp(filepath.Dir(dst), ".onebase-config-*")
 	if err != nil {
 		return err
@@ -1355,7 +1355,7 @@ func importTableJSONL(ctx context.Context, db *storage.DB, tableName, filePath s
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer closeRead("файл резервной копии", f)
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
@@ -1679,14 +1679,17 @@ func restoreAttachments(srcDir, dstDir string) (int, error) {
 		}
 		tmp, err := os.CreateTemp(filepath.Dir(dst), ".onebase-restore-*")
 		if err != nil {
-			src.Close()
+			closeRead("исходный файл", src)
 			return err
 		}
 		tmpName := tmp.Name()
-		defer os.Remove(tmpName)
+		defer removeTemp(tmpName)
 		if err := tmp.Chmod(0o600); err != nil {
-			tmp.Close()
-			src.Close()
+			// Файл ещё пуст — закрытие тут действительно вторично, основная
+			// ошибка уже есть. Ниже, на пути записи, closeErr наоборот
+			// проверяется: там Close сбрасывает буфер.
+			closeRead("временный файл", tmp)
+			closeRead("исходный файл", src)
 			return err
 		}
 		_, copyErr := io.Copy(tmp, src)

--- a/internal/excel/excel.go
+++ b/internal/excel/excel.go
@@ -6,29 +6,90 @@ import (
 	"time"
 
 	"github.com/xuri/excelize/v2"
+
+	oblog "github.com/ivantit66/onebase/internal/logging"
 )
+
+// sheet копит первую ошибку excelize, чтобы заполнение листа не превратилось в
+// лестницу проверок после каждой ячейки.
+//
+// Ошибка здесь не косметическая: не записанная ячейка в выгрузке неотличима от
+// пустого значения в данных. Пользователь открывает .xlsx, видит пробел в
+// колонке «Сумма» и считает, что суммы нет, — а она просто не записалась.
+// Поэтому первая же ошибка доходит до вызывающего, и файл не отдаётся.
+type sheet struct {
+	f    *excelize.File
+	name string
+	err  error
+}
+
+func (s *sheet) setCell(cell string, v any) {
+	if s.err != nil {
+		return
+	}
+	s.err = s.f.SetCellValue(s.name, cell, v)
+}
+
+func (s *sheet) setStyle(cell string, styleID int) {
+	if s.err != nil {
+		return
+	}
+	s.err = s.f.SetCellStyle(s.name, cell, cell, styleID)
+}
+
+func (s *sheet) setRowHeight(row int, h float64) {
+	if s.err != nil {
+		return
+	}
+	s.err = s.f.SetRowHeight(s.name, row, h)
+}
+
+func (s *sheet) setColWidth(col string, w float64) {
+	if s.err != nil {
+		return
+	}
+	s.err = s.f.SetColWidth(s.name, col, col, w)
+}
+
+func (s *sheet) setPanes(p *excelize.Panes) {
+	if s.err != nil {
+		return
+	}
+	s.err = s.f.SetPanes(s.name, p)
+}
+
+// closeBook освобождает временные файлы excelize. Книга к этому моменту уже
+// сериализована, поэтому ошибка вторична — но не молчит.
+func closeBook(f *excelize.File) {
+	if err := f.Close(); err != nil {
+		oblog.Component("excel").Debug("не удалось закрыть книгу excelize", "err", err)
+	}
+}
 
 // ExportList builds an xlsx workbook from headers + rows and returns the raw bytes.
 // Cells are formatted: dates → "ДД.ММ.ГГГГ", numbers → right-aligned.
 func ExportList(cols []string, rows [][]any) ([]byte, error) {
 	f := excelize.NewFile()
-	defer f.Close()
+	defer closeBook(f)
 
-	sheet := "Лист1"
-	f.SetSheetName("Sheet1", sheet)
+	name := "Лист1"
+	if err := f.SetSheetName("Sheet1", name); err != nil {
+		return nil, err
+	}
+	sh := &sheet{f: f, name: name}
 
 	boldStyle, cellStyle, numStyle := listStyles(f)
 
 	// Header row
 	for ci, col := range cols {
 		cell, _ := excelize.CoordinatesToCellName(ci+1, 1)
-		f.SetCellValue(sheet, cell, col)
-		f.SetCellStyle(sheet, cell, cell, boldStyle)
+		sh.setCell(cell, col)
+		sh.setStyle(cell, boldStyle)
 	}
-	f.SetRowHeight(sheet, 1, 22)
+	sh.setRowHeight(1, 22)
 
 	// Freeze header row
-	f.SetPanes(sheet, &excelize.Panes{
+	sh.setPanes(&excelize.Panes{
 		Freeze:      true,
 		Split:       false,
 		YSplit:      1,
@@ -43,20 +104,20 @@ func ExportList(cols []string, rows [][]any) ([]byte, error) {
 			cell, _ := excelize.CoordinatesToCellName(ci+1, rowIdx)
 			switch v := val.(type) {
 			case time.Time:
-				f.SetCellValue(sheet, cell, v.Format("02.01.2006"))
-				f.SetCellStyle(sheet, cell, cell, cellStyle)
+				sh.setCell(cell, v.Format("02.01.2006"))
+				sh.setStyle(cell, cellStyle)
 			case float64, float32, int, int32, int64, uint, uint32, uint64:
-				f.SetCellValue(sheet, cell, v)
-				f.SetCellStyle(sheet, cell, cell, numStyle)
+				sh.setCell(cell, v)
+				sh.setStyle(cell, numStyle)
 			case nil:
-				f.SetCellValue(sheet, cell, "")
-				f.SetCellStyle(sheet, cell, cell, cellStyle)
+				sh.setCell(cell, "")
+				sh.setStyle(cell, cellStyle)
 			default:
-				f.SetCellValue(sheet, cell, fmt.Sprintf("%v", v))
-				f.SetCellStyle(sheet, cell, cell, cellStyle)
+				sh.setCell(cell, fmt.Sprintf("%v", v))
+				sh.setStyle(cell, cellStyle)
 			}
 		}
-		f.SetRowHeight(sheet, rowIdx, 18)
+		sh.setRowHeight(rowIdx, 18)
 	}
 
 	// Auto column width (approximate: max 40 chars)
@@ -78,7 +139,11 @@ func ExportList(cols []string, rows [][]any) ([]byte, error) {
 		if w > 40 {
 			w = 40
 		}
-		f.SetColWidth(sheet, colLetter, colLetter, w)
+		sh.setColWidth(colLetter, w)
+	}
+
+	if sh.err != nil {
+		return nil, sh.err
 	}
 
 	buf, err := f.WriteToBuffer()
@@ -91,10 +156,14 @@ func ExportList(cols []string, rows [][]any) ([]byte, error) {
 // listStyles registers the shared list-export cell styles on f and returns their
 // IDs: bold frozen header, bordered data cell, and right-aligned number cell.
 // Shared by ExportList and WriteList so both render identically.
+// Ошибки NewStyle игнорируются намеренно: excelize возвращает при них нулевой
+// идентификатор, то есть оформление по умолчанию. Последствие чисто
+// косметическое — рамки и выравнивание, — и ронять из-за него готовую выгрузку
+// было бы хуже, чем отдать её без разметки.
 func listStyles(f *excelize.File) (bold, cell, num int) {
 	bold, _ = f.NewStyle(&excelize.Style{
-		Fill: excelize.Fill{Type: "pattern", Color: []string{"E2E8F0"}, Pattern: 1},
-		Font: &excelize.Font{Bold: true},
+		Fill:      excelize.Fill{Type: "pattern", Color: []string{"E2E8F0"}, Pattern: 1},
+		Font:      &excelize.Font{Bold: true},
 		Alignment: &excelize.Alignment{Horizontal: "center", Vertical: "center", WrapText: true},
 		Border: []excelize.Border{
 			{Type: "left", Color: "CBD5E1", Style: 1},
@@ -137,13 +206,15 @@ func listStyles(f *excelize.File) (bold, cell, num int) {
 // send an error status as long as it has not written to w yet.
 func WriteList(w io.Writer, cols []string, rows [][]any) error {
 	f := excelize.NewFile()
-	defer f.Close()
+	defer closeBook(f)
 
-	sheet := "Лист1"
-	f.SetSheetName("Sheet1", sheet)
+	sheetName := "Лист1"
+	if err := f.SetSheetName("Sheet1", sheetName); err != nil {
+		return err
+	}
 	boldStyle, cellStyle, numStyle := listStyles(f)
 
-	sw, err := f.NewStreamWriter(sheet)
+	sw, err := f.NewStreamWriter(sheetName)
 	if err != nil {
 		return err
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -280,10 +280,37 @@ func snapshotMap[K comparable, V any](m map[K]*V) []kv[K, V] {
 	return out
 }
 
+// promWriter копит первую ошибку записи экспозиции.
+//
+// Обрыв здесь не безобиден: Prometheus разбирает то, что успело прийти, и
+// частичный ответ выглядит для него как «эти серии исчезли». Дальше срабатывают
+// алерты на пропавшие метрики либо, наоборот, молчат те, что считались по
+// недошедшим сериям. Поэтому ошибка доходит до обработчика, а он решает, что с
+// ней делать (заголовки уже отправлены — только журнал).
+type promWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (p *promWriter) printf(format string, a ...any) {
+	if p.err != nil {
+		return
+	}
+	_, p.err = fmt.Fprintf(p.w, format, a...)
+}
+
+func (p *promWriter) println(a ...any) {
+	if p.err != nil {
+		return
+	}
+	_, p.err = fmt.Fprintln(p.w, a...)
+}
+
 // WritePrometheus печатает накопленные метрики в формате Prometheus exposition.
 // Под коротким RLock снимает снимок указателей на серии, затем пишет уже без
 // лока (значения читаются атомарно) — скрейп не блокирует горячий путь.
-func (reg *Registry) WritePrometheus(w io.Writer) {
+func (reg *Registry) WritePrometheus(w io.Writer) error {
+	pw := &promWriter{w: w}
 	reg.mu.RLock()
 	funcMetrics := append([]funcMetric(nil), reg.funcMetrics...)
 	reqs := snapshotMap(reg.requests)
@@ -296,8 +323,8 @@ func (reg *Registry) WritePrometheus(w io.Writer) {
 	reg.mu.RUnlock()
 
 	// ── counter: onebase_http_requests_total ──────────────────────────────
-	fmt.Fprintln(w, "# HELP onebase_http_requests_total Общее число обработанных HTTP-запросов.")
-	fmt.Fprintln(w, "# TYPE onebase_http_requests_total counter")
+	pw.println("# HELP onebase_http_requests_total Общее число обработанных HTTP-запросов.")
+	pw.println("# TYPE onebase_http_requests_total counter")
 	sort.Slice(reqs, func(i, j int) bool {
 		a, b := reqs[i].key, reqs[j].key
 		if a.route != b.route {
@@ -309,13 +336,13 @@ func (reg *Registry) WritePrometheus(w io.Writer) {
 		return a.status < b.status
 	})
 	for _, e := range reqs {
-		fmt.Fprintf(w, "onebase_http_requests_total{method=%q,route=%q,status=%q} %d\n",
+		pw.printf("onebase_http_requests_total{method=%q,route=%q,status=%q} %d\n",
 			e.key.method, e.key.route, e.key.status, e.val.Load())
 	}
 
 	// ── histogram: onebase_http_request_duration_seconds ──────────────────
-	fmt.Fprintln(w, "# HELP onebase_http_request_duration_seconds Латентность HTTP-запросов в секундах.")
-	fmt.Fprintln(w, "# TYPE onebase_http_request_duration_seconds histogram")
+	pw.println("# HELP onebase_http_request_duration_seconds Латентность HTTP-запросов в секундах.")
+	pw.println("# TYPE onebase_http_request_duration_seconds histogram")
 	sort.Slice(durs, func(i, j int) bool {
 		a, b := durs[i].key, durs[j].key
 		if a.route != b.route {
@@ -324,19 +351,19 @@ func (reg *Registry) WritePrometheus(w io.Writer) {
 		return a.method < b.method
 	})
 	for _, e := range durs {
-		cum := writeHistogramBuckets(w, reg.buckets, e.val, func(le string, c uint64) {
-			fmt.Fprintf(w, "onebase_http_request_duration_seconds_bucket{method=%q,route=%q,le=%q} %d\n",
+		cum := writeHistogramBuckets(reg.buckets, e.val, func(le string, c uint64) {
+			pw.printf("onebase_http_request_duration_seconds_bucket{method=%q,route=%q,le=%q} %d\n",
 				e.key.method, e.key.route, le, c)
 		})
-		fmt.Fprintf(w, "onebase_http_request_duration_seconds_sum{method=%q,route=%q} %s\n",
+		pw.printf("onebase_http_request_duration_seconds_sum{method=%q,route=%q} %s\n",
 			e.key.method, e.key.route, strconv.FormatFloat(e.val.sum(), 'g', -1, 64))
-		fmt.Fprintf(w, "onebase_http_request_duration_seconds_count{method=%q,route=%q} %d\n",
+		pw.printf("onebase_http_request_duration_seconds_count{method=%q,route=%q} %d\n",
 			e.key.method, e.key.route, cum)
 	}
 
 	// ── operation counters/gauges: reports/export/processors/http services ──
-	fmt.Fprintln(w, "# HELP onebase_operation_total Общее число тяжёлых runtime-операций.")
-	fmt.Fprintln(w, "# TYPE onebase_operation_total counter")
+	pw.println("# HELP onebase_operation_total Общее число тяжёлых runtime-операций.")
+	pw.println("# TYPE onebase_operation_total counter")
 	sort.Slice(ops, func(i, j int) bool {
 		a, b := ops[i].key, ops[j].key
 		if a.kind != b.kind {
@@ -345,37 +372,37 @@ func (reg *Registry) WritePrometheus(w io.Writer) {
 		return a.status < b.status
 	})
 	for _, e := range ops {
-		fmt.Fprintf(w, "onebase_operation_total{kind=%q,status=%q} %d\n", e.key.kind, e.key.status, e.val.Load())
+		pw.printf("onebase_operation_total{kind=%q,status=%q} %d\n", e.key.kind, e.key.status, e.val.Load())
 	}
 
-	fmt.Fprintln(w, "# HELP onebase_active_operations Активные тяжёлые runtime-операции.")
-	fmt.Fprintln(w, "# TYPE onebase_active_operations gauge")
+	pw.println("# HELP onebase_active_operations Активные тяжёлые runtime-операции.")
+	pw.println("# TYPE onebase_active_operations gauge")
 	sort.Slice(active, func(i, j int) bool { return active[i].key < active[j].key })
 	for _, e := range active {
-		fmt.Fprintf(w, "onebase_active_operations{kind=%q} %d\n", e.key, e.val.Load())
+		pw.printf("onebase_active_operations{kind=%q} %d\n", e.key, e.val.Load())
 	}
 
-	fmt.Fprintln(w, "# HELP onebase_operation_duration_seconds Длительность тяжёлых runtime-операций в секундах.")
-	fmt.Fprintln(w, "# TYPE onebase_operation_duration_seconds histogram")
+	pw.println("# HELP onebase_operation_duration_seconds Длительность тяжёлых runtime-операций в секундах.")
+	pw.println("# TYPE onebase_operation_duration_seconds histogram")
 	sort.Slice(opDurs, func(i, j int) bool { return opDurs[i].key < opDurs[j].key })
 	for _, e := range opDurs {
-		cum := writeHistogramBuckets(w, reg.buckets, e.val, func(le string, c uint64) {
-			fmt.Fprintf(w, "onebase_operation_duration_seconds_bucket{kind=%q,le=%q} %d\n", e.key, le, c)
+		cum := writeHistogramBuckets(reg.buckets, e.val, func(le string, c uint64) {
+			pw.printf("onebase_operation_duration_seconds_bucket{kind=%q,le=%q} %d\n", e.key, le, c)
 		})
-		fmt.Fprintf(w, "onebase_operation_duration_seconds_sum{kind=%q} %s\n",
+		pw.printf("onebase_operation_duration_seconds_sum{kind=%q} %s\n",
 			e.key, strconv.FormatFloat(e.val.sum(), 'g', -1, 64))
-		fmt.Fprintf(w, "onebase_operation_duration_seconds_count{kind=%q} %d\n", e.key, cum)
+		pw.printf("onebase_operation_duration_seconds_count{kind=%q} %d\n", e.key, cum)
 	}
 
-	fmt.Fprintln(w, "# HELP onebase_slow_operation_total Тяжёлые операции дольше slow_operation_ms.")
-	fmt.Fprintln(w, "# TYPE onebase_slow_operation_total counter")
+	pw.println("# HELP onebase_slow_operation_total Тяжёлые операции дольше slow_operation_ms.")
+	pw.println("# TYPE onebase_slow_operation_total counter")
 	sort.Slice(slow, func(i, j int) bool { return slow[i].key < slow[j].key })
 	for _, e := range slow {
-		fmt.Fprintf(w, "onebase_slow_operation_total{kind=%q} %d\n", e.key, e.val.Load())
+		pw.printf("onebase_slow_operation_total{kind=%q} %d\n", e.key, e.val.Load())
 	}
 
-	fmt.Fprintln(w, "# HELP onebase_limited_operation_total Операции, отклонённые лимитами/backpressure.")
-	fmt.Fprintln(w, "# TYPE onebase_limited_operation_total counter")
+	pw.println("# HELP onebase_limited_operation_total Операции, отклонённые лимитами/backpressure.")
+	pw.println("# TYPE onebase_limited_operation_total counter")
 	sort.Slice(limited, func(i, j int) bool {
 		a, b := limited[i].key, limited[j].key
 		if a.kind != b.kind {
@@ -384,18 +411,19 @@ func (reg *Registry) WritePrometheus(w io.Writer) {
 		return a.reason < b.reason
 	})
 	for _, e := range limited {
-		fmt.Fprintf(w, "onebase_limited_operation_total{kind=%q,reason=%q} %d\n",
+		pw.printf("onebase_limited_operation_total{kind=%q,reason=%q} %d\n",
 			e.key.kind, e.key.reason, e.val.Load())
 	}
 
-	writeFuncMetrics(w, funcMetrics)
+	writeFuncMetrics(pw, funcMetrics)
+	return pw.err
 }
 
 // writeHistogramBuckets печатает кумулятивные корзины гистограммы (включая +Inf)
 // через emit(le, cumulative) и возвращает итоговое число наблюдений (== корзина
 // +Inf). Значение count берётся отсюда же, поэтому «+Inf == count» соблюдается
 // по построению даже при конкурентных наблюдениях.
-func writeHistogramBuckets(w io.Writer, buckets []float64, h *histogram, emit func(le string, cum uint64)) uint64 {
+func writeHistogramBuckets(buckets []float64, h *histogram, emit func(le string, cum uint64)) uint64 {
 	var cum uint64
 	for i, ub := range buckets {
 		cum += h.counts[i].Load()
@@ -406,12 +434,12 @@ func writeHistogramBuckets(w io.Writer, buckets []float64, h *histogram, emit fu
 	return cum
 }
 
-func writeFuncMetrics(w io.Writer, metrics []funcMetric) {
+func writeFuncMetrics(pw *promWriter, metrics []funcMetric) {
 	sort.Slice(metrics, func(i, j int) bool { return metrics[i].name < metrics[j].name })
 	for _, m := range metrics {
-		fmt.Fprintf(w, "# HELP %s %s\n", m.name, m.help)
-		fmt.Fprintf(w, "# TYPE %s %s\n", m.name, m.metricType)
-		fmt.Fprintf(w, "%s %s\n", m.name, strconv.FormatFloat(safeMetricValue(m.value), 'g', -1, 64))
+		pw.printf("# HELP %s %s\n", m.name, m.help)
+		pw.printf("# TYPE %s %s\n", m.name, m.metricType)
+		pw.printf("%s %s\n", m.name, strconv.FormatFloat(safeMetricValue(m.value), 'g', -1, 64))
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -32,7 +32,9 @@ func TestRegistry_RecordsAndExposes(t *testing.T) {
 	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
 
 	var sb strings.Builder
-	reg.WritePrometheus(&sb)
+	if err := reg.WritePrometheus(&sb); err != nil {
+		t.Fatalf("WritePrometheus: %v", err)
+	}
 	out := sb.String()
 
 	// Метка route — это шаблон chi, а не конкретный id (низкая кардинальность).
@@ -63,7 +65,9 @@ func TestRegistry_OperationMetrics(t *testing.T) {
 	reg.OperationLimited("http_service.run", "concurrency")
 
 	var sb strings.Builder
-	reg.WritePrometheus(&sb)
+	if err := reg.WritePrometheus(&sb); err != nil {
+		t.Fatalf("WritePrometheus: %v", err)
+	}
 	out := sb.String()
 
 	if !strings.Contains(out, `onebase_operation_total{kind="report.run",status="ok"} 1`) {
@@ -86,7 +90,9 @@ func TestRegistry_FuncMetrics(t *testing.T) {
 	reg.RegisterCounterFunc("onebase_webhook_retry_total", "Webhook retries.", func() float64 { return 7 })
 
 	var sb strings.Builder
-	reg.WritePrometheus(&sb)
+	if err := reg.WritePrometheus(&sb); err != nil {
+		t.Fatalf("WritePrometheus: %v", err)
+	}
 	out := sb.String()
 
 	if !strings.Contains(out, "# TYPE onebase_active_sessions gauge") ||
@@ -172,7 +178,9 @@ func TestRegistry_ConcurrentObserveIsRaceFreeAndExact(t *testing.T) {
 	reader.Wait()
 
 	var sb strings.Builder
-	reg.WritePrometheus(&sb)
+	if err := reg.WritePrometheus(&sb); err != nil {
+		t.Fatalf("WritePrometheus: %v", err)
+	}
 	out := sb.String()
 
 	// Точные счётчики — ни один инкремент не потерян под гонкой.
@@ -205,7 +213,9 @@ func TestRegistry_UnmatchedRouteIsOther(t *testing.T) {
 	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/no/such/path", nil))
 
 	var sb strings.Builder
-	reg.WritePrometheus(&sb)
+	if err := reg.WritePrometheus(&sb); err != nil {
+		t.Fatalf("WritePrometheus: %v", err)
+	}
 	if !strings.Contains(sb.String(), `route="other",status="404"`) {
 		t.Errorf("ожидали route=other для незаматченного пути, получили:\n%s", sb.String())
 	}


### PR DESCRIPTION
**errcheck: `metrics` 28 → 0, `excel` 18 → 0, `backup` 16 → 0, `api` 4 → 0.**

Три пакета, где непроверенная запись давала не сообщение об ошибке, а **правдоподобно неверный результат**.

## Мониторинг врёт молча

`WritePrometheus` писал экспозицию, не проверяя ни одной записи. Prometheus разбирает то, что успело прийти, поэтому обрыв выглядит для него **не как сбой, а как «эти серии исчезли»**: срабатывают алерты на пропавшие метрики либо, наоборот, молчат те, что считались по недошедшим сериям.

Функция теперь возвращает ошибку (`promWriter` копит первую), а обработчик `/metrics` пишет Warn — заголовки уже ушли, статус не поменять.

## Пробел в колонке «Сумма»

14 вызовов `SetCellValue`/`SetCellStyle` игнорировали результат. Не записанная ячейка в `.xlsx` **неотличима от пустого значения в данных**: пользователь видит пробел и считает, что суммы нет. Первая же ошибка теперь доходит до вызывающего, и файл не отдаётся.

Ошибки `NewStyle` оставлены с явным `_` **и объяснением**: excelize возвращает при них нулевой идентификатор, то есть оформление по умолчанию, и ронять готовую выгрузку из-за рамок было бы хуже.

## Резервные копии: граница записана явно

Уборка сведена в `cleanup.go` с прямо сформулированной границей: **`Close` пишущей стороны сюда не относится**, потому что он сбрасывает буфер и его ошибка означает усечённый дамп — неисправную копию, выглядящую исправной.

Те места (gzip-writer в `Dump`, `tmp` в `restoreFile`) ошибку уже разбирают сами, и это осталось нетронутым. В `restoreFile` добавлено пояснение, почему на одном пути `Close` вторичен (файл ещё пуст), а на соседнем — нет.

## Тесты

`metrics_test` обновлён под новую сигнатуру: сбой записи в них теперь падение, а не молчание.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)