### PR TITLE
fix(launcher): обход пути при сохранении формы сущности (план 109, этап H)

### DIFF
--- a/internal/launcher/configurator_entity.go
+++ b/internal/launcher/configurator_entity.go
@@ -270,6 +270,18 @@ func (h *handler) configuratorSaveForm(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entityName := r.FormValue("entity")
+	// Имя сущности приходит из формы и ниже попадает в путь, по которому файл
+	// читается и ПЕРЕЗАПИСЫВАЕТСЯ. nameToFilename только приводит к нижнему
+	// регистру и разделители не вычищает, а filepath.Join схлопывает «..» — то
+	// есть без этой проверки «entity=../../foo» уводило запись за пределы
+	// каталога проекта. Соседние обработчики (модуль, обработка, отчёт) такую
+	// проверку делают; здесь её не было.
+	if !validObjectName(entityName) {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя объекта")
+		renderCfg(w, r, data)
+		return
+	}
 	dir := b.Path
 	if b.ConfigSource == "database" {
 		dir, err = workspacePath(b.ID)
@@ -279,11 +291,17 @@ func (h *handler) configuratorSaveForm(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Find entity YAML file
+	// Find entity YAML file.
+	//
+	// SafeJoin — второй рубеж: он подтверждает, что собранный путь остался
+	// внутри dir, даже если проверка имени выше однажды ослабнет.
 	entityDir := ""
 	for _, sub := range []string{"catalogs", "documents"} {
-		p := filepath.Join(dir, sub, nameToFilename(entityName)+".yaml")
-		if _, e := os.Stat(p); e == nil {
+		p, jerr := configdb.SafeJoin(dir, sub+"/"+nameToFilename(entityName)+".yaml")
+		if jerr != nil {
+			continue
+		}
+		if _, e := os.Stat(p); e == nil { //nolint:gosec // G703: p построен SafeJoin, имя проверено validObjectName выше
 			entityDir = sub
 			break
 		}
@@ -295,7 +313,13 @@ func (h *handler) configuratorSaveForm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filePath := filepath.Join(dir, entityDir, nameToFilename(entityName)+".yaml")
+	filePath, jerr := configdb.SafeJoin(dir, entityDir+"/"+nameToFilename(entityName)+".yaml")
+	if jerr != nil {
+		data := h.loadCfgData(r.Context(), b, "tree")
+		data.Error = tr(lang, "Недопустимое имя объекта")
+		renderCfg(w, r, data)
+		return
+	}
 	raw, err := os.ReadFile(filePath)
 	if err != nil {
 		data := h.loadCfgData(r.Context(), b, "tree")

--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -318,7 +318,7 @@ func (h *handler) configuratorSaveApp(w http.ResponseWriter, r *http.Request) {
 			full, err := configdb.SafeJoin(b.Path, existingLogo)
 			if err != nil {
 				saveErr = err
-			} else if err := os.Remove(full); err != nil && !os.IsNotExist(err) {
+			} else if err := os.Remove(full); err != nil && !os.IsNotExist(err) { //nolint:gosec // G703: full построен configdb.SafeJoin
 				saveErr = err
 			}
 		}

--- a/internal/launcher/configurator_predefined_proxy.go
+++ b/internal/launcher/configurator_predefined_proxy.go
@@ -180,14 +180,16 @@ func (h *handler) oneTimeCodeProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	url := fmt.Sprintf("http://localhost:%d/auth/one-time-code", b.Port)
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, url, nil)
+	// Адрес не пользовательский: схема и хост фиксированы, порт берётся
+	// из реестра баз лаунчера. Внешний URL сюда подставить нельзя.
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, url, nil) //nolint:gosec // G704: цель — localhost:<порт базы> из реестра
 	if err != nil {
 		writeJSON(w, 500, map[string]string{"error": err.Error()})
 		return
 	}
 	req.AddCookie(&http.Cookie{Name: "onebase_session", Value: cookie.Value})
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // G704: адрес собран выше из localhost и порта базы из реестра
 	if err != nil {
 		writeJSON(w, 502, map[string]string{"error": "UI server unreachable: " + err.Error()})
 		return
@@ -226,7 +228,9 @@ func (h *handler) debugProxy(w http.ResponseWriter, r *http.Request) {
 
 	uiURL := fmt.Sprintf("http://localhost:%d/debug/global/%s", b.Port, action)
 
-	req, err := http.NewRequestWithContext(r.Context(), r.Method, uiURL, r.Body)
+	// Адрес не пользовательский: схема и хост фиксированы, порт берётся
+	// из реестра баз лаунчера. Внешний URL сюда подставить нельзя.
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, uiURL, r.Body) //nolint:gosec // G704: цель — localhost:<порт базы> из реестра
 	if err != nil {
 		http.Error(w, err.Error(), 500)
 		return

--- a/internal/launcher/configurator_printforms.go
+++ b/internal/launcher/configurator_printforms.go
@@ -121,7 +121,7 @@ func (h *handler) configuratorNewPrintForm(w http.ResponseWriter, r *http.Reques
 		fullPath, jerr := configdb.SafeJoin(b.Path, relPath)
 		if jerr != nil {
 			saveErr = jerr
-		} else if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
+		} else if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) { //nolint:gosec // G703: fullPath построен configdb.SafeJoin — это и есть guard от traversal
 			saveErr = h.writeConfigFileRaw(r.Context(), b, relPath, []byte(source))
 		}
 	}

--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -40,7 +40,10 @@ func normalizeSQLitePath(path, name string) string {
 	case filepath.Ext(p) == "":
 		isDir = true
 	default:
-		if st, err := os.Stat(p); err == nil && st.IsDir() {
+		// Путь вводит администратор в форме регистрации базы — это его
+		// собственный путь на его же машине, а не чужой ввод. Здесь только
+		// определение «файл или каталог», без чтения содержимого.
+		if st, err := os.Stat(p); err == nil && st.IsDir() { //nolint:gosec // G703: путь администратора, только Stat
 			isDir = true
 		}
 	}
@@ -678,7 +681,9 @@ func (h *handler) configExport(w http.ResponseWriter, r *http.Request) {
 // an untouched ~/.onebase/workspace/<base-id> must not be accepted as a valid
 // zero-file configuration.
 func validateConfigImportDir(srcDir string) error {
-	info, err := os.Stat(srcDir)
+	// srcDir — каталог, выбранный администратором в диалоге импорта на его
+	// машине. Проверяем, что это папка проекта, до replace-all транзакции.
+	info, err := os.Stat(srcDir) //nolint:gosec // G703: путь администратора
 	if err != nil {
 		return fmt.Errorf("папка конфигурации недоступна: %w", err)
 	}
@@ -686,7 +691,7 @@ func validateConfigImportDir(srcDir string) error {
 		return fmt.Errorf("путь не является папкой: %s", srcDir)
 	}
 	appPath := filepath.Join(srcDir, "config", "app.yaml")
-	if info, err := os.Stat(appPath); err != nil || info.IsDir() {
+	if info, err := os.Stat(appPath); err != nil || info.IsDir() { //nolint:gosec // G703: appPath собран из того же каталога администратора
 		return fmt.Errorf("папка не содержит config/app.yaml: %s", srcDir)
 	}
 	cfg, err := project.LoadConfig(srcDir)

--- a/internal/launcher/layout_import_pdf.go
+++ b/internal/launcher/layout_import_pdf.go
@@ -126,7 +126,7 @@ func (h *handler) configuratorImportPDFLayout(w http.ResponseWriter, r *http.Req
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+jerr.Error())
 			return
 		}
-		if _, statErr := os.Stat(fullPath); statErr == nil {
+		if _, statErr := os.Stat(fullPath); statErr == nil { //nolint:gosec // G703: fullPath построен configdb.SafeJoin
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Макет уже существует"))
 			return
 		}

--- a/internal/launcher/layout_new.go
+++ b/internal/launcher/layout_new.go
@@ -248,7 +248,7 @@ func (h *handler) configuratorNewLayout(w http.ResponseWriter, r *http.Request) 
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Ошибка создания макета")+": "+jerr.Error())
 			return
 		}
-		if _, statErr := os.Stat(fullPath); statErr == nil {
+		if _, statErr := os.Stat(fullPath); statErr == nil { //nolint:gosec // G703: fullPath построен configdb.SafeJoin — это и есть guard от traversal
 			h.layoutCreateError(w, r, b, lang, tr(lang, "Макет уже существует"))
 			return
 		}

--- a/internal/launcher/layout_preview.go
+++ b/internal/launcher/layout_preview.go
@@ -83,8 +83,9 @@ func (h *handler) configuratorLayoutPreview(w http.ResponseWriter, r *http.Reque
 		// показывает «страница заблокирована Microsoft Edge». Внешнее открытие
 		// работает и в webview, и в обычном браузере (лаунчер локальный).
 		if r.URL.Query().Get("open") == "1" {
-			fp := filepath.Join(os.TempDir(), "onebase-layout-preview.pdf")
-			if werr := os.WriteFile(fp, pdfBytes, 0o600); werr != nil {
+			// Имя фиксированное, из запроса сюда ничего не попадает.
+			fp := filepath.Join(os.TempDir(), "onebase-layout-preview.pdf") //nolint:gosec // G703: путь константный
+			if werr := os.WriteFile(fp, pdfBytes, 0o600); werr != nil {     //nolint:gosec // G703: fp — константное имя в TempDir
 				// Старый файл занят просмотрщиком → уникальное имя.
 				tf, terr := os.CreateTemp("", "onebase-preview-*.pdf")
 				if terr != nil {

--- a/internal/launcher/save_form_traversal_test.go
+++ b/internal/launcher/save_form_traversal_test.go
@@ -1,0 +1,103 @@
+package launcher
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// configuratorSaveForm читает YAML сущности, дописывает в него list_form/
+// item_form и записывает обратно. Имя сущности приходит из формы, а
+// nameToFilename только приводит его к нижнему регистру — разделители пути он
+// не вычищает. filepath.Join при этом схлопывает «..», поэтому «entity=../../X»
+// уводило и чтение, и ЗАПИСЬ за пределы каталога проекта: из подкаталога
+// catalogs/ два уровня вверх — это уже каталог рядом с проектом.
+//
+// Соседние обработчики конфигуратора (модуль, обработка, отчёт, макет) проверяют
+// имя через validObjectName; в этом его не было. Тест держит границу: файл рядом
+// с каталогом проекта не должен ни прочитаться, ни измениться.
+func TestSaveFormRejectsTraversingEntityName(t *testing.T) {
+	root := t.TempDir()
+	cfgDir := filepath.Join(root, "проект")
+	if err := os.MkdirAll(filepath.Join(cfgDir, "catalogs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Цель обхода: валидный YAML СНАРУЖИ каталога проекта.
+	outside := filepath.Join(root, "снаружи.yaml")
+	const original = "name: Снаружи\n"
+	if err := os.WriteFile(outside, []byte(original), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := newTestStore(t)
+	if err := store.Add(&Base{ID: "b", Name: "b", ConfigSource: "file", Path: cfgDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"entity":    {"../../снаружи"},
+		"lf.0.name": {"Наименование"},
+		"lf.0.vis":  {"1"},
+		"ef.0.name": {"Наименование"},
+		"ef.0.vis":  {"1"},
+		"list_form": {"1"},
+		"item_form": {"1"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/bases/b/configurator/form/save",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = requestWithBaseID(req, "b")
+	rec := httptest.NewRecorder()
+
+	(&handler{store: store, runner: NewRunner()}).configuratorSaveForm(rec, req)
+
+	got, err := os.ReadFile(outside) //nolint:gosec // G304: путь собран здесь же, в тесте
+	if err != nil {
+		t.Fatalf("файл снаружи проекта исчез: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("файл снаружи каталога проекта перезаписан:\n%s", got)
+	}
+}
+
+// Обычное имя по-прежнему сохраняется — проверка не должна ломать штатный путь.
+func TestSaveFormAcceptsNormalEntityName(t *testing.T) {
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "catalogs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(cfgDir, "catalogs", "контрагент.yaml")
+	if err := os.WriteFile(target, []byte("name: Контрагент\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := newTestStore(t)
+	if err := store.Add(&Base{ID: "b", Name: "b", ConfigSource: "file", Path: cfgDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{
+		"entity":    {"Контрагент"},
+		"lf.0.name": {"Наименование"},
+		"lf.0.vis":  {"1"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/bases/b/configurator/form/save",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = requestWithBaseID(req, "b")
+	rec := httptest.NewRecorder()
+
+	(&handler{store: store, runner: NewRunner()}).configuratorSaveForm(rec, req)
+
+	got, err := os.ReadFile(target) //nolint:gosec // G304: путь собран здесь же, в тесте
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "list_form") {
+		t.Errorf("штатное сохранение не сработало:\n%s", got)
+	}
+}


### PR DESCRIPTION
Первый PR этапа H. План предписывает начинать с правил с возможным внешним воздействием — и на taint-анализе нашлась настоящая уязвимость.

## Обход пути → перезапись файла вне проекта

`configuratorSaveForm` брал имя сущности из формы и подставлял в путь без проверки:

```go
entityName := r.FormValue("entity")
...
filePath := filepath.Join(dir, entityDir, nameToFilename(entityName)+".yaml")
raw, err := os.ReadFile(filePath)
...
os.WriteFile(filePath, out, 0o644)
```

`nameToFilename` — это **только `strings.ToLower`**, разделители пути он не вычищает, а `filepath.Join` схлопывает `..`. Значит `entity=../../имя` уводило и чтение, и **запись** за пределы каталога проекта: файл читался, в него дописывались `list_form`/`item_form` и он записывался обратно.

**Ограничения эксплуатации:** цель должна существовать, оканчиваться на `.yaml` и разбираться как YAML; обработчик закрыт админской сессией конфигуратора. То есть это не анонимный доступ, а выход администратора конфигуратора за границу своего проекта — на любой доступный процессу `.yaml`.

## Почему это вообще возникло

Соседние обработчики — модуль, обработка, отчёт, макет — проверяют имя через `validObjectName`. В этом её просто не было. Добавлена она же плюс второй рубеж, `configdb.SafeJoin`: он подтверждает, что собранный путь остался внутри каталога проекта, даже если проверка имени когда-нибудь ослабнет.

## Тест

Воспроизводит обход и без правки падает, показывая перезаписанный файл снаружи проекта:

```
        item_form:
            - Наименование
        list_form:
            - Наименование
        name: Снаружи
FAIL
```

> Сначала тест был написан с `../` и **проходил в обоих случаях** — из подкаталога `catalogs/` одного уровня не хватает, путь оставался внутри проекта. Исправлено на `../../`; без этого тест ничего бы не доказывал.

## Остальные G703/G704 — проверены, ложные

- пути строит `configdb.SafeJoin` — он и есть guard, gosec его не распознаёт;
- либо это константное имя в `TempDir`;
- либо путь, который администратор **сам вводит** в форме регистрации базы (и там только `Stat`);
- прокси конфигуратора ходит только на `localhost` с портом из реестра баз — внешний URL туда подставить нельзя.

Каждое подавление точечное, с указанием правила и основания.

## Проверки

Локально: BOM, `i18ncheck`, `go vet`, `go test ./...`, обычный `golangci-lint` (**0 issues**), changed-code gate (**0 issues**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)