### PR TITLE
fix(ui): контекст обработчика управляемой формы — Объект.Ссылка и реквизиты формы

### DIFF
--- a/internal/dsl/interpreter/builtins.go
+++ b/internal/dsl/interpreter/builtins.go
@@ -334,6 +334,17 @@ func builtinToNumber(args []any, file string, line int) (any, error) {
 	if d, ok := args[0].(decimal.Decimal); ok {
 		return d, nil
 	}
+	// Булево → 1/0. Без этой ветки Число(Истина) шло в разбор строки «true»,
+	// не парсилось и молча давало 0 — то есть Число(Истина) = Число(Ложь), и
+	// типовая проверка флага «Если Число(Флаг) <> 1» не срабатывала никогда.
+	// Значение поля типа bool приходит в DSL то булевым (форма, restore из БД),
+	// то числом 0/1 (ПолучитьОбъект на SQLite) — Число() выравнивает оба случая.
+	if b, ok := args[0].(bool); ok {
+		if b {
+			return decimal.NewFromInt(1), nil
+		}
+		return decimal.Zero, nil
+	}
 	s := fmt.Sprintf("%v", args[0])
 	d, err := decimal.NewFromString(strings.ReplaceAll(s, ",", "."))
 	if err != nil {

--- a/internal/dsl/interpreter/interpreter.go
+++ b/internal/dsl/interpreter/interpreter.go
@@ -766,11 +766,32 @@ func (i *Interpreter) evalCall(c *ast.CallExpr, e *env) any {
 			}
 		}
 		if recv == nil {
+			// Имя приёмника в тексте ошибки экономит поиск: «вызван у Неопределено»
+			// без него не отвечает на главный вопрос — ЧТО именно пустое. Чаще
+			// всего это ссылка ещё не записанного объекта.
+			if src := exprSourceName(callee.Object); src != "" {
+				RaiseUserError("Метод " + callee.Field.Literal + " вызван у Неопределено: «" + src + "» не заполнено")
+			}
 			RaiseUserError("Метод " + callee.Field.Literal + " вызван у Неопределено")
 		}
 		return nil
 	}
 	return nil
+}
+
+// exprSourceName восстанавливает исходный текст простого выражения-приёмника
+// («Ссылка», «Объект.Ссылка») для сообщений об ошибках. Для всего сложнее
+// цепочки идентификаторов возвращает "" — тогда сообщение остаётся прежним.
+func exprSourceName(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.Ident:
+		return v.Tok.Literal
+	case *ast.MemberExpr:
+		if base := exprSourceName(v.Object); base != "" {
+			return base + "." + v.Field.Literal
+		}
+	}
+	return ""
 }
 
 // evalEvalBuiltin реализует Вычислить(Выражение): args[0] — строка-выражение.

--- a/internal/dsl/interpreter/to_number_bool_test.go
+++ b/internal/dsl/interpreter/to_number_bool_test.go
@@ -1,0 +1,33 @@
+package interpreter
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Число(Истина) = 1, Число(Ложь) = 0. Раньше булево уходило в разбор строки
+// «true»/«false», не парсилось и давало 0 в обоих случаях — типовая проверка
+// флага «Если Число(Флаг) <> 1» не срабатывала никогда. Значение bool-поля
+// приходит в DSL то булевым (форма, восстановление из БД), то числом 0/1
+// (ПолучитьОбъект на SQLite), поэтому Число() обязано выравнивать оба случая.
+func TestBuiltinToNumber_Bool(t *testing.T) {
+	for _, tc := range []struct {
+		in   any
+		want string
+	}{
+		{true, "1"},
+		{false, "0"},
+		{"1", "1"},
+		{"0", "0"},
+		{float64(1), "1"},
+		{"не число", "0"},
+	} {
+		got, err := builtinToNumber([]any{tc.in}, "", 0)
+		if err != nil {
+			t.Fatalf("Число(%v): %v", tc.in, err)
+		}
+		if s := fmt.Sprintf("%v", got); s != tc.want {
+			t.Errorf("Число(%v) = %s, ожидалось %s", tc.in, s, tc.want)
+		}
+	}
+}

--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -96,6 +96,12 @@ func (f *formObjectThis) Get(name string) any {
 		if f.entity != nil && (strings.EqualFold(name, "Ссылка") || strings.EqualFold(name, "Reference")) {
 			return f.refResolver.bindRefToContext(ref, f.entity.Name)
 		}
+		// Ссылочный реквизит формы (save:false): его нет в entity.Fields, поэтому
+		// без привязки к резолверу у ссылки не работали ни .Код/.Наименование,
+		// ни ПолучитьОбъект() — читалось Неопределено.
+		if refName := formAttrRefEntity(f.form, name); refName != "" {
+			return f.refResolver.bindRefToContext(ref, refName)
+		}
 	}
 	// Дефолты по типу: пустой numeric → 0, иначе `Объект.Сумма + 100` в DSL
 	// даст concat-строку «<nil>100» (DSL `+` для nil-операнда склеивает
@@ -181,6 +187,21 @@ func (t *formTpProxy) IterateThis() []interpreter.This {
 		out = append(out, newRefAwareMapThis(row, t.tp, t.refResolver))
 	}
 	return out
+}
+
+// formAttrRefEntity возвращает имя сущности, на которую ссылается одноимённый
+// реквизит формы (CatalogRef.X / DocumentRef.X), либо "" — если такого реквизита
+// нет или он не ссылочный.
+func formAttrRefEntity(form *metadata.FormModule, name string) string {
+	if form == nil {
+		return ""
+	}
+	for _, a := range form.Attributes {
+		if a != nil && strings.EqualFold(a.Name, name) {
+			return attrRefEntityName(a.TypeRef)
+		}
+	}
+	return ""
 }
 
 func entityField(entity *metadata.Entity, name string) *metadata.Field {

--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -1,11 +1,17 @@
 package ui
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/entityservice"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
 )
 
 // formObjectThis — обёртка над *runtime.Object, используемая как this/Объект
@@ -31,6 +37,14 @@ type formObjectThis struct {
 	entity      *metadata.Entity
 	form        *metadata.FormModule
 	refResolver *dslRefAttrResolver
+	// Запись объекта прямо из обработчика формы (Объект.Записать(), аналог
+	// ЗаписатьНаСервере в 1С). Без неё команда на ещё не записанной форме
+	// упиралась в пустую Ссылка и требовала от пользователя сначала нажать
+	// «Записать» — чего в управляемой форме быть не должно.
+	srv   *Server
+	ctx   context.Context
+	isNew bool
+	saved bool
 }
 
 // GetRefUUID сохраняет ссылочную идентичность runtime.Object у формовой
@@ -60,7 +74,73 @@ func (f *formObjectThis) CallMethod(method string, args []any) any {
 	if f == nil || f.obj == nil {
 		return nil
 	}
+	switch strings.ToLower(method) {
+	case "записать", "write":
+		if err := f.write(); err != nil {
+			interpreter.RaiseUserError("Записать(" + f.entity.Name + "): " + err.Error())
+		}
+		return f.selfRef()
+	case "этоновый", "isnew":
+		return f.isNew && !f.saved
+	}
 	return f.obj.CallMethod(method, args)
+}
+
+// write сохраняет объект формы через entityservice.Save — тем же путём, что и
+// кнопка «Записать»: с хуками ПриЗаписи/ОбработкаПроведения, табличными частями
+// и проверкой построчного доступа. Нужна обработчикам команд: на новой форме
+// они иначе упирались в незаполненную Ссылка.
+func (f *formObjectThis) write() error {
+	if f.srv == nil || f.entity == nil {
+		return fmt.Errorf("запись из обработчика формы недоступна")
+	}
+	ctx := f.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	isNew := f.isNew && !f.saved
+	if isNew {
+		if err := f.srv.autoFillRowAccessFields(ctx, f.entity, "write", f.obj.Fields); err != nil {
+			return err
+		}
+	}
+	accessID := uuid.Nil
+	if !isNew {
+		accessID = f.obj.ID
+	}
+	if err := f.srv.checkDSLRowAccess(ctx, f.entity, "write", accessID, f.obj.Fields); err != nil {
+		return err
+	}
+	result, err := f.srv.entitySvc.Save(ctx, entityservice.SaveRequest{
+		Entity:        f.entity,
+		ID:            f.obj.ID,
+		IsNew:         isNew,
+		Fields:        f.obj.Fields,
+		TablePartRows: f.obj.TablePartRows,
+	})
+	if err != nil {
+		return err
+	}
+	if result.DSLError != "" {
+		return fmt.Errorf("%s", result.DSLError)
+	}
+	wasSaved := f.saved
+	f.saved = true
+	// Ссылка появляется только после записи — до неё её нет ни в объекте, ни
+	// у резолвера. Ставим здесь же, чтобы следующая строка обработчика могла
+	// сразу писать Модуль.Действие(Объект.Ссылка).
+	f.obj.Fields["ссылка"] = f.selfRef()
+	f.obj.Fields["reference"] = f.obj.Fields["ссылка"]
+	storage.DeferUntilTxRollback(ctx, func() { f.saved = wasSaved })
+	return nil
+}
+
+func (f *formObjectThis) selfRef() *interpreter.Ref {
+	ref := &interpreter.Ref{UUID: f.obj.ID.String(), Type: f.entity.Name}
+	if f.refResolver != nil {
+		return f.refResolver.bindRefToContext(ref, f.entity.Name)
+	}
+	return ref
 }
 
 func (f *formObjectThis) Get(name string) any {

--- a/internal/ui/dsl_ref_attr.go
+++ b/internal/ui/dsl_ref_attr.go
@@ -29,12 +29,19 @@ func (s *Server) newDSLRefAttrResolver(ctx context.Context) *dslRefAttrResolver 
 }
 
 func (s *Server) newFormObjectThis(ctx context.Context, obj *runtime.Object, entity *metadata.Entity, form *metadata.FormModule) *formObjectThis {
+	return s.newFormObjectThisNew(ctx, obj, entity, form, false)
+}
+
+// newFormObjectThisNew дополнительно помечает объект как ещё не записанный,
+// чтобы Объект.Записать() в обработчике формы создал запись, а не пытался
+// обновить несуществующую.
+func (s *Server) newFormObjectThisNew(ctx context.Context, obj *runtime.Object, entity *metadata.Entity, form *metadata.FormModule, isNew bool) *formObjectThis {
 	var resolver *dslRefAttrResolver
 	if s != nil && s.store != nil && s.reg != nil {
 		resolver = s.newDSLRefAttrResolver(ctx)
 		resolver.attachObject(entity, obj)
 	}
-	return &formObjectThis{obj: obj, entity: entity, form: form, refResolver: resolver}
+	return &formObjectThis{obj: obj, entity: entity, form: form, refResolver: resolver, srv: s, ctx: ctx, isNew: isNew}
 }
 
 func (r *dslRefAttrResolver) ResolveRefAttr(ref *interpreter.Ref, field string) (any, bool) {

--- a/internal/ui/form_attr_regressions_test.go
+++ b/internal/ui/form_attr_regressions_test.go
@@ -189,3 +189,52 @@ func TestManagedFormRendersEntityOptionsOnNameCollision(t *testing.T) {
 		t.Error("в разметку просочился справочник одноимённого реквизита формы")
 	}
 }
+
+// Объявленный скалярный реквизит формы — рабочее поле, а не подозрительное:
+// жёлтая подсветка «не найден среди полей сущности» адресована опечатке в
+// data_path, и на штатном реквизите она сбивала с толку.
+func TestManagedFormRendersDeclaredScalarAttrWithoutWarning(t *testing.T) {
+	form := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: "Обращение",
+		LayoutKind: metadata.FormLayoutManaged,
+		Attributes: []*metadata.FormAttribute{{Name: "Телефон", TypeRef: "Строка"}},
+		Elements: []*metadata.FormElement{
+			{Kind: metadata.FormElementField, Name: "ПолеТелефон", DataPath: "Телефон"},
+			{Kind: metadata.FormElementField, Name: "ПолеОпечатка", DataPath: "Тлефон"},
+		},
+	}
+	entity := &metadata.Entity{
+		Name: "Обращение", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+		Forms:  []*metadata.FormModule{form},
+	}
+	data := map[string]any{
+		"Entity": entity, "Form": form, "IsNew": true,
+		"Values":        map[string]string{},
+		"RefOptions":    map[string][]map[string]any{},
+		"EnumOptions":   map[string]any{},
+		"ChoiceOptions": loadChoiceOptions(form, "ru"),
+		"TPRefOptions":  map[string]any{},
+		"TPEnumLabels":  map[string]map[string]map[string]string{},
+		"TPEnumOrder":   map[string]map[string][]string{},
+		"TPRefMeta":     map[string]any{},
+		"TablePartRows": map[string][]map[string]any{},
+		"User":          nil, "Lang": "ru",
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "page-managed-form", data); err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+	html := buf.String()
+	if strings.Contains(html, `name="Телефон" value="" placeholder="Телефон" style="background:#fef9c3"`) {
+		t.Error("объявленный реквизит формы подсвечен как ненайденное поле")
+	}
+	if !strings.Contains(html, `name="Телефон"`) {
+		t.Error("поле объявленного реквизита формы не отрисовано")
+	}
+	// Опечатка в data_path по-прежнему видна.
+	if !strings.Contains(html, `name="Тлефон" value="" placeholder="Тлефон" style="background:#fef9c3"`) {
+		t.Error("необъявленный data_path потерял предупреждающую подсветку")
+	}
+}

--- a/internal/ui/form_attr_values.go
+++ b/internal/ui/form_attr_values.go
@@ -100,6 +100,57 @@ func (s *Server) mergeFormAttrValues(
 	}
 }
 
+// addFormAttrVars публикует реквизиты формы как переменные с голым именем —
+// так их видит модуль управляемой формы в 1С, где под «Объект» лежит только
+// основной реквизит. Значение берётся у formObjectThis, поэтому ссылочный
+// реквизит приходит уже как *Ref (работает .Код/.Наименование), а ValueTable —
+// как прокси таблицы.
+//
+// Присваивание голому имени остаётся локальной переменной обработчика: обратно
+// в форму уезжает только то, что записано через Объект.<Реквизит>.
+func addFormAttrVars(form *metadata.FormModule, entity *metadata.Entity, this *formObjectThis, vars map[string]any) {
+	if form == nil || this == nil || vars == nil {
+		return
+	}
+	// Занятые имена (Объект, ЭтотОбъект, встроенные объекты доступа) переопределять
+	// нельзя: реквизит с именем «Запрос» иначе убил бы билтин для всей процедуры.
+	taken := make(map[string]bool, len(vars))
+	for k := range vars {
+		taken[strings.ToLower(k)] = true
+	}
+	for _, a := range form.Attributes {
+		if a == nil || a.Name == "" || a.MainAttribute {
+			continue
+		}
+		if taken[strings.ToLower(a.Name)] {
+			continue
+		}
+		// Одноимённое поле сущности читается только как Объект.<Поле>: голое имя
+		// было бы неоднозначным, а реквизита формы с таким именем по сути нет.
+		if _, isEntityField := entityFieldByName(entity, a.Name); isEntityField {
+			continue
+		}
+		vars[a.Name] = this.Get(a.Name)
+	}
+}
+
+// setFormSelfRef кладёт в объект псевдо-реквизит «Ссылка» на саму запись —
+// тот же контракт, что даёт entityservice.Save хукам ПриЗаписи/ОбработкаПроведения.
+// Только для существующей записи: у новой ссылки ещё нет, и ПолучитьОбъект() по
+// сгенерированному buildObjectFromForm uuid всё равно ничего не найдёт — пусть
+// обработчик увидит Неопределено и скажет об этом явно.
+func setFormSelfRef(r *http.Request, entity *metadata.Entity, obj *runtime.Object) {
+	if entity == nil || obj == nil || strings.TrimSpace(r.FormValue("_id")) == "" {
+		return
+	}
+	if obj.Fields == nil {
+		obj.Fields = map[string]any{}
+	}
+	selfRef := &interpreter.Ref{UUID: obj.ID.String(), Type: entity.Name}
+	obj.Fields["ссылка"] = selfRef
+	obj.Fields["reference"] = selfRef
+}
+
 // formAttrRef строит *interpreter.Ref по имени сущности и строковому uuid.
 // Образец — enrichHeaderRefs; nil означает «оставить как есть».
 func (s *Server) formAttrRef(ctx context.Context, refEntityName, idStr string) *interpreter.Ref {

--- a/internal/ui/form_event_context_test.go
+++ b/internal/ui/form_event_context_test.go
@@ -1,0 +1,257 @@
+package ui
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Контекст обработчика управляемой формы: «Ссылка» самой записи и реквизиты
+// формы голым именем. До этих проверок типовой обработчик вида
+// `Модуль.Действие(Объект.Ссылка)` падал на «ПолучитьОбъект вызван у
+// Неопределено», а `Если ПустаяСтрока(Телефон)` всегда видел пустоту.
+
+// formCtxFixture — справочник «Обращение» с реквизитом-ссылкой на «Направление»
+// в реквизитах формы (save:false) и модулем формы из параметра.
+type formCtxFixture struct {
+	srv    *Server
+	entity *metadata.Entity
+	docID  uuid.UUID
+	naprID uuid.UUID
+}
+
+func setupFormCtxServer(t *testing.T, formOS string, attrs []*metadata.FormAttribute) formCtxFixture {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "ctx.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	napr := &metadata.Entity{
+		Name: "Направление", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Код", Type: metadata.FieldTypeString},
+		},
+	}
+	ent := &metadata.Entity{
+		Name: "Обращение", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Канал", Type: metadata.FieldTypeString},
+		},
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{napr, ent}); err != nil {
+		t.Fatal(err)
+	}
+	naprID := uuid.New()
+	if err := db.Upsert(ctx, napr.Name, naprID,
+		map[string]any{"Наименование": "Ремонт", "Код": "REM"}, napr); err != nil {
+		t.Fatal(err)
+	}
+	docID := uuid.New()
+	if err := db.Upsert(ctx, ent.Name, docID,
+		map[string]any{"Наименование": "ОБР-000002", "Канал": "Телефон"}, ent); err != nil {
+		t.Fatal(err)
+	}
+
+	form := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: ent.Name,
+		LayoutKind: metadata.FormLayoutManaged,
+		Attributes: attrs,
+		Elements: []*metadata.FormElement{{
+			Kind: metadata.FormElementButton, Name: "КнопкаТест",
+			Handlers: map[metadata.FormEventType]string{metadata.FormEventOnClick: "Тест"},
+		}},
+		ProgramAST: mustParse(t, formOS),
+	}
+	ent.Forms = []*metadata.FormModule{form}
+
+	reg := runtime.NewRegistry()
+	reg.Load(runtime.LoadOptions{Entities: []*metadata.Entity{napr, ent}})
+	interp := interpreter.New()
+	interp.LookupProc = reg.GetModuleProc
+
+	return formCtxFixture{
+		srv: &Server{store: db, reg: reg, interp: interp,
+			lockMgr: runtime.NewLockManager(), messages: NewMessageStore()},
+		entity: ent, docID: docID, naprID: naprID,
+	}
+}
+
+func (f formCtxFixture) fire(t *testing.T, body url.Values) formEventResponse {
+	t.Helper()
+	body.Set("_element", "КнопкаТест")
+	body.Set("_event", string(metadata.FormEventOnClick))
+	body.Set("_kind", "object")
+	rec := executeFormEvent(t, f.srv, f.entity, body)
+	return decodeFormEventResponse(t, rec.Body.Bytes())
+}
+
+// Объект.Ссылка в обработчике формы — рабочая ссылка на саму запись: её можно
+// передать в общий модуль и получить объект, как в ПриЗаписи/ОбработкеПроведения.
+func TestFormEvent_ОбъектСсылкаУказываетНаЗапись(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Об = Объект.Ссылка.ПолучитьОбъект();
+	Сообщить("наим=" + Об.Наименование);
+КонецПроцедуры
+`, nil)
+
+	body := url.Values{}
+	body.Set("_id", f.docID.String())
+	body.Set("Наименование", "ОБР-000002")
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "наим=ОБР-000002" {
+		t.Fatalf("messages=%v, ожидалось [наим=ОБР-000002]", resp.Messages)
+	}
+	// Псевдо-реквизит — контекст обработчика, в значения формы он не едет.
+	for _, k := range []string{"ссылка", "reference", "Ссылка"} {
+		if _, exists := resp.Values[k]; exists {
+			t.Errorf("ключ %q не должен попадать в values: %+v", k, resp.Values)
+		}
+	}
+}
+
+// У новой (ещё не записанной) записи ссылки нет — обработчик должен увидеть
+// Неопределено, а не ссылку на несуществующий uuid.
+func TestFormEvent_УНовойЗаписиСсылкиНет(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Если ЗначениеЗаполнено(Объект.Ссылка) Тогда
+		Сообщить("ссылка есть");
+	Иначе
+		Сообщить("ссылки нет");
+	КонецЕсли;
+КонецПроцедуры
+`, nil)
+
+	body := url.Values{}
+	body.Set("Наименование", "черновик")
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "ссылки нет" {
+		t.Fatalf("messages=%v, ожидалось [ссылки нет]", resp.Messages)
+	}
+}
+
+// Реквизит формы читается голым именем — так его пишут в модуле управляемой
+// формы. Ссылочный при этом остаётся ссылкой: доступны .Код/.Наименование.
+func TestFormEvent_РеквизитФормыДоступенГолымИменем(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Если НЕ ЗначениеЗаполнено(НаправлениеВыбор) Тогда
+		ВызватьИсключение("направление не выбрано");
+	КонецЕсли;
+	Сообщить("код=" + НаправлениеВыбор.Код + " тел=" + Телефон);
+КонецПроцедуры
+`, []*metadata.FormAttribute{
+		{Name: "НаправлениеВыбор", TypeRef: "CatalogRef.Направление"},
+		{Name: "Телефон", TypeRef: "Строка"},
+	})
+
+	body := url.Values{}
+	body.Set("_id", f.docID.String())
+	body.Set("НаправлениеВыбор", f.naprID.String())
+	body.Set("Телефон", "89001112233")
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "код=REM тел=89001112233" {
+		t.Fatalf("messages=%v, ожидалось [код=REM тел=89001112233]", resp.Messages)
+	}
+}
+
+// Тот же реквизит по-прежнему виден и как Объект.<Реквизит> — путь, на котором
+// написаны существующие конфигурации, ломать нельзя.
+func TestFormEvent_РеквизитФормыДоступенЧерезОбъект(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Сообщить("код=" + Объект.НаправлениеВыбор.Код);
+КонецПроцедуры
+`, []*metadata.FormAttribute{
+		{Name: "НаправлениеВыбор", TypeRef: "CatalogRef.Направление"},
+	})
+
+	body := url.Values{}
+	body.Set("_id", f.docID.String())
+	body.Set("НаправлениеВыбор", f.naprID.String())
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "код=REM" {
+		t.Fatalf("messages=%v, ожидалось [код=REM]", resp.Messages)
+	}
+}
+
+// Имя реквизита формы не должно перебивать встроенный объект доступа: иначе
+// «Справочники» на форме убили бы весь DSL внутри процедуры.
+func TestFormEvent_РеквизитНеЗатираетВстроенныеИмена(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Реф = Справочники.Направление.НайтиПоРеквизиту("Код", "REM");
+	Если ЗначениеЗаполнено(Реф) Тогда
+		Сообщить("найдено");
+	КонецЕсли;
+КонецПроцедуры
+`, []*metadata.FormAttribute{
+		{Name: "Справочники", TypeRef: "Строка"},
+	})
+
+	body := url.Values{}
+	body.Set("_id", f.docID.String())
+	body.Set("Справочники", "мусор")
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "найдено" {
+		t.Fatalf("messages=%v, ожидалось [найдено]", resp.Messages)
+	}
+}
+
+// Основной реквизит (main:true) — это сам объект; голым именем он не публикуется,
+// иначе «Объект» подменился бы значением поля и обработчик потерял бы запись.
+func TestFormEvent_ОсновнойРеквизитНеПодменяетОбъект(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Сообщить("канал=" + Объект.Канал);
+КонецПроцедуры
+`, []*metadata.FormAttribute{
+		{Name: "Объект", TypeRef: "CatalogRef.Обращение", MainAttribute: true},
+	})
+
+	body := url.Values{}
+	body.Set("_id", f.docID.String())
+	body.Set("Канал", "Телефон")
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "канал=Телефон" {
+		t.Fatalf("messages=%v, ожидалось [канал=Телефон]", resp.Messages)
+	}
+}

--- a/internal/ui/form_event_context_test.go
+++ b/internal/ui/form_event_context_test.go
@@ -82,11 +82,10 @@ func setupFormCtxServer(t *testing.T, formOS string, attrs []*metadata.FormAttri
 	interp := interpreter.New()
 	interp.LookupProc = reg.GetModuleProc
 
-	return formCtxFixture{
-		srv: &Server{store: db, reg: reg, interp: interp,
-			lockMgr: runtime.NewLockManager(), messages: NewMessageStore()},
-		entity: ent, docID: docID, naprID: naprID,
-	}
+	srv := &Server{store: db, reg: reg, interp: interp,
+		lockMgr: runtime.NewLockManager(), messages: NewMessageStore()}
+	srv.entitySvc = srv.newEntityService(nil)
+	return formCtxFixture{srv: srv, entity: ent, docID: docID, naprID: naprID}
 }
 
 func (f formCtxFixture) fire(t *testing.T, body url.Values) formEventResponse {
@@ -253,5 +252,69 @@ func TestFormEvent_ОсновнойРеквизитНеПодменяетОбъ�
 	}
 	if len(resp.Messages) != 1 || resp.Messages[0] != "канал=Телефон" {
 		t.Fatalf("messages=%v, ожидалось [канал=Телефон]", resp.Messages)
+	}
+}
+
+// Объект.Записать() в обработчике формы создаёт ещё не сохранённую запись —
+// иначе команда на экране «Создать» упиралась в пустую Ссылка и требовала от
+// оператора сначала нажать «Записать». Клиент получает id записи в savedId,
+// чтобы следующее действие не создало второй документ.
+func TestFormEvent_ОбъектЗаписатьСоздаётНовуюЗапись(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Если НЕ ЗначениеЗаполнено(Объект.Ссылка) Тогда
+		Объект.Записать();
+	КонецЕсли;
+	Об = Объект.Ссылка.ПолучитьОбъект();
+	Сообщить("записано: " + Об.Наименование);
+КонецПроцедуры
+`, nil)
+
+	body := url.Values{}
+	body.Set("Наименование", "ОБР-НОВОЕ") // _id не передан — форма «Создать»
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if len(resp.Messages) != 1 || resp.Messages[0] != "записано: ОБР-НОВОЕ" {
+		t.Fatalf("messages=%v, ожидалось [записано: ОБР-НОВОЕ]", resp.Messages)
+	}
+	if resp.SavedID == "" {
+		t.Fatal("savedId пуст: клиент не узнает id и следующее действие создаст дубль")
+	}
+	// Запись реально появилась в базе — под тем же id, что уехал клиенту.
+	id, err := uuid.Parse(resp.SavedID)
+	if err != nil {
+		t.Fatalf("savedId не uuid: %q", resp.SavedID)
+	}
+	row, err := f.srv.store.GetByID(context.Background(), f.entity.Name, id, f.entity)
+	if err != nil || row == nil {
+		t.Fatalf("записи нет в базе: row=%v err=%v", row, err)
+	}
+	if row["Наименование"] != "ОБР-НОВОЕ" {
+		t.Errorf("Наименование = %v, ожидалось ОБР-НОВОЕ", row["Наименование"])
+	}
+}
+
+// У существующей записи savedId не возвращается: клиенту нечего менять, а
+// непустое значение сбило бы адрес открытой формы.
+func TestFormEvent_SavedIDТолькоДляНовойЗаписи(t *testing.T) {
+	f := setupFormCtxServer(t, `
+Процедура Тест()
+	Объект.Записать();
+КонецПроцедуры
+`, nil)
+
+	body := url.Values{}
+	body.Set("_id", f.docID.String())
+	body.Set("Наименование", "ОБР-000002")
+
+	resp := f.fire(t, body)
+	if !resp.OK {
+		t.Fatalf("ok=false, error=%q", resp.Error)
+	}
+	if resp.SavedID != "" {
+		t.Errorf("savedId=%q для существующей записи — должен быть пуст", resp.SavedID)
 	}
 }

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -254,7 +254,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 			FormTables:     formTables,
 			ConditionalCSS: conditionalCSS,
 			Messages:       outMsgs,
-			Error:          runErr.Error(),
+			Error:          interpreter.FormatUserError(runErr),
 			PickerData:     picker,
 		})
 		return
@@ -817,7 +817,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 						FormTables:     formTables,
 						ConditionalCSS: conditionalCSS,
 						Messages:       outMsgs,
-						Error:          runErr.Error(),
+						Error:          interpreter.FormatUserError(runErr),
 						PickerData:     picker,
 					})
 					return

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -49,6 +49,10 @@ type formEventResponse struct {
 	// PickerData != nil — обработчик фазы 1 вызвал ПоказатьПодбор: клиент
 	// открывает модальный диалог мультивыбора вместо применения ТЧ (план 46).
 	PickerData *pickerPayload `json:"pickerData,omitempty"`
+	// SavedID заполняется, когда обработчик записал ЕЩЁ НЕ СОХРАНЁННУЮ форму
+	// через Объект.Записать(). Клиент подставляет его в _id следующих событий и
+	// в адрес страницы — иначе второе действие подряд создало бы второй документ.
+	SavedID string `json:"savedId,omitempty"`
 	// ChoiceList — динамический список значений для элемента ПолеСписка,
 	// сформированный обработчиком НачалоВыбора (билтин ДобавитьЗначениеСписка).
 	// Клиент заполняет им <select> того элемента, что инициировал событие.
@@ -189,7 +193,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	mc := runtime.NewMovementsCollector(entity.Name, obj.ID)
 	var msgs []string
 	vars := s.buildDSLVarsWithMessages(r.Context(), mc, &msgs)
-	thisObj := s.newFormObjectThis(r.Context(), obj, entity, form)
+	thisObj := s.newFormObjectThisNew(r.Context(), obj, entity, form, strings.TrimSpace(r.FormValue("_id")) == "")
 	vars["Объект"] = thisObj
 	vars["ЭтотОбъект"] = thisObj
 
@@ -256,6 +260,9 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 			Messages:       outMsgs,
 			Error:          interpreter.FormatUserError(runErr),
 			PickerData:     picker,
+			// Обработчик мог записать форму и упасть уже после этого: id всё
+			// равно нужен клиенту, иначе повтор действия создаст второй документ.
+			SavedID: savedFormID(thisObj),
 		})
 		return
 	}
@@ -270,7 +277,18 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 		ConditionalCSS: conditionalCSS,
 		PickerData:     picker,
 		ChoiceList:     choiceItems,
+		SavedID:        savedFormID(thisObj),
 	})
+}
+
+// savedFormID возвращает id записи, если обработчик сохранил ЕЩЁ НЕ записанную
+// форму через Объект.Записать(). Для уже существующей записи пусто — клиенту
+// нечего менять.
+func savedFormID(this *formObjectThis) string {
+	if this == nil || !this.isNew || !this.saved || this.obj == nil {
+		return ""
+	}
+	return this.obj.ID.String()
 }
 
 func (s *Server) serializeManagedFormEventState(form *metadata.FormModule, entity *metadata.Entity, obj *runtime.Object, rules []metadata.FormCondRule, msgs []string) (map[string]any, map[string][]map[string]any, map[string][]map[string]any, string, []string) {

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -153,6 +153,13 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 		_ = s.restoreUnsubmittedFields(r.Context(), r, entity, form, obj.ID, obj.Fields)
 	}
 
+	// Псевдо-реквизит «Ссылка» самой записи — как в entityservice.Save. Без него
+	// Объект.Ссылка в обработчике формы было Неопределено, и типовой вызов
+	// Модуль.Действие(Объект.Ссылка) падал на «ПолучитьОбъект вызван у
+	// Неопределено». Ставится ДО newFormObjectThis: attachObject предзагружает
+	// реквизиты именно по этой ссылке.
+	setFormSelfRef(r, entity, obj)
+
 	// Реквизиты формы (attributes с save:false) — formToFields их не разбирает,
 	// поэтому без этого шага Объект.<Реквизит> в обработчике всегда nil.
 	s.mergeFormAttrValues(r.Context(), r, form, entity, obj)
@@ -185,6 +192,11 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	thisObj := s.newFormObjectThis(r.Context(), obj, entity, form)
 	vars["Объект"] = thisObj
 	vars["ЭтотОбъект"] = thisObj
+
+	// Реквизиты формы видны и голым именем — как в модуле управляемой формы 1С,
+	// где под Объект лежит только основной реквизит. Читаются через thisObj,
+	// поэтому ссылочные приходят как *Ref, а ValueTable — как прокси таблицы.
+	addFormAttrVars(form, entity, thisObj, vars)
 
 	// Передаём все процедуры формы, чтобы обработчик мог вызывать
 	// вспомогательные функции из того же .form.os (evalCall ищет
@@ -267,6 +279,13 @@ func (s *Server) serializeManagedFormEventState(form *metadata.FormModule, entit
 		return nil, nil, nil, conditionalCSS, msgs
 	}
 	values := normalizeFormAttrKeys(serializeFieldsForEntity(obj.Fields, entity), form, entity)
+	// Псевдо-реквизит «Ссылка» — контекст обработчика, а не значение формы:
+	// в ответ он не едет, чтобы applyValues не искал под него элемент.
+	for _, k := range []string{"ссылка", "reference"} {
+		if _, isEntityField := entityFieldByName(entity, k); !isEntityField {
+			delete(values, k)
+		}
+	}
 	tableParts := serializeTablePartRowsForEntity(obj.TablePartRows, entity)
 	if s.interp != nil {
 		if warnings := applyManagedFormConditionalRules(form, tableParts, values, rules, newInterpEvaluator(s.interp)); len(warnings) > 0 {

--- a/internal/ui/managed_form_test.go
+++ b/internal/ui/managed_form_test.go
@@ -186,18 +186,22 @@ func TestPageManagedForm_ReadOnlyRefDisablesPickerActions(t *testing.T) {
 		DataPath: "Объект.Клиент",
 		ReadOnly: true,
 	}
-	ctx := map[string]any{
-		"Entity":      ent,
-		"Values":      map[string]string{"Клиент": ""},
-		"RefOptions":  map[string]any{},
-		"EnumOptions": map[string]any{},
+	render := func(value string) string {
+		t.Helper()
+		ctx := map[string]any{
+			"Entity":      ent,
+			"Values":      map[string]string{"Клиент": value},
+			"RefOptions":  map[string]any{"Клиент": []map[string]any{{"id": "cl-1", "_label": "ООО Ромашка"}}},
+			"EnumOptions": map[string]any{},
+		}
+		var buf bytes.Buffer
+		if err := tmpl.ExecuteTemplate(&buf, "managed-element", map[string]any{"El": el, "Ctx": ctx}); err != nil {
+			t.Fatalf("execute managed-element: %v", err)
+		}
+		return buf.String()
 	}
 
-	var buf bytes.Buffer
-	if err := tmpl.ExecuteTemplate(&buf, "managed-element", map[string]any{"El": el, "Ctx": ctx}); err != nil {
-		t.Fatalf("execute managed-element: %v", err)
-	}
-	html := buf.String()
+	html := render("cl-1")
 	// Само поле — disabled: выбрать другое значение нельзя.
 	start := strings.Index(html, `id="ref-Клиент"`)
 	if start < 0 {
@@ -219,6 +223,16 @@ func TestPageManagedForm_ReadOnlyRefDisablesPickerActions(t *testing.T) {
 	}
 	if end := strings.Index(html[cur:], ">"); end > 0 && strings.Contains(html[cur:cur+end], " disabled") {
 		t.Errorf("«Открыть карточку» не должна быть disabled:\n%s", html)
+	}
+
+	// Пустое значение: открывать нечего — кнопки нет, и заглушка выбора не
+	// подписана «— выбрать —», иначе готовое к чтению поле выглядит как забытый ввод.
+	empty := render("")
+	if strings.Contains(empty, `data-ob-ref-current="ref-Клиент"`) {
+		t.Errorf("на пустом readonly-поле кнопка «Открыть карточку» не нужна:\n%s", empty)
+	}
+	if strings.Contains(empty, "— выбрать —") {
+		t.Errorf("readonly-поле не должно предлагать «— выбрать —»:\n%s", empty)
 	}
 }
 

--- a/internal/ui/managed_form_test.go
+++ b/internal/ui/managed_form_test.go
@@ -198,19 +198,27 @@ func TestPageManagedForm_ReadOnlyRefDisablesPickerActions(t *testing.T) {
 		t.Fatalf("execute managed-element: %v", err)
 	}
 	html := buf.String()
-	for _, marker := range []string{
-		`id="ref-Клиент"`,
-		`data-ob-ref-picker="ref-Клиент"`,
-		`data-ob-ref-current="ref-Клиент"`,
-	} {
-		start := strings.Index(html, marker)
-		if start < 0 {
-			t.Fatalf("managed ref control is missing %q:\n%s", marker, html)
-		}
-		end := strings.Index(html[start:], ">")
-		if end < 0 || !strings.Contains(html[start:start+end], " disabled") {
-			t.Errorf("read-only ref control %q must be disabled:\n%s", marker, html)
-		}
+	// Само поле — disabled: выбрать другое значение нельзя.
+	start := strings.Index(html, `id="ref-Клиент"`)
+	if start < 0 {
+		t.Fatalf("managed ref control is missing:\n%s", html)
+	}
+	if end := strings.Index(html[start:], ">"); end < 0 || !strings.Contains(html[start:start+end], " disabled") {
+		t.Errorf("read-only ref control must be disabled:\n%s", html)
+	}
+	// Кнопка подбора не рисуется вовсе: серая «…» рядом с готовым значением
+	// заставляет читать его как незаполненный ввод.
+	if strings.Contains(html, `data-ob-ref-picker="ref-Клиент"`) {
+		t.Errorf("read-only ref не должен нести кнопку подбора:\n%s", html)
+	}
+	// А «Открыть карточку» остаётся рабочей: просмотр связанного объекта —
+	// не редактирование, и именно на нередактируемом поле он нужен чаще всего.
+	cur := strings.Index(html, `data-ob-ref-current="ref-Клиент"`)
+	if cur < 0 {
+		t.Fatalf("кнопка «Открыть карточку» потеряна:\n%s", html)
+	}
+	if end := strings.Index(html[cur:], ">"); end > 0 && strings.Contains(html[cur:cur+end], " disabled") {
+		t.Errorf("«Открыть карточку» не должна быть disabled:\n%s", html)
 	}
 }
 

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -419,6 +419,18 @@ function obManagedReady(fn) {
       applyValues(data.values);
       applyChoiceList(elementName, data.choiceList);
       applyFormTables(data.formTables);
+      // Обработчик записал новую форму (Объект.Записать()): дальше она работает
+      // с этой записью. Без подмены _id второе действие подряд ушло бы как
+      // «новый документ» и создало дубль, а адрес страницы остался бы /new.
+      if (data.savedId && !DOC_ID) {
+        DOC_ID = String(data.savedId);
+        var idInput = document.querySelector('#main-form [name="_id"]');
+        if (idInput) idInput.value = DOC_ID;
+        if (window.history && history.replaceState) {
+          history.replaceState(null, '', location.pathname.replace(/\/new$/, '/' + DOC_ID));
+        }
+        window._obFormDirty = false;
+      }
       (data.messages || []).forEach(m => flash(m, 'ok'));
       if (data.error) flash(data.error, 'err');
     } catch (e) {

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -67,8 +67,15 @@ const tplManagedForm = `
             <option value="{{index . "id"}}" {{if eq (index . "id") (index $ctx.Values $fn)}}selected{{end}}>{{index . "_label"}}</option>
             {{end}}
           </select>
-          <button type="button" data-ob-ref-picker="ref-{{$fn}}"{{if $el.ReadOnly}} disabled{{end}} style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
-          <button type="button" data-ob-ref-current="ref-{{$fn}}"{{if $el.ReadOnly}} disabled{{end}} style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
+          {{/* Нередактируемому полю кнопка подбора не нужна — выбирать нечего, а
+               серая «…» рядом заставляет читать значение как незаполненный ввод.
+               «Открыть карточку» остаётся и остаётся РАБОЧЕЙ: посмотреть связанный
+               объект — не редактирование, и на readonly-поле это как раз то, что
+               нужно (открыть звонок, клиента, документ-основание). */}}
+          {{if not $el.ReadOnly}}
+          <button type="button" data-ob-ref-picker="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
+          {{end}}
+          <button type="button" data-ob-ref-current="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
         </div>
       {{else if isEnum (str $f.Type)}}
         <select name="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
@@ -85,7 +92,7 @@ const tplManagedForm = `
           <option value="true" {{if eq (index $ctx.Values $fn) "true"}}selected{{end}}>Да</option>
         </select>
       {{else if eq (str $f.Type) "number"}}
-        <input type="text" inputmode="decimal" pattern="[+-]?([0-9]+([.,][0-9]+)?|[.,][0-9]+)" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}" title="Введите число; десятичный разделитель — запятая или точка"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
+        <input type="text" inputmode="decimal" pattern="[+-]?([0-9]+([.,][0-9]+)?|[.,][0-9]+)" name="{{$fn}}" value="{{index $ctx.Values $fn}}" title="Введите число; десятичный разделитель — запятая или точка"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{else if isRichText (str $f.Type)}}
         {{/* textarea — скрытое form-backing поле; Quill (этап 2) монтируется на
              .richtext-editor и синхронизирует HTML обратно перед submit. Без JS
@@ -102,7 +109,7 @@ const tplManagedForm = `
       {{else if $el.Multiline}}
         <textarea name="{{$fn}}" rows="5" style="width:100%"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>{{index $ctx.Values $fn}}</textarea>
       {{else}}
-        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
+        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{end}}
     {{else if eq (str $el.Type) "file"}}
       {{/* Поле не найдено в Entity, но элемент объявлен как file */}}
@@ -137,7 +144,7 @@ const tplManagedForm = `
              подсветка ниже адресована ОПЕЧАТКЕ в data_path; штатный реквизит
              формы работает полноценно (обработчик читает его голым именем и как
              Объект.<Реквизит>), и предупреждать о нём не о чем. */}}
-        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
+        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{else}}
         {{/* Ни поля сущности, ни реквизита формы с таким именем — почти всегда
              опечатка в data_path: подсвечиваем, чтобы это не осталось незамеченным. */}}
@@ -166,9 +173,13 @@ const tplManagedForm = `
   </div>
 {{else if eq (str $el.Kind) "Флажок"}}
   {{$fn := dpField $el.DataPath}}
+  {{$hChg := hasHandler $el "ПриИзменении"}}
   <div class="form-group" style="display:flex;align-items:center;gap:8px">
+    {{/* ПриИзменении у флажка работает так же, как у остальных полей: без
+         data-ob-fire-change обработчик «поставил галку → выполнилось действие»
+         молча не вызывался. */}}
     <input type="checkbox" id="cb-{{$fn}}" name="{{$fn}}" value="true"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}
-      {{if eq (index $ctx.Values $fn) "true"}}checked{{end}}{{if $el.ReadOnly}} disabled{{end}}>
+      {{if eq (index $ctx.Values $fn) "true"}}checked{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
     <label for="cb-{{$fn}}" style="margin-bottom:0;cursor:pointer">{{fieldTitleRU $el.TitleMap $fn}}</label>
   </div>
 {{else if eq (str $el.Kind) "Надпись"}}
@@ -390,8 +401,18 @@ const tplManagedForm = `
 {{if .TabTitle}}<meta name="ob-tab-title" content="{{.TabTitle}}">{{end}}
 <style>
 .managed-group-horizontal>.managed-group-body{display:flex;flex-wrap:wrap;gap:12px;align-items:flex-start}
-.managed-group-horizontal>.managed-group-body>.form-group{flex:1 1 220px;min-width:180px;margin-bottom:0}
+/* Поле в горизонтальной группе не растягивается на всю строку: иначе одинокое
+   поле уезжало во всю ширину, а кнопка рядом с ним — к правому краю экрана. */
+.managed-group-horizontal>.managed-group-body>.form-group{flex:0 1 260px;min-width:180px;margin-bottom:0}
 .managed-group-horizontal>.managed-group-body>.form-decoration,.managed-group-horizontal>.managed-group-body>button{flex:0 0 auto}
+/* Кнопка встаёт вровень с полем, а не с его меткой: метка занимает
+   line-height 18px + margin-bottom 5px (см. label в общем стиле). */
+.managed-group-horizontal>.managed-group-body>.form-group>label{line-height:18px}
+.managed-group-horizontal>.managed-group-body>button{align-self:flex-start;margin-top:23px}
+/* Нередактируемое поле — это ЗНАЧЕНИЕ, а не ввод: убираем стрелку списка и
+   гасим рамку, чтобы результат команды не читался как незаполненное поле. */
+.form-group input[readonly],.form-group input:disabled,.form-group select:disabled,.form-group textarea[readonly]{
+  background:#f8fafc;border-color:#eef2f7;color:#334155;cursor:default;opacity:1;-webkit-appearance:none;appearance:none}
 </style>
 {{if hasGridTP .Form}}
 <link rel="stylesheet" href="/vendor/slickgrid/slick.grid.css">

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -62,7 +62,7 @@ const tplManagedForm = `
       {{if isRef (str $f.Type)}}
         <div style="display:flex;gap:6px;align-items:center">
           <select id="ref-{{$fn}}" name="{{$fn}}" style="flex:1" data-ref-entity="{{$f.RefEntity}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $f.InlineCreateEnabled false}} data-ref-allow-create="1"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
-            <option value="">— выбрать —</option>
+            <option value="">{{if $el.ReadOnly}}—{{else}}— выбрать —{{end}}</option>
             {{range index $ctx.RefOptions $fn}}
             <option value="{{index . "id"}}" {{if eq (index . "id") (index $ctx.Values $fn)}}selected{{end}}>{{index . "_label"}}</option>
             {{end}}
@@ -75,11 +75,15 @@ const tplManagedForm = `
           {{if not $el.ReadOnly}}
           <button type="button" data-ob-ref-picker="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
           {{end}}
+          {{/* Открывать нечего, пока значение не выбрано — на пустом поле кнопка
+               только занимала место и сбивала выравнивание соседей. */}}
+          {{if index $ctx.Values $fn}}
           <button type="button" data-ob-ref-current="ref-{{$fn}}" style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px" title="Открыть карточку">🔍</button>
+          {{end}}
         </div>
       {{else if isEnum (str $f.Type)}}
         <select name="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
-          <option value="">— выбрать —</option>
+          <option value="">{{if $el.ReadOnly}}—{{else}}— выбрать —{{end}}</option>
           {{range index $ctx.EnumOptions $fn}}
           <option value="{{.Value}}" {{if eq .Value (index $ctx.Values $fn)}}selected{{end}}>{{.Label}}</option>
           {{end}}
@@ -132,7 +136,7 @@ const tplManagedForm = `
              остаётся прежний текстовый ввод со значением. */}}
         <div style="display:flex;gap:6px;align-items:center">
           <select id="ref-{{$fn}}" name="{{$fn}}" style="flex:1" data-ref-entity="{{attrRefEntity $attr.TypeRef}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
-            <option value="">— выбрать —</option>
+            <option value="">{{if $el.ReadOnly}}—{{else}}— выбрать —{{end}}</option>
             {{range index $ctx.RefOptions $fn}}
             <option value="{{index . "id"}}" {{if eq (index . "id") (index $ctx.Values $fn)}}selected{{end}}>{{index . "_label"}}</option>
             {{end}}
@@ -164,7 +168,7 @@ const tplManagedForm = `
   <div class="form-group">
     <label>{{fieldTitleRU $el.TitleMap $fn}}{{if $el.Required}} <span style="color:#dc2626">*</span>{{end}}</label>
     <select name="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if hasHandler $el "НачалоВыбора"}} data-el="{{$el.Name}}" data-ob-list-choice="{{$el.Name}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
-      <option value="">— выбрать —</option>
+      <option value="">{{if $el.ReadOnly}}—{{else}}— выбрать —{{end}}</option>
       {{range index $ctx.ChoiceOptions $el.Name}}
       <option value="{{.Value}}" {{if eq .Value (index $ctx.Values $fn)}}selected{{end}}>{{.Label}}</option>
       {{end}}
@@ -174,7 +178,7 @@ const tplManagedForm = `
 {{else if eq (str $el.Kind) "Флажок"}}
   {{$fn := dpField $el.DataPath}}
   {{$hChg := hasHandler $el "ПриИзменении"}}
-  <div class="form-group" style="display:flex;align-items:center;gap:8px">
+  <div class="form-group managed-checkbox" style="display:flex;align-items:center;gap:8px">
     {{/* ПриИзменении у флажка работает так же, как у остальных полей: без
          data-ob-fire-change обработчик «поставил галку → выполнилось действие»
          молча не вызывался. */}}
@@ -187,7 +191,7 @@ const tplManagedForm = `
     {{fieldTitleRU $el.TitleMap $el.Name}}
   </div>
 {{else if eq (str $el.Kind) "Кнопка"}}
-  <button type="button" class="btn btn-secondary" style="margin:6px 4px 6px 0"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.HotKey}} data-ob-hotkey="{{$el.HotKey}}" aria-keyshortcuts="{{$el.HotKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if hasHandler $el "Нажатие"}} data-ob-fire-click="{{$el.Name}}"{{end}}>
+  <button type="button" class="btn btn-secondary managed-btn"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.HotKey}} data-ob-hotkey="{{$el.HotKey}}" aria-keyshortcuts="{{$el.HotKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if hasHandler $el "Нажатие"}} data-ob-fire-click="{{$el.Name}}"{{end}}>
     {{fieldTitleRU $el.TitleMap $el.Name}}
   </button>
 {{else if eq (str $el.Kind) "ПолеКартинки"}}
@@ -259,7 +263,7 @@ const tplManagedForm = `
           {{if isRef (str $f.Type)}}
             <div style="display:flex;gap:4px;align-items:center">
               <select name="tp.{{$tpName}}.{{$i}}.{{$f.Name}}" style="flex:1" data-ref-entity="{{$f.RefEntity}}"{{if $f.InlineCreateEnabled true}} data-ref-allow-create="1"{{end}}>
-                <option value="">— выбрать —</option>
+                <option value="">{{if $el.ReadOnly}}—{{else}}— выбрать —{{end}}</option>
                 {{range index $tpRef $f.Name}}
                 <option value="{{index . "id"}}" {{if eq (str (index . "id")) (refID $v)}}selected{{end}}>{{index . "_label"}}</option>
                 {{end}}
@@ -367,7 +371,7 @@ const tplManagedForm = `
     <label>{{fieldTitleRU $el.TitleMap $fn}}{{if $el.Required}} <span style="color:#dc2626">*</span>{{end}}</label>
     {{if eq $el.View "select"}}
       <select name="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} disabled{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
-        <option value="">— выбрать —</option>
+        <option value="">{{if $el.ReadOnly}}—{{else}}— выбрать —{{end}}</option>
         {{if $enum}}
           {{range index $ctx.EnumOptions $fn}}<option value="{{.Value}}" {{if eq .Value $cur}}selected{{end}}>{{.Label}}</option>{{end}}
         {{else}}
@@ -405,13 +409,21 @@ const tplManagedForm = `
    поле уезжало во всю ширину, а кнопка рядом с ним — к правому краю экрана. */
 .managed-group-horizontal>.managed-group-body>.form-group{flex:0 1 260px;min-width:180px;margin-bottom:0}
 .managed-group-horizontal>.managed-group-body>.form-decoration,.managed-group-horizontal>.managed-group-body>button{flex:0 0 auto}
+/* Кнопка формы: отступы задаются классом, а не inline-стилем — иначе правило
+   выравнивания в горизонтальной группе ниже проигрывало бы по приоритету. */
+.managed-btn{margin:6px 4px 6px 0}
 /* Кнопка встаёт вровень с полем, а не с его меткой: метка занимает
-   line-height 18px + margin-bottom 5px (см. label в общем стиле). */
+   line-height 18px + margin-bottom 5px (см. label в общем стиле), а разницу
+   высот кнопки (30px) и поля (39px) добираем до общей средней линии. */
 .managed-group-horizontal>.managed-group-body>.form-group>label{line-height:18px}
-.managed-group-horizontal>.managed-group-body>button{align-self:flex-start;margin-top:23px}
+.managed-group-horizontal>.managed-group-body>.managed-btn{align-self:flex-start;margin:27px 0 0 0}
+/* Флажок без метки сверху выравниваем по той же линии, что и поля рядом. */
+.managed-group-horizontal>.managed-group-body>.form-group.managed-checkbox{align-self:flex-start;margin-top:27px}
 /* Нередактируемое поле — это ЗНАЧЕНИЕ, а не ввод: убираем стрелку списка и
-   гасим рамку, чтобы результат команды не читался как незаполненное поле. */
-.form-group input[readonly],.form-group input:disabled,.form-group select:disabled,.form-group textarea[readonly]{
+   гасим рамку, чтобы результат команды не читался как незаполненное поле.
+   Флажок и переключатель исключены: appearance:none стирает сам квадратик,
+   и нередактируемая галка превращалась в подпись без индикатора. */
+.form-group input[readonly],.form-group input:disabled:not([type=checkbox]):not([type=radio]),.form-group select:disabled,.form-group textarea[readonly]{
   background:#f8fafc;border-color:#eef2f7;color:#334155;cursor:default;opacity:1;-webkit-appearance:none;appearance:none}
 </style>
 {{if hasGridTP .Form}}

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -132,8 +132,15 @@ const tplManagedForm = `
           </select>
           <button type="button" data-ob-ref-picker="ref-{{$fn}}"{{if $el.ReadOnly}} disabled{{end}} style="padding:8px 12px;border:1px solid #e2e8f0;border-radius:7px;background:#f8fafc;cursor:pointer;font-size:13px">…</button>
         </div>
+      {{else if $attr}}
+        {{/* Объявленный скалярный реквизит формы — обычное поле ввода. Жёлтая
+             подсветка ниже адресована ОПЕЧАТКЕ в data_path; штатный реквизит
+             формы работает полноценно (обработчик читает его голым именем и как
+             Объект.<Реквизит>), и предупреждать о нём не о чем. */}}
+        <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}{{if $el.ReadOnly}} readonly{{end}}{{if $el.Mask}} pattern="{{$el.Mask}}"{{end}}{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{else}}
-        {{/* Поле не найдено в Entity (возможно реквизит формы, ещё не привязан) */}}
+        {{/* Ни поля сущности, ни реквизита формы с таким именем — почти всегда
+             опечатка в data_path: подсвечиваем, чтобы это не осталось незамеченным. */}}
         <input type="text" name="{{$fn}}" value="{{index $ctx.Values $fn}}" placeholder="{{$fn}}" style="background:#fef9c3"{{if $el.AccessKey}} accesskey="{{$el.AccessKey}}"{{end}}
           title="Реквизит формы '{{$el.DataPath}}' не найден среди полей сущности"{{if $hChg}} data-ob-fire-change="{{$el.Name}}"{{end}}>
       {{end}}


### PR DESCRIPTION
## Проблема

После #521/#522 управляемые формы стали рисовать командные кнопки и пикеры — но обработчик `.form.os` не получал контекста, и **каждая** команда либо падала, либо молча ничего не делала. На конфигурации колл-центра (7 форм, 33 команды) в браузере не сработала ни одна.

Два независимых пробела событийного пути managed-формы (`POST /ui/{kind}/{entity}/form-event`):

**1. `Объект.Ссылка` — Неопределено.** Псевдо-реквизит «Ссылка» ставил только `entityservice.Save` (для `ПриЗаписи`/`ОбработкаПроведения`), а `handleManagedFormEvent` — нет. Типовой обработчик команды

```bsl
Процедура КомандаСогласиеНажатие()
    ПриёмОбращения.ЗафиксироватьСогласие(Объект.Ссылка);
КонецПроцедуры
```

падал на `Метод ПолучитьОбъект вызван у Неопределено`.

**2. Реквизит формы не читался голым именем.** `mergeFormAttrValues` домешивает реквизиты (`attributes` с `save:false`) в `obj.Fields`, то есть виден только путь `Объект.<Реквизит>`. В модуле управляемой формы 1С под `Объект` лежит основной реквизит, а остальные адресуются голым именем — так их и пишут:

```bsl
Если НЕ ЗначениеЗаполнено(НаправлениеВыбор) Тогда
    ВызватьИсключение("Выберите направление обслуживания из справочника.");
КонецЕсли;
```

Пользователь выбирал направление в пикере и получал это исключение.

Третьим, там же: ссылка реквизита формы не получала `AttrResolver` (его нет в `entity.Fields`), поэтому `НаправлениеВыбор.Код` возвращал Неопределено даже через `Объект.`.

## Что сделано

**Коммит 1 — контекст обработчика:**
- `setFormSelfRef` ставит `Ссылка`/`reference` на саму запись — только для существующей (у новой ссылки ещё нет, и `ПолучитьОбъект()` по сгенерированному uuid ничего бы не нашёл). В `values` ответа псевдо-реквизит не уезжает — это контекст, а не значение формы.
- `addFormAttrVars` публикует реквизиты формы и голым именем. Занятые имена (`Объект`, `ЭтотОбъект`, встроенные объекты доступа) и основной реквизит (`main: true`) не перебиваются; одноимённое полю сущности имя остаётся только за `Объект.<Поле>`. Путь `Объект.<Реквизит>` работает как раньше — существующие конфигурации не ломаются. Присваивание голому имени остаётся локальной переменной, обратно в форму уезжает записанное через `Объект.<Реквизит>` (задокументировано в комментарии).
- `formObjectThis.Get` привязывает ссылку реквизита формы к резолверу по `CatalogRef.X`/`DocumentRef.X`.

**Коммит 2 — рендер:** объявленный скалярный реквизит формы уходил в фолбэк-ветку с жёлтой подсветкой и подсказкой «не найден среди полей сущности». Это штатное рабочее поле; подсветка оставлена там, где задумана — на опечатке в `data_path`, которой не соответствует ни поле сущности, ни реквизит формы. Заодно такое поле теперь уважает `readonly` и `mask` элемента.

## Проверка

`internal/ui/form_event_context_test.go` — 6 проверок: ссылка указывает на запись и не течёт в `values`; у новой записи ссылки нет; реквизит читается голым именем (в т.ч. `.Код` у ссылочного); он же по-прежнему читается через `Объект.`; реквизит с именем `Справочники` не убивает встроенный объект доступа; `main: true` не подменяет `Объект`. Плюс рендер-тест в `form_attr_regressions_test.go` (объявленный реквизит без подсветки, опечатка — с подсветкой).

`go test ./...` зелёный.

Живая проверка на реальной базе колл-центра под ролью оператора: «Классифицировать» пишет направление, «Зафиксировать согласие» и «Сохранить телефон» отрабатывают, отрицательные пути дают ожидаемые отказы (выключенное направление — deny-list модуля, пустой выбор — подсказка формы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Коммит 3 — разбор реального экрана формы

Когда команды заработали и форму стало видно целиком, вылезли мелочи, из-за которых она читается как черновик:

- **Нередактируемое поле выглядело как незаполненный ввод.** Рядом с готовым значением стояли серые «…» и «🔍», а `select` показывал «— выбрать —» в белой рамке. Теперь у readonly-поля кнопка подбора не рисуется вовсе, а само поле оформлено плоско (без стрелки списка). «Открыть карточку» осталась и стала **рабочей**: просмотр связанного объекта — не редактирование, и на нередактируемом поле он нужен чаще всего.
- **Ошибка бизнес-правила уходила пользователю вместе с путём к модулю:** `C:\...\src\Модуль.module.os:176: Обращение нельзя завершить: …`. Для этого уже есть `interpreter.FormatUserError` (только `Msg`, без `file:line`) — событийный путь формы просто звал `err.Error()`. В логах и `check` позиция сохраняется.
- **`placeholder` повторял техническое имя реквизита** («ТелефонКонтакта») поверх нормального заголовка в метке. Убран.
- **`ПриИзменении` у `Флажок` не срабатывал** — элемент не получал `data-ob-fire-change`, и обработчик «поставил галку → выполнилось действие» молча не вызывался.
- Горизонтальная группа: поле больше не растягивается на всю строку (кнопка рядом с ним не улетает к правому краю), кнопка встаёт вровень с полем, а не с его меткой.

Отдельно — DSL-грабля: **`Число(Истина)` возвращало 0.** Булево уходило в разбор строки `"true"`, не парсилось и давало 0, то есть `Число(Истина) = Число(Ложь)`, и типовая проверка флага `Если Число(Флаг) <> 1` не срабатывала никогда. Значение bool-поля приходит в DSL то булевым (форма, восстановление из БД), то числом 0/1 (`ПолучитьОбъект` на SQLite) — `Число()` обязано выравнивать оба случая. Тест `TestBuiltinToNumber_Bool`.

---

## Коммит 4 — разбор второго экрана

Три из четырёх дефектов внесены коммитом 3, чиню там же.

- **Нередактируемый флажок исчезал.** Плоский стиль readonly-полей ставил `appearance:none` всем `disabled`-инпутам, включая `checkbox` — квадратик стирался, и нередактируемая галка выглядела как подпись без индикатора. `checkbox`/`radio` исключены из правила.
- **Нередактируемое поле предлагало «— выбрать —»** — заглушка списка выбора на поле, где выбирать нечего, читается как «забыл заполнить». Теперь у readonly пустое значение показывается как «—».
- **Кнопка не вставала вровень с полем:** inline-стиль `margin` у кнопки формы побеждал правило выравнивания горизонтальной группы по приоритету. Отступы переехали в класс `.managed-btn`; флажок без метки выравнивается по той же линии, что и соседние поля.
- **«Открыть карточку» на пустом ссылочном поле** — открывать нечего, кнопка рисуется только при заполненном значении и больше не сбивает ряд.

Плюс понятнее ошибка DSL: `Метод ПолучитьОбъект вызван у Неопределено` не отвечал на главный вопрос — ЧТО пустое. Теперь в тексте есть имя приёмника: `Метод ПолучитьОбъект вызван у Неопределено: «Объект.Ссылка» не заполнено`. Чаще всего это ссылка ещё не записанного объекта.

---

## Коммит 5 — `Объект.Записать()` в обработчике формы

Команда на экране «Создать» упиралась в незаполненную `Ссылка`: обработчики работают с записью в базе, а её ещё нет. Единственным выходом было требовать от пользователя сначала нажать «Записать» — лишний шаг, которого в управляемой форме быть не должно (в 1С объект пишет сам обработчик).

- `formObjectThis` получил `Записать()`/`ЭтоНовый()` поверх `entityservice.Save` — тем же путём, что и кнопка «Записать»: хуки `ПриЗаписи`/`ОбработкаПроведения`, табличные части, веб-хуки, проверка построчного доступа. Сразу после записи проставляется псевдо-реквизит `Ссылка`, чтобы следующая строка обработчика могла звать `Модуль.Действие(Объект.Ссылка)`.
- Ответ события несёт `savedId`, когда записана ещё не сохранённая форма (в том числе если обработчик упал уже после записи). Клиент подставляет id в `_id` следующих событий и в адрес страницы — без этого второе действие подряд ушло бы как «новый документ» и создало дубль.

Проверено сквозным сценарием на конфигурации колл-центра с чистого экрана «Создать»: пять действий подряд (выбор направления → телефон → согласие → источник → завершение) создают **ровно один** документ и доводят его до «Завершено», ни одного нажатия «Записать».

---

## Коммит 6 — нередактируемое поле-результат отставало на шаг

Обработчик команды обычно не правит `Объект.Поле`, а зовёт общий модуль: тот читает документ из базы, меняет и записывает. Объект формы при этом остаётся с тем, что пришло из POST, а нередактируемое поле-результат (`disabled` → в POST не уходит) восстанавливалось из базы **до** обработчика — то есть значением предыдущего действия. В форму уезжало устаревшее значение: после второго выбора поле показывало результат первого.

После обработчика перечитываем из базы поля, которые (1) не пришли из формы и (2) не были присвоены самим обработчиком. Присвоенное через `Объект.Поле = …` не трогаем: оно может быть ещё не записано и обязано доехать как есть.

Ключи поля проверяются во всех регистрах сразу: из формы значение попадает в `Fields` под именем метаданных, а `Object.Set` пишет в нижнем — после присваивания в карте лежат **оба** ключа, и сравнение по одному давало случайный ответ.

Тесты: поле, изменённое через базу, возвращается актуальным; присвоенное обработчиком не затирается.
