### PR TITLE
fix(query): строковые политики в запросах с ОБЪЕДИНИТЬ (план 79)

### DIFF
--- a/Plans/README.md
+++ b/Plans/README.md
@@ -205,7 +205,7 @@ PostgreSQL; для SQLite потребовалось бы суммировани
 | 62 | [62-network-safety-switch.md](62-network-safety-switch.md) | Предохранитель сети: галочка `net.enabled` лочит хуки/HTTP/сервисы/email; сброс при restore | 0.5 дня | ✅ Реализовано |
 | 67 | [67-exec-command.md](67-exec-command.md) | Выполнение команд ОС из DSL (`ВыполнитьКоманду`) за флагом `AllowExec` (выкл. по умолчанию, без shell, таймаут, аудит) | 1–1.5 дня | ✅ Реализовано |
 | 76 | [76-multi-user-scale-readiness.md](76-multi-user-scale-readiness.md) | Готовность к 100+ активным пользователям: REST RBAC, лимиты, индексы, reference picker, атомарная запись, observability и путь к горизонтальному масштабированию | 2–4 недели по этапам | 🟡 Этапы A–F закрыты; остался этап G (горизонталь): realtime-hub через Redis/NATS, leader election планировщика, broadcast перезагрузки конфигурации |
-| 79 | [79-row-level-access.md](79-row-level-access.md) | Строковые политики доступа поверх RBAC: декларативные row filters в ролях, SQL-side фильтрация UI/REST/picker и безопасный контур отчетов/AI | 1–2 недели по этапам | 🟡 Core влит (`assertRowFiltersApplied`); осталось: запросы с `ОБЪЕДИНИТЬ` при активной политике fail-closed отказывают (`query.go:3639`), нет UI-редактора политик, нет нативного PG RLS вторым слоем |
+| 79 | [79-row-level-access.md](79-row-level-access.md) | Строковые политики доступа поверх RBAC: декларативные row filters в ролях, SQL-side фильтрация UI/REST/picker и безопасный контур отчетов/AI | 1–2 недели по этапам | 🟡 Core влит (`assertRowFiltersApplied`); `ОБЪЕДИНИТЬ` поддержан 2026-08-04 (фильтр внедряется в каждую ветвь). Осталось: нет UI-редактора политик, нет нативного PG RLS вторым слоем |
 
 ### Направление Г — Интеграции и экосистема (продолжение)
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -3635,8 +3635,21 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 			} else if kw, ok := sqlKW(t.val); ok {
 				switch kw {
 				case "UNION":
-					if len(tr.opts.RowFilters) > 0 {
-						return Result{}, fmt.Errorf("row-level filters for UNION queries are not supported yet")
+					// Каждая ветвь ОБЪЕДИНИТЬ — самостоятельный SELECT со своим
+					// WHERE (план 79). Отложенный фильтр текущей ветви внедряем
+					// ДО ключевого слова, после чего накопление начинается
+					// заново: внешний WHERE относился бы только к одной ветви,
+					// и раньше такие запросы отклонялись целиком.
+					//
+					// Только на верхнем уровне: источники внутри скобок
+					// фильтруются собственным скоуп-подзапросом
+					// (rowFilteredSourceSQL), в tr.rowFilters они не попадают.
+					if tr.parenDepth == 0 {
+						if err := tr.emitPendingRowFiltersAsWhere(); err != nil {
+							return Result{}, err
+						}
+						tr.rowFilters = nil
+						tr.rowsScoped = false
 					}
 					tr.unionDepths[tr.parenDepth] = true
 				case "WHERE":

--- a/internal/query/row_filters_union_test.go
+++ b/internal/query/row_filters_union_test.go
@@ -1,0 +1,224 @@
+package query_test
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Строковые политики и ОБЪЕДИНИТЬ (план 79).
+//
+// Проверяем поведение, а не форму SQL: фильтр ветви попадает то в её WHERE, то
+// в скоуп-подзапрос источника — и то и другое правильно. Важно единственное:
+// из каждой ветви возвращаются только свои строки. Поэтому запросы здесь
+// по-настоящему исполняются на SQLite.
+
+func unionEntities() []*metadata.Entity {
+	mk := func(name string) *metadata.Entity {
+		return &metadata.Entity{
+			Name: name,
+			Kind: metadata.KindCatalog,
+			Fields: []metadata.Field{
+				{Name: "Наименование", Type: metadata.FieldTypeString},
+				{Name: "Owner", Type: metadata.FieldTypeString},
+			},
+		}
+	}
+	return []*metadata.Entity{mk("Товар"), mk("Услуга")}
+}
+
+func unionFilters() map[query.SourceRef]*storage.Predicate {
+	return map[query.SourceRef]*storage.Predicate{
+		{Kind: "catalog", Name: "Товар"}:  {Field: "Owner", Op: "eq", Value: "свой"},
+		{Kind: "catalog", Name: "Услуга"}: {Field: "Owner", Op: "eq", Value: "свой"},
+	}
+}
+
+// unionDB создаёт базу, где у каждого справочника есть строка своего владельца
+// и строка чужого.
+func unionDB(t *testing.T) *storage.DB {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "union.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db.Close)
+
+	ents := unionEntities()
+	if err := db.Migrate(ctx, ents); err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range ents {
+		for _, row := range []struct{ name, owner string }{
+			{e.Name + "-свой", "свой"},
+			{e.Name + "-чужой", "чужой"},
+		} {
+			if err := db.Upsert(ctx, e.Name, uuid.New(),
+				map[string]any{"Наименование": row.name, "Owner": row.owner}, e); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return db
+}
+
+// runNames исполняет скомпилированный запрос и возвращает первую колонку.
+func runNames(t *testing.T, db *storage.DB, res query.Result) []string {
+	t.Helper()
+	rows, err := db.Query(context.Background(), res.SQL, res.Args...)
+	if err != nil {
+		t.Fatalf("выполнение запроса: %v\n%s", err, res.SQL)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("чтение строки: %v", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func assertNames(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("строки %v, ожидались %v", got, want)
+	}
+}
+
+// Обе ветви объединения фильтруются по своей политике. Раньше такой запрос
+// отклонялся целиком: отложенный фильтр главной таблицы уходил во внешний
+// WHERE, который относится только к одной ветви.
+func TestCompile_RowFiltersUnionFiltersBothBranches(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование ИЗ Справочник.Услуга КАК У`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой", "Услуга-свой")
+}
+
+// Собственное условие ветви не теряется: политика добавляется к нему.
+func TestCompile_RowFiltersUnionKeepsOwnWhere(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т ГДЕ Т.Наименование <> &Нет
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование ИЗ Справочник.Услуга КАК У ГДЕ У.Наименование <> &Нет`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Params:     map[string]any{"Нет": "Услуга-свой"},
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// Политика оставляет только «свои», собственное условие убирает Услуга-свой.
+	assertNames(t, runNames(t, db, res), "Товар-свой")
+}
+
+// Упорядочивание относится ко всему объединению и не ломает фильтрацию ветвей.
+func TestCompile_RowFiltersUnionWithOrderBy(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование КАК Имя ИЗ Справочник.Товар КАК Т
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование КАК Имя ИЗ Справочник.Услуга КАК У
+		 УПОРЯДОЧИТЬ ПО Имя`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой", "Услуга-свой")
+}
+
+// Политика только у одной из объединяемых сущностей: вторая ветвь возвращает
+// всё, первая — только своё.
+func TestCompile_RowFiltersUnionSingleFilteredSource(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование ИЗ Справочник.Услуга КАК У`,
+		query.CompileOpts{
+			Entities: unionEntities(),
+			Dialect:  storage.SQLiteDialect{},
+			RowFilters: map[query.SourceRef]*storage.Predicate{
+				{Kind: "catalog", Name: "Товар"}: {Field: "Owner", Op: "eq", Value: "свой"},
+			},
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой", "Услуга-свой", "Услуга-чужой")
+}
+
+// Три ветви: проверяем, что накопление фильтров сбрасывается на каждой границе,
+// а не только на первой.
+func TestCompile_RowFiltersUnionThreeBranches(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование ИЗ Справочник.Услуга КАК У
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ Т2.Наименование ИЗ Справочник.Товар КАК Т2`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой", "Товар-свой", "Услуга-свой")
+}
+
+// Ветвь с соединением: источник фильтруется скоуп-подзапросом, и сброс
+// накопления на границе ветвей этому не мешает.
+func TestCompile_RowFiltersUnionBranchWithJoin(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование ИЗ Справочник.Услуга КАК У
+		   ЛЕВОЕ СОЕДИНЕНИЕ Справочник.Товар КАК Т2 ПО Т2.Owner = У.Owner`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// Услуга-свой соединяется с единственным своим товаром — одна строка.
+	assertNames(t, runNames(t, db, res), "Товар-свой", "Услуга-свой")
+}


### PR DESCRIPTION
## Проблема

Любой запрос с `ОБЪЕДИНИТЬ` при активной строковой политике отклонялся целиком:

```
row-level filters for UNION queries are not supported yet
```

Отказ был честный — fail-closed, а не тихая утечка чужих строк, — но отчёты, объединяющие два источника, под политикой просто не работали.

Причина в механике внедрения: отложенный фильтр главной таблицы уходит во внешний `WHERE`, а он относится только к одной ветви объединения. Проверять это по месту компилятор не умел, поэтому предпочёл отказать.

## Решение

Фильтр текущей ветви внедряется **перед** ключевым словом `ОБЪЕДИНИТЬ`, после чего накопление начинается заново — у каждой ветви свой `WHERE`.

Сброс только на верхнем уровне: источники внутри скобок в отложенные фильтры не попадают вовсе, они фильтруются собственным скоуп-подзапросом (`rowFilteredSourceSQL`), и трогать их не нужно.

## Тесты — поведение, а не форма SQL

Выяснилось по ходу: фильтр ветви попадает то в её `WHERE`, то в скоуп-подзапрос источника (`FROM (SELECT * FROM услуга WHERE owner = ?) AS у`) — в зависимости от формы ветви. Правильно и то и другое, поэтому проверять текст SQL бессмысленно: первые версии тестов падали на верной реализации.

Тесты **по-настоящему исполняют** скомпилированный запрос на SQLite и смотрят, какие строки вернулись. Покрыто:

- обе ветви под политикой — из каждой приходят только свои строки;
- собственное условие ветви не теряется, политика добавляется к нему;
- `УПОРЯДОЧИТЬ` относится ко всему объединению и не ломает фильтрацию ветвей;
- политика лишь у одного из источников — вторая ветвь без лишнего условия;
- три ветви: сброс накопления происходит на каждой границе, а не только на первой;
- ветвь с соединением.

## Проверка

`go test ./...`, `golangci-lint run ./...` — чисто. `onebase check` на `examples/trade`, `examples/callcenter`, `examples/accounting` — без ошибок (компиляция запросов конфигураций не задета).

🤖 Generated with [Claude Code](https://claude.com/claude-code)