### PR TITLE
fix(query): фильтр строковой политики не теряется при ИЛИ в собственном ГДЕ (план 79)

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -463,29 +463,30 @@ func (rd refDimInfo) displayCol() string {
 }
 
 type translator struct {
-	tokens      []tok
-	pos         int
-	args        []any
-	params      map[string]int // param name → 1-based index in args (0 = NULL sentinel)
-	paramValues map[string]any
-	opts        CompileOpts
-	parts       []string
-	prevWasDot  bool                          // true after emitting "." — used to resolve .Ссылка → .id
-	colMap      map[string]string             // lowercase field name → actual column name (for reference dims)
-	colTypes    map[string]metadata.FieldType // lowercase field name → type (для квалификации и CAST number)
-	refDims     []refDimInfo                  // reference dimensions with auto-JOIN info
-	mainTable   string                        // main FROM table/alias (set when source is emitted)
-	mainEmitted bool                          // главная таблица FROM уже эмитирована (refDims авто-JOIN — только для неё)
-	section     querySection                  // current clause context
-	aliases     map[string]struct{}           // имена алиасов вывода (КАК ...) — их не квалифицируем и не CAST'им
-	sources     []SourceRef                   // объекты-источники запроса (для RBAC, план 54)
-	rowFilters  []pendingRowFilter            // RLS-фильтры обычных источников, внедряемые в WHERE
-	rowsScoped  bool                          // true после внедрения rowFilters в outer WHERE
-	rowApplied  []SourceRef                   // источники, к которым RLS-предикат реально внедрён (для финальной сверки)
-	parenDepth  int                           // глубина незакрытых '(' в основном потоке (VT-аргументы считает parseVTArgs)
-	sourceCtx   sourceContext                 // scoped-типы источников для системных колонок регистра
-	unionDepths map[int]bool                  // глубины SELECT с UNION для compound ORDER BY
-	unionOrders map[int]bool                  // ORDER BY относится ко всему UNION, алиасы таблиц там недоступны
+	tokens       []tok
+	pos          int
+	args         []any
+	params       map[string]int // param name → 1-based index in args (0 = NULL sentinel)
+	paramValues  map[string]any
+	opts         CompileOpts
+	parts        []string
+	prevWasDot   bool                          // true after emitting "." — used to resolve .Ссылка → .id
+	colMap       map[string]string             // lowercase field name → actual column name (for reference dims)
+	colTypes     map[string]metadata.FieldType // lowercase field name → type (для квалификации и CAST number)
+	refDims      []refDimInfo                  // reference dimensions with auto-JOIN info
+	mainTable    string                        // main FROM table/alias (set when source is emitted)
+	mainEmitted  bool                          // главная таблица FROM уже эмитирована (refDims авто-JOIN — только для неё)
+	section      querySection                  // current clause context
+	aliases      map[string]struct{}           // имена алиасов вывода (КАК ...) — их не квалифицируем и не CAST'им
+	sources      []SourceRef                   // объекты-источники запроса (для RBAC, план 54)
+	rowFilters   []pendingRowFilter            // RLS-фильтры обычных источников, внедряемые в WHERE
+	rowsScoped   bool                          // true после внедрения rowFilters в outer WHERE
+	rowGroupOpen bool                          // открыта скобка вокруг собственного условия ГДЕ после внедрённого фильтра
+	rowApplied   []SourceRef                   // источники, к которым RLS-предикат реально внедрён (для финальной сверки)
+	parenDepth   int                           // глубина незакрытых '(' в основном потоке (VT-аргументы считает parseVTArgs)
+	sourceCtx    sourceContext                 // scoped-типы источников для системных колонок регистра
+	unionDepths  map[int]bool                  // глубины SELECT с UNION для compound ORDER BY
+	unionOrders  map[int]bool                  // ORDER BY относится ко всему UNION, алиасы таблиц там недоступны
 }
 
 type sourceClass uint8
@@ -766,8 +767,25 @@ func (tr *translator) emitPendingRowFiltersAfterWhere() error {
 		return nil
 	}
 	tr.emit(strings.Join(conds, " AND "))
-	tr.emit("AND")
+	// Собственное условие ГДЕ оборачиваем в скобки: без них верхнеуровневое
+	// ИЛИ пользователя связывается сильнее внедрённого фильтра
+	// («фильтр AND a ИЛИ b» → «(фильтр AND a) OR b»), и строки правой части
+	// возвращаются мимо политики. Скобку закрывает closeRowFilterGroup в
+	// точке, где секция ГДЕ заканчивается.
+	tr.emit("AND (")
+	tr.rowGroupOpen = true
 	return nil
+}
+
+// closeRowFilterGroup закрывает скобку вокруг собственного условия ГДЕ.
+// Вызывается там, где секция ГДЕ завершается: перед СГРУППИРОВАТЬ/ИМЕЯ/
+// УПОРЯДОЧИТЬ, перед ОБЪЕДИНИТЬ и в конце запроса.
+func (tr *translator) closeRowFilterGroup() {
+	if !tr.rowGroupOpen {
+		return
+	}
+	tr.emit(")")
+	tr.rowGroupOpen = false
 }
 
 func (tr *translator) peek(offset int) tok {
@@ -3515,6 +3533,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		// Multi-word: СГРУППИРОВАТЬ ПО / УПОРЯДОЧИТЬ ПО
 		if t.kind == tIdent && (upper == "СГРУППИРОВАТЬ" || upper == "УПОРЯДОЧИТЬ") {
 			if tr.parenDepth == 0 {
+				tr.closeRowFilterGroup()
 				if err := tr.emitPendingRowFiltersAsWhere(); err != nil {
 					return Result{}, err
 				}
@@ -3645,6 +3664,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 					// фильтруются собственным скоуп-подзапросом
 					// (rowFilteredSourceSQL), в tr.rowFilters они не попадают.
 					if tr.parenDepth == 0 {
+						tr.closeRowFilterGroup()
 						if err := tr.emitPendingRowFiltersAsWhere(); err != nil {
 							return Result{}, err
 						}
@@ -3663,6 +3683,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 					continue
 				case "GROUP", "HAVING", "ORDER":
 					if tr.parenDepth == 0 {
+						tr.closeRowFilterGroup()
 						if err := tr.emitPendingRowFiltersAsWhere(); err != nil {
 							return Result{}, err
 						}
@@ -3730,6 +3751,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 
 		tr.advance()
 	}
+	tr.closeRowFilterGroup()
 	if err := tr.emitPendingRowFiltersAsWhere(); err != nil {
 		return Result{}, err
 	}

--- a/internal/query/row_filters_or_test.go
+++ b/internal/query/row_filters_or_test.go
@@ -1,0 +1,77 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Приоритет операторов и внедрённый фильтр политики (план 79).
+//
+// Фильтр внедряется в начало собственного ГДЕ: «WHERE фильтр AND <условие>».
+// Без скобок вокруг условия верхнеуровневое ИЛИ связывается сильнее фильтра —
+// «(фильтр AND a) OR b» — и строки правой части возвращаются мимо политики.
+// Проверяем исполнением: чужая строка не должна попадать в выдачу.
+
+func TestCompile_RowFiltersOrInOwnWhereStaysFiltered(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ГДЕ Т.Наименование = &Свой ИЛИ Т.Наименование = &Чужой`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+			Params:     map[string]any{"Свой": "Товар-свой", "Чужой": "Товар-чужой"},
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой")
+}
+
+// То же в ветвях объединения: ИЛИ в каждой ветви не поднимается выше фильтра.
+func TestCompile_RowFiltersUnionOrInBranchWhereStaysFiltered(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ГДЕ Т.Наименование = &СвойТ ИЛИ Т.Наименование = &ЧужойТ
+		 ОБЪЕДИНИТЬ ВСЕ
+		 ВЫБРАТЬ У.Наименование ИЗ Справочник.Услуга КАК У
+		 ГДЕ У.Наименование = &СвойУ ИЛИ У.Наименование = &ЧужойУ`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+			Params: map[string]any{
+				"СвойТ": "Товар-свой", "ЧужойТ": "Товар-чужой",
+				"СвойУ": "Услуга-свой", "ЧужойУ": "Услуга-чужой",
+			},
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой", "Услуга-свой")
+}
+
+// Скобка вокруг условия закрывается до СГРУППИРОВАТЬ/УПОРЯДОЧИТЬ — иначе SQL
+// не скомпилируется, а фильтр уехал бы в группировку.
+func TestCompile_RowFiltersOrWithGroupAndOrder(t *testing.T) {
+	db := unionDB(t)
+	res, err := query.Compile(
+		`ВЫБРАТЬ Т.Наименование ИЗ Справочник.Товар КАК Т
+		 ГДЕ Т.Наименование = &Свой ИЛИ Т.Наименование = &Чужой
+		 СГРУППИРОВАТЬ ПО Т.Наименование
+		 УПОРЯДОЧИТЬ ПО Т.Наименование`,
+		query.CompileOpts{
+			Entities:   unionEntities(),
+			Dialect:    storage.SQLiteDialect{},
+			RowFilters: unionFilters(),
+			Params:     map[string]any{"Свой": "Товар-свой", "Чужой": "Товар-чужой"},
+		})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	assertNames(t, runNames(t, db, res), "Товар-свой")
+}


### PR DESCRIPTION
Найдено при ревью #571.

## Проблема

Внедрённый фильтр строковой политики эмитился как `WHERE фильтр AND <условие пользователя>` — **без скобок вокруг условия**. Верхнеуровневое `ИЛИ` связывается сильнее, чем `AND`, поэтому получалось `(фильтр AND a) OR b`: строки правой части возвращались мимо политики.

Проба на `origin/main` до правки:

```
SQL:    SELECT т.наименование FROM товар AS т WHERE (т.owner = ?) AND т.наименование = ? OR т.наименование = ?
Args:   [свой Товар-свой Товар-чужой]
СТРОКИ: [Товар-свой Товар-чужой]   ← чужая строка прошла
```

Дефект жил в `emitPendingRowFiltersAfterWhere` и до поддержки `ОБЪЕДИНИТЬ`, то есть касался обычных запросов с `ГДЕ`. После #571 он распространился и на ветви объединения: там, где раньше был fail-closed отказ, теперь тихая утечка чужих строк.

## Решение

Условие оборачивается в скобки: `WHERE фильтр AND ( <условие> )`. Скобку закрывает `closeRowFilterGroup` в точках, где секция `ГДЕ` заканчивается — перед `СГРУППИРОВАТЬ`/`ИМЕЯ`/`УПОРЯДОЧИТЬ`, перед `ОБЪЕДИНИТЬ` и в конце запроса. Порядок важен: группа закрывается до `emitPendingRowFiltersAsWhere`, иначе новый `WHERE` ветви ушёл бы внутрь незакрытой скобки.

## Тесты

`internal/query/row_filters_or_test.go` — исполняются на SQLite и проверяют строки, а не текст SQL (форма SQL законно различается: фильтр попадает то в `WHERE` ветви, то в скоуп-подзапрос источника):

- `ИЛИ` в обычном `ГДЕ` — чужая строка не возвращается;
- `ИЛИ` в `ГДЕ` обеих ветвей `ОБЪЕДИНИТЬ ВСЕ`;
- `ИЛИ` вместе с `СГРУППИРОВАТЬ ПО` и `УПОРЯДОЧИТЬ ПО` — проверяет, что скобка закрыта до группировки (иначе SQL не скомпилировался бы).

Все 17 тестов `RowFilters` в пакете зелёные, `go test ./...` — exit 0, `go vet` и `gofmt` чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)