### PR TITLE
fix(ui): команда формы висла до таймаута, если модуль открывал транзакцию

### DIFF
--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -85,10 +85,22 @@ func dslMessageCollectorFromContext(ctx context.Context) *[]string {
 // собранные из значений колонок БД, несли менеджера — иначе у Удалить()
 // и ПолучитьОбъект() на них не было бы привязки к типу.
 func (s *Server) refManagerFor(entity *metadata.Entity, ctx context.Context) interpreter.RefManager {
+	return s.refManagerForSrc(entity, interpreter.NewStaticCtx(ctx), ctx)
+}
+
+// refManagerForSrc — та же сборка менеджера, но с ЖИВЫМ источником контекста.
+// Менеджер ссылки создаётся в момент первого чтения реквизита, то есть ДО того,
+// как модуль откроет НачатьТранзакцию. Со снимком контекста его ПолучитьОбъект()
+// уходил за ВТОРЫМ соединением, а пул SQLite — одно соединение, занятое той самой
+// транзакцией: запрос вставал намертво до таймаута. С живым источником вызов
+// выполняется внутри открытой транзакции.
+func (s *Server) refManagerForSrc(entity *metadata.Entity, ctxSrc interpreter.CtxSource, ctx context.Context) interpreter.RefManager {
 	if entity == nil {
 		return nil
 	}
-	ctxSrc := interpreter.NewStaticCtx(ctx)
+	if ctxSrc == nil {
+		ctxSrc = interpreter.NewStaticCtx(ctx)
+	}
 	switch entity.Kind {
 	case metadata.KindCatalog:
 		return interpreter.NewCatalogProxy(entity, s.store, ctxSrc).

--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -41,10 +41,27 @@ type formObjectThis struct {
 	// ЗаписатьНаСервере в 1С). Без неё команда на ещё не записанной форме
 	// упиралась в пустую Ссылка и требовала от пользователя сначала нажать
 	// «Записать» — чего в управляемой форме быть не должно.
-	srv   *Server
-	ctx   context.Context
-	isNew bool
-	saved bool
+	srv *Server
+	ctx context.Context
+	// ctxSrc — «живой» контекст DSL-исполнения: собственная запись объекта тоже
+	// должна попадать в открытую модулем транзакцию, а не ждать второго
+	// соединения (пул SQLite — одно).
+	ctxSrc docsCtxSource
+	isNew  bool
+	saved  bool
+}
+
+// liveCtx — контекст с открытой DSL-транзакцией, если она есть.
+func (f *formObjectThis) liveCtx() context.Context {
+	if f.ctxSrc != nil {
+		if ctx := f.ctxSrc.Ctx(); ctx != nil {
+			return ctx
+		}
+	}
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
 }
 
 // GetRefUUID сохраняет ссылочную идентичность runtime.Object у формовой
@@ -94,10 +111,7 @@ func (f *formObjectThis) write() error {
 	if f.srv == nil || f.entity == nil {
 		return fmt.Errorf("запись из обработчика формы недоступна")
 	}
-	ctx := f.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	ctx := f.liveCtx()
 	isNew := f.isNew && !f.saved
 	if isNew {
 		if err := f.srv.autoFillRowAccessFields(ctx, f.entity, "write", f.obj.Fields); err != nil {

--- a/internal/ui/dsl_ref_attr.go
+++ b/internal/ui/dsl_ref_attr.go
@@ -12,9 +12,33 @@ import (
 )
 
 type dslRefAttrResolver struct {
-	s     *Server
-	ctx   context.Context
-	cache map[string]map[string]map[string]any // entity -> uuid -> field name -> value
+	s   *Server
+	ctx context.Context
+	// ctxSrc — «живой» контекст DSL-исполнения (TxState). Менеджеры ссылок
+	// строятся ДО того, как модуль откроет НачатьТранзакцию, и со статическим
+	// контекстом их ПолучитьОбъект()/Записать() уходили за ВТОРЫМ соединением.
+	// Пул SQLite — одно соединение, занятое транзакцией, поэтому такой вызов
+	// висел до таймаута. nil — остаётся прежний статический контекст.
+	ctxSrc docsCtxSource
+	cache  map[string]map[string]map[string]any // entity -> uuid -> field name -> value
+}
+
+// Ctx реализует interpreter.CtxSource: менеджеры ссылок спрашивают контекст
+// на КАЖДОМ вызове, поэтому ПолучитьОбъект() попадает в транзакцию, открытую
+// уже после создания менеджера.
+func (r *dslRefAttrResolver) Ctx() context.Context { return r.liveCtx() }
+
+// liveCtx возвращает контекст с открытой DSL-транзакцией, если она есть.
+func (r *dslRefAttrResolver) liveCtx() context.Context {
+	if r == nil {
+		return context.Background()
+	}
+	if r.ctxSrc != nil {
+		if ctx := r.ctxSrc.Ctx(); ctx != nil {
+			return ctx
+		}
+	}
+	return r.ctx
 }
 
 func (s *Server) newDSLRefAttrResolver(ctx context.Context) *dslRefAttrResolver {
@@ -29,19 +53,22 @@ func (s *Server) newDSLRefAttrResolver(ctx context.Context) *dslRefAttrResolver 
 }
 
 func (s *Server) newFormObjectThis(ctx context.Context, obj *runtime.Object, entity *metadata.Entity, form *metadata.FormModule) *formObjectThis {
-	return s.newFormObjectThisNew(ctx, obj, entity, form, false)
+	return s.newFormObjectThisLive(ctx, nil, obj, entity, form, false)
 }
 
-// newFormObjectThisNew дополнительно помечает объект как ещё не записанный,
-// чтобы Объект.Записать() в обработчике формы создал запись, а не пытался
-// обновить несуществующую.
-func (s *Server) newFormObjectThisNew(ctx context.Context, obj *runtime.Object, entity *metadata.Entity, form *metadata.FormModule, isNew bool) *formObjectThis {
+// newFormObjectThisLive помечает объект как ещё не записанный (чтобы
+// Объект.Записать() создал запись, а не пытался обновить несуществующую) и
+// принимает «живой» источник контекста: без него ссылки объекта не видят
+// открытую модулем DSL-транзакцию (см. dslRefAttrResolver.ctxSrc).
+func (s *Server) newFormObjectThisLive(ctx context.Context, ctxSrc docsCtxSource, obj *runtime.Object, entity *metadata.Entity, form *metadata.FormModule, isNew bool) *formObjectThis {
 	var resolver *dslRefAttrResolver
 	if s != nil && s.store != nil && s.reg != nil {
 		resolver = s.newDSLRefAttrResolver(ctx)
+		resolver.ctxSrc = ctxSrc
 		resolver.attachObject(entity, obj)
 	}
-	return &formObjectThis{obj: obj, entity: entity, form: form, refResolver: resolver, srv: s, ctx: ctx, isNew: isNew}
+	return &formObjectThis{obj: obj, entity: entity, form: form, refResolver: resolver,
+		srv: s, ctx: ctx, ctxSrc: ctxSrc, isNew: isNew}
 }
 
 func (r *dslRefAttrResolver) ResolveRefAttr(ref *interpreter.Ref, field string) (any, bool) {
@@ -132,7 +159,7 @@ func (r *dslRefAttrResolver) attachRef(ref *interpreter.Ref, entityName string) 
 		ref.Type = entityName
 	}
 	if ref.Manager == nil && r.s != nil {
-		ref.Manager = r.s.refManagerFor(r.s.reg.GetEntity(ref.Type), r.ctx)
+		ref.Manager = r.s.refManagerForSrc(r.s.reg.GetEntity(ref.Type), r, r.liveCtx())
 	}
 	ref.AttrResolver = r
 	return ref
@@ -153,7 +180,7 @@ func (r *dslRefAttrResolver) bindRefToContext(ref *interpreter.Ref, entityName s
 		bound.Type = entityName
 	}
 	if r.s != nil {
-		bound.Manager = r.s.refManagerFor(r.s.reg.GetEntity(bound.Type), r.ctx)
+		bound.Manager = r.s.refManagerForSrc(r.s.reg.GetEntity(bound.Type), r, r.liveCtx())
 	}
 	bound.AttrResolver = r
 	return &bound
@@ -197,7 +224,7 @@ func (r *dslRefAttrResolver) preloadIDs(entity *metadata.Entity, ids []uuid.UUID
 	// реестра при cap>len писал в разделяемый backing array метаданных из
 	// конкурентных запросов (гонка под -race).
 	fields := uniqueObjectFields(entity.Fields)
-	rows, err := r.s.store.GetFieldsByIDs(r.ctx, entity, missing, fields)
+	rows, err := r.s.store.GetFieldsByIDs(r.liveCtx(), entity, missing, fields)
 	if err != nil {
 		return fmt.Errorf("%s: %w", entity.Name, err)
 	}
@@ -209,13 +236,13 @@ func (r *dslRefAttrResolver) cacheRows(entity *metadata.Entity, rows map[string]
 	if r.cache[entity.Name] == nil {
 		r.cache[entity.Name] = map[string]map[string]any{}
 	}
-	refNames := r.s.bulkReferenceNames(r.ctx, rows, entity.Fields)
+	refNames := r.s.bulkReferenceNames(r.liveCtx(), rows, entity.Fields)
 	for idStr, row := range rows {
 		vals := make(map[string]any, len(entity.Fields))
 		for _, fd := range entity.Fields {
 			raw := row[fd.Name]
 			if fd.RefEntity != "" {
-				vals[fd.Name] = r.s.refFromValueCached(r.ctx, fd.RefEntity, raw, refNames[fd.RefEntity])
+				vals[fd.Name] = r.s.refFromValueCached(r.liveCtx(), fd.RefEntity, raw, refNames[fd.RefEntity])
 			} else {
 				vals[fd.Name] = normalizeAttrValue(fd.Type, raw)
 			}

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -56,6 +56,16 @@ func langFromCtx(ctx context.Context) string {
 }
 
 func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollector) map[string]any {
+	vars, _ := s.buildDSLVarsTx(ctx, mc)
+	return vars
+}
+
+// buildDSLVarsTx дополнительно отдаёт «живой» источник контекста (TxState).
+// Он нужен вызывающему, чтобы менеджеры ссылок, построенные ДО открытия
+// DSL-транзакции, всё равно выполняли ПолучитьОбъект()/Записать() ВНУТРИ неё:
+// со статическим контекстом такой вызов уходит за вторым соединением, а пул
+// SQLite — одно соединение, и запрос виснет до таймаута.
+func (s *Server) buildDSLVarsTx(ctx context.Context, mc *runtime.MovementsCollector) (map[string]any, *interpreter.TxState) {
 	// TxState is created before the common variable set so path resolvers and
 	// all write-capable DSL objects observe the same live transaction context.
 	txState := interpreter.NewTxState(ctx)
@@ -290,12 +300,19 @@ func (s *Server) buildDSLVars(ctx context.Context, mc *runtime.MovementsCollecto
 	vars["НСтр"] = nstrFn
 	vars["NStr"] = nstrFn
 
-	return vars
+	return vars, txState
 }
 
 func (s *Server) buildDSLVarsWithMessages(ctx context.Context, mc *runtime.MovementsCollector, msgs *[]string) map[string]any {
+	vars, _ := s.buildDSLVarsWithMessagesTx(ctx, mc, msgs)
+	return vars
+}
+
+// buildDSLVarsWithMessagesTx — то же, что buildDSLVarsWithMessages, но отдаёт и
+// «живой» источник контекста (см. buildDSLVarsTx).
+func (s *Server) buildDSLVarsWithMessagesTx(ctx context.Context, mc *runtime.MovementsCollector, msgs *[]string) (map[string]any, *interpreter.TxState) {
 	ctx = withDSLMessageCollector(ctx, msgs)
-	vars := s.buildDSLVars(ctx, mc)
+	vars, txState := s.buildDSLVarsTx(ctx, mc)
 	userKey := userKeyFromCtx(ctx)
 	msgFunc := interpreter.BuiltinFunc(func(args []any, file string, line int) (any, error) {
 		if len(args) > 0 {
@@ -309,7 +326,7 @@ func (s *Server) buildDSLVarsWithMessages(ctx context.Context, mc *runtime.Movem
 	})
 	vars["Сообщить"] = msgFunc
 	vars["Message"] = msgFunc
-	return vars
+	return vars, txState
 }
 
 func (s *Server) runOnWriteCtx(ctx context.Context, obj *runtime.Object, mc *runtime.MovementsCollector) (string, []string) {

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -197,8 +197,11 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 	// `Объект.Товары.Добавить()` реально модифицировал obj).
 	mc := runtime.NewMovementsCollector(entity.Name, obj.ID)
 	var msgs []string
-	vars := s.buildDSLVarsWithMessages(r.Context(), mc, &msgs)
-	thisObj := s.newFormObjectThisNew(r.Context(), obj, entity, form, strings.TrimSpace(r.FormValue("_id")) == "")
+	// txState — «живой» контекст: обработчик может позвать модуль, который
+	// откроет транзакцию, и ссылки объекта обязаны выполнять ПолучитьОбъект()
+	// внутри неё, а не ждать второго соединения (пул SQLite — одно).
+	vars, txState := s.buildDSLVarsWithMessagesTx(r.Context(), mc, &msgs)
+	thisObj := s.newFormObjectThisLive(r.Context(), txState, obj, entity, form, strings.TrimSpace(r.FormValue("_id")) == "")
 	vars["Объект"] = thisObj
 	vars["ЭтотОбъект"] = thisObj
 


### PR DESCRIPTION
## Симптом

Команда управляемой формы, которая зовёт общий модуль с транзакцией, **виснет**: 60 секунд до таймаута клиента, в одном прогоне запрос отработал за **221 секунду** и вернул 200. Остальные команды той же формы укладываются в 0,01–0,05 с.

Воспроизведение (конфигурация колл-центра, форма Заявки, кнопка «Отправить на согласование»):

```bsl
// .form.os
Согласование.ОтправитьНаСогласование(Объект.Ссылка, ИмяПользователя(), Логин);

// общий модуль
НачатьТранзакцию();
Об = ЗаявкаРеф.ПолучитьОбъект();   // ← здесь встаёт
```

## Причина

Дамп горутин на висящем запросе:

```
ui.handleManagedFormEvent → interpreter.Run → execTry
  → (*Ref).CallMethod → ui.(*docProxy).LoadObject
  → ui.loadRuntimeObject → storage.GetByID → storage.QueryRow   ← ожидание
```

`storage.QueryRow` берёт транзакцию **из контекста**. Менеджер ссылки собирался через `interpreter.NewStaticCtx(ctx)` — то есть запоминал **снимок** контекста в момент своего создания, а создаётся он при первом чтении реквизита, ещё **до** `НачатьТранзакцию`. Поэтому запрос уходил мимо открытой транзакции, за вторым соединением — а пул SQLite это ровно одно соединение, занятое той самой транзакцией. Взаимная блокировка до таймаута.

Тот же контракт для `Документы.X`/`Справочники.X` соблюдён давно: они получают `TxState` и всегда спрашивают контекст заново. Ссылки из полей объекта — нет.

## Что сделано

- `refManagerForSrc(entity, ctxSrc, ctx)` принимает **живой** `interpreter.CtxSource`: менеджер спрашивает контекст на каждом вызове, а не запоминает его при создании. Прежний `refManagerFor(entity, ctx)` сохранён и делегирует статическому источнику — вызовы из хуков entityservice, где контекст уже транзакционный, не меняются.
- `dslRefAttrResolver` сам реализует `CtxSource` поверх нового поля `ctxSrc` и использует живой контекст в предзагрузке реквизитов (`GetFieldsByIDs`, `bulkReferenceNames`).
- `handleManagedFormEvent` получает `TxState` из нового `buildDSLVarsWithMessagesTx` и передаёт его объекту формы; `Объект.Записать()` тоже пишет в открытую транзакцию, а не за вторым соединением.

## Проверка

`go test ./...` зелёный.

Живьём на конфигурации колл-центра, девять команд формы Заявки подряд:

| | было | стало |
|---|---:|---:|
| Отправить на согласование | 60 с (таймаут) | **0,01–0,05 с** |
| остальные восемь | 0,00–0,44 с | без изменений |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
