### PR TITLE
fix(dbcheck): сверка итогов учитывает знак движения (план 114)

### DIFF
--- a/internal/dbcheck/checks.go
+++ b/internal/dbcheck/checks.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/shopspring/decimal"
 )
 
@@ -215,12 +216,20 @@ func (c totalsCheck) Run(ctx context.Context, env *Env) Result {
 		}
 		for _, r := range reg.Resources {
 			checked++
-			col := metadata.ColumnName(r)
-			fromMoves, err := sumColumn(ctx, env, src, col)
+			// Числовое значение ресурса: на SQLite сырая колонка регистра —
+			// TEXT, поэтому CAST обязателен по обе стороны сверки.
+			num := "CAST(" + quoteIdent(metadata.ColumnName(r)) + " AS NUMERIC)"
+			// Движения суммируются ЗНАКОВО — тем же выражением, которым итоги и
+			// заполняются (storage.SignedResourceSum). Беззнаковый SUM давал бы
+			// расхождение на каждом регистре, где есть расход: итоги 100−30=70
+			// против «движений» 100+30=130 — то есть проверка объявляла бы
+			// ошибкой исправную базу.
+			fromMoves, err := sumExpr(ctx, env, src, storage.SignedResourceSum(num))
 			if err != nil {
 				return failed(c, err)
 			}
-			fromTotals, err := sumColumn(ctx, env, totals, col)
+			// В итогах знак уже учтён при записи — здесь просто сумма по месяцам.
+			fromTotals, err := sumExpr(ctx, env, totals, "SUM("+num+")")
 			if err != nil {
 				return failed(c, err)
 			}
@@ -263,21 +272,25 @@ func (c totalsCheck) Fix(ctx context.Context, env *Env, res Result) (int, error)
 	return fixed, nil
 }
 
-// sumColumn возвращает сумму колонки как decimal. Значение читается строкой:
-// на SQLite числа хранятся в TEXT, и float здесь дал бы копеечные расхождения
-// на ровном месте (тот самый дефект Д2 из аудита).
-func sumColumn(ctx context.Context, env *Env, table, column string) (decimal.Decimal, error) {
+// sumExpr вычисляет агрегат agg по таблице и возвращает его как decimal.
+// Значение читается строкой: на SQLite числа хранятся в TEXT, и float здесь дал
+// бы копеечные расхождения на ровном месте (тот самый дефект Д2 из аудита).
+//
+// Выражение агрегата задаёт вызывающий: движения и итоги сверяются РАЗНЫМИ
+// выражениями (знаковая сумма против обычной), и прятать эту разницу внутрь
+// помощника значило бы снова сделать её незаметной.
+func sumExpr(ctx context.Context, env *Env, table, agg string) (decimal.Decimal, error) {
 	var raw *string
-	q := "SELECT CAST(COALESCE(SUM(CAST(" + quoteIdent(column) + " AS NUMERIC)), 0) AS TEXT) FROM " + quoteIdent(table)
+	q := "SELECT CAST(COALESCE(" + agg + ", 0) AS TEXT) FROM " + quoteIdent(table)
 	if err := env.DB.QueryRow(ctx, q).Scan(&raw); err != nil {
-		return decimal.Zero, fmt.Errorf("%s.%s: сумма: %w", table, column, err)
+		return decimal.Zero, fmt.Errorf("%s: сумма %s: %w", table, agg, err)
 	}
 	if raw == nil {
 		return decimal.Zero, nil
 	}
 	d, err := decimal.NewFromString(strings.TrimSpace(*raw))
 	if err != nil {
-		return decimal.Zero, fmt.Errorf("%s.%s: сумма %q не разбирается как число: %w", table, column, *raw, err)
+		return decimal.Zero, fmt.Errorf("%s: сумма %q не разбирается как число: %w", table, *raw, err)
 	}
 	return d, nil
 }

--- a/internal/dbcheck/totals_sign_test.go
+++ b/internal/dbcheck/totals_sign_test.go
@@ -1,0 +1,98 @@
+package dbcheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Знак движения в сверке итогов.
+//
+// Таблица итогов заполняется ЗНАКОВОЙ суммой (storage.SignedResourceSum):
+// приход плюсом, расход минусом. Сверка обязана суммировать движения тем же
+// выражением — иначе на любом регистре с расходом она объявляет ошибкой
+// исправную базу: итоги 100−30=70 против «движений» 100+30=130.
+//
+// Цена такой ложной тревоги высока: doctor выходит с ненулевым кодом, а
+// --fix totals её не снимает — пересчёт даёт те же (правильные) итоги, проверка
+// перезапускается и снова красная. Администратору остаётся либо перестать
+// доверять диагностике, либо «чинить» здоровую базу.
+
+// movement вписывает одно движение регистра Остатки.
+func movement(t *testing.T, env *Env, doc uuid.UUID, ctr uuid.UUID, line int, kind, sum string) {
+	t.Helper()
+	if _, err := env.DB.Exec(context.Background(),
+		`INSERT INTO рег_остатки (id, recorder, recorder_type, line_number, period, вид_движения, контрагент_id, сумма)
+		 VALUES (?, ?, 'Реализация', ?, '2026-01-15T00:00:00Z', ?, ?, ?)`,
+		uuid.New().String(), doc.String(), line, kind, ctr.String(), sum); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// seedIncomeAndExpense готовит обычную жизнь регистра остатков: приход и расход
+// по одному контрагенту, итоги пересчитаны самой платформой.
+func seedIncomeAndExpense(t *testing.T, env *Env) {
+	t.Helper()
+	ctx := context.Background()
+	ctr := uuid.New()
+	if _, err := env.DB.Exec(ctx, `INSERT INTO контрагенты (id, наименование) VALUES (?, ?)`,
+		ctr.String(), "Живой"); err != nil {
+		t.Fatal(err)
+	}
+	doc := uuid.New()
+	if _, err := env.DB.Exec(ctx,
+		`INSERT INTO реализация (id, контрагент_id, сумма) VALUES (?, ?, ?)`,
+		doc.String(), ctr.String(), "100"); err != nil {
+		t.Fatal(err)
+	}
+	movement(t, env, doc, ctr, 1, "Приход", "100")
+	movement(t, env, doc, ctr, 2, "Расход", "30")
+	for _, reg := range env.Registers {
+		if err := env.DB.RecalcRegisterTotals(ctx, reg); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// Здоровая база с расходом: проверка обязана молчать. Без учёта знака здесь
+// «итоги 70, движения 130» и severity=error.
+func TestTotalsCheckIgnoresNothingWhenSignsMatch(t *testing.T) {
+	env := testEnv(t)
+	seedIncomeAndExpense(t, env)
+
+	res := totalsCheck{}.Run(context.Background(), env)
+	if res.Severity != SeverityOK {
+		t.Fatalf("ложная тревога на здоровой базе: %s / %s (находки: %+v)",
+			res.Severity, res.Summary, res.Findings)
+	}
+}
+
+// Обратная сторона: настоящее расхождение проверка по-прежнему видит. Иначе
+// «починку» знака можно было бы изобразить, просто перестав сравнивать.
+func TestTotalsCheckStillFindsRealMismatch(t *testing.T) {
+	ctx := context.Background()
+	env := testEnv(t)
+	seedIncomeAndExpense(t, env)
+
+	// Портим итоги мимо пересчёта — ровно то, ради чего проверка и написана.
+	if _, err := env.DB.Exec(ctx, `UPDATE итоги_остатки SET сумма = сумма + 5`); err != nil {
+		t.Fatal(err)
+	}
+	res := totalsCheck{}.Run(ctx, env)
+	if res.Severity != SeverityError {
+		t.Fatalf("испорченные итоги не найдены: %s / %s", res.Severity, res.Summary)
+	}
+
+	// И чинятся: после пересчёта проверка снова чистая.
+	n, err := (totalsCheck{}).Fix(ctx, env, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("пересчитано регистров: %d, ожидался 1", n)
+	}
+	if after := (totalsCheck{}).Run(ctx, env); after.Severity != SeverityOK {
+		t.Fatalf("после починки проверка осталась красной: %s / %s", after.Severity, after.Summary)
+	}
+}

--- a/internal/storage/register_totals.go
+++ b/internal/storage/register_totals.go
@@ -37,8 +37,18 @@ func monthKeyExpr(d Dialect, col string) string {
 	return "to_char(" + col + " AT TIME ZONE 'UTC', 'YYYY-MM')"
 }
 
-// signedResourceSum возвращает выражение знаковой суммы ресурса (как в genBalances).
-func signedResourceSum(col string) string {
+// SignedResourceSum возвращает выражение знаковой суммы ресурса (как в
+// genBalances): приход со знаком плюс, всё остальное — минус.
+//
+// Экспортирована, потому что этим же выражением обязан пользоваться всякий, кто
+// сверяет движения с итогами: итоги заполняются знаковой суммой, и беззнаковый
+// SUM по сырой колонке не сойдётся с ними ни на одном регистре, где есть расход.
+// Проверка состояния базы (internal/dbcheck) на этом и погорела — держим одно
+// выражение на всех, чтобы разойтись было негде.
+//
+// Аргумент подставляется как есть, так что вызывающий волен передать не голую
+// колонку, а выражение — например CAST(x AS NUMERIC).
+func SignedResourceSum(col string) string {
 	return "SUM(CASE WHEN вид_движения = 'Приход' THEN " + col + " ELSE -" + col + " END)"
 }
 
@@ -96,7 +106,7 @@ func insertTotalsSelectSQL(d Dialect, reg *metadata.Register, where string) stri
 	for _, f := range reg.Resources {
 		col := metadata.ColumnName(f)
 		insertCols = append(insertCols, col)
-		selectCols = append(selectCols, signedResourceSum(col))
+		selectCols = append(selectCols, SignedResourceSum(col))
 	}
 
 	var sb strings.Builder

--- a/internal/storage/register_totals_test.go
+++ b/internal/storage/register_totals_test.go
@@ -46,7 +46,7 @@ func onTheFlyBalances(ctx context.Context, t *testing.T, db *DB, reg *metadata.R
 	var sel []string
 	sel = append(sel, dims...)
 	for _, r := range reg.Resources {
-		sel = append(sel, signedResourceSum(metadata.ColumnName(r)))
+		sel = append(sel, SignedResourceSum(metadata.ColumnName(r)))
 	}
 	q := "SELECT " + strings.Join(sel, ", ") + " FROM " + metadata.RegisterTableName(reg.Name)
 	if len(dims) > 0 {


### PR DESCRIPTION
`onebase doctor` объявляет ошибкой исправную базу на любом регистре накопления, где есть расход.

## Что происходит

Таблица итогов заполняется **знаковой** суммой — `signedResourceSum` (`internal/storage/register_totals.go`): приход плюсом, остальное минусом. А сверка в `totalsCheck` суммировала сырую колонку движений **без знака**:

```go
q := "SELECT CAST(COALESCE(SUM(CAST(" + quoteIdent(column) + " AS NUMERIC)), 0) AS TEXT) FROM " + quoteIdent(table)
```

Приход 100 и расход 30 по одному контрагенту дают:

```
severity=error  summary=итоги расходятся с движениями: 1 ресурс(ов)
  находка: Остатки.Сумма — итоги 70, движения 130
```

Итоги здесь **верны** (100 − 30 = 70) — неверна проверка.

## Почему это дороже обычного шума

`Report.Worst()` поднимает уровень до `error`, то есть `doctor` выходит с ненулевым кодом. А `--fix totals` симптом не снимает: `RecalcRegisterTotals` даёт те же (правильные) итоги, `dbcheck.Run` перезапускает проверку — и она снова красная. Администратору остаётся либо перестать доверять диагностике, либо пойти «чинить» здоровую базу.

Тесты пакета вставляли только `'Приход'` (`dbcheck_test.go`, `movements_test.go`), поэтому расхождения не видели.

## Правка

`signedResourceSum` → `storage.SignedResourceSum`. Сверять движения с итогами полагается ровно тем выражением, которым итоги и заполняются, — иначе две реализации разойдутся снова. Аргумент подставляется как есть, поэтому `dbcheck` передаёт `CAST(… AS NUMERIC)`: на SQLite сырая колонка регистра — TEXT, приведение нужно по обе стороны сверки.

`sumColumn` заменён на `sumExpr`, принимающий выражение агрегата целиком. Движения и итоги считаются **разными** выражениями, и прятать эту разницу внутрь помощника значило бы снова сделать её незаметной.

## Проверка

Два регресс-теста, оба падают без правки:

- здоровая база с расходом — проверка молчит;
- итоги, испорченные мимо пересчёта, по-прежнему находятся, чинятся `Fix`, и после починки проверка чистая.

Второй нужен именно потому, что «починку» знака легко изобразить, просто перестав сравнивать.

Локально: `go build ./...`, `go test ./internal/dbcheck/ ./internal/storage/` — зелено.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
