### PR TITLE
fix(storage): сохранять истинные булевы при ретайпе string→boolean на SQLite

### DIFF
--- a/internal/storage/schemaapply.go
+++ b/internal/storage/schemaapply.go
@@ -164,7 +164,7 @@ func (db *DB) retypeSQLite(ctx context.Context, c SchemaChange, newSQL string) e
 		if _, err := db.Exec(ctx, "ALTER TABLE "+q+" ADD COLUMN "+quoteIdent(tmp)+" "+newSQL); err != nil {
 			return fmt.Errorf("%s.%s: временная колонка: %w", c.Table, c.To, err)
 		}
-		if _, err := db.Exec(ctx, "UPDATE "+q+" SET "+quoteIdent(tmp)+" = CAST("+quoteIdent(c.To)+" AS "+newSQL+")"); err != nil {
+		if _, err := db.Exec(ctx, "UPDATE "+q+" SET "+quoteIdent(tmp)+" = "+sqliteRetypeExpr(c.Field, quoteIdent(c.To), newSQL)); err != nil {
 			return fmt.Errorf("%s.%s: перенос значений: %w", c.Table, c.To, err)
 		}
 		if err := db.dropColumn(ctx, c.Table, c.To); err != nil {
@@ -175,6 +175,23 @@ func (db *DB) retypeSQLite(ctx context.Context, c SchemaChange, newSQL string) e
 		}
 		return nil
 	})
+}
+
+// sqliteRetypeExpr — выражение переноса значений при смене типа колонки на SQLite.
+//
+// Обычный CAST(<col> AS INTEGER) годится не для всякого типа: SQLite приводит к
+// целому только числовой литерал, а словесные формы булева ('true', 'yes', 'on'…)
+// даёт нулём — то есть молча обнулил бы все истинные значения (#607). Для булева
+// типа (TypeBool → INTEGER) переносим значения CASE-выражением, понимающим те же
+// формы, что и valueChecker; к этому месту checkConvertible уже отсеяла всё, что
+// не булев литерал, поэтому «иначе» здесь — только ложь.
+func sqliteRetypeExpr(f metadata.Field, col, newSQL string) string {
+	if f.RefEntity == "" && f.Type == metadata.FieldTypeBool {
+		return "CASE WHEN " + col + " IS NULL THEN NULL" +
+			" WHEN lower(CAST(" + col + " AS TEXT)) IN ('true','t','yes','on','1') THEN 1" +
+			" ELSE 0 END"
+	}
+	return "CAST(" + col + " AS " + newSQL + ")"
 }
 
 // dropColumn удаляет колонку. В SQLite DROP COLUMN отказывается работать, если

--- a/internal/storage/schemaplan_guards_test.go
+++ b/internal/storage/schemaplan_guards_test.go
@@ -185,6 +185,54 @@ func TestRetypeSQLiteRollsBackWhole(t *testing.T) {
 	}
 }
 
+// Ретайп string→boolean на SQLite обязан сохранять истинные значения. Прежде
+// перенос шёл слепым CAST(<col> AS INTEGER): SQLite отдаёт целое только для
+// числового литерала, а 'true'/'yes'/'on'/'t' превращал в 0 — миграция молча
+// обнуляла все истины (#607). Проверяем словесные формы на реальном драйвере.
+func TestRetypeSQLiteStringToBoolPreservesTrue(t *testing.T) {
+	ctx := context.Background()
+	db := schemaTestDB(t)
+
+	e := catalogWithField(metadata.Field{ID: "f_flag", Name: "Активен", Type: metadata.FieldTypeString})
+	if err := db.Migrate(ctx, []*metadata.Entity{e}); err != nil {
+		t.Fatal(err)
+	}
+	tbl := metadata.TableName(e.Name)
+
+	truthy := []string{"true", "TRUE", "t", "yes", "on", "1"}
+	falsy := []string{"false", "f", "no", "off", "0"}
+	for _, v := range append(append([]string{}, truthy...), falsy...) {
+		if _, err := db.Exec(ctx,
+			"INSERT INTO "+quoteIdent(tbl)+" (id, "+quoteIdent("активен")+") VALUES (?, ?)",
+			uuid.NewString(), v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := db.applyRetype(ctx, SchemaChange{
+		Table: tbl, FieldID: "f_flag", Kind: ChangeRetype, From: "string", To: "активен",
+		Field: metadata.Field{ID: "f_flag", Name: "Активен", Type: metadata.FieldTypeBool},
+	}); err != nil {
+		t.Fatalf("ретайп string→bool сорвался: %v", err)
+	}
+
+	var ones, zeros int
+	if err := db.QueryRow(ctx,
+		"SELECT COUNT(*) FROM "+quoteIdent(tbl)+" WHERE "+quoteIdent("активен")+" = 1").Scan(&ones); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(ctx,
+		"SELECT COUNT(*) FROM "+quoteIdent(tbl)+" WHERE "+quoteIdent("активен")+" = 0").Scan(&zeros); err != nil {
+		t.Fatal(err)
+	}
+	if ones != len(truthy) {
+		t.Errorf("истинных значений после ретайпа %d, ожидалось %d — словесные формы обнулены", ones, len(truthy))
+	}
+	if zeros != len(falsy) {
+		t.Errorf("ложных значений после ретайпа %d, ожидалось %d", zeros, len(falsy))
+	}
+}
+
 // Пропавшая колонка должна называться прямо. На SQLite неизвестный идентификатор
 // в двойных кавычках вырождается в строковый литерал, поэтому прежняя проверка
 // возвращала «1 значение не преобразуется», а примером было имя колонки — и


### PR DESCRIPTION
## Проблема

Смена типа реквизита `string → boolean` на SQLite молча превращала все истинные значения в ложь: `retypeSQLite` переносил данные слепым `CAST(<col> AS INTEGER)`, а SQLite приводит к целому только числовой литерал — словесные формы (`true`, `yes`, `on`, `t`) давали `0`. Миграция проходила без ошибки и без `--allow-destructive`, уцелевало только `'1'`. На PostgreSQL те же данные конвертировались верно.

## Исправление

Перенос булева типа теперь идёт `CASE`-выражением, понимающим те же формы, что и `valueChecker`/`checkConvertible`:

```sql
CASE WHEN col IS NULL THEN NULL
     WHEN lower(CAST(col AS TEXT)) IN ('true','t','yes','on','1') THEN 1
     ELSE 0 END
```

Остальные типы переносятся прежним `CAST`. К моменту переноса `checkConvertible` уже отсеяла всё, что не булев литерал, поэтому «иначе» — только ложь.

## Тест

`TestRetypeSQLiteStringToBoolPreservesTrue` гоняет ретайп `string→bool` на реальном драйвере со всеми словесными формами и сверяет, что истины/лжи сохранились. Без фикса падает (1 истина из 6).

Закрывает #607 (план 81, регрессия #562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)