### PR TITLE
fix(ui): маскировать защищённые реквизиты в ответе события управляемой формы

### DIFF
--- a/internal/ui/field_access_test.go
+++ b/internal/ui/field_access_test.go
@@ -145,6 +145,70 @@ func TestUI_SubmitEdit_MaskedFieldWriteGuard(t *testing.T) {
 	}
 }
 
+// #609: реквизит, закрытый полевой политикой роли (план 88), обязан уезжать
+// клиенту маской и через события управляемой формы. restoreUnsubmittedFields
+// дочитывает незапрошенное поле из БД РЕАЛЬНЫМ значением (это верно для записи
+// и предикатов доступа), но в ответ /form-event оно шло сырым, в обход маски
+// отрисовки — applyValues подставлял бы реальное значение в DOM.
+func TestUI_ManagedFormEvent_MasksProtectedField(t *testing.T) {
+	cat := uiClientEntity()
+	// Управляемая форма с обработчиком-пустышкой: событие доходит до сериализации
+	// ответа, а restoreUnsubmittedFields по пути дочитывает Телефон из БД.
+	form := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: cat.Name,
+		LayoutKind: metadata.FormLayoutManaged,
+		Elements: []*metadata.FormElement{{
+			Kind: metadata.FormElementButton, Name: "Кнопка",
+			Handlers: map[metadata.FormEventType]string{metadata.FormEventOnClick: "Ничего"},
+		}},
+		ProgramAST: mustParse(t, "Процедура Ничего()\nКонецПроцедуры\n"),
+	}
+	cat.Forms = []*metadata.FormModule{form}
+
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{cat})
+	id := uuid.New()
+	const realPhone = "+79161234455"
+	if err := s.store.Upsert(ctx, "Клиент", id, map[string]any{
+		"Наименование": "Иванов", "Телефон": realPhone,
+	}, cat); err != nil {
+		t.Fatal(err)
+	}
+	user := uiMaskUser([]string{"read"}, auth.FieldPolicies{"Телефон": {Read: "mask_tail", Keep: 4}})
+
+	// Телефон в теле события НЕ шлём — именно его дочитывает restoreUnsubmittedFields.
+	body := url.Values{
+		"_element": {"Кнопка"}, "_event": {string(metadata.FormEventOnClick)},
+		"_kind": {"object"}, "_id": {id.String()}, "Наименование": {"Иванов"},
+	}
+	r := reqWithChi("POST", "/ui/catalog/Клиент/form-event", body,
+		map[string]string{"kind": "catalog", "entity": "Клиент"})
+	r = r.WithContext(auth.ContextWithUser(r.Context(), user))
+	w := httptest.NewRecorder()
+	s.handleManagedFormEvent(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	var resp formEventResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json: %v; body=%s", err, w.Body.String())
+	}
+	got := fmt.Sprintf("%v", resp.Values["Телефон"])
+	if strings.Contains(got, realPhone) {
+		t.Fatalf("реальный телефон утёк клиенту через событие формы: %q", got)
+	}
+	if !strings.HasSuffix(got, "4455") {
+		t.Fatalf("ожидалась маска mask_tail(4) c хвостом 4455, получили %q", got)
+	}
+	// В БД лежит исходное значение: маска в базу не попала.
+	row, err := s.store.GetByID(ctx, "Клиент", id, cat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row["Телефон"] != realPhone {
+		t.Fatalf("в БД должно остаться реальное значение, лежит %v", row["Телефон"])
+	}
+}
+
 // Раскрытие под правом disclose: возвращает полное значение и пишет аудит без
 // значения.
 func TestUI_DiscloseField(t *testing.T) {

--- a/internal/ui/form_conditional_test.go
+++ b/internal/ui/form_conditional_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bytes"
+	"context"
 	"html/template"
 	"net/url"
 	"strings"
@@ -97,7 +98,7 @@ func TestManagedFormEventStateAddsConditionalClasses(t *testing.T) {
 		},
 	}
 	s := &Server{interp: interpreter.New()}
-	_, tableParts, _, css, msgs := s.serializeManagedFormEventState(form, ent, obj, form.Conditional, nil)
+	_, tableParts, _, css, msgs := s.serializeManagedFormEventState(context.Background(), form, ent, obj, form.Conditional, nil)
 	if len(msgs) != 0 {
 		t.Fatalf("unexpected messages: %v", msgs)
 	}

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -287,7 +288,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 		s.refreshTablePartsWrittenByHandler(r.Context(), entity, obj, tpBefore, tpDBBefore)
 	}
 	if runErr != nil {
-		values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, entity, obj, condRuntime.rules, msgs)
+		values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(r.Context(), form, entity, obj, condRuntime.rules, msgs)
 		respondJSON(enc, formEventResponse{
 			OK:             false,
 			Values:         values,
@@ -305,7 +306,7 @@ func (s *Server) handleManagedFormEvent(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, entity, obj, condRuntime.rules, msgs)
+	values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(r.Context(), form, entity, obj, condRuntime.rules, msgs)
 	respondJSON(enc, formEventResponse{
 		OK:             true,
 		Values:         values,
@@ -330,7 +331,7 @@ func savedFormID(this *formObjectThis) string {
 	return this.obj.ID.String()
 }
 
-func (s *Server) serializeManagedFormEventState(form *metadata.FormModule, entity *metadata.Entity, obj *runtime.Object, rules []metadata.FormCondRule, msgs []string) (map[string]any, map[string][]map[string]any, map[string][]map[string]any, string, []string) {
+func (s *Server) serializeManagedFormEventState(ctx context.Context, form *metadata.FormModule, entity *metadata.Entity, obj *runtime.Object, rules []metadata.FormCondRule, msgs []string) (map[string]any, map[string][]map[string]any, map[string][]map[string]any, string, []string) {
 	conditionalCSS := formConditionalRulesCSS(rules)
 	if obj == nil {
 		return nil, nil, nil, conditionalCSS, msgs
@@ -349,6 +350,15 @@ func (s *Server) serializeManagedFormEventState(form *metadata.FormModule, entit
 			msgs = append(msgs, warnings...)
 		}
 	}
+	// Маскирование реквизитов, закрытых полевой политикой роли (план 88), перед
+	// отправкой клиенту. restoreUnsubmittedFields и refreshFieldsWrittenByHandler
+	// намеренно держат в obj.Fields РЕАЛЬНЫЕ значения — их видят и запись из
+	// обработчика (Объект.Записать), и предикаты доступа, и в БД маска попасть не
+	// должна. Но в ответ /form-event защищённое поле обязано уехать маской, иначе
+	// applyValues подставит реальное значение в DOM в обход маски отрисовки (#609).
+	// Ключи values для полей сущности — канонические имена, MaskRecord матчит их
+	// регистронезависимо; условные правила выше уже посчитаны по реальным значениям.
+	s.maskRecord(ctx, entity, values)
 	return values, tableParts, formTablesFromRows(tableParts, form), conditionalCSS, msgs
 }
 
@@ -866,7 +876,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 				}
 
 				if runErr := s.interp.Run(decl, thisObj, vars); runErr != nil {
-					values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, virtEntity, obj, condRuntime.rules, msgs)
+					values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(r.Context(), form, virtEntity, obj, condRuntime.rules, msgs)
 					respondJSON(enc, formEventResponse{
 						OK:             false,
 						Values:         values,
@@ -880,7 +890,7 @@ func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request
 					return
 				}
 
-				values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(form, virtEntity, obj, condRuntime.rules, msgs)
+				values, tableParts, formTables, conditionalCSS, outMsgs := s.serializeManagedFormEventState(r.Context(), form, virtEntity, obj, condRuntime.rules, msgs)
 				respondJSON(enc, formEventResponse{
 					OK:             true,
 					Values:         values,


### PR DESCRIPTION
## Проблема

Реквизит, закрытый полевой политикой роли (план 88), уезжал клиенту в **реальном** виде через события управляемой формы. На отрисовке форма показывает маску, но любой ответ `/form-event` клал в JSON настоящее значение, и клиентский `applyValues` подставлял его в DOM.

Два пути читают строку сырым `GetByID` и кладут реальные значения в `obj.Fields`:
- `restoreUnsubmittedFields` (`form_partial_write.go`) — дочитывает незапрошенные поля ДО обработчика;
- `refreshFieldsWrittenByHandler` (`form_event_refresh.go`) — перечитывает нередактируемые поля ПОСЛЕ обработчика.

Это **намеренно** реальные значения: их видят запись из обработчика (`Объект.Записать`) и предикаты построчного доступа, и в БД маска попасть не должна. Но `serializeManagedFormEventState` отдавал `obj.Fields` в `formEventResponse.Values` без маскирования. Утечке подвержены ровно те поля, что политика закрывает (замаскированный реквизит как раз не присылается формой и потому дочитывается).

## Исправление

Ответ маскируется в единой точке — `serializeManagedFormEventState`, **после** расчёта условных правил (они по-прежнему считаются по реальным значениям) и перед отправкой клиенту, через тот же чокпоинт `maskRecord`, что и остальные читатели (экспорт, печать, AI). `obj.Fields` остаётся реальным — путь записи не затронут, маска в базу не попадает.

## Тест

`TestUI_ManagedFormEvent_MasksProtectedField`: роль с `mask_tail` на `Телефон`, событие формы без присланного телефона (его дочитывает `restoreUnsubmittedFields`). Проверяет, что в `values` ответа приходит маска (хвост `4455`, без реального номера), а в БД остаётся исходное `+79161234455`. Без фикса тест падает — реальный номер утекает.

Закрывает #609 (регрессия #528, #573; план 88E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)