### PR TITLE
fix(storage): сухой прогон --forget-document не глотает ошибку запроса (#622)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -128,7 +128,12 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 				strings.Join(inConfig, ", "))
 		}
 		if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
-			n := db.CountMovementsOfRecorderType(ctx, proj.Registers, forget)
+			n, err := db.CountMovementsOfRecorderType(ctx, proj.Registers, forget)
+			if err != nil {
+				// Молчаливый «0» здесь опаснее отказа: администратор прочитал бы
+				// его как «удалять нечего» и снял бы --dry-run (#622).
+				return fmt.Errorf("сухой прогон --forget-document: %w", err)
+			}
 			outf("Сухой прогон: к удалению движений документов %s: %d (ничего не изменено)\n",
 				strings.Join(forget, ", "), n)
 			outln("")

--- a/internal/dbcheck/movements_test.go
+++ b/internal/dbcheck/movements_test.go
@@ -136,7 +136,10 @@ func TestCountMovementsOfRecorderTypeDoesNotDelete(t *testing.T) {
 	addMovement(t, env, "СовсемУбранныйДокумент", uuid.New(), "600")
 	addMovement(t, env, "ДругойДокумент", uuid.New(), "700")
 
-	n := env.DB.CountMovementsOfRecorderType(ctx, env.Registers, []string{"СовсемУбранныйДокумент"})
+	n, err := env.DB.CountMovementsOfRecorderType(ctx, env.Registers, []string{"СовсемУбранныйДокумент"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if n != 2 {
 		t.Fatalf("сухой прогон насчитал %d, ожидалось 2", n)
 	}
@@ -145,7 +148,7 @@ func TestCountMovementsOfRecorderTypeDoesNotDelete(t *testing.T) {
 		t.Fatalf("сухой прогон изменил данные: осталось %d из 3", got)
 	}
 	// Пустой/служебный список — ноль.
-	if n := env.DB.CountMovementsOfRecorderType(ctx, env.Registers, nil); n != 0 {
-		t.Fatalf("пустой список насчитал %d", n)
+	if n, err := env.DB.CountMovementsOfRecorderType(ctx, env.Registers, nil); err != nil || n != 0 {
+		t.Fatalf("пустой список насчитал %d, err=%v", n, err)
 	}
 }

--- a/internal/storage/orphan_movements_test.go
+++ b/internal/storage/orphan_movements_test.go
@@ -109,3 +109,44 @@ func TestOrphanMovements_QueryErrorSurfaces(t *testing.T) {
 		t.Fatal("нечитаемый регистр обязан вернуть ошибку, а не пустую статистику")
 	}
 }
+
+// #622: то же для сухого прогона --forget-document. Здесь проглоченная ошибка
+// опаснее всего: прогон существует, чтобы показать объём НЕОБРАТИМОГО удаления,
+// и недосчитанный «0» читается как «удалять нечего» — то есть уговаривает снять
+// --dry-run и снести историю вслепую.
+func TestCountMovementsOfRecorderType_QueryErrorSurfaces(t *testing.T) {
+	ctx := context.Background()
+	db, err := ConnectSQLite(ctx, filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	reg := &metadata.Register{
+		Name:       "Битый",
+		Dimensions: []metadata.Field{{Name: "Номенклатура", Type: metadata.FieldTypeString}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+	regs := []*metadata.Register{reg}
+
+	// Регистр НЕ мигрирован: таблицы нет — законный пропуск, не ошибка.
+	n, err := db.CountMovementsOfRecorderType(ctx, regs, []string{"СовсемУбранныйДокумент"})
+	if err != nil {
+		t.Fatalf("отсутствие таблицы регистра — не ошибка: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("для несуществующего регистра ожидался ноль, получили %d", n)
+	}
+
+	// Таблица есть, но без колонки recorder_type — счётный запрос не выполнится.
+	if _, err := db.Exec(ctx, `CREATE TABLE `+metadata.RegisterTableName(reg.Name)+` (id TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	n, err = db.CountMovementsOfRecorderType(ctx, regs, []string{"СовсемУбранныйДокумент"})
+	if err == nil {
+		t.Fatal("нечитаемый регистр обязан вернуть ошибку, а не молчаливый ноль")
+	}
+	if n != 0 {
+		t.Errorf("вместе с ошибкой уехала частичная сумма %d — её примут за настоящий объём", n)
+	}
+}

--- a/internal/storage/register.go
+++ b/internal/storage/register.go
@@ -247,27 +247,39 @@ func (db *DB) DeleteMovementsOfUnknownRecorderType(
 // CountMovementsOfRecorderType считает движения по названным типам регистратора
 // во всех регистрах, ничего не меняя, — сухой прогон для --forget-document:
 // удаление необратимо, поэтому объём стоит увидеть заранее.
+//
+// Ошибку запроса возвращаем наверх, а не проглатываем. Сухой прогон существует
+// ровно затем, чтобы показать объём предстоящей потери, и недосчитанное из-за
+// нечитаемого регистра «0» читается как «удалять нечего» — то есть подталкивает
+// к тому самому необратимому шагу, от которого прогон и страхует (#622).
+// Отсутствие таблицы — законный случай (регистр ещё не мигрирован), его
+// отличаем явной проверкой HasTable и пропускаем, как в OrphanMovements.
 func (db *DB) CountMovementsOfRecorderType(
 	ctx context.Context, registers []*metadata.Register, recorderTypes []string,
-) int64 {
+) (int64, error) {
 	wanted := wantedRecorderTypes(recorderTypes)
 	if len(wanted) == 0 {
-		return 0
+		return 0, nil
 	}
 	d := db.dialect
 	var total int64
 	for _, reg := range registers {
 		table := metadata.RegisterTableName(reg.Name)
+		if !db.HasTable(ctx, table) {
+			continue // регистр ещё не мигрирован — считать нечего
+		}
 		for t := range wanted {
 			var n int64
-			err := db.QueryRow(ctx, fmt.Sprintf(
-				"SELECT COUNT(*) FROM %s WHERE recorder_type = %s", table, d.Placeholder(1)), t).Scan(&n)
-			if err == nil {
-				total += n
+			if err := db.QueryRow(ctx, fmt.Sprintf(
+				"SELECT COUNT(*) FROM %s WHERE recorder_type = %s", table, d.Placeholder(1)), t).Scan(&n); err != nil {
+				// Частичную сумму не отдаём: она выглядит как настоящий объём,
+				// а им не является.
+				return 0, fmt.Errorf("%s: подсчёт движений %s: %w", reg.Name, t, err)
 			}
+			total += n
 		}
 	}
-	return total
+	return total, nil
 }
 
 // wantedRecorderTypes нормализует список типов регистратора для forget-операций.


### PR DESCRIPTION
## Проблема

`CountMovementsOfRecorderType` складывала только удачные `COUNT(*)`:

```go
err := db.QueryRow(ctx, "SELECT COUNT(*) …").Scan(&n)
if err == nil {
    total += n
}
```

Сбойный регистр (нет таблицы, блокировка, обрыв соединения) молча выпадал из суммы. Это тот же класс, что закрывал #648, но в самом неудачном месте: сухой прогон существует ровно затем, чтобы показать объём **необратимого** удаления. Недосчитанный «0» читается как «удалять нечего» — то есть уговаривает снять `--dry-run` и снести историю вслепую.

## Исправление

- `CountMovementsOfRecorderType` возвращает `(int64, error)`; ошибка запроса идёт наверх.
- Частичную сумму вместе с ошибкой не отдаём — её приняли бы за настоящий объём.
- Отсутствие таблицы (регистр ещё не мигрирован) остаётся законным пропуском и отделяется явной проверкой `HasTable` — тем же приёмом, что в `OrphanMovements` после #648.
- `doctor --forget-document --dry-run` отказывается с внятной ошибкой вместо печати нуля.

## Тест

`TestCountMovementsOfRecorderType_QueryErrorSurfaces` — парный к `TestOrphanMovements_QueryErrorSurfaces` из #648: таблица без `recorder_type` обязана дать ошибку, отсутствующая таблица — нет, и вместе с ошибкой не должно уезжать частичной суммы. Без фикса падает (ошибка всегда `nil`).

Хвост #622: PR #648 закрыл отзыв сессий и проверку осиротевших движений, этот случай в него не попал.

Generated-with: Claude Code