### PR TITLE
fix(627): восстановление не пишет поверх усыновлённой живой базы

### DIFF
--- a/internal/backup/sqlite.go
+++ b/internal/backup/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -139,6 +140,69 @@ func validateSQLiteBackup(ctx context.Context, path string) error {
 	return nil
 }
 
+// sqliteInUse сообщает, держит ли файл базы открытым кто-то ещё.
+//
+// Восстановление подменяет файл целиком и удаляет -wal/-shm. Под работающей
+// базой это уничтожает незачекпойнченные транзакции и оставляет процесс с
+// удалённым inode (issue #627). Останавливать базу обязан вызывающий, но
+// проверка здесь не даёт порче случиться из-за того, что очередной обработчик
+// спросил живость не той функцией.
+//
+// Приём: в WAL-режиме соединение держит shared-блокировку «мёртвой руки» в
+// -shm всё время, пока база открыта, поэтому первая же транзакция в
+// exclusive-режиме упирается в SQLITE_BUSY, пока базу держит кто-то ещё.
+// Ограничение: базу в journal-режиме простаивающее соединение не блокирует —
+// такую занятость проверка не увидит.
+//
+// «Занята» возвращается только по явному SQLITE_BUSY/SQLITE_LOCKED: любая
+// другая ошибка означает «проверить не удалось», и восстановление продолжается
+// как раньше — иначе проверка запрещала бы восстановление ровно тех баз,
+// которые сломаны и восстановления и ждут.
+func sqliteInUse(ctx context.Context, dbPath string) bool {
+	if _, err := os.Stat(dbPath); err != nil {
+		return false // файла нет — некому его и держать
+	}
+	db, err := sql.Open("sqlite", filepath.ToSlash(dbPath))
+	if err != nil {
+		return false
+	}
+	defer closeRead("проверочное соединение с базой", db)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return false
+	}
+	defer closeRead("проверочное соединение с базой", conn)
+	// busy_timeout=0: ждать освобождения незачем, ответ нужен сразу.
+	if _, err := conn.ExecContext(ctx, "PRAGMA busy_timeout=0"); err != nil {
+		return false
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA locking_mode=EXCLUSIVE"); err != nil {
+		return false
+	}
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return isSQLiteBusy(err)
+	}
+	if _, err := conn.ExecContext(ctx, "ROLLBACK"); err != nil {
+		backupLog().Debug("не удалось откатить проверочную транзакцию", "err", err)
+	}
+	return false
+}
+
+// isSQLiteBusy распознаёт отказ по занятости: у драйвера modernc код лежит в
+// ошибке (5 — SQLITE_BUSY, 6 — SQLITE_LOCKED, старший байт — уточнение),
+// строковая проверка оставлена запасной на случай обёрнутой ошибки.
+func isSQLiteBusy(err error) bool {
+	var coded interface{ Code() int }
+	if errors.As(err, &coded) {
+		switch coded.Code() & 0xff {
+		case 5, 6:
+			return true
+		}
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") || strings.Contains(msg, "sqlite_busy")
+}
+
 func copyFileSynced(ctx context.Context, srcPath, dstPath string, perm os.FileMode) (err error) {
 	src, err := os.Open(srcPath)
 	if err != nil {
@@ -187,6 +251,9 @@ func RestoreSQLite(ctx context.Context, dbPath, backupPath string) error {
 	}
 	if dstInfo, statErr := os.Stat(dbPath); statErr == nil && os.SameFile(srcInfo, dstInfo) {
 		return fmt.Errorf("sqlite restore: backup and target are the same file")
+	}
+	if sqliteInUse(ctx, dbAbs) {
+		return fmt.Errorf("sqlite restore: база %s открыта другим процессом — остановите её и повторите", dbAbs)
 	}
 
 	dir := filepath.Dir(dbAbs)

--- a/internal/backup/sqlite_test.go
+++ b/internal/backup/sqlite_test.go
@@ -132,3 +132,57 @@ func TestRestoreSQLiteRejectsCorruptBackupAndPreservesTarget(t *testing.T) {
 		t.Fatalf("live target changed: value=%q err=%v", got, err)
 	}
 }
+
+// Восстановление поверх открытой базы уничтожает её WAL и подменяет inode под
+// живым процессом. Останавливать базу обязан вызывающий, но проверка занятости
+// здесь — последний рубеж на случай, если очередной обработчик спросил живость
+// не той функцией (issue #627).
+func TestRestoreSQLiteRefusesWhileDatabaseInUse(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "live.db")
+
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	if _, err := db.Exec(ctx, "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := db.Exec(ctx, "INSERT INTO t(name) VALUES('alpha')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Копию снимаем на живой базе — это разрешено (VACUUM INTO не блокирует).
+	outPath, err := DumpSQLite(ctx, dbPath, filepath.Join(dir, "backups"))
+	if err != nil {
+		t.Fatalf("DumpSQLite: %v", err)
+	}
+
+	err = RestoreSQLite(ctx, dbPath, outPath)
+	if err == nil {
+		db.Close()
+		t.Fatal("восстановление выполнено поверх открытой базы")
+	}
+	if !strings.Contains(err.Error(), "открыта другим процессом") {
+		db.Close()
+		t.Fatalf("ожидался отказ по занятости базы, получено: %v", err)
+	}
+	if _, statErr := os.Stat(dbPath + ".old"); statErr == nil {
+		db.Close()
+		t.Error("создана копия .old — восстановление дошло до подмены файла")
+	}
+	// База осталась рабочей: соединение живо и файл на месте.
+	var n int
+	if err := db.QueryRow(ctx, "SELECT count(*) FROM t").Scan(&n); err != nil {
+		db.Close()
+		t.Fatalf("база после отказа нечитаема: %v", err)
+	}
+	db.Close()
+
+	// После остановки базы то же восстановление обязано пройти — проверка не
+	// должна запирать нормальный сценарий.
+	if err := RestoreSQLite(ctx, dbPath, outPath); err != nil {
+		t.Fatalf("RestoreSQLite на остановленной базе: %v", err)
+	}
+}

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -713,6 +713,7 @@
   "Укажите имя роли": "Geben Sie den Rollennamen an",
   "Ошибка синхронизации": "Synchronisationsfehler",
   "База не остановилась — восстановление отменено, чтобы не повредить данные": "Die Basis wurde nicht gestoppt — die Wiederherstellung wurde abgebrochen, um Datenverlust zu vermeiden",
+  "База работает, но запущена не этим лаунчером — остановите её и повторите": "Die Basis läuft, wurde aber nicht von diesem Launcher gestartet — stoppen Sie sie und wiederholen Sie es",
   "отчёт %s не найден в конфигурации": "Bericht %s wurde in der Konfiguration nicht gefunden",
   "константа %s не найдена в конфигурации": "Konstante %s wurde in der Konfiguration nicht gefunden",
   "Данные восстановлены, но миграция схемы не выполнена": "Daten wiederhergestellt, aber die Schemamigration wurde nicht ausgeführt",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -64,6 +64,7 @@
   "База данных будет создана автоматически, если не существует.": "Database will be created automatically if it does not exist.",
   "База данных восстановлена из": "Database restored from",
   "База не остановилась — восстановление отменено, чтобы не повредить данные": "The base did not stop — the restore was cancelled to avoid corrupting data",
+  "База работает, но запущена не этим лаунчером — остановите её и повторите": "The base is running but was not started by this launcher — stop it and retry",
   "База остановлена — запустите её заново для применения изменений.": "The base was stopped — start it again to apply the changes.",
   "База остановлена — запустите её заново.": "The base was stopped — start it again.",
   "Без галки — быстрый бинарный дамп, только для той же СУБД": "Without the checkbox — fast binary dump, same DBMS only",

--- a/internal/launcher/backup_handlers.go
+++ b/internal/launcher/backup_handlers.go
@@ -209,6 +209,44 @@ func restoreForBase(ctx context.Context, b *Base, fp string) error {
 	return backup.Restore(ctx, b.DB, fp)
 }
 
+// ensureBaseStoppedForRestore останавливает базу перед перезаписью её данных.
+//
+// Живость проверяется через baseRunning, а не через runner.IsRunning: лаунчер
+// «усыновляет» базу, запущенную прежним экземпляром (см. baseRunning в
+// handlers.go), и для такой базы в runner.procs процесса нет. По IsRunning она
+// выглядела остановленной, поэтому защита «не восстанавливать работающую базу»
+// не срабатывала вовсе: восстановление шло поверх открытого файла БД, унося
+// незачекпойнченный WAL и подменяя inode под живым процессом (issue #627).
+//
+// Усыновлённую базу лаунчер остановить не может — её процесса у него нет, а
+// глушить чужой процесс по номеру порта здесь нельзя. Правильный исход —
+// внятный отказ, а не молчаливая перезапись.
+//
+// Возвращает (wasRunning, ok). При ok == false ответ пользователю уже отправлен
+// и обработчику остаётся только выйти.
+func (h *handler) ensureBaseStoppedForRestore(w http.ResponseWriter, r *http.Request, b *Base, lang string) (bool, bool) {
+	if !h.baseRunning(b) {
+		return false, true
+	}
+	if !h.runner.IsRunning(b.ID) {
+		data := h.loadCfgData(r.Context(), b, "backup")
+		data.Error = tr(lang, "База работает, но запущена не этим лаунчером — остановите её и повторите")
+		renderCfg(w, r, data)
+		return true, false
+	}
+	h.runner.Stop(b.ID)
+	h.invalidateStatus(b.ID) // индикатор в списке должен погаснуть сразу
+	// Отправка сигнала остановки успех не подтверждает — подтверждает только
+	// освободившийся порт.
+	if !waitPortFree(b.Port, 3*time.Second) {
+		data := h.loadCfgData(r.Context(), b, "backup")
+		data.Error = tr(lang, "База не остановилась — восстановление отменено, чтобы не повредить данные")
+		renderCfg(w, r, data)
+		return true, false
+	}
+	return true, true
+}
+
 // checkBackupFileMismatch returns an error when the backup file engine does not
 // match the target base engine (e.g. restoring a .sql.gz PG dump into SQLite).
 func checkBackupFileMismatch(b *Base, filename string) error {
@@ -445,19 +483,10 @@ func (h *handler) backupRestore(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Восстанавливать поверх работающей базы нельзя: процесс держит файл БД
-	// открытым, и запись дампа поверх него портит данные. Отправка сигнала
-	// остановки успех не подтверждает — подтверждает только освободившийся
-	// порт. Раньше его ждали, но результат ожидания отбрасывали и шли
-	// восстанавливать в любом случае.
-	wasRunning := h.runner.IsRunning(b.ID)
-	if wasRunning {
-		h.runner.Stop(b.ID)
-		if !waitPortFree(b.Port, 3*time.Second) {
-			data := h.loadCfgData(r.Context(), b, "backup")
-			data.Error = tr(lang, "База не остановилась — восстановление отменено, чтобы не повредить данные")
-			renderCfg(w, r, data)
-			return
-		}
+	// открытым, и запись дампа поверх него портит данные.
+	wasRunning, ok := h.ensureBaseStoppedForRestore(w, r, b, lang)
+	if !ok {
+		return
 	}
 
 	restoreErr := restoreForBase(r.Context(), b, fp)
@@ -680,26 +709,19 @@ func (h *handler) backupFullImport(w http.ResponseWriter, r *http.Request) {
 
 	// Universal format: cross-engine restore.
 	if archiveFormat == "universal" {
-		wasRunning := h.runner.IsRunning(b.ID)
-		stopped := false
+		// Перезалив таблиц идёт в БД под работающим приложением, а ниже по ветке
+		// «file is not a database» ещё и переименовывается файл БД — и то и
+		// другое требует остановленной базы.
+		wasRunning, ok := h.ensureBaseStoppedForRestore(w, r, b, lang)
+		if !ok {
+			return
+		}
 		db, cerr := OpenDB(r.Context(), b)
 		if cerr != nil {
 			// For SQLite: if the file exists but is not a valid database (new/empty/corrupt),
 			// preserve it, then let SQLite create a fresh file for the restore.
 			if b.DBType == "sqlite" && b.DBPath != "" &&
 				strings.Contains(cerr.Error(), "file is not a database") {
-				// Ниже переименовывается файл БД — делать это под работающим
-				// процессом нельзя.
-				if wasRunning {
-					h.runner.Stop(b.ID)
-					if !waitPortFree(b.Port, 3*time.Second) {
-						data := h.loadCfgData(r.Context(), b, "backup")
-						data.Error = tr(lang, "База не остановилась — восстановление отменено, чтобы не повредить данные")
-						renderCfg(w, r, data)
-						return
-					}
-					stopped = true
-				}
 				oldPath := b.DBPath + ".old"
 				_ = os.Remove(oldPath)
 				if os.Rename(b.DBPath, oldPath) == nil {
@@ -714,15 +736,6 @@ func (h *handler) backupFullImport(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer db.Close()
-		if wasRunning && !stopped {
-			h.runner.Stop(b.ID)
-			if !waitPortFree(b.Port, 3*time.Second) {
-				data := h.loadCfgData(r.Context(), b, "backup")
-				data.Error = tr(lang, "База не остановилась — восстановление отменено, чтобы не повредить данные")
-				renderCfg(w, r, data)
-				return
-			}
-		}
 
 		configDest := b.ConfigSource
 		if configDest == "" {
@@ -817,15 +830,9 @@ func (h *handler) backupFullImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wasRunning := h.runner.IsRunning(b.ID)
-	if wasRunning {
-		h.runner.Stop(b.ID)
-		if !waitPortFree(b.Port, 3*time.Second) {
-			data := h.loadCfgData(r.Context(), b, "backup")
-			data.Error = tr(lang, "База не остановилась — восстановление отменено, чтобы не повредить данные")
-			renderCfg(w, r, data)
-			return
-		}
+	wasRunning, ok := h.ensureBaseStoppedForRestore(w, r, b, lang)
+	if !ok {
+		return
 	}
 
 	// Restore database

--- a/internal/launcher/backup_restore_running_test.go
+++ b/internal/launcher/backup_restore_running_test.go
@@ -1,0 +1,274 @@
+package launcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"archive/zip"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/backup"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// adoptedBase поднимает живую базу так, как её видит лаунчер после перезапуска:
+// на порту отвечает /health, но процесса в runner.procs нет («усыновление»,
+// см. baseRunning). Возвращает базу с заполненным файлом SQLite.
+func adoptedBase(t *testing.T, id string, alive bool) (*handler, *Base, string) {
+	t.Helper()
+	ctx := context.Background()
+	projDir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "live.db")
+
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	if _, err := db.Exec(ctx, "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := db.Exec(ctx, "INSERT INTO t(name) VALUES('alpha')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	db.Close()
+
+	port := freePort(t)
+	if alive {
+		ln, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		if err != nil {
+			t.Fatalf("занять порт базы: %v", err)
+		}
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		// Порт базы фиксирован в реестре — слушатель на нём подменяем своим.
+		if err := srv.Listener.Close(); err != nil {
+			t.Fatalf("закрыть слушатель httptest: %v", err)
+		}
+		srv.Listener = ln
+		srv.Start()
+		t.Cleanup(srv.Close)
+	}
+
+	store := newTestStore(t)
+	b := &Base{
+		ID: id, Name: "Тест восстановления", ConfigSource: "file",
+		Path: projDir, DBType: "sqlite", DBPath: dbPath, Port: port,
+	}
+	if err := store.Add(b); err != nil {
+		t.Fatalf("store.Add: %v", err)
+	}
+	return &handler{store: store, runner: NewRunner()}, b, dbPath
+}
+
+// stubExePath не даёт обработчику запустить «платформу» дочерним процессом:
+// под `go test` os.Executable() — это тест-бинарь, и его запуск прогоняет весь
+// пакет заново (рекурсивно). Нужен там, где путь восстановления доходит до
+// MigrateBase — то есть в проверке, что до него как раз не доходит.
+func stubExePath(t *testing.T) {
+	t.Helper()
+	prev := exePath
+	missing := filepath.Join(t.TempDir(), "onebase-not-here")
+	exePath = func() (string, error) { return missing, nil }
+	t.Cleanup(func() { exePath = prev })
+}
+
+// makeBackup снимает копию базы в каталог копий этой базы и возвращает имя файла.
+func makeBackup(t *testing.T, h *handler, b *Base) string {
+	t.Helper()
+	out, err := backup.DumpSQLite(context.Background(), b.DBPath, h.backupDir(b))
+	if err != nil {
+		t.Fatalf("DumpSQLite: %v", err)
+	}
+	return filepath.Base(out)
+}
+
+func postRestore(t *testing.T, h *handler, b *Base, file string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/bases/"+b.ID+"/configurator/backup/"+file+"/restore", nil)
+	req.Header.Set("X-Onebase-Ajax", "1")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", b.ID)
+	rctx.URLParams.Add("file", file)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.backupRestore(rec, req)
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("ответ не JSON: %v (%s)", err, rec.Body.String())
+	}
+	return resp
+}
+
+// Восстановление поверх «усыновлённой» живой базы обязано отказать: её процесса
+// у лаунчера нет, остановить он её не может, а подмена файла БД под работающим
+// процессом уносит незачекпойнченный WAL (issue #627). Раньше живость
+// проверялась через runner.IsRunning, который усыновление не видит, — защита не
+// срабатывала вовсе.
+func TestBackupRestore_AdoptedRunningBaseRefused(t *testing.T) {
+	h, b, dbPath := adoptedBase(t, "adopted-restore", true)
+	file := makeBackup(t, h, b)
+
+	before, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("чтение файла БД: %v", err)
+	}
+
+	resp := postRestore(t, h, b, file)
+	if resp["ok"] == true {
+		t.Fatalf("восстановление выполнено поверх работающей базы: %v", resp)
+	}
+	errText, _ := resp["error"].(string)
+	if !strings.Contains(errText, "не этим лаунчером") {
+		t.Errorf("ожидался отказ «база запущена не этим лаунчером», получено: %q", errText)
+	}
+
+	after, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatalf("чтение файла БД: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("файл работающей базы перезаписан")
+	}
+	if _, err := os.Stat(dbPath + ".old"); err == nil {
+		t.Error("создана копия .old — восстановление дошло до подмены файла")
+	}
+}
+
+// Контроль: остановленная база (порт свободен) восстанавливается как прежде —
+// защита не должна запирать нормальный сценарий.
+func TestBackupRestore_StoppedBaseRestores(t *testing.T) {
+	h, b, dbPath := adoptedBase(t, "stopped-restore", false)
+	file := makeBackup(t, h, b)
+
+	// Меняем живую базу после снятия копии: успешное восстановление обязано
+	// вернуть её к состоянию копии.
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	if _, err := db.Exec(ctx, "INSERT INTO t(name) VALUES('beta')"); err != nil {
+		t.Fatalf("insert beta: %v", err)
+	}
+	db.Close()
+
+	resp := postRestore(t, h, b, file)
+	if resp["ok"] != true {
+		t.Fatalf("восстановление остановленной базы не выполнено: %v", resp)
+	}
+
+	db, err = storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("ConnectSQLite после восстановления: %v", err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow(ctx, "SELECT count(*) FROM t").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("после восстановления строк %d, ожидалась 1 (состояние копии)", n)
+	}
+}
+
+// Полное восстановление из .obz устроено так же и точно так же не видело
+// усыновлённую базу: universal-ветка перезаливает таблицы в БД под работающим
+// приложением, бинарная — подменяет файл (issue #627, те же две строки).
+func TestBackupFullImport_AdoptedRunningBaseRefused(t *testing.T) {
+	for _, tc := range []struct{ name, format string }{
+		{"universal", "universal"},
+		{"binary", "binary"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubExePath(t)
+			h, b, dbPath := adoptedBase(t, "adopted-obz-"+tc.name, true)
+
+			var archive bytes.Buffer
+			zw := zip.NewWriter(&archive)
+			meta, err := zw.Create("META.txt")
+			if err != nil {
+				t.Fatalf("zip META.txt: %v", err)
+			}
+			if _, err := meta.Write([]byte("onebase_full_export\nformat=" + tc.format + "\ndb_type=sqlite\n")); err != nil {
+				t.Fatalf("запись META.txt: %v", err)
+			}
+			dbEntry, err := zw.Create("database.db")
+			if err != nil {
+				t.Fatalf("zip database.db: %v", err)
+			}
+			dump, err := os.ReadFile(dbPath)
+			if err != nil {
+				t.Fatalf("чтение файла БД: %v", err)
+			}
+			if _, err := dbEntry.Write(dump); err != nil {
+				t.Fatalf("запись database.db: %v", err)
+			}
+			if err := zw.Close(); err != nil {
+				t.Fatalf("закрытие архива: %v", err)
+			}
+
+			var body bytes.Buffer
+			mw := multipart.NewWriter(&body)
+			part, err := mw.CreateFormFile("obz_file", "full.obz")
+			if err != nil {
+				t.Fatalf("CreateFormFile: %v", err)
+			}
+			if _, err := part.Write(archive.Bytes()); err != nil {
+				t.Fatalf("запись формы: %v", err)
+			}
+			if err := mw.Close(); err != nil {
+				t.Fatalf("закрытие формы: %v", err)
+			}
+
+			before, err := os.ReadFile(dbPath)
+			if err != nil {
+				t.Fatalf("чтение файла БД: %v", err)
+			}
+
+			req := httptest.NewRequest("POST", "/bases/"+b.ID+"/configurator/backup/full-import", &body)
+			req.Header.Set("Content-Type", mw.FormDataContentType())
+			req.Header.Set("X-Onebase-Ajax", "1")
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", b.ID)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+			rec := httptest.NewRecorder()
+			h.backupFullImport(rec, req)
+
+			var resp map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("ответ не JSON: %v (%s)", err, rec.Body.String())
+			}
+			if resp["ok"] == true {
+				t.Fatalf("полное восстановление выполнено поверх работающей базы: %v", resp)
+			}
+			errText, _ := resp["error"].(string)
+			if !strings.Contains(errText, "не этим лаунчером") {
+				t.Errorf("ожидался отказ «база запущена не этим лаунчером», получено: %q", errText)
+			}
+
+			after, err := os.ReadFile(dbPath)
+			if err != nil {
+				t.Fatalf("чтение файла БД: %v", err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Error("файл работающей базы перезаписан")
+			}
+		})
+	}
+}

--- a/internal/launcher/runner.go
+++ b/internal/launcher/runner.go
@@ -120,7 +120,7 @@ func (r *Runner) Start(base *Base) error {
 		return i18nerr.Errorf("порт %d уже занят другим процессом — остановите его вручную или смените порт базы", base.Port)
 	}
 
-	exe, err := os.Executable()
+	exe, err := exePath()
 	if err != nil {
 		return fmt.Errorf("runner: executable: %w", err)
 	}
@@ -189,6 +189,12 @@ func (r *Runner) recordExit(baseID string, cmd *exec.Cmd) {
 	}
 	r.exits[baseID] = true
 }
+
+// exePath — путь к бинарю платформы, который лаунчер запускает дочерним
+// процессом (сервер базы, migrate). Вынесено в переменную ради тестов: под
+// `go test` os.Executable() указывает на тест-бинарь, и запуск его «как
+// платформы» прогоняет весь пакет заново — рекурсивно и без конца.
+var exePath = os.Executable
 
 // Stop снимает отслеживаемый процесс базы. Возврата нет намеренно: результат
 // всегда был nil, и проверка его ничего бы не значила. Сама по себе отправка
@@ -375,7 +381,7 @@ func (r *Runner) BaseURL(base *Base) string {
 }
 
 func (r *Runner) MigrateBase(ctx context.Context, base *Base) (string, error) {
-	exe, err := os.Executable()
+	exe, err := exePath()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Закрывает #627.

## Причина

Лаунчер «усыновляет» базу, запущенную прежним экземпляром (`baseRunning`,
`internal/launcher/handlers.go:456`) — процесса в `runner.procs` у неё нет. Все
три пути восстановления спрашивали живость через `runner.IsRunning`, который
усыновления не видит, поэтому для такой базы ни `Stop`, ни `waitPortFree` не
выполнялись: защита «не восстанавливать базу, которая не остановилась» не
срабатывала вовсе, а `restoreForBase` шёл по живому файлу БД.

## Что сделано

- Общий страж `ensureBaseStoppedForRestore` спрашивает `baseRunning` и разводит
  два случая: свою базу останавливает и ждёт освобождения порта, усыновлённую —
  остановить не может (глушить чужой процесс по номеру порта нельзя), поэтому
  отказывает сообщением «База работает, но запущена не этим лаунчером —
  остановите её и повторите».
- Применён во всех трёх местах: `backupRestore` и обе ветки `backupFullImport`
  (universal и binary). В universal-ветке остановка поднялась выше `OpenDB` —
  ниже по ветке переименовывается файл БД.
- Защита в глубину в `RestoreSQLite`: перед подменой файла проверяется, не
  держит ли базу кто-то ещё. В WAL соединение держит shared-блокировку «мёртвой
  руки» в `-shm`, поэтому первая транзакция в exclusive-режиме упирается в
  `SQLITE_BUSY`. Теперь защита не зависит от того, какую функцию спросил
  очередной обработчик, и покрывает путь `onebase backup restore`. Занятость
  сообщается **только** по явному `SQLITE_BUSY`/`SQLITE_LOCKED`: прочие ошибки
  означают «проверить не удалось» и восстановление не запрещают — иначе проверка
  запирала бы ровно те базы, которые сломаны и восстановления ждут.

## Тесты

Все через публичные точки входа и все проверены на падение с откаченной правкой:

| тест | что ловит без правки |
|---|---|
| `TestBackupRestore_AdoptedRunningBaseRefused` | `ok:true` — восстановление прошло поверх живой базы |
| `TestBackupFullImport_…/universal` | файл работающей базы перезаписан |
| `TestBackupFullImport_…/binary` | то же для бинарной ветки |
| `TestRestoreSQLiteRefusesWhileDatabaseInUse` | подмена файла под открытым соединением |

Контрольные проверки на месте: остановленная база восстанавливается как прежде
(`TestBackupRestore_StoppedBaseRestores`, вторая половина теста в `internal/backup`).

## Побочно

`os.Executable` в `runner.go` вынесен в переменную `exePath`: под `go test` это
тест-бинарь, и `MigrateBase` запускала его «как платформу», прогоняя весь пакет
заново — рекурсивно и без конца. Тест полного восстановления подменяет путь,
иначе провал проверки оборачивался бы не падением, а зависанием (проверено:
первый прогон контрольного откáта висел до таймаута).

## Проверки

`go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run`,
`go run ./tools/i18ncheck` — чисто.