### PR TITLE
fix(auth): миграции схемы не зависят от текста ошибки драйвера — старт на чистой PostgreSQL (#672)

### DIFF
--- a/internal/auth/schema_migrations_test.go
+++ b/internal/auth/schema_migrations_test.go
@@ -1,0 +1,181 @@
+package auth_test
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// На чистой PostgreSQL-базе платформа не стартовала вовсе: auth-схема падала на
+// «столбец "token_hash" отношения "_sessions" уже существует (SQLSTATE 42701)»
+// (issue #672).
+//
+// Догоняющие ALTER TABLE ADD COLUMN, нужные базам, созданным до появления этих
+// колонок, на свежей базе неизбежно натыкаются на уже созданную CREATE TABLE
+// колонку. Это штатно и раньше гасилось — но проверкой ТЕКСТА ошибки драйвера
+// («duplicate column» / «already exists»). На сервере с локализованными
+// сообщениями текст другой, проверка не срабатывала, и запуск падал.
+//
+// Поэтому регрессия закрыта двумя тестами: структурным (в auth не должно быть
+// классификации ошибок драйвера по тексту — он ловит причину и работает
+// везде) и поведенческим на реально пустой схеме PostgreSQL.
+
+// Классификация ошибок драйвера по человекочитаемому тексту зависит от локали
+// сервера, поэтому в auth её быть не должно: есть storage.AddColumnIfMissing
+// (PostgreSQL — ADD COLUMN IF NOT EXISTS, SQLite — проверка каталога) и разбор
+// по SQLSTATE, как в storage/constraint_errors.go.
+func TestAuthSchema_NoDriverErrorTextMatching(t *testing.T) {
+	fset := token.NewFileSet()
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Слова, по которым узнают ошибку драйвера. Все они переводятся сервером.
+	markers := []string{
+		"duplicate column", "already exists", "does not exist",
+		"no such column", "no such table", "duplicate key",
+	}
+	var violations []string
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		af, err := parser.ParseFile(fset, f, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		ast.Inspect(af, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			val := strings.ToLower(lit.Value)
+			for _, m := range markers {
+				if strings.Contains(val, m) {
+					violations = append(violations,
+						fset.Position(lit.Pos()).String()+": "+lit.Value)
+				}
+			}
+			return true
+		})
+	}
+	sort.Strings(violations)
+	if len(violations) > 0 {
+		t.Fatalf("ошибка драйвера распознаётся по тексту (%d) — на сервере с локализованными сообщениями это не сработает:\n  %s\n\n"+
+			"Используйте storage.AddColumnIfMissing или разбор по SQLSTATE (образец — storage/constraint_errors.go).",
+			len(violations), strings.Join(violations, "\n  "))
+	}
+}
+
+// Приёмка ровно по issue: на ПУСТОЙ базе PostgreSQL auth-схема разворачивается
+// без ошибок, и повторный вызов ничего не ломает. Пустоту даёт эфемерная схема —
+// в общей тестовой базе таблицы уже созданы соседними тестами, и дефект на ней
+// не воспроизвёлся бы.
+func TestAuthSchema_EnsureSchemaOnEmptyPostgres(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL не задан — проверка чистой базы требует PostgreSQL")
+	}
+	ctx := context.Background()
+	schema := storage.NewEphemeralSchemaName()
+	db, err := storage.ConnectWithSchema(ctx, dsn, schema)
+	if err != nil {
+		t.Fatalf("ConnectWithSchema: %v", err)
+	}
+	if err := db.CreateSchema(ctx, schema); err != nil {
+		db.Close()
+		t.Fatalf("CreateSchema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.DropSchemaCascade(context.Background(), schema); err != nil {
+			t.Errorf("DropSchemaCascade(%s): %v", schema, err)
+		}
+		db.Close()
+	})
+
+	repo := auth.NewRepo(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema на пустой базе: %v", err)
+	}
+	// Повторный вызов — тот же путь, что при каждом старте сервера.
+	if err := repo.EnsureSchema(ctx); err != nil {
+		t.Fatalf("повторный EnsureSchema: %v", err)
+	}
+	// Колонки, на которых падал запуск, должны существовать.
+	for _, c := range []struct{ table, col string }{
+		{"_sessions", "token_hash"},
+		{"_sessions", "public_id"},
+		{"_users", "totp_secret"},
+		{"_users", "lang"},
+	} {
+		var exists bool
+		if err := db.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM information_schema.columns
+			   WHERE table_schema = current_schema() AND table_name = $1 AND column_name = $2)`,
+			c.table, c.col).Scan(&exists); err != nil {
+			t.Fatalf("проверка %s.%s: %v", c.table, c.col, err)
+		}
+		if !exists {
+			t.Errorf("колонка %s.%s не создана", c.table, c.col)
+		}
+	}
+}
+
+// Тот же прогон на сервере с локализованными сообщениями — воспроизведение
+// ровно того окружения, где дефект и проявился. Пропускается, если сервер
+// собран без каталогов переводов (тогда сообщения остаются английскими и
+// прежний разбор по тексту сработал бы).
+func TestAuthSchema_EnsureSchemaOnLocalizedPostgres(t *testing.T) {
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL не задан")
+	}
+	ctx := context.Background()
+	schema := storage.NewEphemeralSchemaName()
+	db, err := storage.ConnectWithSchema(ctx, dsn, schema)
+	if err != nil {
+		t.Fatalf("ConnectWithSchema: %v", err)
+	}
+	if err := db.CreateSchema(ctx, schema); err != nil {
+		db.Close()
+		t.Fatalf("CreateSchema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.DropSchemaCascade(context.Background(), schema); err != nil {
+			t.Errorf("DropSchemaCascade(%s): %v", schema, err)
+		}
+		db.Close()
+	})
+
+	if _, err := db.Exec(ctx, `SET lc_messages TO 'ru_RU.UTF-8'`); err != nil {
+		t.Skipf("сервер не принимает локаль ru_RU.UTF-8: %v", err)
+	}
+	// Проверяем, что сообщения действительно переведены: без каталогов
+	// переводов PostgreSQL молча оставляет их английскими.
+	if _, err := db.Exec(ctx, `CREATE TABLE _probe672 (a int)`); err != nil {
+		t.Fatalf("проба: %v", err)
+	}
+	_, probeErr := db.Exec(ctx, `ALTER TABLE _probe672 ADD COLUMN a int`)
+	if probeErr == nil {
+		t.Fatal("проба: повторная колонка добавилась без ошибки")
+	}
+	if strings.Contains(strings.ToLower(probeErr.Error()), "already exists") {
+		t.Skip("сервер собран без каталогов переводов — сообщения английские, окружение из #672 не воспроизводится")
+	}
+	if _, err := db.Exec(ctx, `DROP TABLE _probe672`); err != nil {
+		t.Fatalf("уборка пробы: %v", err)
+	}
+
+	if err := auth.NewRepo(db).EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema на сервере с локализованными сообщениями: %v", err)
+	}
+}

--- a/internal/auth/twofactor.go
+++ b/internal/auth/twofactor.go
@@ -57,17 +57,17 @@ const backupCodeAlphabet = "abcdefghjkmnpqrstuvwxyz23456789"
 // кодов. Вызывается из EnsureSchema; идемпотентна.
 func (r *Repo) ensureTwoFactorSchema(ctx context.Context) error {
 	d := r.db.Dialect()
-	for _, ddl := range []string{
-		`ALTER TABLE _users ADD COLUMN totp_secret TEXT NOT NULL DEFAULT ''`,
-		fmt.Sprintf(`ALTER TABLE _users ADD COLUMN totp_enabled %s NOT NULL DEFAULT %s`, d.TypeBool(), boolFalseFor(d)),
-		`ALTER TABLE _users ADD COLUMN totp_last_step BIGINT NOT NULL DEFAULT 0`,
+	for _, c := range []struct{ col, typ string }{
+		{"totp_secret", "TEXT NOT NULL DEFAULT ''"},
+		{"totp_enabled", d.TypeBool() + " NOT NULL DEFAULT " + boolFalseFor(d)},
+		{"totp_last_step", "BIGINT NOT NULL DEFAULT 0"},
 		// Привязка к внешнему провайдеру (SSO): по паре (провайдер, subject)
 		// учётка находится даже после смены адреса почты в каталоге.
-		`ALTER TABLE _users ADD COLUMN auth_provider TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE _users ADD COLUMN auth_subject TEXT NOT NULL DEFAULT ''`,
+		{"auth_provider", "TEXT NOT NULL DEFAULT ''"},
+		{"auth_subject", "TEXT NOT NULL DEFAULT ''"},
 	} {
-		if _, err := r.db.Exec(ctx, ddl); err != nil && !isDuplicateColumnErr(err) {
-			return fmt.Errorf("auth: migrate _users (2fa): %w", err)
+		if err := r.db.AddColumnIfMissing(ctx, "_users", c.col, c.typ); err != nil {
+			return fmt.Errorf("auth: migrate _users.%s (2fa): %w", c.col, err)
 		}
 	}
 	codesDDL := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS _auth_backup_codes (

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -131,36 +130,35 @@ func (r *Repo) EnsureSchema(ctx context.Context) error {
 	if err := r.ensureTwoFactorSchema(ctx); err != nil {
 		return err
 	}
-	// Idempotent user migrations. Ignore only an actual duplicate-column error:
-	// swallowing SQLITE_BUSY, permission, or connection errors leaves a partially
-	// migrated schema that fails later on unrelated requests.
-	for _, ddl := range []string{
-		fmt.Sprintf(`ALTER TABLE _users ADD COLUMN deny_passwd_change %s NOT NULL DEFAULT %s`, d.TypeBool(), boolFalseFor(d)),
-		fmt.Sprintf(`ALTER TABLE _users ADD COLUMN show_in_list %s NOT NULL DEFAULT %s`, d.TypeBool(), boolFalseFor(d)),
-		`ALTER TABLE _users ADD COLUMN lang TEXT NOT NULL DEFAULT ''`,
-		fmt.Sprintf(`ALTER TABLE _users ADD COLUMN ai_data_access %s NOT NULL DEFAULT %s`, d.TypeBool(), boolFalseFor(d)),
+	// Догоняющие миграции для баз, созданных до появления этих колонок.
+	// На свежей базе колонки уже созданы через CREATE TABLE выше, поэтому проба
+	// обязана быть идемпотентной — этим занимается storage.AddColumnIfMissing
+	// (PostgreSQL: ADD COLUMN IF NOT EXISTS, SQLite: проверка каталога), а не
+	// разбор текста ошибки драйвера.
+	for _, c := range []struct{ col, typ string }{
+		{"deny_passwd_change", d.TypeBool() + " NOT NULL DEFAULT " + boolFalseFor(d)},
+		{"show_in_list", d.TypeBool() + " NOT NULL DEFAULT " + boolFalseFor(d)},
+		{"lang", "TEXT NOT NULL DEFAULT ''"},
+		{"ai_data_access", d.TypeBool() + " NOT NULL DEFAULT " + boolFalseFor(d)},
 	} {
-		if _, err := r.db.Exec(ctx, ddl); err != nil && !isDuplicateColumnErr(err) {
-			return fmt.Errorf("auth: migrate _users: %w", err)
+		if err := r.db.AddColumnIfMissing(ctx, "_users", c.col, c.typ); err != nil {
+			return fmt.Errorf("auth: migrate _users.%s: %w", c.col, err)
 		}
 	}
 	// Мультисессии (план 78): служебные метаданные сессии. Колонки nullable без
 	// DEFAULT — SQLite не разрешает ни UNIQUE, ни CURRENT_TIMESTAMP в ADD COLUMN;
-	// уникальность public_id обеспечивает отдельный индекс. EnsureSchema зовётся
-	// конкурентно из процесса базы и лаунчера, поэтому глотаем только «колонка уже
-	// есть» — молча проглоченный SQLITE_BUSY оставил бы колонку несозданной и
-	// сломал INSERT сессий.
-	for _, ddl := range []string{
-		`ALTER TABLE _sessions ADD COLUMN token_hash TEXT`,
-		`ALTER TABLE _sessions ADD COLUMN public_id TEXT`,
-		`ALTER TABLE _sessions ADD COLUMN kind TEXT`,
-		fmt.Sprintf(`ALTER TABLE _sessions ADD COLUMN created_at %s`, d.TypeTimestamp()),
-		fmt.Sprintf(`ALTER TABLE _sessions ADD COLUMN last_seen_at %s`, d.TypeTimestamp()),
-		`ALTER TABLE _sessions ADD COLUMN ip TEXT`,
-		`ALTER TABLE _sessions ADD COLUMN user_agent TEXT`,
+	// уникальность public_id обеспечивает отдельный индекс.
+	for _, c := range []struct{ col, typ string }{
+		{"token_hash", "TEXT"},
+		{"public_id", "TEXT"},
+		{"kind", "TEXT"},
+		{"created_at", d.TypeTimestamp()},
+		{"last_seen_at", d.TypeTimestamp()},
+		{"ip", "TEXT"},
+		{"user_agent", "TEXT"},
 	} {
-		if _, err := r.db.Exec(ctx, ddl); err != nil && !isDuplicateColumnErr(err) {
-			return fmt.Errorf("auth: migrate _sessions: %w", err)
+		if err := r.db.AddColumnIfMissing(ctx, "_sessions", c.col, c.typ); err != nil {
+			return fmt.Errorf("auth: migrate _sessions.%s: %w", c.col, err)
 		}
 	}
 	if err := r.migrateSessionTokens(ctx); err != nil {
@@ -177,13 +175,6 @@ func (r *Repo) EnsureSchema(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-// isDuplicateColumnErr распознаёт «колонка уже существует» у SQLite
-// («duplicate column name») и PostgreSQL («column ... already exists»).
-func isDuplicateColumnErr(err error) bool {
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "duplicate column") || strings.Contains(s, "already exists")
 }
 
 // boolFalseFor returns "FALSE" for PG and "0" for SQLite, used in DEFAULT clauses.


### PR DESCRIPTION
## Проблема

На чистой PostgreSQL-базе платформа не стартует вовсе:

```
auth schema: auth: migrate _sessions: ОШИБКА: столбец "token_hash" отношения "_sessions" уже существует (SQLSTATE 42701)
```

## Причина — не та, что предполагалась в тикете

Тикет предполагает, что «догоняющий» `ADD COLUMN` выполняется **безусловно**. На самом деле защита есть, и она даже написана правильно по замыслу — гасить только настоящую «колонка уже существует», не глотая `SQLITE_BUSY` и ошибки соединения. Но распознавание шло по **тексту** ошибки драйвера (`internal/auth/users.go`):

```go
func isDuplicateColumnErr(err error) bool {
	s := strings.ToLower(err.Error())
	return strings.Contains(s, "duplicate column") || strings.Contains(s, "already exists")
}
```

На сервере с локализованными сообщениями текст другой — «столбец … уже существует» — и не содержит ни одной из двух подстрок. Проверка возвращает `false`, `EnsureSchema` отдаёт ошибку, сервер не поднимается.

Это объясняет и обе аномалии из тикета:

- **«на SQLite всё работает»** — сообщения SQLite не переводятся никогда, поэтому там разбор по тексту всегда попадает;
- **«CI зелёный»** — официальный образ `postgres` отвечает по-английски, так что этот класс дефектов для CI невидим в принципе.

Сама по себе связка «`CREATE TABLE` уже создаёт колонку + догоняющий `ADD COLUMN`» не дефект: догонялки нужны базам, созданным до появления этих колонок, и на свежей базе они обязаны штатно упираться в уже существующую колонку.

## Исправление

Обе группы догоняющих миграций — `_users` (включая колонки 2FA/SSO из `ensureTwoFactorSchema`) и `_sessions` — переведены на `storage.AddColumnIfMissing`. Это канонический хелпер платформы, который и так используется везде в `internal/storage`:

- PostgreSQL — `ALTER TABLE … ADD COLUMN IF NOT EXISTS`;
- SQLite — предварительная сверка с каталогом (`ADD COLUMN IF NOT EXISTS` там не поддерживается).

Разбор по тексту удалён совсем. Это было **последнее** такое место в `internal/`: все остальные классификаторы уже разбирают SQLSTATE и расширенные коды SQLite (`storage/constraint_errors.go`, где в комментарии прямо записано «распознаётся по коду ошибки драйвера, а не по тексту»). То есть инвариант был применён в N−1 месте из N — ровно та форма дефекта, которую разбирает план 115.

Побочный эффект: ошибки миграции стали адресными — `auth: migrate _sessions.token_hash: …` вместо `auth: migrate _sessions: …`.

## Тесты

| тест | что ловит | без фикса |
|---|---|---|
| `TestAuthSchema_NoDriverErrorTextMatching` | в `internal/auth` нет классификации ошибок драйвера по тексту. Ловит **причину**, а не симптом, и работает при любой локали сервера — в том числе в CI, где симптом не воспроизводится | **падает**: `ошибка драйвера распознаётся по тексту (2)` |
| `TestAuthSchema_EnsureSchemaOnEmptyPostgres` | приёмка по тикету: на пустой базе `EnsureSchema` проходит, повторный вызов идемпотентен, колонки `_sessions.token_hash`, `_sessions.public_id`, `_users.totp_secret`, `_users.lang` созданы | на английском сервере проходит и без фикса — поэтому и нужен структурный тест |
| `TestAuthSchema_EnsureSchemaOnLocalizedPostgres` | воспроизводит окружение тикета дословно: `lc_messages = ru_RU.UTF-8`, проба на реальную локализацию сообщения, затем `EnsureSchema` | пропускается там, где сервер собран без каталогов переводов |

Пустоту базы даёт эфемерная схема (`ConnectWithSchema` + `CreateSchema`): в общей тестовой базе таблицы уже созданы соседними тестами, и дефект на ней не воспроизвёлся бы вовсе.

## Проверки

`go build ./...`, `CGO_ENABLED=0 GOOS=windows go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (0 issues), `go run ./tools/i18ncheck`, `gofmt -l` — чисто.

Интеграционные на живом PostgreSQL, **чистая база**: `./internal/auth`, `./internal/storage`, `./internal/configdb`, `./internal/query` — зелёные.

## Замечание про гейты

Этот класс дефектов CI поймать не может: джоб `postgres-integration` поднимает `postgres:16` с английскими сообщениями. Структурный тест — как раз ответ на это: он проверяет не поведение на конкретном сервере, а отсутствие зависимости от локали. Если появится желание закрыть класс шире — стоит отдельно обсудить прогон одной интеграционной сборки на локализованном сервере.

Закрывает #672.
Closes #672

Generated-with: Claude Code
