### PR TITLE
fix(launcher): новый предопределённый элемент сохраняется из конфигуратора (#671)

### DIFF
--- a/internal/launcher/configurator_predefined_proxy.go
+++ b/internal/launcher/configurator_predefined_proxy.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -25,17 +26,12 @@ func (h *handler) configuratorSavePredefined(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	entityName := r.FormValue("entity")
-	// collect predefined items
-	type rawPD struct {
-		Name   string                 `yaml:"name"`
-		Fields map[string]interface{} `yaml:"fields,omitempty"`
-	}
-	var predefined []rawPD
 	fieldNames := r.Form["pre_field_names"]
-	for i := 0; i < 500; i++ {
+	var predefined []rawPredefinedRow
+	for _, i := range formRowIndices(r, "pre") {
 		name := strings.TrimSpace(r.FormValue(fmt.Sprintf("pre.%d.name", i)))
 		if name == "" {
-			break
+			continue // строку очистили — считаем удалённой
 		}
 		fields := make(map[string]interface{})
 		for _, fn := range fieldNames {
@@ -43,7 +39,7 @@ func (h *handler) configuratorSavePredefined(w http.ResponseWriter, r *http.Requ
 				fields[fn] = v
 			}
 		}
-		pd := rawPD{Name: name}
+		pd := rawPredefinedRow{Name: name}
 		if len(fields) > 0 {
 			pd.Fields = fields
 		}
@@ -66,7 +62,7 @@ func (h *handler) configuratorSavePredefined(w http.ResponseWriter, r *http.Requ
 	renderCfg(w, r, data)
 }
 
-func savePredefinedToFile(dir, entityName string, predefined interface{}) error {
+func savePredefinedToFile(dir, entityName string, predefined []rawPredefinedRow) error {
 	// find entity file in catalogs/ or documents/
 	for _, subdir := range []string{"catalogs", "documents"} {
 		entries, _ := os.ReadDir(filepath.Join(dir, subdir))
@@ -85,26 +81,20 @@ func savePredefinedToFile(dir, entityName string, predefined interface{}) error 
 			if yaml.Unmarshal(raw, &top) != nil || top.Name != entityName {
 				continue
 			}
-			var node map[string]interface{}
-			if err := yaml.Unmarshal(raw, &node); err != nil {
-				return err
-			}
-			if predefined == nil {
-				delete(node, "predefined")
-			} else {
-				node["predefined"] = predefined
-			}
-			out, err := yaml.Marshal(node)
+			out, err := applyPredefined(raw, subdir+"/"+e.Name(), predefined)
 			if err != nil {
 				return err
 			}
-			return os.WriteFile(p, out, fsmode.File)
+			// p собран из каталога базы и имени файла, полученного от os.ReadDir
+			// того же каталога: ReadDir отдаёт базовые имена, выйти за пределы
+			// dir/subdir нечем. gosec этого не распознаёт.
+			return os.WriteFile(p, out, fsmode.File) //nolint:gosec // G703: путь построен из ReadDir-имени, traversal невозможен
 		}
 	}
 	return fmt.Errorf("entity %q not found", entityName)
 }
 
-func (h *handler) savePredefinedToDB(ctx context.Context, b *Base, entityName string, predefined interface{}) error {
+func (h *handler) savePredefinedToDB(ctx context.Context, b *Base, entityName string, predefined []rawPredefinedRow) error {
 	db, err := OpenDB(ctx, b)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
@@ -136,20 +126,53 @@ func (h *handler) savePredefinedToDB(ctx context.Context, b *Base, entityName st
 	if targetPath == "" {
 		return fmt.Errorf("entity %q not found in DB config", entityName)
 	}
-	var node map[string]interface{}
-	if err := yaml.Unmarshal(rawContent, &node); err != nil {
-		return err
-	}
-	if predefined == nil {
-		delete(node, "predefined")
-	} else {
-		node["predefined"] = predefined
-	}
-	out, err := yaml.Marshal(node)
+	out, err := applyPredefined(rawContent, targetPath, predefined)
 	if err != nil {
 		return err
 	}
 	return cfgUpsert(ctx, db, targetPath, out)
+}
+
+// rawPredefinedRow — одна строка формы «Предопределённые элементы».
+type rawPredefinedRow struct {
+	Name   string                 `yaml:"name"`
+	Fields map[string]interface{} `yaml:"fields,omitempty"`
+}
+
+// applyPredefined точечно заменяет блок predefined в YAML сущности, сохраняя
+// порядок остальных ключей и комментарии. Пустой список удаляет ключ.
+//
+// Раньше файл круглился через map[string]interface{}: порядок ключей и
+// комментарии терялись при каждом сохранении — тот же класс, что #656 у
+// app.yaml. Идиома взята у applyAccountRegFields.
+func applyPredefined(raw []byte, what string, predefined []rawPredefinedRow) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(raw, &root); err != nil {
+		return nil, err
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("applyPredefined: ожидалось YAML-отображение в корне %s", what)
+	}
+	// Пустой список — ключ убрать. Типизированный nil-слайс, обёрнутый в any,
+	// не равен nil, поэтому передаём нетипизированный (ср. anyOrNil).
+	var val any
+	if len(predefined) > 0 {
+		val = predefined
+	}
+	if err := setYAMLMapField(root.Content[0], "predefined", val); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2) // файл пользовательский и лежит под git — не менять отступ
+	if err := enc.Encode(&root); err != nil {
+		_ = enc.Close()
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // ── one-time code proxy ──────────────────────────────────────────────────────

--- a/internal/launcher/configurator_predefined_save_test.go
+++ b/internal/launcher/configurator_predefined_save_test.go
@@ -1,0 +1,135 @@
+package launcher
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Новая строка «Предопределённые элементы» молча не сохранялась (issue #671):
+// элемент виден в конфигураторе, сохранение отвечает успехом, но ни в YAML, ни в
+// режиме предприятия его нет.
+//
+// Клиент называет поля новой строки индексом из счётчика, начинающегося с 10000
+// (`cfgAddPreRow`, static/configurator.js), а обработчик перебирал индексы
+// подряд от нуля, останавливаясь на первом пропуске. Существующие строки при
+// этом сохранялись, поэтому и ошибки не было — форма просто записывала прежний
+// список.
+
+const predefinedCatalogYAML = `name: СтавкаНДС
+fields:
+  - {name: Наименование, type: string}
+  - {name: Ставка, type: number}
+predefined:
+  - name: БезНДС
+    fields: {Наименование: "Без НДС", Ставка: "0"}
+`
+
+// Индекс новой строки приходит разреженным — ровно так, как его формирует
+// клиент. Элемент обязан сохраниться, а существующий — уцелеть.
+func TestConfiguratorSavePredefined_SparseRowIndexIsSaved(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "catalogs", "ставка_ндс.yaml", predefinedCatalogYAML)
+
+	rec := postCfg(t, "test", "/bases/test/configurator/predefined", url.Values{
+		"entity":                       {"СтавкаНДС"},
+		"pre_field_names":              {"Наименование", "Ставка"},
+		"pre.0.name":                   {"БезНДС"},
+		"pre.0.field.Наименование":     {"Без НДС"},
+		"pre.0.field.Ставка":           {"0"},
+		"pre.10001.name":               {"НДС22"},
+		"pre.10001.field.Наименование": {"НДС 22%"},
+		"pre.10001.field.Ставка":       {"22"},
+	}, h.configuratorSavePredefined)
+	if ok, errText := cfgResponse(t, rec); !ok {
+		t.Fatalf("сохранение не удалось: %s", errText)
+	}
+
+	assertFileContains(t, p, "БезНДС", "НДС22", "НДС 22%")
+}
+
+// Порядок строк задаёт пользователь перетаскиванием и удалением, поэтому
+// разреженность бывает и в середине: удалили строку — в индексах дыра. Прежний
+// обработчик обрывался на ней и терял всё, что после.
+func TestConfiguratorSavePredefined_GapInIndexesKeepsAllRows(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "catalogs", "ставка_ндс.yaml", predefinedCatalogYAML)
+
+	rec := postCfg(t, "test", "/bases/test/configurator/predefined", url.Values{
+		"entity":          {"СтавкаНДС"},
+		"pre_field_names": {"Наименование", "Ставка"},
+		"pre.0.name":      {"БезНДС"},
+		// индекс 1 удалён пользователем
+		"pre.2.name": {"НДС20"},
+		"pre.3.name": {"НДС22"},
+	}, h.configuratorSavePredefined)
+	if ok, errText := cfgResponse(t, rec); !ok {
+		t.Fatalf("сохранение не удалось: %s", errText)
+	}
+	assertFileContains(t, p, "БезНДС", "НДС20", "НДС22")
+}
+
+// Пустой список — законное состояние: пользователь удалил все предопределённые.
+// Ключ predefined при этом должен исчезнуть, а не остаться прежним.
+func TestConfiguratorSavePredefined_EmptyListRemovesKey(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	p := writeCfgFile(t, cfgDir, "catalogs", "ставка_ндс.yaml", predefinedCatalogYAML)
+
+	rec := postCfg(t, "test", "/bases/test/configurator/predefined", url.Values{
+		"entity":          {"СтавкаНДС"},
+		"pre_field_names": {"Наименование", "Ставка"},
+	}, h.configuratorSavePredefined)
+	if ok, errText := cfgResponse(t, rec); !ok {
+		t.Fatalf("сохранение не удалось: %s", errText)
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("чтение: %v", err)
+	}
+	if got := string(raw); strings.Contains(got, "predefined:") {
+		t.Errorf("ключ predefined не удалён:\n%s", got)
+	}
+}
+
+// Сохранение предопределённых круглило файл сущности через map[string]any,
+// поэтому порядок ключей и комментарии терялись при каждом нажатии «Сохранить»
+// — тот же класс, что #656 у app.yaml. Файл пользовательский и лежит под git.
+func TestConfiguratorSavePredefined_KeepsFileOrderAndComments(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	const src = `# Ставки НДС для торговли
+name: СтавкаНДС
+title: Ставка НДС
+fields:
+  - {name: Наименование, type: string}
+  - {name: Ставка, type: number}
+`
+	p := writeCfgFile(t, cfgDir, "catalogs", "ставка_ндс.yaml", src)
+
+	rec := postCfg(t, "test", "/bases/test/configurator/predefined", url.Values{
+		"entity":          {"СтавкаНДС"},
+		"pre_field_names": {"Наименование", "Ставка"},
+		"pre.10001.name":  {"НДС22"},
+	}, h.configuratorSavePredefined)
+	if ok, errText := cfgResponse(t, rec); !ok {
+		t.Fatalf("сохранение не удалось: %s", errText)
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("чтение: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "# Ставки НДС для торговли") {
+		t.Errorf("комментарий потерян:\n%s", got)
+	}
+	if strings.Index(got, "name: СтавкаНДС") > strings.Index(got, "fields:") {
+		t.Errorf("порядок ключей переставлен:\n%s", got)
+	}
+	if !strings.Contains(got, "НДС22") {
+		t.Errorf("предопределённый не сохранён:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Проблема

Добавленный в конфигураторе предопределённый элемент справочника виден на экране, сохранение отвечает успехом, но ни в YAML, ни в режиме предприятия его нет. Ручная правка файла работает — значит теряется именно ввод формы.

Клиент нумерует **добавленные** строки отдельным счётчиком, начинающимся с 10000 (`cfgAddPreRow`, `internal/launcher/static/configurator.js`):

```js
var _cfgPreRowIdx = 10000;
function cfgAddPreRow(tblId, fieldCount) {
  _cfgPreRowIdx++;
  ...  name="pre.10001.name"
```

А обработчик перебирал индексы **подряд от нуля**, останавливаясь на первом пропуске (`configurator_predefined_proxy.go`):

```go
for i := 0; i < 500; i++ {
	name := strings.TrimSpace(r.FormValue(fmt.Sprintf("pre.%d.name", i)))
	if name == "" {
		break
	}
```

Новая строка не читалась никогда — её индекс и в диапазон-то не попадал. Существующие строки при этом записывались как есть, поэтому ошибки не было: форма молча сохраняла прежний список.

Показательно, что **правильный хелпер в пакете уже был**: `formRowIndices` (`configurator_entity.go:446`) собирает фактически присланные индексы, и в его комментарии прямо написано, почему непрерывности нет — «индексы на фронте выдаёт глобальный счётчик». Им пользуются реквизиты сущности, табличные части и ресурсы регистров. Обработчик предопределённых — единственное место, где вместо него был написан плотный цикл. Та же форма дефекта, что разбирает план 115: инвариант применён в N−1 месте из N.

## Ещё два дефекта в том же обработчике

Их вскрыли тесты, написанные под основной баг:

**Пустой список не убирал ключ.** Пользователь удалил все предопределённые → в файл писалось `predefined: []` вместо удаления ключа. Причина — `predefined interface{}` в сигнатуре: nil-слайс, обёрнутый в интерфейс, не равен `nil`, поэтому ветка `delete(node, "predefined")` была недостижима. Ровно та ловушка, ради которой рядом живёт `anyOrNil` (`configurator_entity.go:464`).

**Файл сущности круглился через `map[string]interface{}`** — при каждом сохранении терялись порядок ключей и комментарии:

```
# Ставки НДС для торговли      ← комментарий исчезал
name: СтавкаНДС                ← ключи пересортировывались
```

Тот же класс, что #656 у `app.yaml`, и лечится тем же приёмом — точечной правкой узла `yaml.Node`, по образцу `applyAccountRegFields`.

## Исправление

- разбор строк — через существующий `formRowIndices`, без своего цикла и без потолка в 500 строк;
- очищенное имя строки считается удалением (`continue`), а не концом списка;
- `savePredefinedToFile`/`savePredefinedToDB` принимают конкретный `[]rawPredefinedRow` вместо `interface{}` — типизированный nil больше не пролезает;
- `applyPredefined` правит блок `predefined` точечно в дереве `yaml.Node`, сохраняя порядок ключей и комментарии; пустой список удаляет ключ.

Диф — один файл, +55/−32.

## Тесты

Через POST-обработчик конфигуратора, как пользователь.

| тест | что ловит |
|---|---|
| `TestConfiguratorSavePredefined_SparseRowIndexIsSaved` | сценарий из issue: строка с индексом `10001` сохраняется, существующая цела |
| `TestConfiguratorSavePredefined_GapInIndexesKeepsAllRows` | дыра в середине (удалили строку) не обрывает список |
| `TestConfiguratorSavePredefined_EmptyListRemovesKey` | пустой список убирает ключ, а не пишет `predefined: []` |
| `TestConfiguratorSavePredefined_KeepsFileOrderAndComments` | порядок ключей и комментарии файла сущности не теряются |

Все четыре без фикса падают.

## Проверки

`go build ./...`, `CGO_ENABLED=0 GOOS=windows go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt -l` — чисто.

## Смежное

Тот же счётчик с 10000 используется в `cfgAddARField` (ресурсы регистра, `res.*`), но там серверный разбор идёт через `parseRegSection` → `formRowIndices`, то есть устойчив. `enumAddVal` и `repAddParam` считают индекс от числа строк — тоже плотно и корректно. Отдельная сплошная сверка всех пар «клиент добавляет строку ↔ сервер её читает» запущена; если найдётся ещё несовместимая пара, заведу тикетом.

Закрывает #671.
Closes #671

Generated-with: Claude Code
