### PR TITLE
fix(backup): локальная ротация оставляет keep_last копий каждой базы (#673)

### DIFF
--- a/internal/backup/auto.go
+++ b/internal/backup/auto.go
@@ -326,19 +326,38 @@ func dumpAutoTarget(ctx context.Context, target AutoTarget, dir string) (string,
 	return Dump(ctx, target.DSN, dir)
 }
 
-// RotateBackups keeps the newest keepLast backup files and removes older ones.
+// RotateBackups оставляет keepLast свежих копий КАЖДОЙ базы в каталоге и удаляет
+// остальные.
+//
+// Раньше выборка сужалась одной лишь маской backup_* — имя базы в отбор не
+// входило, поэтому при общем каталоге ротация одной базы сносила копии соседних.
+// Общий каталог не экзотика: docs/DEPLOYMENT.md показывает фиксированный
+// абсолютный путь, а AutoBackupDir разводит базы по подкаталогам, только если
+// backup.directory не задан вовсе. Тот же дефект был в off-site ротации и
+// закрыт в #628; здесь он оставался, хотя issue #628 приводила локальную
+// ротацию как эталон (issue #673).
+//
+// Порядок внутри семейства — по времени изменения файла: для локальных копий это
+// надёжнее метки в имени. Файлы backup_*, чьё имя не разбирается на
+// backup_<БД>_<дата>, не трогаются вовсе — чьи они, неизвестно.
 func RotateBackups(dir string, keepLast int) error {
 	if keepLast <= 0 {
 		return nil
 	}
-	files, err := BackupFiles(dir)
+	files, err := BackupFiles(dir) // уже отсортированы «новые первыми»
 	if err != nil {
 		return err
 	}
-	if len(files) <= keepLast {
-		return nil
-	}
-	for _, f := range files[keepLast:] {
+	kept := make(map[string]int, 4)
+	for _, f := range files {
+		family, _, ok := splitBackupName(filepath.Base(f.Path))
+		if !ok {
+			continue
+		}
+		kept[family]++
+		if kept[family] <= keepLast {
+			continue
+		}
 		if err := os.Remove(f.Path); err != nil && !os.IsNotExist(err) {
 			return err
 		}

--- a/internal/backup/auto_test.go
+++ b/internal/backup/auto_test.go
@@ -2,8 +2,11 @@ package backup
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,12 +43,16 @@ func TestRegisterAutoBackup_DisabledNoop(t *testing.T) {
 func TestCreateAutoBackup_RotatesWithDefaults(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &project.BackupConfig{Directory: dir}
+	// Имена — те, что платформа реально генерирует (backup_<БД>_<дата>):
+	// раньше здесь стояли backup_old_a.sql.gz и backup_new.sql.gz, которых не
+	// бывает, и тест не проверял отбор по семейству вовсе.
 	for i := 0; i < defaultAutoBackupKeepLast; i++ {
-		touchBackup(t, dir, "backup_old_"+string(rune('a'+i))+".sql.gz", time.Now().Add(-time.Duration(i+10)*time.Hour))
+		name := fmt.Sprintf("backup_trade_2026-08-%02d_03-00-00.sql.gz", i+1)
+		touchBackup(t, dir, name, time.Now().Add(-time.Duration(i+10)*time.Hour))
 	}
 
 	created, err := createAutoBackup(context.Background(), cfg, AutoTarget{}, func(_ context.Context, _ AutoTarget, outDir string) (string, error) {
-		path := filepath.Join(outDir, "backup_new.sql.gz")
+		path := filepath.Join(outDir, "backup_trade_2026-08-20_03-00-00.sql.gz")
 		if err := os.WriteFile(path, []byte("ok"), 0o644); err != nil {
 			return "", err
 		}
@@ -58,7 +65,7 @@ func TestCreateAutoBackup_RotatesWithDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createAutoBackup: %v", err)
 	}
-	if filepath.Base(created) != "backup_new.sql.gz" {
+	if filepath.Base(created) != "backup_trade_2026-08-20_03-00-00.sql.gz" {
 		t.Fatalf("created = %s", created)
 	}
 	files, err := BackupFiles(dir)
@@ -68,9 +75,71 @@ func TestCreateAutoBackup_RotatesWithDefaults(t *testing.T) {
 	if len(files) != defaultAutoBackupKeepLast {
 		t.Fatalf("files len = %d, want %d", len(files), defaultAutoBackupKeepLast)
 	}
-	if filepath.Base(files[0].Path) != "backup_new.sql.gz" {
+	if filepath.Base(files[0].Path) != "backup_trade_2026-08-20_03-00-00.sql.gz" {
 		t.Fatalf("newest = %s", files[0].Path)
 	}
+}
+
+// Приёмка по issue #673: две базы пишут в ОДИН каталог (docs/DEPLOYMENT.md
+// показывает фиксированный абсолютный путь, и при двух базах на хосте он общий),
+// keep_last=2 — у каждой обязано остаться по две своих копии.
+//
+// Раньше отбор шёл одной маской backup_*, поэтому ротация одной базы сносила
+// копии соседней: при невезучем расписании у базы не оставалось ни одной.
+func TestRotateBackups_KeepsPerDatabase(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	for i, name := range []string{
+		"backup_alpha_2026-08-01_03-00-00.sql.gz",
+		"backup_alpha_2026-08-02_03-00-00.sql.gz",
+		"backup_alpha_2026-08-03_03-00-00.sql.gz",
+		"backup_zeta_2026-08-01_09-00-00.db",
+		"backup_zeta_2026-08-02_09-00-00.db",
+		"backup_zeta_2026-08-03_09-00-00.db",
+	} {
+		touchBackup(t, dir, name, now.Add(-time.Duration(len([]string{})+i)*time.Hour))
+	}
+	// Файл backup_* с неразбираемым именем: чей он — неизвестно, трогать нельзя.
+	touchBackup(t, dir, "backup_вручную.sql.gz", now.Add(-100*time.Hour))
+
+	if err := RotateBackups(dir, 2); err != nil {
+		t.Fatalf("RotateBackups: %v", err)
+	}
+
+	files, err := BackupFiles(dir)
+	if err != nil {
+		t.Fatalf("BackupFiles: %v", err)
+	}
+	count := map[string]int{}
+	for _, f := range files {
+		base := filepath.Base(f.Path)
+		switch {
+		case strings.HasPrefix(base, "backup_alpha_"):
+			count["alpha"]++
+		case strings.HasPrefix(base, "backup_zeta_"):
+			count["zeta"]++
+		default:
+			count["прочее"]++
+		}
+	}
+	if count["alpha"] != 2 {
+		t.Errorf("копий alpha осталось %d, ожидалось 2; в каталоге: %v", count["alpha"], namesOf(files))
+	}
+	if count["zeta"] != 2 {
+		t.Errorf("копий zeta осталось %d, ожидалось 2; в каталоге: %v", count["zeta"], namesOf(files))
+	}
+	if count["прочее"] != 1 {
+		t.Errorf("посторонний файл удалён ротацией; в каталоге: %v", namesOf(files))
+	}
+}
+
+func namesOf(files []FileInfo) []string {
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		out = append(out, filepath.Base(f.Path))
+	}
+	sort.Strings(out)
+	return out
 }
 
 func TestBackupFiles_KnownExtensionsNewestFirst(t *testing.T) {


### PR DESCRIPTION
## Проблема

При общем каталоге резервных копий ротация одной базы удаляла копии соседних. `RotateBackups` сужала выборку одной лишь маской `backup_*` — имя базы в отбор не входило, поэтому все файлы каталога считались копиями текущей базы.

**Сценарий с полной потерей.** Две базы, `keep_last: 7`, общий каталог. `alpha` бэкапится ночью, `zeta` — раз в час. К моменту ночного прогона `alpha` первые семь файлов по времени изменения принадлежат `zeta`, и **все** копии `alpha`, включая только что созданную, попадают в хвост и удаляются.

Приёмочный тест на неисправленном коде показывает ровно это:

```
копий zeta осталось 0, ожидалось 2; в каталоге: [backup_alpha_2026-08-01…, backup_alpha_2026-08-02…]
посторонний файл удалён ротацией
```

То есть у одной базы не остаётся ни одной копии, а положенный руками `backup_*` тоже сносится.

**Общий каталог — не экзотика.** `docs/DEPLOYMENT.md` показывает фиксированный абсолютный путь:

```yaml
backup:
  keep_last: 7
  directory: "C:/onebase/backups"
```

`AutoBackupDir` разводит базы по подкаталогам, только если `directory` не задан вовсе.

**Это тот же дефект, что закрыт для off-site копий в #628** — и он оставался здесь, при том что issue #628 приводила локальную ротацию как **эталон**, по которому надо править S3. Эталон сам был сломан.

## Исправление

Переиспользован `splitBackupName` из #628: файлы группируются по семейству `backup_<БД>_`, и в каждом остаётся `keep_last` свежих. Публичная сигнатура не меняется — `keep_last` просто получает смысл «сколько копий **этой** базы хранить», а не «сколько файлов в каталоге».

- Порядок внутри семейства — по **времени изменения файла**: для локальных копий это надёжнее метки в имени (файл могли скопировать, метка осталась прежней).
- Файлы `backup_*` с неразбираемым именем не трогаются вовсе — чьи они, неизвестно.
- `BackupFiles` **не тронута**: она питает список копий в лаунчере и обязана показывать всё, что лежит в каталоге.

## Тесты

| тест | что ловит | без фикса |
|---|---|---|
| `TestRotateBackups_KeepsPerDatabase` | приёмка по issue: две базы в одном каталоге, `keep_last: 2` → у каждой по две своих копии; посторонний `backup_*` цел | `копий zeta осталось 0, ожидалось 2`, `посторонний файл удалён ротацией` |
| `TestCreateAutoBackup_RotatesWithDefaults` | **переписан**: использовал `backup_old_a.sql.gz` и `backup_new.sql.gz`, которых платформа не генерирует, и потому отбор по семейству не проверял в принципе |  |

Второй пункт стоит отметить отдельно: старый тест был зелёным на именах, которых не бывает, — ровно тот класс, от которого предостерегает CLAUDE.md («зелёный тест на мёртвом коде хуже отсутствующего»).

## Проверки

`go build ./...`, `CGO_ENABLED=0 GOOS=windows go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt -l` — чисто.

Закрывает #673.
Closes #673

Generated-with: Claude Code
