### PR TITLE
fix(ui): файл-параметр обработки не обрезан мегабайтом (#674)

### DIFF
--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -788,14 +788,17 @@ func serializeValue(v any) any {
 // Аналог handleManagedFormEvent, но вместо Entity использует виртуальную entity
 // из параметров обработки. Кнопка «Выполнить» запускает proc.os через interp.
 func (s *Server) handleProcessorFormEvent(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, defaultFormMemoryBytes)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	enc := json.NewEncoder(w)
 
-	s.limitMultipartRequest(w, r)
+	// Один предел, а не два вложенных: пределы не композируются, и прежний
+	// MaxBytesReader на defaultFormMemoryBytes связывал раньше, обрезая
+	// файл-параметр обработки мегабайтом (issue #674). Присваивание r.Body —
+	// здесь, а не в хелпере: иначе gosec (G120) не видит предел.
+	r.Body = http.MaxBytesReader(w, r.Body, s.effectiveUploadLimit()+uiMultipartOverhead)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		w.WriteHeader(uploadErrorStatus(err))
-		respondJSON(enc, formEventResponse{Error: "bad form: " + err.Error()})
+		respondJSON(enc, formEventResponse{Error: s.errText(r, formBodyError(err, nil))})
 		return
 	}
 

--- a/internal/ui/handlers_processors.go
+++ b/internal/ui/handlers_processors.go
@@ -137,7 +137,18 @@ func paramDefaultValue(def any, typ string) any {
 }
 
 func (s *Server) processorRun(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, defaultFormMemoryBytes)
+	// Предел тела ставится РОВНО ОДИН раз. Раньше их было два: сначала
+	// defaultFormMemoryBytes, следом limitMultipartRequest на предел вложений —
+	// и связывал всегда первый, потому что пределы не композируются, вложенный
+	// MaxBytesReader режет по МЕНЬШЕМУ. Из-за этого параметр обработки типа file
+	// был обрезан мегабайтом вместо заявленных attachments.max_file_size_mb
+	// (issue #674).
+	//
+	// Присваивание r.Body остаётся здесь, в теле обработчика: вынеси его в
+	// хелпер — и gosec (G120) перестанет видеть предел, пометив каждый
+	// r.FormValue ниже.
+	maxSize := s.effectiveUploadLimit()
+	r.Body = http.MaxBytesReader(w, r.Body, maxSize+uiMultipartOverhead)
 	proc := s.getProcessor(w, r)
 	if proc == nil {
 		return
@@ -158,7 +169,6 @@ func (s *Server) processorRun(w http.ResponseWriter, r *http.Request) {
 	opStatus := "ok"
 	defer func() { finish(opStatus, 0, false) }()
 
-	maxSize := s.limitMultipartRequest(w, r)
 	if err := parseBoundedForm(r, 32<<20); err != nil {
 		opStatus = "error"
 		http.Error(w, s.errText(r, err), uploadErrorStatus(err))

--- a/internal/ui/processor_upload_limit_test.go
+++ b/internal/ui/processor_upload_limit_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/processor"
+)
+
+// Параметр обработки типа file был обрезан одним мегабайтом вместо заявленных
+// attachments.max_file_size_mb (issue #674): в обработчике стояли ДВА предела
+// тела — сначала defaultFormMemoryBytes, следом limitMultipartRequest на предел
+// вложений. Пределы не композируются, вложенный MaxBytesReader режет по
+// МЕНЬШЕМУ, поэтому связывал всегда первый, а второй был мёртв.
+//
+// Пользователь при этом получал сырое «http: request body too large», хотя
+// понятный текст про предел файла для этого случая уже написан
+// (uploadTooLargeText) — до него исполнение просто не доходило.
+
+func fileParamProcessor() *processor.Processor {
+	return &processor.Processor{
+		Name:  "Загрузка",
+		Title: "Загрузка данных",
+		Params: []processor.Param{
+			{Name: "Файл", Type: "file", Label: "Файл"},
+		},
+	}
+}
+
+// postProcessorFile шлёт multipart с файлом заданного размера в параметр Файл.
+func postProcessorFile(t *testing.T, ts *httptest.Server, procName string, size int) (int, string) {
+	t.Helper()
+	body := new(bytes.Buffer)
+	mw := multipart.NewWriter(body)
+	fw, err := mw.CreateFormFile("Файл", "data.csv")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(bytes.Repeat([]byte("a"), size)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("multipart Close: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/ui/processor/"+procName, body)
+	if err != nil {
+		t.Fatalf("запрос: %v", err)
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // тело читается ниже
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	return resp.StatusCode, string(buf[:n])
+}
+
+func newProcessorTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	s, _ := newSubmitTestServer(t, nil)
+	s.reg.LoadProcessors([]*processor.Processor{fileParamProcessor()})
+	r := chi.NewRouter()
+	s.Mount(r)
+	ts := httptest.NewServer(r)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// Файл на несколько мегабайт обязан доехать до обработчика: предел вложений по
+// умолчанию — 50 МБ. До фикса — 413 с сырым «request body too large».
+func TestProcessorRun_FileParamAboveOneMiB(t *testing.T) {
+	ts := newProcessorTestServer(t)
+	code, body := postProcessorFile(t, ts, "загрузка", 5<<20)
+	if code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("файл на 5 МиБ отклонён по размеру тела: %s", body)
+	}
+	if strings.Contains(body, "request body too large") {
+		t.Errorf("в ответе сырая ошибка про размер тела: %s", body)
+	}
+}
+
+// Предел вложений при этом остаётся действующим — правка убирает мёртвый
+// предел, а не защиту. Файл заведомо больше 50 МБ отклоняется.
+func TestProcessorRun_FileParamAboveUploadLimitRejected(t *testing.T) {
+	ts := newProcessorTestServer(t)
+	code, _ := postProcessorFile(t, ts, "загрузка", int(defaultUIUploadBytes)+(4<<20))
+	if code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("статус = %d, ожидался 413: предел вложений должен остаться в силе", code)
+	}
+}


### PR DESCRIPTION
## Проблема

Параметр обработки типа `file` де-факто ограничивался **одним мегабайтом** вместо заявленных `attachments.max_file_size_mb`. Файл больше мегабайта не загружался, а пользователь получал сырое `http: request body too large` вместо понятного «файл превышает максимальный размер N МБ», которое для этого случая уже написано (`uploadTooLargeText`).

В обработчике стояли **два** предела тела:

```go
r.Body = http.MaxBytesReader(w, r.Body, defaultFormMemoryBytes)   // 1 МиБ
...
maxSize := s.limitMultipartRequest(w, r)                          // предел вложений, уже ничего не значит
if err := parseBoundedForm(r, 32<<20); err != nil {
```

Пределы **не композируются**: вложенный `MaxBytesReader` режет по МЕНЬШЕМУ, поэтому связывал всегда первый, а второй был мёртв. Дальше `maxSize` честно передавался в `readUploadedBytes` и в проверку с внятным текстом — но исполнение туда не доходило, `parseBoundedForm` падал раньше.

То же самое было в `handleProcessorFormEvent` на событийном пути формы обработки.

## Исправление

Мёртвый первый предел убран, остался один. Присваивание `r.Body` **остаётся в теле обработчика**, а не уезжает в хелпер: иначе gosec (G120) перестаёт видеть предел и помечает каждый `r.FormValue` ниже — та же грабля, что всплыла в #629 (проверено: вынос в хелпер дал 5 находок линтера).

Предел вложений при этом остаётся действующим — правка убирает мёртвый предел, а не защиту.

## Тесты

| тест | что ловит | без фикса |
|---|---|---|
| `TestProcessorRun_FileParamAboveOneMiB` | файл на 5 МиБ доезжает до обработчика | `файл на 5 МиБ отклонён по размеру тела: http: request body too large` |
| `TestProcessorRun_FileParamAboveUploadLimitRejected` | файл сверх предела вложений по-прежнему отклоняется 413 — правка не сняла защиту | — |

Оба идут настоящим multipart-запросом по роутеру, как браузер.

## Проверки

`go build ./...`, `CGO_ENABLED=0 GOOS=windows go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt -l` — чисто.

## Контекст

Корневая причина общая с #629: пределы тела расставлялись одной константой в кампании gosec/G120 (план 109) без различения «форма из коротких полей» и «форма с большим телом». В #629 закрыты пути записи объекта и события управляемой формы; здесь — пути обработок, которых richtext не касается и которые в тот PR намеренно не вошли.

Побочно замечено: тип параметра `file` обрабатывается в `processorRun`, но **не перечислен** в комментарии к `processor.Param.Type` (там только `string, text, number, date, bool, choice, reference:Entity`). Документация расходится с кодом; оставил как есть, чтобы не смешивать с фиксом.

Закрывает #674.
Closes #674

Generated-with: Claude Code
