### PR TITLE
fix(converter): импорт из 1С переносит номер, дату, автонумерацию и иерархию (план 117, этап A)

### DIFF
--- a/internal/converter/parser1c/metadata.go
+++ b/internal/converter/parser1c/metadata.go
@@ -19,6 +19,16 @@ type xmlProperties struct {
 	// Accumulation registers
 	Dimensions []xmlAttribute `xml:"Dimensions>Dimension"`
 	Resources  []xmlAttribute `xml:"Resources>Resource"`
+	// Свойства кода и номера — см. комментарий у xmlV8ObjProps.
+	Hierarchical      string `xml:"Hierarchical"`
+	CodeLength        string `xml:"CodeLength"`
+	CodeType          string `xml:"CodeType"`
+	CheckUnique       string `xml:"CheckUnique"`
+	Autonumbering     string `xml:"Autonumbering"`
+	NumberType        string `xml:"NumberType"`
+	NumberLength      string `xml:"NumberLength"`
+	NumberPeriodicity string `xml:"NumberPeriodicity"`
+	Posting           string `xml:"Posting"`
 }
 
 type xmlLang struct {
@@ -65,6 +75,18 @@ type xmlV8Obj struct {
 
 type xmlV8ObjProps struct {
 	Name string `xml:"Name"`
+	// Свойства кода справочника и номера документа. До этого не читались вовсе,
+	// поэтому автонумерация, длина кода и контроль уникальности терялись молча —
+	// а импортированный документ приходил вообще без «Номера» (план 117, Д6–Д8).
+	Hierarchical      string `xml:"Hierarchical"`
+	CodeLength        string `xml:"CodeLength"`
+	CodeType          string `xml:"CodeType"`
+	CheckUnique       string `xml:"CheckUnique"`
+	Autonumbering     string `xml:"Autonumbering"`
+	NumberType        string `xml:"NumberType"`
+	NumberLength      string `xml:"NumberLength"`
+	NumberPeriodicity string `xml:"NumberPeriodicity"`
+	Posting           string `xml:"Posting"`
 }
 
 type xmlV8Children struct {
@@ -328,6 +350,37 @@ func objectNames(dir string) []string {
 	return names
 }
 
+// xmlBool разбирает булево свойство 1С: «true»/«Allow»/«Use» — да.
+func xmlBool(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "allow", "use", "1":
+		return true
+	}
+	return false
+}
+
+func xmlInt(v string) int {
+	n := 0
+	for _, r := range strings.TrimSpace(v) {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// codeNumbering собирает свойства кода/номера из сырых полей выгрузки.
+func codeNumbering(auto, length, typ, unique, periodicity string) Numbering {
+	return Numbering{
+		Auto:        xmlBool(auto),
+		Length:      xmlInt(length),
+		Type:        strings.TrimSpace(typ),
+		CheckUnique: xmlBool(unique),
+		Periodicity: strings.TrimSpace(periodicity),
+	}
+}
+
 func parseCatalogs(dir string) ([]*CatalogMeta, error) {
 	var result []*CatalogMeta
 	for _, name := range objectNames(dir) {
@@ -345,8 +398,11 @@ func parseCatalogs(dir string) ([]*CatalogMeta, error) {
 			}
 			if obj != nil {
 				cat := &CatalogMeta{
-					Name:       orDefault(obj.Props.Name, name),
-					Attributes: convertV83Attrs(obj.ChildObjects.Attributes),
+					Name:         orDefault(obj.Props.Name, name),
+					Attributes:   convertV83Attrs(obj.ChildObjects.Attributes),
+					Hierarchical: xmlBool(obj.Props.Hierarchical),
+					Code: codeNumbering(obj.Props.Autonumbering, obj.Props.CodeLength,
+						obj.Props.CodeType, obj.Props.CheckUnique, ""),
 				}
 				for _, ts := range obj.ChildObjects.TabularSections {
 					cat.TabularSections = append(cat.TabularSections, TabularSection{
@@ -370,9 +426,12 @@ func parseCatalogs(dir string) ([]*CatalogMeta, error) {
 			continue
 		}
 		cat := &CatalogMeta{
-			Name:       orDefault(props.Name, name),
-			Synonym:    props.Synonym.Content,
-			Attributes: convertAttrs(props.Attributes),
+			Name:         orDefault(props.Name, name),
+			Synonym:      props.Synonym.Content,
+			Attributes:   convertAttrs(props.Attributes),
+			Hierarchical: xmlBool(props.Hierarchical),
+			Code: codeNumbering(props.Autonumbering, props.CodeLength,
+				props.CodeType, props.CheckUnique, ""),
 		}
 		for _, ts := range props.TabularSections {
 			cat.TabularSections = append(cat.TabularSections, TabularSection{
@@ -396,6 +455,9 @@ func parseDocuments(dir string) ([]*DocumentMeta, error) {
 			doc := &DocumentMeta{
 				Name:       orDefault(obj.Props.Name, name),
 				Attributes: convertV83Attrs(obj.ChildObjects.Attributes),
+				Posting:    xmlBool(obj.Props.Posting),
+				Number: codeNumbering(obj.Props.Autonumbering, obj.Props.NumberLength,
+					obj.Props.NumberType, "", obj.Props.NumberPeriodicity),
 			}
 			for _, ts := range obj.ChildObjects.TabularSections {
 				doc.TabularSections = append(doc.TabularSections, TabularSection{
@@ -421,6 +483,9 @@ func parseDocuments(dir string) ([]*DocumentMeta, error) {
 			Name:       orDefault(props.Name, name),
 			Synonym:    props.Synonym.Content,
 			Attributes: convertAttrs(props.Attributes),
+			Posting:    xmlBool(props.Posting),
+			Number: codeNumbering(props.Autonumbering, props.NumberLength,
+				props.NumberType, "", props.NumberPeriodicity),
 		}
 		for _, ts := range props.TabularSections {
 			doc.TabularSections = append(doc.TabularSections, TabularSection{

--- a/internal/converter/parser1c/numbering_test.go
+++ b/internal/converter/parser1c/numbering_test.go
@@ -1,0 +1,99 @@
+package parser1c
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Свойства кода справочника и номера документа парсер не читал вовсе: в
+// CatalogMeta/DocumentMeta не было ни одного соответствующего поля, а
+// xml-структуры их не объявляли. Автонумерация, длина, периодичность,
+// контроль уникальности и признак иерархии терялись молча — в отчёте
+// конвертации об этом не было ни строки (план 117, Д8).
+
+const catalogWithCodeXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject>
+  <Catalog>
+    <Properties>
+      <Name>Контрагенты</Name>
+      <Hierarchical>true</Hierarchical>
+      <CodeLength>9</CodeLength>
+      <CodeType>String</CodeType>
+      <CheckUnique>true</CheckUnique>
+      <Autonumbering>true</Autonumbering>
+    </Properties>
+    <ChildObjects>
+      <Attribute><Properties>
+        <Name>ИНН</Name>
+        <Type><Type xmlns="http://v8.1c.ru/8.1/data/core">xs:string</Type></Type>
+      </Properties></Attribute>
+    </ChildObjects>
+  </Catalog>
+</MetaDataObject>`
+
+const documentWithNumberXML = `<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject>
+  <Document>
+    <Properties>
+      <Name>РеализацияТоваров</Name>
+      <Posting>Allow</Posting>
+      <NumberType>String</NumberType>
+      <NumberLength>11</NumberLength>
+      <NumberPeriodicity>Year</NumberPeriodicity>
+      <Autonumbering>true</Autonumbering>
+    </Properties>
+    <ChildObjects>
+      <Attribute><Properties>
+        <Name>Контрагент</Name>
+        <Type><Type xmlns="http://v8.1c.ru/8.1/data/core">cfg:CatalogRef.Контрагенты</Type></Type>
+      </Properties></Attribute>
+    </ChildObjects>
+  </Document>
+</MetaDataObject>`
+
+func writeObj(t *testing.T, dir, name, xml string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".xml"), []byte(xml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParse_ЧитаетСвойстваКодаИНомера(t *testing.T) {
+	src := t.TempDir()
+	writeObj(t, filepath.Join(src, "Catalogs"), "Контрагенты", catalogWithCodeXML)
+	writeObj(t, filepath.Join(src, "Documents"), "РеализацияТоваров", documentWithNumberXML)
+
+	cats, err := parseCatalogs(filepath.Join(src, "Catalogs"))
+	if err != nil {
+		t.Fatalf("parseCatalogs: %v", err)
+	}
+	if len(cats) != 1 {
+		t.Fatalf("справочников %d, ожидался 1", len(cats))
+	}
+	c := cats[0]
+	if !c.Hierarchical {
+		t.Error("иерархия справочника не прочитана")
+	}
+	if !c.Code.Auto || c.Code.Length != 9 || c.Code.Type != "String" || !c.Code.CheckUnique {
+		t.Errorf("свойства кода прочитаны неверно: %+v", c.Code)
+	}
+
+	docs, err := parseDocuments(filepath.Join(src, "Documents"))
+	if err != nil {
+		t.Fatalf("parseDocuments: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("документов %d, ожидался 1", len(docs))
+	}
+	d := docs[0]
+	if !d.Posting {
+		t.Error("признак проведения не прочитан")
+	}
+	if !d.Number.Auto || d.Number.Length != 11 || d.Number.Periodicity != "Year" {
+		t.Errorf("свойства номера прочитаны неверно: %+v", d.Number)
+	}
+}

--- a/internal/converter/parser1c/types.go
+++ b/internal/converter/parser1c/types.go
@@ -1,5 +1,15 @@
 package parser1c
 
+// Numbering — свойства кода справочника или номера документа из выгрузки 1С.
+// Раньше не читались вовсе и терялись молча (план 117, Д8).
+type Numbering struct {
+	Auto        bool   // Autonumbering
+	Length      int    // CodeLength / NumberLength
+	Type        string // CodeType / NumberType: String | Number
+	CheckUnique bool   // контроль уникальности кода
+	Periodicity string // NumberPeriodicity: Year | Month | Day | Nonperiodical
+}
+
 // CatalogMeta — справочник из Metadata.xml
 type CatalogMeta struct {
 	Name            string
@@ -7,6 +17,8 @@ type CatalogMeta struct {
 	Attributes      []Attribute
 	TabularSections []TabularSection
 	Forms           []FormSource // управляемые формы объекта (Forms/<X>/Ext/Form.xml)
+	Hierarchical    bool
+	Code            Numbering
 }
 
 // DocumentMeta — документ из Metadata.xml
@@ -16,6 +28,8 @@ type DocumentMeta struct {
 	Attributes      []Attribute
 	TabularSections []TabularSection
 	Forms           []FormSource
+	Posting         bool
+	Number          Numbering
 }
 
 // FormSource — управляемая форма объекта, найденная в выгрузке 1С.

--- a/internal/converter/writer/standard_fields_test.go
+++ b/internal/converter/writer/standard_fields_test.go
@@ -1,0 +1,115 @@
+package writer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/converter/parser1c"
+)
+
+// Импортированный из 1С документ приезжал вообще без «Номера», «Даты», блока
+// numerator: и признака posting — WriteDocuments звал convertFields напрямую,
+// минуя стандартные реквизиты, которые справочник получал. Из-за этого жалоба
+// «в документах нет НОМЕРА» (issue #658) относилась к конвертеру, а не к
+// движку: автонумерацию документов платформа умеет и делает атомарно
+// (план 117, Д6).
+
+func readOut(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("чтение %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestWriteDocuments_ДобавляетСтандартныеРеквизитыИНумератор(t *testing.T) {
+	out := t.TempDir()
+	notes := &ConversionReport{}
+	docs := []*parser1c.DocumentMeta{{
+		Name:       "РеализацияТоваров",
+		Attributes: []parser1c.Attribute{{Name: "Контрагент", Type: parser1c.FieldType{Primary: "xs:string"}}},
+		Posting:    true,
+		Number:     parser1c.Numbering{Auto: true, Length: 11, Type: "String", Periodicity: "Year"},
+	}}
+	if err := WriteDocuments(docs, out, notes); err != nil {
+		t.Fatalf("WriteDocuments: %v", err)
+	}
+	got := readOut(t, filepath.Join(out, "documents", fileName("РеализацияТоваров")+".yaml"))
+	for _, must := range []string{"name: Номер", "name: Дата", "posting: true", "numerator:", "length: 11", "period: year"} {
+		if !strings.Contains(got, must) {
+			t.Errorf("в YAML документа нет %q:\n%s", must, got)
+		}
+	}
+	// Стандартные реквизиты идут первыми, как в 1С.
+	if strings.Index(got, "name: Номер") > strings.Index(got, "name: Контрагент") {
+		t.Errorf("«Номер» должен идти перед пользовательскими реквизитами:\n%s", got)
+	}
+}
+
+// Документ без автонумерации получает «Номер» и «Дату», но без блока numerator:
+// — иначе конвертер навязал бы нумерацию там, где её в 1С не было.
+func TestWriteDocuments_БезАвтонумерацииНетБлока(t *testing.T) {
+	out := t.TempDir()
+	notes := &ConversionReport{}
+	docs := []*parser1c.DocumentMeta{{Name: "Заявка"}}
+	if err := WriteDocuments(docs, out, notes); err != nil {
+		t.Fatalf("WriteDocuments: %v", err)
+	}
+	got := readOut(t, filepath.Join(out, "documents", fileName("Заявка")+".yaml"))
+	if strings.Contains(got, "numerator:") {
+		t.Errorf("блок numerator: не должен появляться без автонумерации:\n%s", got)
+	}
+	if !strings.Contains(got, "name: Номер") || !strings.Contains(got, "name: Дата") {
+		t.Errorf("стандартные реквизиты обязаны быть всегда:\n%s", got)
+	}
+}
+
+// Уже объявленные пользователем «Номер»/«Дата» не дублируются.
+func TestWriteDocuments_НеДублируетСуществующие(t *testing.T) {
+	out := t.TempDir()
+	notes := &ConversionReport{}
+	docs := []*parser1c.DocumentMeta{{
+		Name:       "Заявка",
+		Attributes: []parser1c.Attribute{{Name: "Номер", Type: parser1c.FieldType{Primary: "xs:string"}}},
+	}}
+	if err := WriteDocuments(docs, out, notes); err != nil {
+		t.Fatalf("WriteDocuments: %v", err)
+	}
+	got := readOut(t, filepath.Join(out, "documents", fileName("Заявка")+".yaml"))
+	if strings.Count(got, "name: Номер") != 1 {
+		t.Errorf("«Номер» задвоился:\n%s", got)
+	}
+}
+
+// Иерархия справочника переносится, а то, что платформа пока не умеет
+// (автонумерация кода, контроль уникальности), попадает в отчёт, а не пропадает
+// молча.
+func TestWriteCatalogs_ИерархияИОтчётПоКоду(t *testing.T) {
+	out := t.TempDir()
+	notes := &ConversionReport{}
+	cats := []*parser1c.CatalogMeta{{
+		Name:         "Контрагенты",
+		Hierarchical: true,
+		Code:         parser1c.Numbering{Auto: true, Length: 9, Type: "String", CheckUnique: true},
+	}}
+	if err := WriteCatalogs(cats, out, notes); err != nil {
+		t.Fatalf("WriteCatalogs: %v", err)
+	}
+	got := readOut(t, filepath.Join(out, "catalogs", fileName("Контрагенты")+".yaml"))
+	if !strings.Contains(got, "hierarchical: true") {
+		t.Errorf("иерархия не перенесена:\n%s", got)
+	}
+	if strings.Contains(got, "numerator:") {
+		t.Errorf("блок numerator: у справочника пока no-op, писать его нельзя:\n%s", got)
+	}
+	joined := strings.Join(notes.TypeWarnings, "\n")
+	if !strings.Contains(joined, "автонумерация кода не перенесена") {
+		t.Errorf("в отчёте нет предупреждения об автонумерации кода: %v", notes.TypeWarnings)
+	}
+	if !strings.Contains(joined, "контроль уникальности кода не перенесён") {
+		t.Errorf("в отчёте нет предупреждения о контроле уникальности: %v", notes.TypeWarnings)
+	}
+}

--- a/internal/converter/writer/yaml.go
+++ b/internal/converter/writer/yaml.go
@@ -23,15 +23,22 @@ type yamlTablePart struct {
 }
 
 type yamlCatalog struct {
-	Name       string          `yaml:"name"`
-	Title      string          `yaml:"title,omitempty"`
-	Fields     []yamlField     `yaml:"fields"`
-	TableParts []yamlTablePart `yaml:"tableparts,omitempty"`
+	Name         string          `yaml:"name"`
+	Title        string          `yaml:"title,omitempty"`
+	Hierarchical bool            `yaml:"hierarchical,omitempty"`
+	Fields       []yamlField     `yaml:"fields"`
+	TableParts   []yamlTablePart `yaml:"tableparts,omitempty"`
 }
 
+type yamlNumerator struct {
+	Length int    `yaml:"length,omitempty"`
+	Period string `yaml:"period,omitempty"`
+}
 type yamlDocument struct {
 	Name       string          `yaml:"name"`
 	Title      string          `yaml:"title,omitempty"`
+	Posting    bool            `yaml:"posting,omitempty"`
+	Numerator  *yamlNumerator  `yaml:"numerator,omitempty"`
 	Fields     []yamlField     `yaml:"fields"`
 	TableParts []yamlTablePart `yaml:"tableparts,omitempty"`
 }
@@ -51,9 +58,22 @@ func WriteCatalogs(cats []*parser1c.CatalogMeta, outDir string, notes *Conversio
 	}
 	for _, cat := range cats {
 		obj := yamlCatalog{
-			Name:   cat.Name,
-			Title:  synonymTitle(cat.Name, cat.Synonym),
-			Fields: withStandardCatalogFields(convertFields(cat.Attributes, notes)),
+			Name:         cat.Name,
+			Title:        synonymTitle(cat.Name, cat.Synonym),
+			Hierarchical: cat.Hierarchical,
+			Fields:       withStandardCatalogFields(convertFields(cat.Attributes, notes)),
+		}
+		// Автонумерацию кода справочника платформа пока не выполняет: блок
+		// numerator: у справочника разбирается и ничего не делает (план 117, Д2).
+		// Писать его сюда значило бы отдать конфигурацию, которая выглядит
+		// рабочей и молчит, — поэтому честнее сказать вслух.
+		if cat.Code.Auto {
+			notes.TypeWarnings = append(notes.TypeWarnings,
+				"справочник "+cat.Name+": автонумерация кода не перенесена — платформа пока нумерует только документы (план 117)")
+		}
+		if cat.Code.CheckUnique {
+			notes.TypeWarnings = append(notes.TypeWarnings,
+				"справочник "+cat.Name+": контроль уникальности кода не перенесён — задайте indexes: [{fields: [Код], unique: true}] вручную")
 		}
 		for _, ts := range cat.TabularSections {
 			obj.TableParts = append(obj.TableParts, yamlTablePart{
@@ -70,6 +90,52 @@ func WriteCatalogs(cats []*parser1c.CatalogMeta, outDir string, notes *Conversio
 }
 
 // WriteDocuments записывает документы в out/documents/*.yaml.
+// withStandardDocumentFields добавляет «Номер» и «Дату» — стандартные реквизиты
+// документа в 1С, которых у импортированного объекта не было вовсе. Из-за этого
+// документ приезжал без номера и даты, и жалоба «в документах нет НОМЕРА»
+// (issue #658) относилась к конвертеру, а не к движку: автонумерацию платформа
+// умеет (план 117, Д6).
+//
+// Порядок как в 1С: сначала стандартные, потом пользовательские.
+func withStandardDocumentFields(fields []yamlField) []yamlField {
+	has := func(name string) bool {
+		for _, f := range fields {
+			if strings.EqualFold(f.Name, name) {
+				return true
+			}
+		}
+		return false
+	}
+	var std []yamlField
+	if !has("Номер") {
+		std = append(std, yamlField{Name: "Номер", Type: "string"})
+	}
+	if !has("Дата") {
+		std = append(std, yamlField{Name: "Дата", Type: "date"})
+	}
+	return append(std, fields...)
+}
+
+// numeratorFrom переносит автонумерацию документа. Период 1С «Year»/«Month»/
+// «Day» соответствует period платформы; «Nonperiodical» — сквозная нумерация.
+func numeratorFrom(n parser1c.Numbering) *yamlNumerator {
+	if !n.Auto {
+		return nil
+	}
+	out := &yamlNumerator{Length: n.Length}
+	switch strings.ToLower(n.Periodicity) {
+	case "year":
+		out.Period = "year"
+	case "month":
+		out.Period = "month"
+	case "day":
+		out.Period = "day"
+	case "nonperiodical", "":
+		out.Period = "none"
+	}
+	return out
+}
+
 func WriteDocuments(docs []*parser1c.DocumentMeta, outDir string, notes *ConversionReport) error {
 	dir := filepath.Join(outDir, "documents")
 	if err := os.MkdirAll(dir, fsmode.Dir); err != nil {
@@ -77,9 +143,15 @@ func WriteDocuments(docs []*parser1c.DocumentMeta, outDir string, notes *Convers
 	}
 	for _, doc := range docs {
 		obj := yamlDocument{
-			Name:   doc.Name,
-			Title:  synonymTitle(doc.Name, doc.Synonym),
-			Fields: convertFields(doc.Attributes, notes),
+			Name:      doc.Name,
+			Title:     synonymTitle(doc.Name, doc.Synonym),
+			Posting:   doc.Posting,
+			Numerator: numeratorFrom(doc.Number),
+			Fields:    withStandardDocumentFields(convertFields(doc.Attributes, notes)),
+		}
+		if doc.Number.Auto && strings.EqualFold(doc.Number.Type, "Number") {
+			notes.TypeWarnings = append(notes.TypeWarnings,
+				"документ "+doc.Name+": числовой номер перенесён строковым — платформа нумерует строками")
 		}
 		for _, ts := range doc.TabularSections {
 			obj.TableParts = append(obj.TableParts, yamlTablePart{


### PR DESCRIPTION
## Проблема

Импортированный из 1С **документ приезжал вообще без «Номера», «Даты», блока `numerator:` и признака `posting`**: `WriteDocuments` звал `convertFields` напрямую, минуя стандартные реквизиты, которые справочник получал.

Из-за этого жалоба **«отсутствие в документах НОМЕРА» из #658 относилась к конвертеру, а не к движку** — автонумерацию документов платформа умеет и делает атомарно.

Свойства кода и номера парсер не читал **вовсе**: в `CatalogMeta`/`DocumentMeta` не было соответствующих полей, а xml-структуры их не объявляли. Терялись молча `Hierarchical`, `CodeLength`, `CodeType`, `CheckUnique`, `Autonumbering`, `NumberType`, `NumberLength`, `NumberPeriodicity`, `Posting` — в отчёте конвертации об этом не было ни строки.

## Исправление

- Документ получает **«Номер» и «Дату» первыми**, как в 1С, и не дублирует их, если пользователь объявил такой реквизит сам.
- Автонумерация переносится в `numerator:` с длиной и периодом (`Year`/`Month`/`Day` → `year`/`month`/`day`, `Nonperiodical` → `none`). **Без автонумерации блок не пишется** — навязывать нумерацию там, где её в 1С не было, конвертер не вправе.
- Признак проведения → `posting`.
- Иерархия справочника → `hierarchical`.

**Автонумерация кода справочника и контроль уникальности намеренно НЕ переносятся.** Блок `numerator:` у справочника платформа сегодня разбирает и не исполняет (план 117, Д2). Записать его значило бы отдать конфигурацию, которая выглядит рабочей и молчит, — ровно тот дефект, который план и разбирает. Вместо этого оба свойства попадают в отчёт отдельными предупреждениями:

```
⚠  справочник Контрагенты: автонумерация кода не перенесена — платформа пока нумерует только документы (план 117)
⚠  справочник Контрагенты: контроль уникальности кода не перенесён — задайте indexes: [{fields: [Код], unique: true}] вручную
```

Числовой номер (`NumberType: Number`) переносится строковым — с предупреждением, потому что платформа нумерует строками.

## Проверено сквозным прогоном

`onebase convert` на выгрузке с этими свойствами:

```yaml
name: РеализацияТоваров        name: Контрагенты
posting: true                  hierarchical: true
numerator:                     fields:
  length: 11                     - name: Код
  period: year                   - name: Наименование
fields:                          - name: ИНН
  - name: Номер
  - name: Дата
  - name: Контрагент
```

Результат конвертации проходит `onebase check` — `OK: ошибок не найдено`.

## Тесты

| тест | что ловит | без фикса |
|---|---|---|
| `TestParse_ЧитаетСвойстваКодаИНомера` | парсер читает иерархию, длину, тип, уникальность, периодичность, проведение | поля отсутствуют в структурах |
| `TestWriteDocuments_ДобавляетСтандартныеРеквизитыИНумератор` | «Номер», «Дата», `posting`, `numerator` с длиной и периодом; стандартные идут первыми | шесть строк `в YAML документа нет …` |
| `TestWriteDocuments_БезАвтонумерацииНетБлока` | блок не навязывается | — |
| `TestWriteDocuments_НеДублируетСуществующие` | объявленный пользователем «Номер» не задваивается | — |
| `TestWriteCatalogs_ИерархияИОтчётПоКоду` | иерархия перенесена, `numerator:` у справочника **не** записан, предупреждения в отчёте | — |

## Проверки

`go build ./...`, `CGO_ENABLED=0 GOOS=windows go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt -l`, линт всех `examples/*` и `templates/*` — чисто.

Относится к #658 (план 117, этап A). Первая половина этапа — представление объекта по имени реквизита — в PR #691.

Generated-with: Claude Code
