### PR TITLE
fix(dsl): присваивание константы сохраняется в базу, а не только в память

### DIFF
--- a/internal/dsl/interpreter/constants_proxy.go
+++ b/internal/dsl/interpreter/constants_proxy.go
@@ -1,0 +1,104 @@
+package interpreter
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// ConstantsDB — то, что нужно объекту Константы от хранилища.
+type ConstantsDB interface {
+	SetConstant(ctx context.Context, name string, value any) error
+}
+
+// ConstantsRoot — объект `Константы` в DSL.
+//
+// Прежде это была обычная карта-снимок (MapThis поверх ListConstants), поэтому
+// присваивание `Константы.Имя = Значение` меняло значение ТОЛЬКО в памяти
+// текущего процесса: код отрабатывал без ошибки, следующее чтение в том же
+// прогоне возвращало новое значение — и всё, в базу не уходило ничего. Ровно на
+// этом молча не работало аварийное отключение интеграции по 401: обработка
+// «выключить» отчитывалась об успехе, а после перезапуска константа снова была
+// включена (#719).
+//
+// Чтение по-прежнему идёт из снимка, снятого на старте прогона: константы
+// читают часто, и лишний запрос на каждое обращение того не стоит. Запись
+// уходит в базу сразу и обновляет снимок, поэтому в пределах прогона Get после
+// Set видит записанное.
+type ConstantsRoot struct {
+	ctx   context.Context
+	db    ConstantsDB
+	names map[string]string // нижний регистр → объявленное имя
+	cache map[string]any    // объявленное имя → значение
+}
+
+// NewConstantsRoot собирает объект Константы. declared — имена из конфигурации,
+// values — снимок значений из базы.
+func NewConstantsRoot(ctx context.Context, db ConstantsDB, declared []string, values map[string]any) *ConstantsRoot {
+	r := &ConstantsRoot{
+		ctx:   ctx,
+		db:    db,
+		names: make(map[string]string, len(declared)),
+		cache: make(map[string]any, len(values)),
+	}
+	for _, n := range declared {
+		if n == "" {
+			continue
+		}
+		r.names[strings.ToLower(n)] = n
+	}
+	for k, v := range values {
+		// Значение из базы может лежать под именем, которого в конфигурации уже
+		// нет (константу удалили) — тогда оно доступно на чтение под своим
+		// именем, как и раньше.
+		if _, ok := r.names[strings.ToLower(k)]; !ok {
+			r.names[strings.ToLower(k)] = k
+		}
+		r.cache[r.names[strings.ToLower(k)]] = v
+	}
+	return r
+}
+
+func (r *ConstantsRoot) Get(name string) any {
+	if canon, ok := r.names[strings.ToLower(name)]; ok {
+		return r.cache[canon]
+	}
+	return nil
+}
+
+// Set записывает константу в базу и обновляет снимок.
+//
+// Неизвестное имя — ошибка, а не тихое заведение ключа. Прежде опечатка в имени
+// создавала запись в карте, которая жила до конца прогона и никого ни о чём не
+// оповещала; отличить «выключил не ту константу» от «выключил не существующую»
+// было нельзя ничем.
+func (r *ConstantsRoot) Set(name string, v any) {
+	canon, ok := r.names[strings.ToLower(name)]
+	if !ok {
+		RaiseUserError("Константы: неизвестная константа «" + name + "»" + r.hint())
+		return
+	}
+	if r.db == nil {
+		RaiseUserError("Константы: запись «" + canon + "» невозможна — нет соединения с базой")
+		return
+	}
+	if err := r.db.SetConstant(r.ctx, canon, v); err != nil {
+		RaiseUserError("Константы: запись «" + canon + "»: " + err.Error())
+		return
+	}
+	r.cache[canon] = v
+}
+
+// hint перечисляет объявленные константы: имя ошиблись почти всегда в регистре
+// или в раскладке, и список избавляет от похода в конфигурацию.
+func (r *ConstantsRoot) hint() string {
+	if len(r.names) == 0 {
+		return "; в конфигурации не объявлено ни одной константы"
+	}
+	out := make([]string, 0, len(r.names))
+	for _, canon := range r.names {
+		out = append(out, canon)
+	}
+	sort.Strings(out)
+	return "; известны: " + strings.Join(out, ", ")
+}

--- a/internal/dslvars/constants_write_test.go
+++ b/internal/dslvars/constants_write_test.go
@@ -1,0 +1,121 @@
+package dslvars
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/dsl/lexer"
+	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Присваивание константы обязано доезжать до базы.
+//
+// Объект `Константы` был обычной картой-снимком, поэтому
+// `Константы.Имя = Значение` меняло значение только в памяти прогона: код
+// отрабатывал без ошибки, чтение сразу после записи возвращало новое значение —
+// и всё. Следующий запуск снова видел старое. Ровно на этом молча не работало
+// аварийное отключение интеграции: обработка отчитывалась об успехе, а
+// константа оставалась включённой (#719).
+//
+// Проверяем через ту же сборку переменных, которой пользуются UI и планировщик
+// (Common.Build), и читаем результат ЗАНОВО из хранилища — не из снимка.
+
+func constantsFixture(t *testing.T) (*storage.DB, *runtime.Registry, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "consts.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	consts := []*metadata.Constant{{Name: "LLMEnabled", Type: metadata.FieldTypeBool}}
+	if err := db.MigrateConstants(ctx, consts); err != nil {
+		t.Fatal(err)
+	}
+	reg := runtime.NewRegistry()
+	reg.Load(runtime.LoadOptions{Constants: consts})
+	return db, reg, ctx
+}
+
+func runConstantsProc(t *testing.T, db *storage.DB, reg *runtime.Registry, ctx context.Context, src string) error {
+	t.Helper()
+	prog, err := parser.New(lexer.New(src, "t.os")).ParseProgram()
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	in := interpreter.New()
+	vars := Common{Ctx: ctx, Reg: reg, Store: db}.Build()
+	obj := runtime.NewObject("T", metadata.KindCatalog)
+	return in.Run(prog.Procedures[0], obj, vars)
+}
+
+func TestКонстанты_ПрисваиваниеДоезжаетДоБазы(t *testing.T) {
+	db, reg, ctx := constantsFixture(t)
+
+	if err := runConstantsProc(t, db, reg, ctx, `Процедура Тест()
+		Константы.LLMEnabled = Истина;
+	КонецПроцедуры`); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	// Читаем заново из хранилища: снимок прогона тут ничего не доказывает.
+	got, err := db.GetConstant(ctx, "LLMEnabled")
+	if err != nil {
+		t.Fatalf("GetConstant: %v", err)
+	}
+	if got != true {
+		t.Fatalf("в базе %#v, ждали true: присваивание не сохранилось", got)
+	}
+}
+
+// Чтение сразу после записи в том же прогоне обязано видеть записанное — иначе
+// сквозная запись сломала бы привычное поведение снимка.
+func TestКонстанты_ЧтениеПослеЗаписиВТомЖеПрогоне(t *testing.T) {
+	db, reg, ctx := constantsFixture(t)
+
+	prog, err := parser.New(lexer.New(`Функция Тест()
+		Константы.LLMEnabled = Истина;
+		Возврат Константы.LLMEnabled;
+	КонецФункции`, "t.os")).ParseProgram()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := interpreter.New()
+	var res any
+	if err := in.RunWithResult(prog.Procedures[0], runtime.NewObject("T", metadata.KindCatalog),
+		&res, Common{Ctx: ctx, Reg: reg, Store: db}.Build()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res != true {
+		t.Fatalf("после записи прочитано %#v, ждали true", res)
+	}
+}
+
+// Опечатка в имени — ошибка, а не тихое заведение ключа в памяти: отличить
+// «выключил не ту константу» от «выключил несуществующую» иначе нечем.
+func TestКонстанты_НеизвестноеИмяЭтоОшибка(t *testing.T) {
+	db, reg, ctx := constantsFixture(t)
+
+	err := runConstantsProc(t, db, reg, ctx, `Процедура Тест()
+		Константы.LLMEnabledd = Истина;
+	КонецПроцедуры`)
+	if err == nil {
+		t.Fatal("опечатка в имени константы прошла молча")
+	}
+	// Интерпретатор приводит имя поля к нижнему регистру ещё до Set
+	// (interpreter.assign), поэтому исходного написания у прокси уже нет —
+	// сравниваем без учёта регистра.
+	if !strings.Contains(strings.ToLower(err.Error()), "llmenabledd") {
+		t.Errorf("в ошибке нет имени константы: %v", err)
+	}
+	if !strings.Contains(err.Error(), "LLMEnabled") {
+		t.Errorf("в ошибке нет подсказки с известными именами: %v", err)
+	}
+}

--- a/internal/dslvars/dslvars.go
+++ b/internal/dslvars/dslvars.go
@@ -73,13 +73,22 @@ func (c Common) Build() map[string]any {
 	if vals, err := c.Store.ListConstants(c.Ctx); err == nil {
 		constsMap = vals
 	}
+	declaredConsts := make([]string, 0)
+	for _, k := range c.Reg.Constants() {
+		if k != nil {
+			declaredConsts = append(declaredConsts, k.Name)
+		}
+	}
 	queryFactory := interpreter.NewQueryFactory(c.Ctx, c.Store, c.Reg)
 	predefined := interpreter.NewPredefinedRoot(c.Ctx, c.Store)
 
 	vars := map[string]any{
-		"Движения":                 c.Movements,
-		"Перечисления":             &interpreter.MapThis{M: enumsMap},
-		"Константы":                &interpreter.MapThis{M: constsMap},
+		"Движения":     c.Movements,
+		"Перечисления": &interpreter.MapThis{M: enumsMap},
+		// Не MapThis: тот писал бы присвоенное значение только в память
+		// процесса, и `Константы.Имя = Значение` молча не доезжало до базы
+		// (#719). ConstantsRoot пишет сквозь.
+		"Константы":                interpreter.NewConstantsRoot(c.Ctx, c.Store, declaredConsts, constsMap),
 		"__factory_Запрос":         queryFactory,
 		"__factory_Query":          queryFactory,
 		"ПредопределённыеЗначения": predefined,


### PR DESCRIPTION
## Дефект

Объект `Константы` собирался как обычная карта-снимок:

```go
"Константы": &interpreter.MapThis{M: constsMap},   // constsMap = ListConstants(...)
```

`MapThis.Set` пишет в карту — и только в неё. Поэтому `Константы.Имя = Значение`:

- не возвращает ошибку;
- меняет значение так, что чтение **в том же прогоне** его видит;
- в базу не пишет ничего.

Пользователь получает полное впечатление успешной записи. Следующий запуск снова видит старое значение.

Из issue: на этом молча не работало аварийное отключение интеграции по 401 — обработка «выключить» отчитывалась об успехе, а после перезапуска константа опять была включена.

## Правка

`Константы` теперь `ConstantsRoot`:

| | было | стало |
|---|---|---|
| чтение | из снимка прогона | из снимка прогона (без изменений) |
| запись | в карту в памяти | `SetConstant` в базу + обновление снимка |
| запись в неизвестное имя | заводит ключ в памяти | ошибка со списком объявленных имён |

Чтение оставлено на снимке сознательно: константы читают часто, и запрос на каждое обращение того не стоит. Снимок обновляется при записи, поэтому привычное «прочитал сразу после записи — вижу новое» работает по-прежнему (отдельный тест).

Сборка объекта одна на всю платформу (`dslvars.Common.Build`, её зовут и UI, и планировщик), так что второй забытой точки здесь нет — проверил grep'ом по репозиторию.

## Про изменение поведения на неизвестном имени

Раньше `Константы.Опечатка = Истина` тихо заводила ключ в карте, живший до конца прогона. Теперь это ошибка со списком известных констант.

Формально это ужесточение, и его стоит назвать прямо. Но опереться на прежнее поведение нельзя было ни в чём: значение никуда не сохранялось и не переживало прогон. Зато отличить «выключил не ту константу» от «выключил несуществующую» было нечем — обе выглядели одинаково успешно, и это ровно то, чем дефект и опасен.

## Проверка

`internal/dslvars/constants_write_test.go` — через ту же сборку переменных, которой пользуются UI и планировщик, а результат читается **заново** из хранилища (`GetConstant`), не из снимка: снимок здесь ничего не доказывал бы.

Контрольный прогон с возвращённым `MapThis`:

```
--- FAIL: TestКонстанты_ПрисваиваниеДоезжаетДоБазы
    GetConstant: sql: no rows in result set
--- FAIL: TestКонстанты_НеизвестноеИмяЭтоОшибка
    опечатка в имени константы прошла молча
```

Гейты локально: `gofmt`, `go vet ./...`, `go build ./...`, кросс-сборка Windows, `golangci-lint` (0 issues), `go test ./...`.

Closes #719