### PR TITLE
fix(metadata): починить ID синтезированного «Кода» + команда onebase renumber

### DIFF
--- a/internal/cli/renumber.go
+++ b/internal/cli/renumber.go
@@ -130,7 +130,7 @@ func renumberTargets(proj *project.Project, only string) ([]*metadata.Entity, er
 		out = append(out, ent)
 	}
 	if only != "" && len(out) == 0 {
-		return nil, fmt.Errorf("объект %q не найден или у него не объявлен numerator:", only)
+		return nil, fmt.Errorf("объект %q не найден или у него не объявлен нумератор", only)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil

--- a/internal/cli/renumber.go
+++ b/internal/cli/renumber.go
@@ -1,0 +1,234 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/project"
+	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/spf13/cobra"
+)
+
+// onebase renumber — дозаполнение пустых кодов и номеров (план 117C).
+//
+// Когда нумератор включают на живой базе, старые элементы остаются без кода:
+// автоматически проставлять его при правке YAML нельзя — правка конфигурации не
+// должна незаметно переписывать данные, а на большом справочнике это ещё и
+// долгая операция. Отсюда отдельная команда: администратор решает сам и видит
+// объём заранее.
+//
+// По умолчанию команда НИЧЕГО не пишет — печатает, что сделала бы. Запись
+// включается флагом --write, как у refactor.
+
+var renumberCmd = &cobra.Command{
+	Use:   "renumber",
+	Short: "Дозаполнить пустые коды справочников и номера документов",
+	Long: `Проставляет код (справочник) или номер (документ) тем записям, у которых он пуст.
+
+Заполненные значения не трогаются никогда: команда дозаполняет, а не
+перенумеровывает. Порядок выдачи детерминирован (по идентификатору записи),
+чтобы повторный запуск дал тот же результат.
+
+По умолчанию ничего не пишет — показывает объём и примеры. Запись включается
+флагом --write.
+
+Примеры:
+  onebase renumber --project . --sqlite base.db
+  onebase renumber --project . --sqlite base.db --object Контрагенты --write`,
+	RunE:          runRenumber,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	// addBaseFlags уже даёт --project/--sqlite/--db/--id.
+	addBaseFlags(renumberCmd)
+	renumberCmd.Flags().String("object", "", "имя объекта; без флага — все с объявленным нумератором")
+	renumberCmd.Flags().Bool("write", false, "выполнить запись (без флага только показ)")
+	renumberCmd.Flags().Bool("json", false, "машинный отчёт")
+	rootCmd.AddCommand(renumberCmd)
+}
+
+// renumberEntityReport — итог по одному объекту.
+type renumberEntityReport struct {
+	Object  string   `json:"object"`
+	Field   string   `json:"field"`
+	Empty   int      `json:"empty"`
+	Filled  int      `json:"filled"`
+	Samples []string `json:"samples,omitempty"`
+}
+
+func runRenumber(cmd *cobra.Command, _ []string) error {
+	ctx := context.Background()
+	dir, _ := cmd.Flags().GetString("project")
+	sqlitePath, _ := cmd.Flags().GetString("sqlite")
+	only, _ := cmd.Flags().GetString("object")
+	write, _ := cmd.Flags().GetBool("write")
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		return err
+	}
+	defer proj.Close()
+
+	var db *storage.DB
+	if sqlitePath != "" {
+		db, err = openCLIStorage(ctx, "sqlite", sqlitePath, "")
+	} else {
+		db, err = openCLIStorage(ctx, "postgres", "", dsnFromFlags(cmd))
+	}
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if err := db.EnsureNumeratorSchema(ctx); err != nil {
+		return err
+	}
+
+	targets, err := renumberTargets(proj, only)
+	if err != nil {
+		return err
+	}
+
+	reports := make([]renumberEntityReport, 0, len(targets))
+	for _, ent := range targets {
+		rep, err := renumberEntity(ctx, db, ent, write)
+		if err != nil {
+			return fmt.Errorf("%s: %w", ent.Name, err)
+		}
+		reports = append(reports, rep)
+	}
+
+	if asJSON {
+		out, err := json.MarshalIndent(map[string]any{"write": write, "objects": reports}, "", "  ")
+		if err != nil {
+			return err
+		}
+		outf("%s\n", out)
+		return nil
+	}
+	printRenumberReport(reports, write)
+	return nil
+}
+
+// renumberTargets отбирает объекты с объявленным нумератором.
+func renumberTargets(proj *project.Project, only string) ([]*metadata.Entity, error) {
+	var out []*metadata.Entity
+	for _, ent := range proj.Entities {
+		if storage.AutoNumberField(ent) == "" || ent.Numerator == nil {
+			continue
+		}
+		if only != "" && !strings.EqualFold(ent.Name, only) {
+			continue
+		}
+		out = append(out, ent)
+	}
+	if only != "" && len(out) == 0 {
+		return nil, fmt.Errorf("объект %q не найден или у него не объявлен numerator:", only)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// renumberEntity дозаполняет пустые значения одного объекта.
+func renumberEntity(ctx context.Context, db *storage.DB, ent *metadata.Entity, write bool) (renumberEntityReport, error) {
+	field := storage.AutoNumberField(ent)
+	rep := renumberEntityReport{Object: ent.Name, Field: field}
+
+	rows, err := db.List(ctx, ent.Name, ent, storage.ListParams{Limit: storage.MaxListPageSize})
+	if err != nil {
+		return rep, err
+	}
+	// Порядок выдачи детерминирован: сортируем по идентификатору записи, а не
+	// полагаемся на порядок выборки. Иначе повторный запуск на другой машине
+	// раздал бы те же коды другим элементам.
+	sort.Slice(rows, func(i, j int) bool {
+		return fmt.Sprintf("%v", rows[i]["id"]) < fmt.Sprintf("%v", rows[j]["id"])
+	})
+
+	for _, row := range rows {
+		if !isBlankValue(rowFieldValue(row, field)) {
+			continue // заполненное не трогаем: дозаполнение, а не перенумерация
+		}
+		rep.Empty++
+		if !write {
+			if len(rep.Samples) < 3 {
+				rep.Samples = append(rep.Samples, fmt.Sprintf("%v", row["id"]))
+			}
+			continue
+		}
+		value, err := db.GenerateNumber(ctx, ent, row)
+		if err != nil {
+			return rep, err
+		}
+		if value == "" {
+			continue
+		}
+		id, err := uuid.Parse(fmt.Sprintf("%v", row["id"]))
+		if err != nil {
+			return rep, fmt.Errorf("неразбираемый идентификатор %v: %w", row["id"], err)
+		}
+		if err := db.SetAutoNumberValue(ctx, ent, id, field, value); err != nil {
+			return rep, err
+		}
+		rep.Filled++
+		if len(rep.Samples) < 3 {
+			rep.Samples = append(rep.Samples, value)
+		}
+	}
+	return rep, nil
+}
+
+// isBlankValue — пусто ли значение колонки. Отдельная функция потому, что
+// fmt.Sprintf("%v", nil) даёт "<nil>", и наивная проверка на пустую строку
+// считала незаполненный код заполненным: команда молча ничего не делала.
+func isBlankValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	return strings.TrimSpace(fmt.Sprintf("%v", v)) == ""
+}
+
+func rowFieldValue(row map[string]any, field string) any {
+	if v, ok := row[field]; ok {
+		return v
+	}
+	low := strings.ToLower(field)
+	for k, v := range row {
+		if strings.ToLower(k) == low {
+			return v
+		}
+	}
+	return nil
+}
+
+func printRenumberReport(reports []renumberEntityReport, write bool) {
+	if len(reports) == 0 {
+		outf("Объектов с объявленным numerator: не найдено.\n")
+		return
+	}
+	total := 0
+	for _, r := range reports {
+		if write {
+			outf("%s.%s: заполнено %d\n", r.Object, r.Field, r.Filled)
+			total += r.Filled
+		} else {
+			outf("%s.%s: без значения %d\n", r.Object, r.Field, r.Empty)
+			total += r.Empty
+		}
+		if len(r.Samples) > 0 {
+			outf("  примеры: %s\n", strings.Join(r.Samples, ", "))
+		}
+	}
+	if write {
+		outf("\nИтого заполнено: %d\n", total)
+		return
+	}
+	outf("\nИтого без значения: %d. Ничего не изменено — повторите с --write.\n", total)
+}

--- a/internal/cli/renumber_test.go
+++ b/internal/cli/renumber_test.go
@@ -1,0 +1,229 @@
+package cli
+
+// onebase renumber — дозаполнение пустых кодов и номеров (план 117C).
+//
+// Команда нужна потому, что при включении нумератора на живой базе старые
+// элементы остаются без кода: автоматически проставлять его при правке YAML
+// нельзя — правка конфигурации не должна незаметно переписывать данные.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/project"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func renumberCatalog() *metadata.Entity {
+	return &metadata.Entity{
+		Name: "Контрагенты",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: metadata.StandardCodeField, Type: metadata.FieldTypeString},
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+		},
+		Numerator: &metadata.Numerator{Prefix: "К-", Length: 6, Period: "none"},
+	}
+}
+
+func renumberDB(t *testing.T, ent *metadata.Entity, rows []map[string]any) *storage.DB {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "renumber.db"))
+	if err != nil {
+		t.Fatalf("ConnectSQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+	if err := db.Migrate(ctx, []*metadata.Entity{ent}); err != nil {
+		t.Fatalf("миграция: %v", err)
+	}
+	if err := db.EnsureNumeratorSchema(ctx); err != nil {
+		t.Fatalf("схема нумератора: %v", err)
+	}
+	for _, r := range rows {
+		if err := db.Upsert(ctx, ent.Name, uuid.New(), r, ent); err != nil {
+			t.Fatalf("вставка %v: %v", r, err)
+		}
+	}
+	return db
+}
+
+func codesOf(t *testing.T, db *storage.DB, ent *metadata.Entity) map[string]string {
+	t.Helper()
+	rows, err := db.List(context.Background(), ent.Name, ent, storage.ListParams{Limit: 100})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	out := map[string]string{}
+	for _, r := range rows {
+		name := strings.TrimSpace(asAnyString(rowFieldValue(r, "Наименование")))
+		out[name] = strings.TrimSpace(asAnyString(rowFieldValue(r, metadata.StandardCodeField)))
+	}
+	return out
+}
+
+func asAnyString(v any) string {
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// Без --write команда ничего не пишет: администратор сначала видит объём.
+func TestRenumber_DryRunWritesNothing(t *testing.T) {
+	ent := renumberCatalog()
+	db := renumberDB(t, ent, []map[string]any{
+		{"Наименование": "Альфа"},
+		{"Наименование": "Бета"},
+	})
+
+	rep, err := renumberEntity(context.Background(), db, ent, false)
+	if err != nil {
+		t.Fatalf("renumberEntity: %v", err)
+	}
+	if rep.Empty != 2 || rep.Filled != 0 {
+		t.Errorf("отчёт = %+v, ожидалось empty=2 filled=0", rep)
+	}
+	for name, code := range codesOf(t, db, ent) {
+		if code != "" {
+			t.Errorf("%s получил код %q без --write", name, code)
+		}
+	}
+}
+
+// С --write заполняются только пустые: команда дозаполняет, а не
+// перенумеровывает — иначе она переписала бы коды, на которые уже ссылаются
+// документы и внешние системы.
+func TestRenumber_FillsOnlyEmpty(t *testing.T) {
+	ent := renumberCatalog()
+	db := renumberDB(t, ent, []map[string]any{
+		{"Наименование": "Альфа", metadata.StandardCodeField: "СТАРЫЙ-1"},
+		{"Наименование": "Бета"},
+		{"Наименование": "Гамма"},
+	})
+
+	rep, err := renumberEntity(context.Background(), db, ent, true)
+	if err != nil {
+		t.Fatalf("renumberEntity: %v", err)
+	}
+	if rep.Filled != 2 {
+		t.Errorf("заполнено %d, ожидалось 2", rep.Filled)
+	}
+	codes := codesOf(t, db, ent)
+	if codes["Альфа"] != "СТАРЫЙ-1" {
+		t.Errorf("существующий код переписан: %q", codes["Альфа"])
+	}
+	for _, name := range []string{"Бета", "Гамма"} {
+		if !strings.HasPrefix(codes[name], "К-") {
+			t.Errorf("%s не получил код: %q", name, codes[name])
+		}
+	}
+	if codes["Бета"] == codes["Гамма"] {
+		t.Errorf("выдан одинаковый код обеим записям: %q", codes["Бета"])
+	}
+}
+
+// Повторный запуск ничего не делает: заполнять больше нечего.
+func TestRenumber_Idempotent(t *testing.T) {
+	ent := renumberCatalog()
+	db := renumberDB(t, ent, []map[string]any{{"Наименование": "Альфа"}})
+
+	if _, err := renumberEntity(context.Background(), db, ent, true); err != nil {
+		t.Fatalf("первый прогон: %v", err)
+	}
+	before := codesOf(t, db, ent)["Альфа"]
+
+	rep, err := renumberEntity(context.Background(), db, ent, true)
+	if err != nil {
+		t.Fatalf("второй прогон: %v", err)
+	}
+	if rep.Filled != 0 || rep.Empty != 0 {
+		t.Errorf("повторный прогон что-то нашёл: %+v", rep)
+	}
+	if after := codesOf(t, db, ent)["Альфа"]; after != before {
+		t.Errorf("код изменился при повторном прогоне: %q → %q", before, after)
+	}
+}
+
+// Объект без numerator: в цели не попадает — раздача кодов всем справочникам
+// молча изменила бы данные существующих конфигураций.
+func TestRenumberTargets_SkipsWithoutNumerator(t *testing.T) {
+	withNum := renumberCatalog()
+	plain := &metadata.Entity{
+		Name: "Склады", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	proj := &project.Project{Entities: []*metadata.Entity{withNum, plain}}
+
+	targets, err := renumberTargets(proj, "")
+	if err != nil {
+		t.Fatalf("renumberTargets: %v", err)
+	}
+	if len(targets) != 1 || targets[0].Name != "Контрагенты" {
+		t.Fatalf("цели = %v, ожидались только Контрагенты", names(targets))
+	}
+
+	if _, err := renumberTargets(proj, "Склады"); err == nil {
+		t.Error("объект без numerator: принят как цель")
+	}
+}
+
+func names(ents []*metadata.Entity) []string {
+	out := make([]string, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+// Полный путь команды: проект на диске + база; без --write ничего не меняется.
+func TestRunRenumber_EndToEndDryRun(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "catalogs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "name: Контрагенты\nnumerator: {prefix: \"К-\", length: 6}\nfields:\n  - {name: Наименование, type: string}\n"
+	if err := os.WriteFile(filepath.Join(dir, "catalogs", "контрагенты.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ent := renumberCatalog()
+	dbPath := filepath.Join(t.TempDir(), "e2e.db")
+	ctx := context.Background()
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrate(ctx, []*metadata.Entity{ent}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Upsert(ctx, ent.Name, uuid.New(), map[string]any{"Наименование": "Альфа"}, ent); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	cmd := renumberCmd
+	if err := cmd.Flags().Set("project", dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("sqlite", dbPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := runRenumber(cmd, nil); err != nil {
+		t.Fatalf("runRenumber: %v", err)
+	}
+
+	db2, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(db2.Close)
+	if code := codesOf(t, db2, ent)["Альфа"]; code != "" {
+		t.Errorf("без --write код проставлен: %q", code)
+	}
+}

--- a/internal/metadata/catalog_code_test.go
+++ b/internal/metadata/catalog_code_test.go
@@ -171,3 +171,18 @@ func TestValidateNumerator(t *testing.T) {
 		})
 	}
 }
+
+// Регрессия: идентификатор синтезированного «Кода» обязан проходить валидацию
+// ID. С точкой («std.code») ЛЮБОЙ справочник с numerator: переставал грузиться —
+// project.Load падал ещё до всякой работы. Поймано тестом команды renumber,
+// закреплено здесь.
+func TestCatalogCode_IDPassesValidation(t *testing.T) {
+	e := writeCatalog(t, `name: Контрагенты
+numerator: {prefix: "К-", length: 6}
+fields:
+  - {name: Наименование, type: string}
+`)
+	if err := Validate([]*Entity{e}, nil); err != nil {
+		t.Fatalf("справочник с numerator: не проходит валидацию: %v", err)
+	}
+}

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -187,7 +187,7 @@ func (n *Numerator) PeriodOrDefault(kind Kind) string {
 // колонку и завести новую пустую».
 const (
 	StandardCodeField   = "Код"
-	StandardCodeFieldID = "std.code"
+	StandardCodeFieldID = "std_code"
 )
 
 // PredefinedItem describes a catalog record that is always present in the DB

--- a/internal/storage/numbering.go
+++ b/internal/storage/numbering.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"context"
 	"fmt"
+
+	"github.com/google/uuid"
 	"strings"
 	"time"
 
@@ -151,4 +153,33 @@ func formatScopeValue(v any) string {
 		return t.Format(time.RFC3339)
 	}
 	return strings.TrimSpace(fmt.Sprintf("%v", v))
+}
+
+// SetAutoNumberValue проставляет значение автонумерации ОДНОЙ колонке.
+//
+// Узкая функция намеренно: дозаполнение кода не должно идти через Upsert,
+// который пишет запись целиком — не перечисленные в карте реквизиты он обнулил
+// бы, а ссылки в прочитанной строке приходят представлением, а не UUID. Здесь
+// меняется ровно один столбец, остальные данные не участвуют.
+//
+// Значение проставляется только если оно ещё пусто: условие в SQL, а не в Go,
+// поэтому параллельная запись не перетирается.
+func (db *DB) SetAutoNumberValue(ctx context.Context, entity *metadata.Entity, id uuid.UUID, field, value string) error {
+	if entity == nil || field == "" {
+		return nil
+	}
+	var col string
+	for _, f := range entity.Fields {
+		if strings.EqualFold(f.Name, field) {
+			col = metadata.ColumnName(f)
+			break
+		}
+	}
+	if col == "" {
+		return fmt.Errorf("%s: нет реквизита %s", entity.Name, field)
+	}
+	d := db.dialect
+	q := fmt.Sprintf("UPDATE %s SET %s = %s WHERE id = %s AND (%s IS NULL OR %s = '')",
+		metadata.TableName(entity.Name), col, d.Placeholder(1), d.Placeholder(2), col, col)
+	return db.exec(ctx, q, value, id)
 }


### PR DESCRIPTION
## Срочное: справочники с `numerator:` не грузятся

Идентификатор синтезированного «Кода» был `std.code`, а валидатор ID точку не принимает. Поэтому **любой** справочник с блоком `numerator:` переставал загружаться — `project.Load` падал ещё до всякой работы:

```
entity Контрагенты: поле Код: id "std.code" — допустимы латиница, цифры и подчёркивание, первый знак не цифра
```

Дефект уехал в `main` с 117B (#770). Исправлено на `std_code`; проверено на настоящем проекте — `onebase check` снова отвечает «ошибок не найдено».

Отдельно отмечу, **как** он нашёлся: его поймал end-to-end прогон новой команды. Юнит-тест на синтез поля был зелёным, потому что проверял состав реквизитов и не звал валидацию. Ровно тот случай, ради которого в проекте требуют тесты через публичную точку входа, — я это правило соблюдал в остальных местах, а здесь понадеялся на юнит.

## `onebase renumber`

Команду мы пообещали в 117B, когда решили не проставлять коды существующим элементам автоматически: правка YAML не должна незаметно переписывать данные, а на большом справочнике это ещё и долгая операция.

```
onebase renumber --project . --sqlite base.db                     # только показ
onebase renumber --project . --sqlite base.db --object Контрагенты --write
```

- **По умолчанию ничего не пишет** — показывает объём и примеры; запись включает `--write`, как у `refactor`.
- **Заполняет только пустые.** Команда дозаполняет, а не перенумеровывает: иначе она переписала бы коды, на которые уже ссылаются документы и внешние системы.
- Порядок детерминирован, повторный запуск идемпотентен.
- Объекты без `numerator:` в цели не попадают.

`storage.SetAutoNumberValue` меняет ровно **одну** колонку. Через `Upsert` было бы опасно: он пишет запись целиком и обнулил бы неперечисленные реквизиты, а ссылки в прочитанной строке приходят представлением, а не UUID. Условие «только если пусто» стоит в SQL, поэтому параллельная запись не перетирается.

## Второй дефект, найденный тестами

Пустой код считался заполненным: `fmt.Sprintf("%v", nil)` даёт `"<nil>"`, что непусто. Команда молча не делала бы ничего — то есть я чуть не выпустил ровно тот класс дефекта, который мы весь день чиним. Вынес проверку в отдельную функцию с объяснением.

## Проверка

`go test ./...` — зелёный на SQLite и PostgreSQL, `i18ncheck` — OK.

Шесть тестов: dry-run ничего не пишет; `--write` заполняет только пустые и не трогает существующий код; идемпотентность; отбор целей; end-to-end через `runRenumber` с проектом на диске; регрессия на валидность ID синтезированного «Кода».