### PR TITLE
fix(entityservice): проверять ссылки при удалении на всех путях (#774)

### DIFF
--- a/internal/api/delete_checkrefs_test.go
+++ b/internal/api/delete_checkrefs_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// DATA-01 / issue #774: удаление через публичный REST-путь не должно оставлять
+// висячие ссылки. Раньше CheckRefs звал только UI-обработчик, а DELETE по REST
+// v1 удалял объект, на который ссылается табличная часть другого документа (FK
+// для полей ТЧ не создаётся), — строка ТЧ оставалась указывать в никуда.
+// Предохранитель теперь живёт внутри entityservice.Delete, поэтому REST обязан
+// вернуть 409 и сохранить объект. Проверяем через реальный обработчик маршрута.
+func TestAPI_Delete_BlockedByTablePartReference(t *testing.T) {
+	client := &metadata.Entity{
+		Name:   "Контрагент",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+	order := &metadata.Entity{
+		Name:   "Заказ",
+		Kind:   metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+		TableParts: []metadata.TablePart{
+			{Name: "Строки", Fields: []metadata.Field{
+				{Name: "Контрагент", Type: metadata.FieldType("reference:Контрагент"), RefEntity: client.Name},
+			}},
+		},
+	}
+	h, ctx := newAPITestHandler(t, []*metadata.Entity{client, order}, nil)
+
+	clientID := uuid.New()
+	if err := h.store.Upsert(ctx, "Контрагент", clientID, map[string]any{"Наименование": "ООО Ромашка"}, client); err != nil {
+		t.Fatal(err)
+	}
+
+	// Заказ со строкой ТЧ, ссылающейся на контрагента.
+	body := []byte(`{"Номер":"1","__tableparts":{"Строки":[{"Контрагент":"` + clientID.String() + `"}]}}`)
+	cr := reqWithEntity("POST", "/documents/Заказ", body, map[string]string{"entity": "Заказ"}, nil)
+	cw := httptest.NewRecorder()
+	h.createObject(metadata.KindDocument).ServeHTTP(cw, cr)
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("создание заказа: ожидался 201, получено %d: %s", cw.Code, cw.Body.String())
+	}
+
+	// Удаление ссылаемого контрагента через REST должно быть отклонено.
+	dr := reqWithEntity("DELETE", "/catalogs/Контрагент", nil,
+		map[string]string{"entity": "Контрагент", "id": clientID.String()}, nil)
+	dw := httptest.NewRecorder()
+	h.deleteObject(metadata.KindCatalog).ServeHTTP(dw, dr)
+	if dw.Code != http.StatusConflict {
+		t.Fatalf("удаление ссылаемого контрагента: ожидался 409, получено %d: %s", dw.Code, dw.Body.String())
+	}
+
+	// Контрагент обязан уцелеть — иначе ссылка из ТЧ осиротела.
+	if _, err := h.store.GetByID(ctx, "Контрагент", clientID, client); err != nil {
+		t.Fatalf("контрагент удалён несмотря на 409 — ссылочная целостность нарушена: %v", err)
+	}
+}

--- a/internal/entityservice/delete_checkrefs_matrix_test.go
+++ b/internal/entityservice/delete_checkrefs_matrix_test.go
@@ -1,0 +1,100 @@
+package entityservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// DATA-01 / issue #774: entityservice.Delete — единая точка удаления для REST
+// v1/v2 и DSL — обязана работать как fail-closed предохранитель ссылочной
+// целостности, когда на объект ссылается ТАБЛИЧНАЯ ЧАСТЬ другого документа.
+// Такие ссылки не покрываются внешним ключом БД (FK создаётся только для полей
+// шапки), поэтому раньше объект удалялся, а строка ТЧ оставалась указывать в
+// никуда. CheckRefs звал лишь UI-путь — удаление тем же объектом через REST/DSL
+// проверку обходило. Матрично: SQLite и PostgreSQL обязаны вести себя одинаково
+// (COUNT-подзапросы CheckRefs диалектозависимы).
+func TestDelete_BlockedByTablePartReference(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+
+		client := &metadata.Entity{
+			Name:   "Контрагент",
+			Kind:   metadata.KindCatalog,
+			Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+		}
+		order := &metadata.Entity{
+			Name:   "Заказ",
+			Kind:   metadata.KindDocument,
+			Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
+			TableParts: []metadata.TablePart{
+				{Name: "Строки", Fields: []metadata.Field{
+					{Name: "Контрагент", Type: metadata.FieldType("reference:Контрагент"), RefEntity: client.Name},
+				}},
+			},
+		}
+		if err := db.Migrate(ctx, []*metadata.Entity{client, order}); err != nil {
+			t.Fatal(err)
+		}
+		registry := runtime.NewRegistry()
+		registry.Load(runtime.LoadOptions{Entities: []*metadata.Entity{client, order}})
+		svc := &Service{Store: db, Reg: registry, Interp: interpreter.New()}
+
+		// Контрагент, на которого сошлётся строка ТЧ документа.
+		clientID := uuid.New()
+		if err := db.Upsert(ctx, "Контрагент", clientID, map[string]any{"Наименование": "ООО Ромашка"}, client); err != nil {
+			t.Fatal(err)
+		}
+		// Заказ с одной строкой ТЧ, ссылающейся на контрагента (через общий путь
+		// записи — так же, как это делают REST/DSL/форма).
+		orderID := uuid.New()
+		if _, err := svc.Save(ctx, SaveRequest{
+			Entity: order,
+			ID:     orderID,
+			IsNew:  true,
+			Fields: map[string]any{"Номер": "1"},
+			TablePartRows: map[string][]map[string]any{
+				"Строки": {{"Контрагент": clientID.String()}},
+			},
+		}); err != nil {
+			t.Fatalf("Save заказа: %v", err)
+		}
+
+		// Удаление ссылаемого контрагента должно быть отклонено как soft-отказ
+		// (объект на месте), а не техническим сбоем.
+		res, err := svc.Delete(ctx, client, clientID)
+		if err != nil {
+			t.Fatalf("Delete вернул технический сбой вместо soft-отказа: %v", err)
+		}
+		if res.DSLError == "" {
+			t.Fatal("DATA-01: удаление контрагента, на которого ссылается ТЧ, НЕ отклонено")
+		}
+		if _, err := db.GetByID(ctx, "Контрагент", clientID, client); err != nil {
+			t.Fatalf("контрагент удалён несмотря на отказ — ссылочная целостность нарушена: %v", err)
+		}
+
+		// Контроль: объект без ссылок удаляется штатно — предохранитель не
+		// блокирует лишнего.
+		freeID := uuid.New()
+		if err := db.Upsert(ctx, "Контрагент", freeID, map[string]any{"Наименование": "ООО Свободный"}, client); err != nil {
+			t.Fatal(err)
+		}
+		res2, err := svc.Delete(ctx, client, freeID)
+		if err != nil {
+			t.Fatalf("Delete без ссылок: %v", err)
+		}
+		if res2.DSLError != "" {
+			t.Fatalf("удаление объекта без ссылок ошибочно отклонено: %s", res2.DSLError)
+		}
+		if _, err := db.GetByID(ctx, "Контрагент", freeID, client); err == nil {
+			t.Fatal("контрагент без ссылок не был удалён")
+		}
+	})
+}

--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -486,11 +486,28 @@ func (s *Service) unpostInTx(
 }
 
 // DeleteResult — результат Service.Delete. Как и у Save, отказ прикладного
-// хука — не технический сбой: DSLError != "" при err == nil.
+// хука — не технический сбой: DSLError != "" при err == nil. Тот же soft-канал
+// несёт и отказ предохранителя ссылочной целостности (см. refsExistError).
 type DeleteResult struct {
 	ID          uuid.UUID
-	DSLError    string   // хук отменил удаление — объект на месте
+	DSLError    string   // удаление отклонено (хук или ссылки) — объект на месте
 	DSLMessages []string // сообщения из builtin Сообщить
+}
+
+// refsExistError — отказ удаления из-за существующих ссылок на объект.
+// Внутренний тип: Service.Delete переводит его в DeleteResult.DSLError, чтобы
+// все транспорты (UI, пачки, REST, DSL) обработали его как soft-отказ, а не как
+// технический сбой.
+type refsExistError struct {
+	refs []storage.RefInfo
+}
+
+func (e *refsExistError) Error() string {
+	parts := make([]string, 0, len(e.refs))
+	for _, r := range e.refs {
+		parts = append(parts, fmt.Sprintf("%s.%s (%d)", r.EntityName, r.FieldName, r.Count))
+	}
+	return "невозможно удалить: на объект ссылаются " + strings.Join(parts, ", ")
 }
 
 // Delete физически удаляет объект, выполняя хуки модуля объекта
@@ -521,6 +538,14 @@ func (s *Service) Delete(ctx context.Context, entity *metadata.Entity, id uuid.U
 			result.DSLError = interpreter.FormatUserError(hookErr.err)
 			return result, nil
 		}
+		var refsErr *refsExistError
+		if errors.As(err, &refsErr) {
+			// Отказ по ссылочной целостности — не сбой, а «удаление отклонено,
+			// объект на месте»: тот же soft-канал, что и отмена хуком, поэтому
+			// REST отдаёт 409, DSL — ошибку Попытки, UI — сообщение.
+			result.DSLError = refsErr.Error()
+			return result, nil
+		}
 		return DeleteResult{}, err
 	}
 	return result, nil
@@ -542,6 +567,23 @@ func (s *Service) deleteInTx(
 	}
 	if err := s.runDeleteHook(txCtx, entity, id, "BeforeDelete", obj, messages, lockCollector); err != nil {
 		return err
+	}
+	// Ссылочная целостность (issue #774): fail-closed предохранитель, общий для
+	// ВСЕХ путей удаления. Раньше CheckRefs звал только UI перед вызовом
+	// entityservice, поэтому удаление того же объекта через REST v1/v2 или DSL
+	// шло мимо проверки и оставляло висячие ссылки — в том числе из табличных
+	// частей и измерений регистров, которые FK на уровне БД не покрывают.
+	// Проверка идёт ВНУТРИ транзакции удаления и ПОСЛЕ хука «ПередУдалением»:
+	// хук может осознанно снять часть ссылок до неё. s.Reg == nil бывает только
+	// в служебных контекстах (migrate/procrun), где перечислить сущности нечем.
+	if s.Reg != nil {
+		refs, err := s.Store.CheckRefs(txCtx, entity.Name, id, s.Reg.Entities())
+		if err != nil {
+			return err
+		}
+		if len(refs) > 0 {
+			return &refsExistError{refs: refs}
+		}
 	}
 	// Движения снимаются до удаления регистратора: иначе остались бы строки,
 	// ссылающиеся на несуществующий документ.


### PR DESCRIPTION
Closes #774

CheckRefs звал только UI-обработчик удаления, поэтому удаление того же
объекта через REST v1/v2 или DSL шло мимо проверки и оставляло висячие
ссылки — в том числе из табличных частей и измерений регистров, которые
внешний ключ БД не покрывает (FK создаётся только для полей шапки). Через
эту дыру DELETE возвращал 204 и физически удалял объект, а строка ТЧ
оставалась указывать в никуда — тихая порча ссылочной целостности (DATA-01).

Предохранитель перенесён внутрь общей entityservice.Delete: fail-closed,
внутри транзакции удаления и после хука «ПередУдалением» (хук может осознанно
снять часть ссылок до проверки). Отказ идёт тем же soft-каналом
(DeleteResult.DSLError), что и отмена хуком, поэтому REST отдаёт 409, DSL —
ошибку Попытки, UI — сообщение, без правок вызывающего кода.

Тесты воспроизводят расхождение на старом коде: матричный
(SQLite+PostgreSQL) через entityservice.Delete и REST-тест через реальный
обработчик маршрута (на старом коде — 204 вместо 409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
