### PR TITLE
fix(cli): зарегистрировать команду device-agent и захолдить её (#794)

### DIFF
--- a/internal/cli/deviceagent.go
+++ b/internal/cli/deviceagent.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/ivantit66/onebase/internal/api"
 	"github.com/ivantit66/onebase/internal/deviceagent"
 	"github.com/ivantit66/onebase/internal/equipment"
 )
@@ -28,11 +31,35 @@ func runDeviceAgent(cmd *cobra.Command, _ []string) error {
 	listen, _ := cmd.Flags().GetString("listen")
 	token, _ := cmd.Flags().GetString("token")
 
+	host, _, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fmt.Errorf("неверный адрес --listen %q: %w", listen, err)
+	}
+	// Пустой host в адресе прослушивания — это все интерфейсы, поэтому он
+	// НЕ считается loopback (в отличие от api.IsLoopbackHost, где "" = дефолт
+	// 127.0.0.1). Наружу агент печатает на кассовое оборудование по открытому
+	// HTTP — bind не на loopback без токена означал бы удалённое управление
+	// кассой кем угодно, поэтому запрещаем.
+	safeLoopback := host != "" && api.IsLoopbackHost(host)
+	if !safeLoopback && token == "" {
+		return fmt.Errorf("bind на не-loopback адрес %q требует --token", listen)
+	}
+
 	fmt.Printf("onebase device-agent слушает %s (драйверы: %v)\n", listen, equipment.Drivers())
 	if token == "" {
 		fmt.Println("ВНИМАНИЕ: токен не задан — команды принимаются без аутентификации")
 	}
 
-	srv := &http.Server{Addr: listen, Handler: deviceagent.New(token).Handler()} //nolint:gosec // G112: таймауты HTTP-сервера выставляются вызывающим, см. настройку сервера
+	// Таймауты выставляем здесь (раньше их не было вовсе, вопреки комментарию):
+	// без ReadHeaderTimeout медленный клиент держит соединение бесконечно
+	// (slowloris), а агент — одноузловой процесс на машине кассира.
+	srv := &http.Server{
+		Addr:              listen,
+		Handler:           deviceagent.New(token).Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 	return srv.ListenAndServe()
 }

--- a/internal/cli/deviceagent_test.go
+++ b/internal/cli/deviceagent_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import "testing"
+
+// CLI-01 / issue #794: команда device-agent была объявлена, но отсутствовала в
+// rootCmd.AddCommand — то есть была недостижима из CLI (Go не ругается на
+// неиспользуемую package-level переменную, поэтому дефект компилировался
+// молча). Контракт: документированная команда обязана находиться rootCmd.Find.
+func TestDeviceAgentCommandRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"device-agent"})
+	if err != nil {
+		t.Fatalf("device-agent не найдена rootCmd.Find: %v", err)
+	}
+	if cmd == nil || cmd.Name() != "device-agent" {
+		t.Fatalf("rootCmd.Find(device-agent) вернул %v, ожидалась команда device-agent", cmd)
+	}
+	if cmd.RunE == nil {
+		t.Fatal("device-agent зарегистрирована без RunE — команда ничего не делает")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -37,5 +37,5 @@ func init() {
 	rootCmd.SilenceErrors = true
 	rootCmd.PersistentFlags().BoolVar(&noGUI, "no-gui", false,
 		"не показывать модальные окна с ошибками — для скриптов и CI (также ONEBASE_NO_GUI=1)")
-	rootCmd.AddCommand(initCmd, devCmd, runCmd, migrateCmd, buildCmd, startCmd, ibasesCmd, convertCmd, backupCmd, restoreCmd, demoResetCmd, deployCmd, serviceCmd, benchCmd, generateCmd, recalcTotalsCmd, reindexCmd, updateCmd, settingsCmd)
+	rootCmd.AddCommand(initCmd, devCmd, runCmd, migrateCmd, buildCmd, startCmd, ibasesCmd, convertCmd, backupCmd, restoreCmd, demoResetCmd, deployCmd, serviceCmd, benchCmd, generateCmd, recalcTotalsCmd, reindexCmd, updateCmd, settingsCmd, deviceAgentCmd)
 }


### PR DESCRIPTION
Closes #794

deviceAgentCmd была объявлена и описана в документации, но отсутствовала в
rootCmd.AddCommand — команда была недостижима из CLI (неиспользуемая
package-level переменная компилируется без ошибки, поэтому дефект был тихим).

  * команда добавлена в rootCmd.AddCommand;
  * контракт-тест через rootCmd.Find, чтобы регистрация не отвалилась молча;
  * bind не на loopback теперь требует --token (агент печатает на кассовое
    оборудование по открытому HTTP — иначе это удалённое управление кассой
    без аутентификации);
  * выставлены таймауты HTTP-сервера (ReadHeaderTimeout и др.) — раньше их не
    было вовсе, вопреки прежнему //nolint-комментарию.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
