### PR TITLE
refactor(report): единый sandbox-evaluator формул компоновки (#788)

### DIFF
--- a/internal/api/report_eval.go
+++ b/internal/api/report_eval.go
@@ -1,96 +1,14 @@
 package api
 
 import (
-	"errors"
-	"fmt"
-	"sync"
-	"time"
-
-	"github.com/shopspring/decimal"
-
-	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
-	"github.com/ivantit66/onebase/internal/dsl/lexer"
-	"github.com/ivantit66/onebase/internal/dsl/parser"
-	"github.com/ivantit66/onebase/internal/report/compose"
+	"github.com/ivantit66/onebase/internal/report/expreval"
 )
 
-type reportEvaluator struct {
-	interp *interpreter.Interpreter
-	mu     sync.Mutex
-	cache  map[string]*ast.ProcedureDecl
-}
-
-var _ compose.Evaluator = (*reportEvaluator)(nil)
-
-func newReportEvaluator(interp *interpreter.Interpreter) *reportEvaluator {
-	return &reportEvaluator{interp: interp, cache: map[string]*ast.ProcedureDecl{}}
-}
-
-func (e *reportEvaluator) compile(expr string) (*ast.ProcedureDecl, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if p, ok := e.cache[expr]; ok {
-		return p, nil
-	}
-	src := "Функция __cond()\nВозврат (" + expr + ");\nКонецФункции\n"
-	prog, err := parser.New(lexer.New(src, "cond.os")).ParseProgram()
-	if err != nil {
-		return nil, err
-	}
-	var proc *ast.ProcedureDecl
-	for _, d := range prog.Procedures {
-		proc = d
-		break
-	}
-	if proc == nil {
-		return nil, fmt.Errorf("пустое выражение условия")
-	}
-	e.cache[expr] = proc
-	return proc, nil
-}
-
-// composeExprProfile ограничивает одну формулу композиции по времени и
-// итерациям: формула вычисляется на каждую строку отчёта и обязана быть
-// мгновенной. Без лимитов «Пока Истина Цикл» в формуле вешал хендлер навсегда
-// (ctx-таймаут интерпретатор не прерывает) и навечно занимал слот
-// concurrency-лимита отчётов. Запреты возможностей не включаем: формулы —
-// доверенный код конфигурации, как и запрос отчёта.
-func composeExprProfile() interpreter.SandboxProfile {
-	return interpreter.SandboxProfile{
-		MaxWallClock: 10 * time.Second,
-		MaxLoopIters: 1_000_000,
-	}
-}
-
-func (e *reportEvaluator) EvalBool(expr string, row compose.Row) (bool, error) {
-	proc, err := e.compile(expr)
-	if err != nil {
-		return false, err
-	}
-	result, err := e.interp.CallSandboxed(proc, &interpreter.MapThis{M: row}, nil, composeExprProfile(), map[string]any(row))
-	if err != nil {
-		if errors.Is(err, interpreter.ErrDivisionByZero) {
-			return false, nil
-		}
-		return false, err
-	}
-	b, _ := result.(bool)
-	return b, nil
-}
-
-func (e *reportEvaluator) EvalNum(expr string, row compose.Row) (decimal.Decimal, bool, error) {
-	proc, err := e.compile(expr)
-	if err != nil {
-		return decimal.Zero, false, err
-	}
-	result, err := e.interp.CallSandboxed(proc, &interpreter.MapThis{M: row}, nil, composeExprProfile(), map[string]any(row))
-	if err != nil {
-		if errors.Is(err, interpreter.ErrDivisionByZero) {
-			return decimal.Zero, false, nil
-		}
-		return decimal.Zero, false, err
-	}
-	d, ok := compose.ExportToDecimal(result)
-	return d, ok, nil
+// newReportEvaluator строит evaluator условий/показателей компоновки для REST.
+// Реализация вынесена в общий expreval.Evaluator (issue #788): раньше UI и API
+// держали две почти одинаковые копии, и UI-копия исполняла формулы без
+// песочницы. Профиль лимитов обязателен и передаётся явно.
+func newReportEvaluator(interp *interpreter.Interpreter) *expreval.Evaluator {
+	return expreval.New(interp, expreval.DefaultProfile())
 }

--- a/internal/report/expreval/expreval.go
+++ b/internal/report/expreval/expreval.go
@@ -1,0 +1,117 @@
+// Package expreval вычисляет DSL-выражения компоновки отчётов (условия `when`
+// и вычисляемые показатели) построчно, в песочнице.
+//
+// Единственный вход — New(interp, profile): выражение НЕЛЬЗЯ исполнить без
+// явного SandboxProfile. Раньше существовали две почти одинаковые копии
+// evaluator'а — в internal/api (через CallSandboxed с лимитами) и в internal/ui
+// (через обычный RunWithResult БЕЗ песочницы). UI-путь исполнял формулы без
+// лимитов времени/итераций, поэтому «Пока Истина Цикл» в формуле вешал хендлер
+// навсегда (ctx-таймаут интерпретатор не прерывает) и навечно занимал слот
+// concurrency-лимита отчётов (issue #788). Общий пакет убирает вторую копию и
+// делает песочницу обязательной конструктивно.
+package expreval
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/dsl/lexer"
+	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/report/compose"
+)
+
+// Evaluator вычисляет выражения компоновки. Каждое выражение компилируется в
+// процедуру один раз (кэш) и исполняется на строку с полями строки как
+// переменными. Не-bool результат условия трактуется как false.
+type Evaluator struct {
+	interp  *interpreter.Interpreter
+	profile interpreter.SandboxProfile
+	mu      sync.Mutex
+	cache   map[string]*ast.ProcedureDecl
+}
+
+// Контракт: Evaluator реализует compose.Evaluator.
+var _ compose.Evaluator = (*Evaluator)(nil)
+
+// DefaultProfile — лимиты по умолчанию для формул компоновки: формула считается
+// на каждую строку отчёта и обязана быть практически мгновенной. Запреты
+// возможностей не включаем: формулы — доверенный код конфигурации, как и сам
+// запрос отчёта; ограничиваем только время и число итераций.
+func DefaultProfile() interpreter.SandboxProfile {
+	return interpreter.SandboxProfile{
+		MaxWallClock: 10 * time.Second,
+		MaxLoopIters: 1_000_000,
+	}
+}
+
+// New строит evaluator. profile обязателен и передаётся явно: мимо песочницы
+// выражение выполнить нельзя.
+func New(interp *interpreter.Interpreter, profile interpreter.SandboxProfile) *Evaluator {
+	return &Evaluator{interp: interp, profile: profile, cache: map[string]*ast.ProcedureDecl{}}
+}
+
+func (e *Evaluator) compile(expr string) (*ast.ProcedureDecl, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if p, ok := e.cache[expr]; ok {
+		return p, nil
+	}
+	src := "Функция __cond()\nВозврат (" + expr + ");\nКонецФункции\n"
+	prog, err := parser.New(lexer.New(src, "cond.os")).ParseProgram()
+	if err != nil {
+		return nil, err
+	}
+	var proc *ast.ProcedureDecl
+	for _, d := range prog.Procedures {
+		proc = d
+		break
+	}
+	if proc == nil {
+		return nil, fmt.Errorf("пустое выражение условия")
+	}
+	e.cache[expr] = proc
+	return proc, nil
+}
+
+func (e *Evaluator) EvalBool(expr string, row compose.Row) (bool, error) {
+	proc, err := e.compile(expr)
+	if err != nil {
+		return false, err
+	}
+	result, err := e.interp.CallSandboxed(proc, &interpreter.MapThis{M: row}, nil, e.profile, map[string]any(row))
+	if err != nil {
+		// Деление на ноль — неопределённое значение: условие просто не срабатывает
+		// (без ошибки), как пустая ячейка в 1С. Прочие ошибки пробрасываем.
+		if errors.Is(err, interpreter.ErrDivisionByZero) {
+			return false, nil
+		}
+		return false, err
+	}
+	b, _ := result.(bool)
+	return b, nil
+}
+
+func (e *Evaluator) EvalNum(expr string, row compose.Row) (decimal.Decimal, bool, error) {
+	proc, err := e.compile(expr)
+	if err != nil {
+		return decimal.Zero, false, err
+	}
+	result, err := e.interp.CallSandboxed(proc, &interpreter.MapThis{M: row}, nil, e.profile, map[string]any(row))
+	if err != nil {
+		// Деление на ноль — неопределённое значение (пустая ячейка, как в 1С), а не
+		// runtime-ошибка: ok=false без ошибки, чтобы компоновка не поднимала
+		// предупреждение. Прочие ошибки пробрасываем для показа.
+		if errors.Is(err, interpreter.ErrDivisionByZero) {
+			return decimal.Zero, false, nil
+		}
+		return decimal.Zero, false, err
+	}
+	d, ok := compose.ExportToDecimal(result)
+	return d, ok, nil
+}

--- a/internal/report/expreval/expreval_test.go
+++ b/internal/report/expreval/expreval_test.go
@@ -1,0 +1,66 @@
+package expreval
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/dsl/ast"
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/dsl/lexer"
+	"github.com/ivantit66/onebase/internal/dsl/parser"
+	"github.com/ivantit66/onebase/internal/report/compose"
+)
+
+// #788: формула компоновки, вызывающая зацикленную функцию конфигурации, обязана
+// прерываться песочницей по лимиту итераций, а не считаться вечно. Раньше
+// UI-путь исполнял формулы без песочницы вовсе — этот сценарий вешал хендлер.
+func TestEvaluator_SandboxBoundsRunawayExpression(t *testing.T) {
+	src := "Функция Вечность()\n\tПока Истина Цикл\n\tКонецЦикла;\n\tВозврат Истина;\nКонецФункции\n"
+	prog, err := parser.New(lexer.New(src, "t.os")).ParseProgram()
+	if err != nil {
+		t.Fatal(err)
+	}
+	procs := map[string]*ast.ProcedureDecl{}
+	for _, d := range prog.Procedures {
+		procs[d.Name.Literal] = d
+		procs[strings.ToLower(d.Name.Literal)] = d
+	}
+	interp := interpreter.New()
+	interp.LookupProc = func(name string) *ast.ProcedureDecl {
+		if p, ok := procs[name]; ok {
+			return p
+		}
+		return procs[strings.ToLower(name)]
+	}
+
+	ev := New(interp, interpreter.SandboxProfile{MaxLoopIters: 10_000})
+
+	done := make(chan struct{})
+	var evalErr error
+	go func() {
+		_, evalErr = ev.EvalBool("Вечность()", compose.Row{})
+		close(done)
+	}()
+	select {
+	case <-done:
+		if evalErr == nil {
+			t.Fatal("зацикленная формула вернулась без ошибки — песочница не ограничила цикл")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("формула не прервана — песочница не применилась (вычисление зависло)")
+	}
+}
+
+// Контроль: нормальная формула считается штатно — та же реализация, что и до
+// объединения путей.
+func TestEvaluator_NormalExpression(t *testing.T) {
+	ev := New(interpreter.New(), DefaultProfile())
+	got, err := ev.EvalBool("1 = 1", compose.Row{})
+	if err != nil {
+		t.Fatalf("EvalBool: %v", err)
+	}
+	if !got {
+		t.Fatal("ожидалось true для «1 = 1»")
+	}
+}

--- a/internal/ui/report_eval.go
+++ b/internal/ui/report_eval.go
@@ -1,96 +1,15 @@
 package ui
 
 import (
-	"errors"
-	"fmt"
-	"sync"
-
-	"github.com/shopspring/decimal"
-
-	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
-	"github.com/ivantit66/onebase/internal/dsl/lexer"
-	"github.com/ivantit66/onebase/internal/dsl/parser"
-	"github.com/ivantit66/onebase/internal/report/compose"
+	"github.com/ivantit66/onebase/internal/report/expreval"
 )
 
-// interpEvaluator вычисляет DSL-условия `when` на интерпретаторе.
-// Каждое выражение компилируется в процедуру один раз (кэш) и исполняется
-// на строку через RunWithResult с полями строки как переменными.
-//
-// Не-bool результат when трактуется как false (правило не срабатывает);
-// синтаксис when проверяется на этапе onebase check (план 59, Task 11).
-type interpEvaluator struct {
-	interp *interpreter.Interpreter
-	mu     sync.Mutex
-	cache  map[string]*ast.ProcedureDecl
-}
-
-// Контракт: interpEvaluator реализует compose.Evaluator (используется в Task 10).
-var _ compose.Evaluator = (*interpEvaluator)(nil)
-
-func newInterpEvaluator(interp *interpreter.Interpreter) *interpEvaluator {
-	return &interpEvaluator{interp: interp, cache: map[string]*ast.ProcedureDecl{}}
-}
-
-func (e *interpEvaluator) compile(expr string) (*ast.ProcedureDecl, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if p, ok := e.cache[expr]; ok {
-		return p, nil
-	}
-	src := "Функция __cond()\nВозврат (" + expr + ");\nКонецФункции\n"
-	prog, err := parser.New(lexer.New(src, "cond.os")).ParseProgram()
-	if err != nil {
-		return nil, err
-	}
-	var proc *ast.ProcedureDecl
-	for _, d := range prog.Procedures {
-		proc = d
-		break
-	}
-	if proc == nil {
-		return nil, fmt.Errorf("пустое выражение условия")
-	}
-	e.cache[expr] = proc
-	return proc, nil
-}
-
-func (e *interpEvaluator) EvalBool(expr string, row compose.Row) (bool, error) {
-	proc, err := e.compile(expr)
-	if err != nil {
-		return false, err
-	}
-	var result any
-	if err := e.interp.RunWithResult(proc, &interpreter.MapThis{M: row}, &result, map[string]any(row)); err != nil {
-		// Деление на ноль — неопределённое значение: условие просто не срабатывает
-		// (без ошибки), как пустая ячейка в 1С. Прочие ошибки пробрасываем.
-		if errors.Is(err, interpreter.ErrDivisionByZero) {
-			return false, nil
-		}
-		return false, err
-	}
-	b, _ := result.(bool)
-	return b, nil
-}
-
-// EvalNum исполняет DSL-выражение и приводит результат к decimal.
-// Используется для вычисляемых показателей компоновки (Task B2).
-func (e *interpEvaluator) EvalNum(expr string, row compose.Row) (decimal.Decimal, bool, error) {
-	proc, err := e.compile(expr)
-	if err != nil {
-		return decimal.Zero, false, err
-	}
-	var result any
-	if err := e.interp.RunWithResult(proc, &interpreter.MapThis{M: row}, &result, map[string]any(row)); err != nil {
-		// Деление на ноль — неопределённое значение (пустая ячейка, как в 1С), а не
-		// runtime-ошибка: возвращаем ok=false без ошибки, чтобы компоновка не
-		// поднимала предупреждение. Прочие ошибки пробрасываем для показа.
-		if errors.Is(err, interpreter.ErrDivisionByZero) {
-			return decimal.Zero, false, nil
-		}
-		return decimal.Zero, false, err
-	}
-	d, ok := compose.ExportToDecimal(result)
-	return d, ok, nil
+// newInterpEvaluator строит evaluator условий/показателей компоновки. Раньше
+// UI-путь исполнял выражения БЕЗ песочницы (обычный RunWithResult), поэтому
+// формула с бесконечным циклом вешала хендлер навсегда. Теперь используется
+// общий expreval.Evaluator с обязательным SandboxProfile — та же реализация,
+// что и в REST-пути (issue #788).
+func newInterpEvaluator(interp *interpreter.Interpreter) *expreval.Evaluator {
+	return expreval.New(interp, expreval.DefaultProfile())
 }


### PR DESCRIPTION
Closes #788

internal/api/report_eval.go и internal/ui/report_eval.go держали две почти
одинаковые копии evaluator'а условий/показателей компоновки. API считал
формулы через CallSandboxed с лимитами времени и итераций, а UI — через
обычный RunWithResult БЕЗ песочницы: формула с бесконечным циклом (или
вызывающая зацикленную функцию конфигурации) вешала хендлер навсегда и
навечно занимала слот concurrency-лимита отчётов (ARCH-02).

Реализация вынесена в internal/report/expreval.Evaluator. Единственный вход —
New(interp, profile): выражение нельзя исполнить без явного SandboxProfile,
поэтому «путь без песочницы» больше не появится по невнимательности. UI и API
получили тонкие конструкторы поверх общего пакета — call sites не менялись.

Тесты: expreval_test проверяет, что зацикленная формула прерывается лимитом
итераций (раньше зависала) и что нормальная формула считается штатно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
