### PR TITLE
fix(auth): ограничить тело JSON-логина и захолдить rate limiter (#776)

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -18,6 +18,11 @@ func authLog() *slog.Logger { return oblog.Component("auth") }
 // запас на порядки больше любого разумного значения и при этом конечен.
 const maxLoginFormBytes = int64(64 << 10)
 
+// maxCredentialLen — верхний предел длины логина и пароля. bcrypt всё равно
+// использует лишь первые 72 байта пароля, а логин — короткое поле; ограничение
+// отсекает патологически длинные значения до хеширования (issue #776).
+const maxCredentialLen = 1024
+
 var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 <html lang="ru">
 <head><meta charset="utf-8"><title>Вход — onebase</title>
@@ -268,11 +273,19 @@ func (h *Handlers) LoginSubmit(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) LoginJSON(w http.ResponseWriter, r *http.Request) {
+	// Публичный неаутентифицированный маршрут: тело ограничиваем тем же
+	// пределом, что и форму входа. Без этого клиент мог слать сколь угодно
+	// большое тело и заставлять сервер аллоцировать под него память (issue #776).
+	r.Body = http.MaxBytesReader(w, r.Body, maxLoginFormBytes)
 	var req struct {
 		Login    string `json:"login"`
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+	if len(req.Login) > maxCredentialLen || len(req.Password) > maxCredentialLen {
 		http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
 		return
 	}

--- a/internal/auth/login_dos_test.go
+++ b/internal/auth/login_dos_test.go
@@ -1,0 +1,71 @@
+package auth_test
+
+// SEC-01 / issue #776: публичный JSON-логин не должен принимать неограниченное
+// тело и раздувать rate limiter гигантскими логинами.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/auth"
+)
+
+func TestLoginJSON_RejectsOversizedBody(t *testing.T) {
+	repo, ctx := newTestRepo(t)
+	if _, err := repo.Create(ctx, "ivan", "secret123", "Иван", false); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h := &auth.Handlers{Repo: repo, LoginLimit: auth.NewLoginLimiter(3, time.Minute)}
+
+	// Тело заведомо больше предела (64 КиБ): MaxBytesReader обрывает чтение и
+	// Decode падает — хендлер обязан ответить 400/413, а не пытаться прочитать
+	// всё в память.
+	body := `{"login":"ivan","password":"` + strings.Repeat("x", 70*1024) + `"}`
+	req := httptest.NewRequest("POST", "/auth/login", strings.NewReader(body))
+	req.RemoteAddr = "10.0.0.9:1234"
+	rec := httptest.NewRecorder()
+	h.LoginJSON(rec, req)
+
+	if rec.Code != http.StatusBadRequest && rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("оверсайз-тело: ожидался 400/413, получен %d", rec.Code)
+	}
+}
+
+func TestLoginJSON_RejectsOverlongCredentials(t *testing.T) {
+	repo, ctx := newTestRepo(t)
+	if _, err := repo.Create(ctx, "ivan", "secret123", "Иван", false); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	h := &auth.Handlers{Repo: repo, LoginLimit: auth.NewLoginLimiter(3, time.Minute)}
+
+	// Пароль в пределах тела, но патологически длинный — должен быть отклонён до
+	// хеширования и до лимитера.
+	body := `{"login":"ivan","password":"` + strings.Repeat("x", 2000) + `"}`
+	req := httptest.NewRequest("POST", "/auth/login", strings.NewReader(body))
+	req.RemoteAddr = "10.0.0.10:1234"
+	rec := httptest.NewRecorder()
+	h.LoginJSON(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("слишком длинный пароль: ожидался 400, получен %d", rec.Code)
+	}
+}
+
+func TestLoginKey_TruncatesLongLogin(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.RemoteAddr = "1.2.3.4:5678"
+
+	// Логины, различающиеся только за пределом усечения, обязаны дать один ключ
+	// — иначе перебором уникальных «хвостов» можно раздувать map лимитера.
+	base := strings.Repeat("x", 256)
+	if k1, k2 := auth.LoginKey(r, base+"AAAA"), auth.LoginKey(r, base+"BBBB"); k1 != k2 {
+		t.Fatalf("длинные логины не усечены до общего ключа:\n%q\n%q", k1, k2)
+	}
+	// Ключ не растёт с длиной логина.
+	if huge := auth.LoginKey(r, strings.Repeat("y", 100_000)); len(huge) > len("1.2.3.4|")+300 {
+		t.Fatalf("ключ лимитера не ограничен по длине: %d", len(huge))
+	}
+}

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -20,10 +20,11 @@ type loginBucket struct {
 }
 
 type LoginLimiter struct {
-	mu       sync.Mutex
-	maxFails int
-	window   time.Duration
-	attempts map[string]*loginBucket
+	mu        sync.Mutex
+	maxFails  int
+	window    time.Duration
+	attempts  map[string]*loginBucket
+	lastPurge time.Time
 }
 
 func NewLoginLimiter(maxFails int, window time.Duration) *LoginLimiter {
@@ -73,16 +74,31 @@ func (l *LoginLimiter) Reset(key string) {
 }
 
 // purgeLocked лениво вычищает неактуальные записи, чтобы map не рос бесконечно.
+//
+// Полный проход идёт под общим мьютексом и стоит O(n). Раньше он выполнялся на
+// КАЖДУЮ неудачную попытку, как только записей становилось ≥10000, — при флуде
+// уникальными логинами с одного IP это давало квадратичное поведение и
+// сериализовало все входы в процессе (issue #776). Теперь проход ограничен по
+// частоте: не чаще одного раза за окно. Этого достаточно, чтобы вычищать
+// протухшие записи, а пиковый размер map ограничен темпом флуда × длина окна.
 func (l *LoginLimiter) purgeLocked(now time.Time) {
 	if len(l.attempts) < 10000 {
 		return
 	}
+	if !l.lastPurge.IsZero() && now.Sub(l.lastPurge) < l.window {
+		return
+	}
+	l.lastPurge = now
 	for k, b := range l.attempts {
 		if now.After(b.blockedUntil) && now.Sub(b.windowStart) > l.window {
 			delete(l.attempts, k)
 		}
 	}
 }
+
+// maxLoginKeyLen ограничивает длину логина в ключе лимитера: без него
+// неаутентифицированный клиент раздувал бы записи гигантскими строками логина.
+const maxLoginKeyLen = 256
 
 // LoginKey строит ключ лимитера (IP, login). X-Forwarded-For намеренно не
 // используется: без доверенного прокси заголовок подделывается и позволил бы
@@ -92,5 +108,9 @@ func LoginKey(r *http.Request, login string) string {
 	if err != nil {
 		host = r.RemoteAddr
 	}
-	return host + "|" + strings.ToLower(strings.TrimSpace(login))
+	login = strings.ToLower(strings.TrimSpace(login))
+	if len(login) > maxLoginKeyLen {
+		login = login[:maxLoginKeyLen]
+	}
+	return host + "|" + login
 }


### PR DESCRIPTION
Closes #776

Публичный неаутентифицированный POST /auth/login читал тело json-декодером
без MaxBytesReader (форма — с ним), а rate limiter раздувался и деградировал
под флудом уникальными логинами (SEC-01):
  * тело LoginJSON ограничено тем же пределом 64 КиБ, что и форма;
  * логин/пароль длиннее 1024 байт отклоняются до хеширования и лимитера;
  * логин в ключе лимитера усекается до 256 байт — гигантские логины больше
    не раздувают записи;
  * purgeLocked (полный O(n)-проход под общим мьютексом) раньше выполнялся на
    КАЖДУЮ неудачу при ≥10000 записей — квадратичное поведение,
    сериализовавшее все входы. Теперь проход ограничен по частоте: не чаще
    одного раза за окно.

Тесты: оверсайз-тело → 400/413, слишком длинные учётные данные → 400,
усечение ключа лимитера; существующие тесты лимитера не затронуты.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
