### PR TITLE
ci: concurrency cancel-in-progress и timeout-minutes для job'ов (#793)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,18 @@ on:
   # статус-чеки при этом блокируют мерж — восстановиться было нечем.
   workflow_dispatch:
 
+# Отменять устаревшие прогоны того же ref (QUAL-04): новый push в ту же ветку/PR
+# снимает предыдущий незавершённый прогон, чтобы зависшие/лишние runs не
+# потребляли раннеры бесконечно. По ref, а не глобально, — параллельные ветки
+# не мешают друг другу.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -151,6 +160,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -165,6 +175,7 @@ jobs:
 
   postgres-integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: postgres:16
@@ -233,6 +244,7 @@ jobs:
     # Держите go-version актуальным и пиньте патч-версию: floating 1.26.x может
     # взять устаревший toolcache на GitHub runner и завалить govulncheck.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -251,6 +263,7 @@ jobs:
     # сервисов не нужно. Только для pull_request (нужна база для сравнения).
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Closes #793

Тяжёлые workflow не были ограничены ни concurrency, ни таймаутами job:
зависший или устаревший прогон потреблял раннеры до глобального лимита
GitHub (часть QUAL-04).

  * добавлен workflow-level concurrency по ref с cancel-in-progress — новый
    push в ту же ветку/PR снимает предыдущий незавершённый прогон;
  * каждому job задан timeout-minutes (build/postgres/bench 30, lint/vuln 15).

Остальные пункты QUAL-04 (diff-гейт непадения покрытия по критическим
пакетам, scheduled govulncheck и go mod tidy -diff, минимальный ESLint-слой)
оставлены в issue #793 отдельными задачами.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
