### PR TITLE
fix(ui): проведение из списка не теряет пост-эффекты (#775)

### DIFF
--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -1554,10 +1554,20 @@ func (s *Server) postDocument(w http.ResponseWriter, r *http.Request) {
 			hookErrMsg = errMsg
 			return errPostingHookFailed
 		}
+		// OnPost мог изменить расчётные реквизиты шапки — персистим их без
+		// второго инкремента _version, как это делают проведение через форму,
+		// REST и DSL. Раньше проведение из списка эти изменения теряло (#775).
+		if err := s.store.UpsertPreserveVersion(ctx, entity.Name, id, obj.Fields, entity); err != nil {
+			return err
+		}
 		if err := s.saveMovements(ctx, entity.Name, id, mc); err != nil {
 			return err
 		}
-		return s.store.SetPosted(ctx, entity.Name, id, true)
+		if err := s.store.SetPosted(ctx, entity.Name, id, true); err != nil {
+			return err
+		}
+		// Регистрация изменения в планах обмена (план 86) — в той же транзакции.
+		return exchange.RegisterOnSave(ctx, s.store, s.reg.ExchangePlans(), entity, id, false)
 	}); err != nil {
 		if hookErrMsg != "" {
 			http.Redirect(w, r, docURL+"?posting_error="+url.QueryEscape(hookErrMsg), http.StatusSeeOther)
@@ -1566,6 +1576,11 @@ func (s *Server) postDocument(w http.ResponseWriter, r *http.Request) {
 		s.serverError(w, r, err)
 		return
 	}
+	// Пост-коммит эффекты, которые проведение из списка раньше пропускало
+	// (#775): живой список и веб-хук document.post — как в проведении через
+	// форму, REST и DSL. Симметрично unpostDocument/удалению.
+	s.publishDocChange(r.Context(), entity, id, "проведён", nil)
+	s.dispatchDocWebhook(r.Context(), "document.post", entity, id, obj.Fields)
 	http.Redirect(w, r, docURL, http.StatusSeeOther)
 }
 

--- a/internal/ui/post_document_effects_test.go
+++ b/internal/ui/post_document_effects_test.go
@@ -1,0 +1,55 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// CORE-01 / issue #775: проведение документа кнопкой из списка (postDocument)
+// раньше теряло пост-эффекты — в частности веб-хук document.post, — которые
+// срабатывают при проведении через форму, REST и DSL. Проверяем, что событие
+// теперь публикуется и документ действительно проведён.
+func TestPostDocumentFromList_DispatchesPostWebhook(t *testing.T) {
+	sink := &dslHookSink{}
+	srv := httptest.NewServer(sink.handler())
+	defer srv.Close()
+
+	doc := dslWebhookDoc()
+	s, d, db, ctx := dslWebhookServer(t, srv.URL, doc, nil)
+
+	id := uuid.New()
+	if err := db.Upsert(ctx, doc.Name, id, map[string]any{"Номер": "ПОС-1"}, doc); err != nil {
+		t.Fatal(err)
+	}
+
+	r := reqWithChi("POST", "/ui/document/поступлениетоваров/"+id.String()+"/post", url.Values{},
+		map[string]string{"kind": "document", "entity": "поступлениетоваров", "id": id.String()})
+	rec := httptest.NewRecorder()
+	s.postDocument(rec, r)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("ожидался 303, получен %d: %s", rec.Code, rec.Body.String())
+	}
+	d.Wait()
+
+	found := false
+	for _, e := range sink.sorted() {
+		if e == "document.post" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("проведение из списка не отправило document.post; события: %v", sink.sorted())
+	}
+
+	row, err := db.GetByID(ctx, doc.Name, id, doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !asBool(row["posted"]) {
+		t.Fatalf("документ не отмечен проведённым: %#v", row)
+	}
+}


### PR DESCRIPTION
Closes #775

Кнопка «Провести» из списка (postDocument) выполняла только хук + движения +
признак проведения, а четыре эффекта теряла — в отличие от проведения через
форму, REST и DSL (конкретное расхождение класса CORE-01):
  * не сохранялись изменённые хуком реквизиты шапки;
  * изменение не регистрировалось в планах обмена;
  * не обновлялись живые списки;
  * не отправлялся веб-хук document.post.

Добавлены ровно эти эффекты, повторяя проверенный DSL-путь postInContext:
UpsertPreserveVersion (поля хука) + RegisterOnSave (обмен) в той же
транзакции, publishDocChange + dispatchDocWebhook после коммита.

Тест TestPostDocumentFromList_DispatchesPostWebhook воспроизводит расхождение
(без фикса document.post не уходит) и проверяет проведение. Полная
консолидация проведения в единый use-case остаётся более крупной задачей
CORE-01 в issue #775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
