### PR TITLE
feat(configcheck): предупреждать о пустом auth у изменяющего сервиса (#786)

### DIFF
--- a/internal/configcheck/full.go
+++ b/internal/configcheck/full.go
@@ -61,6 +61,7 @@ func RunFullWithOptions(dir string, opts Options) Result {
 		warnings = append(warnings, CheckSecretHygiene(appCfg, proj)...)
 		warnings = append(warnings, CheckStages(proj)...)
 		issues = append(issues, CheckHTTPServices(proj)...)
+		warnings = append(warnings, CheckHTTPServiceAuthWarnings(proj)...)
 		issues = append(issues, CheckExchangePlans(proj)...)
 		issues = append(issues, CheckIntakes(proj)...)
 		issues = append(issues, CheckPages(proj)...)

--- a/internal/configcheck/services.go
+++ b/internal/configcheck/services.go
@@ -12,6 +12,41 @@ import (
 	"github.com/ivantit66/onebase/internal/project"
 )
 
+// CheckHTTPServiceAuthWarnings — advisory-предупреждения (issue #786): у сервиса
+// с ИЗМЕНЯЮЩИМИ методами (POST/PUT/DELETE/PATCH) не задан auth (пустое поле
+// молча нормализуется к «none») и нет rate_limit. Это не ошибка — публичный
+// сервис бывает осознанным, — но такой endpoint стоит либо защитить, либо
+// пометить публичным ЯВНО (auth: none). Явный auth: none предупреждения не
+// вызывает.
+func CheckHTTPServiceAuthWarnings(proj *project.Project) []Issue {
+	var warnings []Issue
+	for _, svc := range proj.HTTPServices {
+		if svc.AuthExplicit || svc.RateLimit > 0 {
+			continue
+		}
+		mutating := false
+		for _, t := range svc.Templates {
+			for m := range t.Methods {
+				if m == "POST" || m == "PUT" || m == "DELETE" || m == "PATCH" {
+					mutating = true
+				}
+			}
+		}
+		if !mutating {
+			continue
+		}
+		warnings = append(warnings, Issue{
+			File:   "services",
+			Object: svc.Name,
+			Kind:   "HTTP-сервис",
+			Message: "изменяющий endpoint без явного auth и без rate_limit: пустой auth молча " +
+				"трактуется как публичный (none). Укажите auth (token/hmac/basic/session) или, " +
+				"если сервис действительно публичный, задайте auth: none явно и/или rate_limit.",
+		})
+	}
+	return warnings
+}
+
 // CheckHTTPServices проверяет services/*.yaml против загруженных модулей.
 func CheckHTTPServices(proj *project.Project) []Issue {
 	var issues []Issue

--- a/internal/configcheck/services_auth_warn_test.go
+++ b/internal/configcheck/services_auth_warn_test.go
@@ -1,0 +1,43 @@
+package configcheck
+
+// INT-02 / issue #786: advisory-предупреждение о пустом auth у изменяющего
+// сервиса. Пустой auth молча нормализуется к none — предупреждаем, но не
+// роняем check; явный auth: none валиден и предупреждения не вызывает.
+
+import (
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/httpservice"
+	"github.com/ivantit66/onebase/internal/project"
+)
+
+func TestCheckHTTPServiceAuthWarnings(t *testing.T) {
+	mut := func(name, auth string, rateLimit int) *httpservice.Service {
+		s := &httpservice.Service{
+			Name: name, RootURL: name, Auth: auth, RateLimit: rateLimit,
+			Templates: []httpservice.URLTemplate{{Template: "/", Methods: map[string]string{"POST": "H"}}},
+		}
+		s.Normalize()
+		return s
+	}
+	readOnly := &httpservice.Service{
+		Name: "ЧтениеБезAuth", RootURL: "ro",
+		Templates: []httpservice.URLTemplate{{Template: "/", Methods: map[string]string{"GET": "H"}}},
+	}
+	readOnly.Normalize()
+
+	proj := &project.Project{HTTPServices: []*httpservice.Service{
+		mut("ПустойAuthИзменяющий", "", 0), // пустой auth + POST + без rate_limit → предупреждение
+		mut("ЯвныйNone", "none", 0),        // явный none → без предупреждения
+		mut("ПустойСРейтЛимитом", "", 60),  // пустой auth, но есть rate_limit → без предупреждения
+		readOnly, // пустой auth, но только GET → без предупреждения
+	}}
+
+	warnings := CheckHTTPServiceAuthWarnings(proj)
+	if len(warnings) != 1 {
+		t.Fatalf("ожидалось ровно 1 предупреждение, получено %d: %+v", len(warnings), warnings)
+	}
+	if warnings[0].Object != "ПустойAuthИзменяющий" {
+		t.Fatalf("предупреждение не про тот сервис: %q", warnings[0].Object)
+	}
+}

--- a/internal/httpservice/service.go
+++ b/internal/httpservice/service.go
@@ -44,6 +44,12 @@ type Service struct {
 	// X-Webhook-Signature = hex(HMAC-SHA256(тело, secret)) — формат платёжек
 	// и Telegram). token/hmac поглощены из плана 58.
 	Auth string `yaml:"auth"`
+	// AuthExplicit — был ли auth ЯВНО задан в YAML (до нормализации пустого к
+	// «none»). Захватывается один раз в Normalize, не читается из YAML. Нужен
+	// валидатору, чтобы отличить осознанный `auth: none` от ОТСУТСТВУЮЩЕГО auth
+	// у анонимного изменяющего сервиса (issue #786).
+	AuthExplicit bool `yaml:"-"`
+	authCaptured bool // страж однократного захвата AuthExplicit
 	// Secret — секрет для auth token/hmac. Задавайте через ${env:VAR} —
 	// значение живёт в окружении, не в YAML/git/.obz.
 	Secret string `yaml:"secret"`
@@ -96,6 +102,12 @@ func (s *Service) Normalize() {
 		s.SecretRaw = s.Secret
 	}
 	s.RootURL = strings.Trim(strings.TrimSpace(s.RootURL), "/")
+	// Захватываем «был ли auth задан явно» до дефолтинга пустого к none —
+	// один раз, чтобы повторный Normalize (уже с auth=none) не затёр факт.
+	if !s.authCaptured {
+		s.authCaptured = true
+		s.AuthExplicit = strings.TrimSpace(s.Auth) != ""
+	}
 	if s.Auth == "" {
 		s.Auth = "none"
 	}


### PR DESCRIPTION
Closes #786

Пустой `auth` в HTTP-сервисе молча нормализуется к `none` — валидатор не
отличал осознанный `auth: none` от отсутствующего auth (INT-02). По решению
владельца выбран мягкий вариант: предупреждение, не ошибка.

  * httpservice.Service получил поле AuthExplicit — Normalize захватывает
    (однократно) факт «auth задан явно» ДО дефолтинга пустого к none;
  * CheckHTTPServiceAuthWarnings выдаёт advisory-warning для сервиса с
    ИЗМЕНЯЮЩИМ методом (POST/PUT/DELETE/PATCH), у которого auth не задан явно
    и нет rate_limit. Явный `auth: none` предупреждения не вызывает.

Warning не влияет на код возврата `onebase check` (OK считается по issues).
Все shipped-примеры используют явный auth (none/hmac/basic) — 0 срабатываний,
CI-lint не ломается. Тест проверяет: пустой+POST+без лимита → 1 warning;
явный none / read-only / с rate_limit → без предупреждения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
