### PR TITLE
fix(auth): OIDC callback и secure-куки за прокси (#780)

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -94,11 +94,16 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 	}
 
 	// Public auth routes (no authentication required)
+	publicURL := strings.TrimSpace(os.Getenv("ONEBASE_PUBLIC_URL"))
 	authH := &auth.Handlers{
-		Repo:          authRepo,
-		Auditor:       store,
-		Codes:         auth.NewOneTimeCodes(30 * time.Second),
-		SecureCookies: envBool("ONEBASE_SECURE_COOKIES"),
+		Repo:    authRepo,
+		Auditor: store,
+		Codes:   auth.NewOneTimeCodes(30 * time.Second),
+		// Secure-куки: явный ONEBASE_SECURE_COOKIES ИЛИ https в публичном адресе
+		// (SEC-05). За HTTPS-терминатором r.TLS у запроса пустой, и без этого
+		// вывода куки уходили бы без флага Secure, хотя соединение до
+		// пользователя зашифровано.
+		SecureCookies: envBool("ONEBASE_SECURE_COOKIES") || strings.HasPrefix(strings.ToLower(publicURL), "https://"),
 		// 5 неудач с одного IP по одному логину → блок на минуту (план 53).
 		// Общий с basic-auth HTTP-сервисов (см. uiCfg.LoginLimit).
 		LoginLimit: loginLimit,
@@ -107,7 +112,7 @@ func New(reg *runtime.Registry, store *storage.DB, interp *interpreter.Interpret
 		AppName: uiCfg.AppName,
 		// Внешний адрес для redirect_uri провайдера SSO: за обратным прокси
 		// Host запроса не совпадает с публичным адресом.
-		BaseURL: strings.TrimSpace(os.Getenv("ONEBASE_PUBLIC_URL")),
+		BaseURL: publicURL,
 	}
 	r.Get("/login", authH.LoginPage)
 	r.Post("/login", authH.LoginSubmit)

--- a/internal/auth/handlers_oidc.go
+++ b/internal/auth/handlers_oidc.go
@@ -146,16 +146,37 @@ func (h *Handlers) redirectURI(r *http.Request, providerID string) string {
 		if r.TLS != nil {
 			scheme = "https"
 		}
+		usedForwarded := false
 		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
 			scheme = strings.TrimSpace(strings.Split(proto, ",")[0])
+			usedForwarded = true
 		}
 		host := r.Host
 		if fwd := r.Header.Get("X-Forwarded-Host"); fwd != "" {
 			host = strings.TrimSpace(strings.Split(fwd, ",")[0])
+			usedForwarded = true
+		}
+		if usedForwarded {
+			warnForwardedWithoutPublicURL()
 		}
 		base = scheme + "://" + host
 	}
 	return base + "/auth/oidc/" + url.PathEscape(providerID) + "/callback"
+}
+
+var forwardedWarnOnce sync.Once
+
+// warnForwardedWithoutPublicURL один раз за процесс предупреждает, что
+// redirect_uri OIDC строится из X-Forwarded-* при незаданном ONEBASE_PUBLIC_URL.
+// За НЕдоверенным прокси эти заголовки подделываются, и callback мог бы
+// указывать на чужой хост. Это не жёсткая ошибка (провайдер всё равно сверяет
+// redirect_uri с зарегистрированным списком, а state-кука привязывает callback
+// к браузеру), но за обратным прокси следует задать ONEBASE_PUBLIC_URL (SEC-05).
+func warnForwardedWithoutPublicURL() {
+	forwardedWarnOnce.Do(func() {
+		authLog().Warn("OIDC redirect_uri построен из X-Forwarded-* без ONEBASE_PUBLIC_URL",
+			"подсказка", "за обратным прокси задайте ONEBASE_PUBLIC_URL=https://ваш-домен (SEC-05)")
+	})
 }
 
 // OIDCStart начинает вход через внешнего провайдера.

--- a/internal/auth/oidc_redirect_uri_test.go
+++ b/internal/auth/oidc_redirect_uri_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// SEC-05 / issue #780: redirect_uri OIDC берётся из заданного публичного адреса
+// (ONEBASE_PUBLIC_URL), а не из подделываемых X-Forwarded-* заголовков.
+func TestRedirectURI_PrefersPublicURL(t *testing.T) {
+	h := &Handlers{BaseURL: "https://erp.example.com/"}
+	r := httptest.NewRequest("GET", "/auth/oidc/google/start", nil)
+	r.Host = "attacker.example"
+	r.Header.Set("X-Forwarded-Host", "attacker.example")
+	r.Header.Set("X-Forwarded-Proto", "http")
+
+	got := h.redirectURI(r, "google")
+	want := "https://erp.example.com/auth/oidc/google/callback"
+	if got != want {
+		t.Fatalf("redirectURI = %q, ожидался %q — public URL должен побеждать forwarded-заголовки", got, want)
+	}
+}
+
+// Без public URL callback строится из запроса — совместимость сохранена.
+func TestRedirectURI_FallsBackToRequest(t *testing.T) {
+	h := &Handlers{}
+	r := httptest.NewRequest("GET", "/auth/oidc/google/start", nil)
+	r.Host = "erp.local:8080"
+
+	got := h.redirectURI(r, "google")
+	want := "http://erp.local:8080/auth/oidc/google/callback"
+	if got != want {
+		t.Fatalf("redirectURI = %q, ожидался %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #780

Если ONEBASE_PUBLIC_URL не задан, redirect_uri OIDC строился из
X-Forwarded-Proto/Host без модели доверенных прокси — за недоверенным прокси
эти заголовки подделываются (SEC-05). По решению владельца выбран
не ломающий вариант.

  * при незаданном public URL и использовании X-Forwarded-* redirectURI один
    раз за процесс предупреждает в лог, что за прокси нужно задать
    ONEBASE_PUBLIC_URL. Прямой HTTP/HTTPS и корректно настроенный public URL
    работают без изменений (заданный BaseURL всегда побеждает заголовки);
  * SecureCookies теперь выводится из https в ONEBASE_PUBLIC_URL, а не только
    из ONEBASE_SECURE_COOKIES — за HTTPS-терминатором (r.TLS пуст) куки больше
    не уходят без флага Secure.

Тесты: redirectURI берёт public URL и игнорирует поддельные forwarded-хосты;
без public URL fallback на адрес запроса сохранён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
