### PR TITLE
feat(services): freshness и защита от replay для HMAC generic-сервисов (#785)

### DIFF
--- a/internal/ui/service_hmac.go
+++ b/internal/ui/service_hmac.go
@@ -1,0 +1,119 @@
+package ui
+
+// Проверка подписи HMAC для generic HTTP-сервисов и защита от повторов (#785).
+//
+// Старая схема подписывала только тело (X-Webhook-Signature =
+// hex(HMAC-SHA256(тело, secret))): подпись не связывала запрос с методом,
+// путём и временем, поэтому перехваченный запрос можно было воспроизвести. Новая
+// (versioned) схема — opt-in — подписывает timestamp+method+path+хэш тела,
+// требует свежую метку времени и отклоняет повтор той же подписи. Старая схема
+// принимается для совместимости, но без freshness/replay — клиентам стоит
+// перейти на v1.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// hmacFreshnessWindow — допустимое расхождение X-Webhook-Timestamp с текущим
+// временем. Запрос за пределами окна отклоняется; его подпись столько же
+// хранится в кэше повторов.
+const hmacFreshnessWindow = 5 * time.Minute
+
+// serviceReplay — общий кэш повторов подписей generic HTTP-сервисов.
+var serviceReplay = newReplayCache(hmacFreshnessWindow)
+
+type replayCache struct {
+	mu        sync.Mutex
+	ttl       time.Duration
+	seen      map[string]time.Time
+	lastPurge time.Time
+}
+
+func newReplayCache(ttl time.Duration) *replayCache {
+	return &replayCache{ttl: ttl, seen: map[string]time.Time{}}
+}
+
+// seenBefore возвращает true, если ключ уже встречался в пределах TTL (повтор);
+// иначе запоминает ключ и возвращает false.
+func (c *replayCache) seenBefore(key string, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.purgeLocked(now)
+	if t, ok := c.seen[key]; ok && now.Sub(t) <= c.ttl {
+		return true
+	}
+	c.seen[key] = now
+	return false
+}
+
+// purgeLocked чистит протухшие записи не чаще раза за TTL — чтобы не сканировать
+// map под мьютексом на каждый запрос.
+func (c *replayCache) purgeLocked(now time.Time) {
+	if !c.lastPurge.IsZero() && now.Sub(c.lastPurge) < c.ttl {
+		return
+	}
+	c.lastPurge = now
+	for k, t := range c.seen {
+		if now.Sub(t) > c.ttl {
+			delete(c.seen, k)
+		}
+	}
+}
+
+// verifyServiceHMAC проверяет подпись запроса к generic HTTP-сервису.
+// Возвращает (true, "") при успехе или (false, причина) при отказе.
+func verifyServiceHMAC(secret, svcName string, r *http.Request, body []byte, cache *replayCache) (ok bool, reason string) {
+	sig := strings.TrimSpace(r.Header.Get("X-Webhook-Signature"))
+	tsRaw := strings.TrimSpace(r.Header.Get("X-Webhook-Timestamp"))
+	lowSig := strings.ToLower(sig)
+
+	// Новая схема: включается заголовком X-Webhook-Timestamp или префиксом v1=.
+	if tsRaw != "" || strings.HasPrefix(lowSig, "v1=") {
+		ts, err := strconv.ParseInt(tsRaw, 10, 64)
+		if err != nil {
+			return false, "неверная или отсутствующая метка времени"
+		}
+		now := time.Now()
+		window := int64(cache.ttl.Seconds())
+		if d := now.Unix() - ts; d > window || d < -window {
+			return false, "метка времени вне окна свежести"
+		}
+		got := strings.TrimPrefix(lowSig, "v1=")
+		bodyHash := sha256.Sum256(body)
+		canonical := "v1:" + tsRaw + ":" + strings.ToUpper(r.Method) + ":" + r.URL.Path + ":" + hex.EncodeToString(bodyHash[:])
+		if !hmacEqualHex(secret, []byte(canonical), got) {
+			return false, "неверная подпись"
+		}
+		if cache.seenBefore(svcName+"|"+got, now) {
+			return false, "повтор запроса (replay)"
+		}
+		return true, ""
+	}
+
+	// Старая схема (совместимость): подпись только тела, без freshness/replay.
+	got := strings.TrimPrefix(lowSig, "sha256=")
+	if !hmacEqualHex(secret, body, got) {
+		return false, "неверная подпись"
+	}
+	return true, ""
+}
+
+// hmacEqualHex сравнивает hex-подпись gotHex с HMAC-SHA256(msg, secret)
+// constant-time.
+func hmacEqualHex(secret string, msg []byte, gotHex string) bool {
+	if gotHex == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(msg)
+	want := hex.EncodeToString(mac.Sum(nil))
+	return subtle.ConstantTimeCompare([]byte(gotHex), []byte(want)) == 1
+}

--- a/internal/ui/service_hmac_test.go
+++ b/internal/ui/service_hmac_test.go
@@ -1,0 +1,83 @@
+package ui
+
+// INT-01 / issue #785: подпись generic HTTP-сервиса — freshness + replay.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func signV1(secret, ts, method, path string, body []byte) string {
+	h := sha256.Sum256(body)
+	canonical := "v1:" + ts + ":" + strings.ToUpper(method) + ":" + path + ":" + hex.EncodeToString(h[:])
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(canonical))
+	return "v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func signBody(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyServiceHMAC_OldSchemeCompat(t *testing.T) {
+	secret, body := "s3cr3t", []byte(`{"a":1}`)
+	r := httptest.NewRequest("POST", "/hs/svc/x", nil)
+	r.Header.Set("X-Webhook-Signature", signBody(secret, body))
+	if ok, reason := verifyServiceHMAC(secret, "svc", r, body, newReplayCache(5*time.Minute)); !ok {
+		t.Fatalf("старая схема (подпись тела) должна проходить: %s", reason)
+	}
+}
+
+func TestVerifyServiceHMAC_V1AndReplay(t *testing.T) {
+	secret, body := "s3cr3t", []byte(`{"a":1}`)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	cache := newReplayCache(5 * time.Minute)
+	newReq := func() *http.Request {
+		r := httptest.NewRequest("POST", "/hs/svc/x", nil)
+		r.Header.Set("X-Webhook-Timestamp", ts)
+		r.Header.Set("X-Webhook-Signature", signV1(secret, ts, "POST", "/hs/svc/x", body))
+		return r
+	}
+	if ok, reason := verifyServiceHMAC(secret, "svc", newReq(), body, cache); !ok {
+		t.Fatalf("v1-подпись должна проходить: %s", reason)
+	}
+	if ok, reason := verifyServiceHMAC(secret, "svc", newReq(), body, cache); ok {
+		t.Fatal("повтор той же v1-подписи должен отклоняться (replay)")
+	} else if !strings.Contains(reason, "replay") {
+		t.Fatalf("ожидалась причина replay, получено %q", reason)
+	}
+}
+
+func TestVerifyServiceHMAC_StaleTimestamp(t *testing.T) {
+	secret, body := "s3cr3t", []byte(`{}`)
+	oldTs := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+	r := httptest.NewRequest("POST", "/hs/svc/x", nil)
+	r.Header.Set("X-Webhook-Timestamp", oldTs)
+	r.Header.Set("X-Webhook-Signature", signV1(secret, oldTs, "POST", "/hs/svc/x", body))
+	if ok, reason := verifyServiceHMAC(secret, "svc", r, body, newReplayCache(5*time.Minute)); ok {
+		t.Fatal("устаревшая метка времени должна отклоняться")
+	} else if !strings.Contains(reason, "окн") {
+		t.Fatalf("ожидалась причина про окно свежести, получено %q", reason)
+	}
+}
+
+func TestVerifyServiceHMAC_TamperedPath(t *testing.T) {
+	secret, body := "s3cr3t", []byte(`{}`)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	// Подпись для одного пути, запрос на другой — v1 связывает путь → отказ.
+	r := httptest.NewRequest("POST", "/hs/svc/OTHER", nil)
+	r.Header.Set("X-Webhook-Timestamp", ts)
+	r.Header.Set("X-Webhook-Signature", signV1(secret, ts, "POST", "/hs/svc/x", body))
+	if ok, _ := verifyServiceHMAC(secret, "svc", r, body, newReplayCache(5*time.Minute)); ok {
+		t.Fatal("подпись для другого пути должна отклоняться")
+	}
+}

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -8,10 +8,7 @@ package ui
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
 	"crypto/subtle"
-	"encoding/hex"
 	"errors"
 	"io"
 	"net"
@@ -317,18 +314,14 @@ func (s *Server) resolveServiceAuth(svc *httpservice.Service, w http.ResponseWri
 		return r.Context(), true
 
 	case "hmac":
-		// Подпись тела — формат платёжек/Telegram: X-Webhook-Signature =
-		// hex(HMAC-SHA256(тело, secret)); допускается префикс "sha256=".
+		// Подпись запроса. Новая (versioned) схема с freshness/replay и старая
+		// схема «подпись только тела» — в verifyServiceHMAC (#785).
 		secret, ok := resolveAuthSecret(svc.Secret, "сервиса", svc.Name, w)
 		if !ok {
 			return nil, false
 		}
-		mac := hmac.New(sha256.New, []byte(secret))
-		mac.Write(body)
-		want := hex.EncodeToString(mac.Sum(nil))
-		got := strings.TrimPrefix(strings.ToLower(r.Header.Get("X-Webhook-Signature")), "sha256=")
-		if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(want)) != 1 {
-			writeServiceError(w, http.StatusUnauthorized, "неверная подпись")
+		if ok, reason := verifyServiceHMAC(secret, svc.Name, r, body, serviceReplay); !ok {
+			writeServiceError(w, http.StatusUnauthorized, reason)
 			return nil, false
 		}
 		return r.Context(), true


### PR DESCRIPTION
Closes #785

Generic HTTP-сервис подписывал только тело (X-Webhook-Signature =
hex(HMAC-SHA256(тело, secret))): подпись не связывала запрос с методом, путём
и временем, поэтому перехваченный запрос можно было воспроизвести (INT-01). У
intake, в отличие от этого, уже есть обязательный idempotency key.

Добавлена versioned-схема (opt-in по заголовку X-Webhook-Timestamp или
префиксу подписи v1=): подпись покрывает timestamp+method+path+хэш тела,
метка времени обязана попадать в окно свежести (±5 минут), а повтор той же
подписи в пределах окна отклоняется (replay-кэш с TTL и троттлингом чистки).
Старая схема «подпись только тела» принимается для совместимости, но без
freshness/replay — клиентам стоит перейти на v1.

Тесты: старая схема проходит; v1 проходит и повтор отклоняется; устаревшая
метка времени и подпись для другого пути отклоняются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
