### PR TITLE
feat(auth): видимость и миграция plaintext TOTP-seed'ов (#779)

### DIFF
--- a/internal/auth/totp_migrate_test.go
+++ b/internal/auth/totp_migrate_test.go
@@ -1,0 +1,57 @@
+package auth_test
+
+// SEC-04 / issue #779: видимость plaintext TOTP-seed'ов и их перешифрование
+// существующим мастер-ключом.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ivantit66/onebase/internal/auth"
+	"github.com/ivantit66/onebase/internal/secrets"
+)
+
+func TestMigratePlaintextTOTP(t *testing.T) {
+	// Гарантируем отсутствие ключа на этапе включения 2FA → seed ляжет открытым.
+	t.Setenv("ONEBASE_MASTER_KEY", "")
+	t.Setenv("ONEBASE_MASTER_KEY_FILE", "")
+
+	repo, ctx := newTestRepo(t)
+	userID, secret := enable2FA(t, repo, ctx, "ivan")
+
+	if n, err := repo.CountPlaintextTOTP(ctx); err != nil {
+		t.Fatalf("CountPlaintextTOTP: %v", err)
+	} else if n != 1 {
+		t.Fatalf("ожидался 1 plaintext-seed, получено %d", n)
+	}
+
+	// Задаём мастер-ключ и мигрируем.
+	key, err := secrets.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	t.Setenv("ONEBASE_MASTER_KEY", key.Hex())
+
+	migrated, err := repo.MigratePlaintextTOTP(ctx)
+	if err != nil {
+		t.Fatalf("MigratePlaintextTOTP: %v", err)
+	}
+	if migrated != 1 {
+		t.Fatalf("ожидалась миграция 1 seed, получено %d", migrated)
+	}
+	if n, err := repo.CountPlaintextTOTP(ctx); err != nil {
+		t.Fatalf("CountPlaintextTOTP после миграции: %v", err)
+	} else if n != 0 {
+		t.Fatalf("после миграции plaintext-seed'ов быть не должно, осталось %d", n)
+	}
+
+	// Второй фактор по-прежнему работает: seed зашифрован, но расшифровывается.
+	now := time.Now()
+	code, err := auth.TOTPCode(secret, auth.TOTPStep(now))
+	if err != nil {
+		t.Fatalf("TOTPCode: %v", err)
+	}
+	if err := repo.VerifySecondFactor(ctx, userID, code, now); err != nil {
+		t.Fatalf("2FA после миграции не работает: %v", err)
+	}
+}

--- a/internal/auth/twofactor.go
+++ b/internal/auth/twofactor.go
@@ -116,6 +116,76 @@ func (r *Repo) TwoFactorInfoFor(ctx context.Context, userID string) (TwoFactorIn
 	return info, nil
 }
 
+// CountPlaintextTOTP возвращает число включённых 2FA, чей секрет лежит в базе
+// ОТКРЫТЫМ ТЕКСТОМ (не зашифрован мастер-ключом). Используется как
+// health/admin-сигнал: пока значение > 0, конфиденциальность seed'ов ниже
+// ожидаемой (issue #779).
+func (r *Repo) CountPlaintextTOTP(ctx context.Context) (int, error) {
+	rows, err := r.db.Query(ctx, `SELECT totp_secret FROM _users WHERE totp_enabled AND totp_secret <> ''`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	n := 0
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return 0, err
+		}
+		if !secrets.IsRef(s) {
+			n++
+		}
+	}
+	return n, rows.Err()
+}
+
+// MigratePlaintextTOTP перешифровывает открытые (plaintext) секреты TOTP
+// текущим мастер-ключом. Если ключ не задан — миграция невозможна, возвращает
+// (0, nil): это не ошибка, а сигнал «нечего мигрировать без ключа». Ключ здесь
+// уже СУЩЕСТВУЮЩИЙ (задан оператором) — метод не создаёт новых ключей и не
+// добавляет скрытых зависимостей (issue #779).
+func (r *Repo) MigratePlaintextTOTP(ctx context.Context) (int, error) {
+	key, err := secrets.Default().Key()
+	if err != nil {
+		return 0, nil
+	}
+	rows, err := r.db.Query(ctx, `SELECT id, totp_secret FROM _users WHERE totp_enabled AND totp_secret <> ''`)
+	if err != nil {
+		return 0, err
+	}
+	type pending struct{ id, secret string }
+	var todo []pending
+	for rows.Next() {
+		var id, s string
+		if err := rows.Scan(&id, &s); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		if !secrets.IsRef(s) {
+			todo = append(todo, pending{id, s})
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	d := r.db.Dialect()
+	migrated := 0
+	for _, p := range todo {
+		enc, encErr := key.Encrypt(p.secret)
+		if encErr != nil {
+			return migrated, fmt.Errorf("auth: шифрование секрета TOTP при миграции: %w", encErr)
+		}
+		q := fmt.Sprintf(`UPDATE _users SET totp_secret = %s WHERE id = %s`, d.Placeholder(1), d.Placeholder(2))
+		if _, err := r.db.Exec(ctx, q, enc, p.id); err != nil {
+			return migrated, err
+		}
+		migrated++
+	}
+	return migrated, nil
+}
+
 func (r *Repo) countBackupCodes(ctx context.Context, userID string) (int, error) {
 	d := r.db.Dialect()
 	var n int

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -418,6 +418,21 @@ func runServerGeneration(ctx context.Context, cmd *cobra.Command, _ []string, br
 	if err := authRepo.EnsureSchema(ctx); err != nil {
 		return fmt.Errorf("auth schema: %w", err)
 	}
+	// Шифрование TOTP-seed'ов (SEC-04, #779): при заданном мастер-ключе тихо
+	// перешифровываем открытые seed'ы существующим ключом (миграция не создаёт
+	// новых ключей и не добавляет скрытых зависимостей). Если после этого
+	// открытые seed'ы остаются — ключа нет; это постоянный admin-сигнал, что
+	// конфиденциальность второго фактора ниже ожидаемой.
+	if migrated, err := authRepo.MigratePlaintextTOTP(ctx); err != nil {
+		runLog.Warn("миграция открытых TOTP-seed'ов не выполнена", "err", err)
+	} else if migrated > 0 {
+		runLog.Info("TOTP-seed'ы перешифрованы мастер-ключом", "мигрировано", migrated)
+	}
+	if plaintext, err := authRepo.CountPlaintextTOTP(ctx); err == nil && plaintext > 0 {
+		runLog.Warn("открытые (незашифрованные) TOTP-seed'ы в базе — задайте мастер-ключ",
+			"количество", plaintext,
+			"выход", "ONEBASE_MASTER_KEY или ONEBASE_MASTER_KEY_FILE, затем перезапуск (план 83)")
+	}
 	// Сценарий обновления (#620): база, где второй фактор требовался, а привязка
 	// шла на входе (до #577), после обновления получает SelfEnroll2FA=false — и
 	// все, кто не успел привязать фактор, теряют вход, снять политику нечем.


### PR DESCRIPTION
Closes #779

Без мастер-ключа секрет TOTP лежит в базе открытым текстом — было
предупреждение при включении, но не было ни постоянного сигнала, ни миграции
после того, как ключ появился (SEC-04).

  * CountPlaintextTOTP — сколько включённых 2FA хранят seed открытым текстом
    (health/admin-сигнал);
  * MigratePlaintextTOTP — перешифровывает открытые seed'ы СУЩЕСТВУЮЩИМ
    мастер-ключом (не создаёт новых ключей, не добавляет скрытых зависимостей);
  * на старте: при заданном ключе открытые seed'ы тихо мигрируются, а если
    после этого остаются открытыми (ключа нет) — громкое постоянное
    предупреждение с указанием ONEBASE_MASTER_KEY/…_FILE.

Автосоздание мастер-ключа (тоже из SEC-04) в этот коммит НЕ входит: молчаливое
создание постоянного крипто-ключа несёт риск лока 2FA при его потере
(seed'ы, зашифрованные авто-ключом, при утере файла нечитаемы), и требует
отдельного решения о стабильном расположении ключа и его включении в backup.
Оставлено в issue #779.

Тест: seed включён без ключа → 1 plaintext; после задания ключа миграция → 0
plaintext, второй фактор продолжает работать.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
