### PR TITLE
fix(launcher): регистры бухгалтерии в конструкторе запросов конфигуратора (#789)

### DIFF
--- a/internal/launcher/configurator_load.go
+++ b/internal/launcher/configurator_load.go
@@ -809,6 +809,32 @@ func buildQBSchema(d *configuratorData) template.JS {
 		}
 	}
 
+	// Регистры бухгалтерии (issue #789): конструктор запросов в конфигураторе
+	// раньше их пропускал, хотя UI-конструктор (internal/ui/query_builder.go) их
+	// показывает — расхождение двух копий схемы. Формат совпадает с UI-копией:
+	// Остатки(&НаДату) и Обороты(&Начало, &Конец) с полями Счёт/Наименование и
+	// показателями по ресурсам.
+	for _, ar := range d.AccountRegisters {
+		bal := cfgQBSource{ID: "vt_acct_bal:" + ar.Name, Label: "РегистрБухгалтерии." + ar.Name + ".Остатки(&НаДату)", Group: "Регистры бухгалтерии", VTParam: "&НаДату"}
+		bal.Fields = append(bal.Fields, cfgQBField{Name: "Счёт", Label: "Счёт", Type: "string"})
+		bal.Fields = append(bal.Fields, cfgQBField{Name: "Наименование", Label: "Наименование", Type: "string"})
+		for _, f := range ar.Resources {
+			bal.Fields = append(bal.Fields, cfgQBField{Name: f.Name + "Остаток", Label: f.Name + "Остаток", Type: "res"})
+			bal.Fields = append(bal.Fields, cfgQBField{Name: f.Name + "Дт", Label: f.Name + "Дт", Type: "res"})
+			bal.Fields = append(bal.Fields, cfgQBField{Name: f.Name + "Кт", Label: f.Name + "Кт", Type: "res"})
+		}
+		sources = append(sources, bal)
+
+		trn := cfgQBSource{ID: "vt_acct_trn:" + ar.Name, Label: "РегистрБухгалтерии." + ar.Name + ".Обороты(&Начало, &Конец)", Group: "Регистры бухгалтерии", VTParam: "&Начало, &Конец"}
+		trn.Fields = append(trn.Fields, cfgQBField{Name: "Счёт", Label: "Счёт", Type: "string"})
+		trn.Fields = append(trn.Fields, cfgQBField{Name: "Наименование", Label: "Наименование", Type: "string"})
+		for _, f := range ar.Resources {
+			trn.Fields = append(trn.Fields, cfgQBField{Name: f.Name + "Дт", Label: f.Name + "Дт", Type: "res"})
+			trn.Fields = append(trn.Fields, cfgQBField{Name: f.Name + "Кт", Label: f.Name + "Кт", Type: "res"})
+		}
+		sources = append(sources, trn)
+	}
+
 	if sources == nil {
 		sources = []cfgQBSource{}
 	}

--- a/internal/launcher/configurator_qb_acctreg_test.go
+++ b/internal/launcher/configurator_qb_acctreg_test.go
@@ -1,0 +1,31 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+)
+
+// ARCH-03 / issue #789: конструктор запросов конфигуратора должен предлагать и
+// регистры бухгалтерии — как UI-конструктор (internal/ui/query_builder.go).
+// Раньше launcher-копия схемы их пропускала (расхождение двух копий).
+func TestBuildQBSchema_IncludesAccountRegisters(t *testing.T) {
+	d := &configuratorData{
+		AccountRegisters: []cfgAccountRegister{{
+			Name:      "Хозрасчётный",
+			Resources: []cfgField{{Name: "Сумма"}},
+		}},
+	}
+	js := string(buildQBSchema(d))
+	for _, want := range []string{
+		"vt_acct_bal:Хозрасчётный",
+		"vt_acct_trn:Хозрасчётный",
+		"РегистрБухгалтерии.Хозрасчётный.Остатки",
+		"РегистрБухгалтерии.Хозрасчётный.Обороты",
+		"СуммаОстаток", "СуммаДт", "СуммаКт",
+		"Регистры бухгалтерии",
+	} {
+		if !strings.Contains(js, want) {
+			t.Fatalf("схема QB конфигуратора не содержит %q; получено: %s", want, js)
+		}
+	}
+}


### PR DESCRIPTION
Closes #789

Схема конструктора запросов задублирована двумя копиями: UI
(internal/ui/query_builder.go) и конфигуратор
(internal/launcher/configurator_load.go). Копии разошлись — конкретно,
launcher-копия не строила источники регистров бухгалтерии, хотя UI-копия их
показывает (ARCH-03). `configurator.js` потребляет схему обобщённо (группирует
по source.group), поэтому добавление новой группы безопасно.

Добавлены источники «РегистрБухгалтерии.X.Остатки(&НаДату)» и
«.Обороты(&Начало, &Конец)» в том же формате, что у UI-копии (Счёт,
Наименование и показатели по ресурсам). Golden-тест проверяет их появление.

Полное извлечение обеих копий в общий internal/queryschema НЕ входит в этот
коммит: копии расходятся ещё и по семантике типов полей ("dim"/"res" против
типов данных), и слияние меняет контракт как минимум одного JS-потребителя —
это требует согласованной правки Go+JS и браузерной проверки. Оставлено в
issue #789 как больший шаг.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
