### PR TITLE
fix(ui): «+ Создать» в подборе из ячейки табличной части управляемой формы

### DIFF
--- a/internal/ui/managed_ref_create_node_test.go
+++ b/internal/ui/managed_ref_create_node_test.go
@@ -1,0 +1,18 @@
+package ui
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestManagedRefCreateBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required for the ref-editor inline-create regression test")
+	}
+	cmd := exec.Command(node, "--test", "static/managed_ref_create_behavior_test.js") //nolint:gosec // test-only executable resolved by exec.LookPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node ref-editor inline-create behavior test: %v\n%s", err, output)
+	}
+}

--- a/internal/ui/managed_ref_create_test.go
+++ b/internal/ui/managed_ref_create_test.go
@@ -1,0 +1,57 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Колонки SlickGrid уезжают в data-sg-cols. Чтобы подбор из ячейки ТЧ мог
+// предложить «+ Создать», признак allow_inline_create должен доехать до
+// клиента: без него редактор открывает форму выбора без создания (issue #765).
+func TestManagedGridColumnsCarryInlineCreate(t *testing.T) {
+	yes := true
+	ent := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Дата", Type: metadata.FieldTypeDate}},
+		TableParts: []metadata.TablePart{{Name: "Строки", Fields: []metadata.Field{
+			{Name: "КлиентБезСоздания", Type: "reference:Клиент", RefEntity: "Клиент"},
+			{Name: "КлиентСоСозданием", Type: "reference:Клиент", RefEntity: "Клиент", AllowInlineCreate: &yes},
+			{Name: "Количество", Type: metadata.FieldTypeNumber},
+		}}},
+	}
+	form := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: ent.Name,
+		LayoutKind: metadata.FormLayoutManaged,
+		Elements: []*metadata.FormElement{{
+			Kind: metadata.FormElementTablePart, Name: "Строки", DataPath: "Объект.Строки",
+		}},
+	}
+
+	var buf bytes.Buffer
+	err := tmpl.ExecuteTemplate(&buf, "page-managed-form", map[string]any{
+		"Entity": ent, "Form": form, "IsNew": true, "CanWrite": true,
+		"Values": map[string]string{}, "RefOptions": map[string]any{},
+		"EnumOptions": map[string]any{}, "TablePartRows": map[string][]map[string]any{},
+		"TPRefOptions": map[string]any{}, "TPEnumLabels": map[string]any{},
+		"Lang": "ru",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+	html := buf.String()
+
+	cols := html[strings.Index(html, "data-sg-cols="):]
+	cols = cols[:strings.Index(cols[len("data-sg-cols='"):], "'")+len("data-sg-cols='")]
+	if !strings.Contains(cols, `"id":"КлиентСоСозданием","name":"КлиентСоСозданием","type":"reference:Клиент","ref":"Клиент","allowCreate":true`) {
+		t.Errorf("колонка с allow_inline_create не отдала allowCreate клиенту:\n%s", cols)
+	}
+	if strings.Contains(cols, `"id":"КлиентБезСоздания","name":"КлиентБезСоздания","type":"reference:Клиент","ref":"Клиент","allowCreate":true`) {
+		t.Errorf("создание включилось у колонки без allow_inline_create (в ТЧ дефолт — выключено):\n%s", cols)
+	}
+	if strings.Contains(cols, `"id":"Количество"`) && strings.Contains(cols, `"allowCreate":true,"enum"`) {
+		t.Errorf("allowCreate протёк в неcсылочную колонку:\n%s", cols)
+	}
+}

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -1403,6 +1403,11 @@ obManagedReady(obManagedInitDelegates);
       if (typeof window.openRefPicker !== 'function') return;
       var selEl = document.createElement('select');
       selEl.setAttribute('data-ref-entity', refEntity);
+      // «+ Создать» в форме подбора включается тем же признаком колонки, что и
+      // в автоформе (allow_inline_create у поля ТЧ). Без переноса на временный
+      // select подбор из ячейки не давал создать элемент НИКОГДА, даже когда
+      // конфигурация это разрешила.
+      if (args.column && args.column.allowCreate) selEl.setAttribute('data-ref-allow-create', '1');
       var opts = candidates('');
       for (var k = 0; k < opts.length; k++) {
         var o = document.createElement('option');
@@ -1605,6 +1610,9 @@ obManagedReady(obManagedInitDelegates);
         // него в ячейке были видны только предзагруженные опции, а модалка
         // подбора уходила в локальный фильтр вместо /ui/_ref-options.
         col.refEntity = c.ref;
+        // allowCreate приходит из allow_inline_create поля ТЧ (сервер кладёт
+        // его в data-sg-cols только когда создание разрешено).
+        col.allowCreate = !!c.allowCreate;
         col.editor = (function(refField, refOptsList) {
           return ObRefEditor.bind(null, refField, refOptsList);
         })(c.id, refOpts[c.id] || []);

--- a/internal/ui/static/managed_ref_create_behavior_test.js
+++ b/internal/ui/static/managed_ref_create_behavior_test.js
@@ -1,0 +1,90 @@
+// Редактор ссылки в ячейке ТЧ: форма подбора должна предлагать «+ Создать»
+// ровно тогда, когда колонка это разрешает (allow_inline_create у поля ТЧ).
+// Проверяем настоящий ObRefEditor из managed.js, а не его пересказ.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const source = fs.readFileSync('static/managed.js', 'utf8');
+// refId живёт рядом с редактором в той же области видимости инициализатора —
+// берём срез от него, иначе редактор не соберётся.
+const start = source.indexOf('  function refId(');
+const end = source.indexOf('  function ObNumberEditor(', start);
+if (start < 0 || end < 0) throw new Error('managed ref editor slice not found');
+const editorSource = source.slice(start, end);
+
+function element(tag) {
+  const attrs = {};
+  const el = {
+    tagName: String(tag).toUpperCase(),
+    style: {},
+    children: [],
+    listeners: {},
+    value: '',
+    parentElement: null,
+    textContent: '',
+    setAttribute(name, value) { attrs[name] = String(value); },
+    getAttribute(name) { return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null; },
+    appendChild(child) { this.children.push(child); child.parentElement = this; return child; },
+    removeChild(child) { this.children = this.children.filter((c) => c !== child); },
+    remove() { if (this.parentElement) this.parentElement.removeChild(this); },
+    addEventListener(type, fn) { (this.listeners[type] || (this.listeners[type] = [])).push(fn); },
+    removeEventListener() {},
+    dispatch(type, event) { (this.listeners[type] || []).forEach((fn) => fn(event || {preventDefault() {}, stopPropagation() {}})); },
+    focus() {},
+    select() {},
+    querySelectorAll() { return []; },
+    getBoundingClientRect() { return {left: 0, top: 0, bottom: 0, width: 0, height: 0}; },
+  };
+  return el;
+}
+
+function runEditor(allowCreate) {
+  const picked = [];
+  global.document = {
+    body: element('body'),
+    createElement: element,
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  global.window = {
+    openRefPicker(sel) { picked.push(sel); },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  global.clearTimeout = () => {};
+  global.setTimeout = () => 0;
+
+  const container = element('div');
+  const column = {field: 'Клиент', refEntity: 'Клиент'};
+  if (allowCreate) column.allowCreate = true;
+  const args = {
+    column,
+    item: {Клиент: ''},
+    container,
+    commitChanges() {},
+    cancelChanges() {},
+    grid: {getOptions() { return {}; }},
+  };
+  const factory = new Function('args', 'refField', 'refOptsList', editorSource + '\nreturn new ObRefEditor(refField, refOptsList, args);');
+  factory(args, 'Клиент', [{id: 'id-1', _label: 'ООО Ромашка'}]);
+
+  // «…» в ячейке открывает общую форму подбора.
+  const wrapper = container.children[0];
+  const dropBtn = wrapper.children[1];
+  dropBtn.dispatch('click');
+  assert.equal(picked.length, 1, 'редактор не открыл форму подбора');
+  return picked[0];
+}
+
+test('колонка с allow_inline_create даёт подбору «+ Создать»', () => {
+  const sel = runEditor(true);
+  assert.equal(sel.getAttribute('data-ref-entity'), 'Клиент');
+  assert.equal(sel.getAttribute('data-ref-allow-create'), '1');
+});
+
+test('без разрешения колонки создание из подбора недоступно', () => {
+  const sel = runEditor(false);
+  assert.equal(sel.getAttribute('data-ref-entity'), 'Клиент');
+  assert.equal(sel.getAttribute('data-ref-allow-create'), null);
+});

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -276,7 +276,7 @@ const tplManagedForm = `
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПриАктивизацииСтроки")}}data-sg-rowactivate="1"{{end}}
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПриИзмененииСтроки")}}data-sg-rowchange="1"{{end}}
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПослеДобавленияСтроки")}}data-sg-rowafteradd="1"{{end}}
-       data-sg-cols='[{{range $i, $f := $tpMeta.Fields}}{{if $i}},{{end}}{"id":"{{$f.Name}}","name":"{{$f.Name}}","type":"{{$f.Type}}"{{if $f.RefEntity}},"ref":"{{$f.RefEntity}}"{{end}}{{if isEnum (str $f.Type)}},"enum":true{{end}}}{{end}}]'
+       data-sg-cols='[{{range $i, $f := $tpMeta.Fields}}{{if $i}},{{end}}{"id":"{{$f.Name}}","name":"{{$f.Name}}","type":"{{$f.Type}}"{{if $f.RefEntity}},"ref":"{{$f.RefEntity}}"{{if $f.InlineCreateEnabled true}},"allowCreate":true{{end}}{{end}}{{if isEnum (str $f.Type)}},"enum":true{{end}}}{{end}}]'
        data-sg-ref='{{jsJSON $tpRef}}'
        data-sg-enum='{{jsJSON $tpEnum}}'
        data-sg-rows='{{jsJSON $tpRows}}'


### PR DESCRIPTION
Closes #828 (вопрос из Q&A — #765).

## Что было

Ссылочная колонка табличной части с `allow_inline_create: true` всё равно не давала создать элемент справочника: подбор из ячейки (F4 / Alt+↓ / «…») открывался **без** кнопки «+ Создать».

Редактор ячейки (`ObRefEditor`) зовёт общую форму подбора через временный `<select>`, а тому проставлялся только `data-ref-entity`. Кнопку рисует `openRefPicker` по `data-ref-allow-create` — в ячейке ТЧ этот признак не появлялся никогда. То есть флаг работал в автогенерируемой форме и в простой таблице (`no_grid`), но не в основном рендере ТЧ управляемой формы.

## Что стало

Признак доезжает до клиента: `allowCreate` в `data-sg-cols` → `col.allowCreate` в `buildColumns` → `data-ref-allow-create` на временном select. Дефолты не менялись: в шапке создание по-прежнему включено, в ТЧ — выключено, пока конфигурация не разрешит явно.

## Проверено

- `internal/ui/static/managed_ref_create_behavior_test.js` (+ раннер `managed_ref_create_node_test.go`) — настоящий `ObRefEditor` из `managed.js` в маленьком DOM-стенде: клик по «…» отдаёт подбору select с `data-ref-allow-create` при `column.allowCreate` и без него в обратном случае. Убедился, что тест не пустой: с выключенной правкой первый случай падает.
- `internal/ui/managed_ref_create_test.go` — серверная половина: `data-sg-cols` несёт `"allowCreate":true` для колонки с `allow_inline_create: true` и не несёт для соседней без флага.
- Живая проверка в браузере (headless Edge + CDP) на мини-конфигурации `Заказ` → `Клиент`: до правки подбор из ячейки открывался без кнопки, после — с «+ Создать»; созданный элемент возвращается выбранным в ячейку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
