### PR TITLE
fix(ui): копия справочника с нумератором получает свой «Код»

### DIFF
--- a/internal/ui/copy_item_test.go
+++ b/internal/ui/copy_item_test.go
@@ -78,7 +78,8 @@ func TestApplyCopyFromQuery_CopiesHeaderAndTableParts(t *testing.T) {
 	if values["Наименование"] != "ООО Ромашка" || values["Телефон"] != "+7 900 111-22-33" {
 		t.Errorf("шапка не скопирована: %#v", values)
 	}
-	// Код справочника платформа не генерирует — копия несёт его как есть.
+	// Код справочника без нумератора платформа не генерирует — копия несёт его
+	// как есть (со включённым нумератором см. TestApplyCopyFromQuery_CatalogCode…).
 	if values["Код"] != "К-001" {
 		t.Errorf("Код = %q, ожидался перенос из источника", values["Код"])
 	}
@@ -93,6 +94,34 @@ func TestApplyCopyFromQuery_CopiesHeaderAndTableParts(t *testing.T) {
 	}
 	if len(rows) != 1 {
 		t.Errorf("записей после копирования = %d, ожидалась 1 (копия живёт только в форме)", len(rows))
+	}
+}
+
+// Справочник с нумератором сам выдаёт «Код» (план 117), поэтому копия обязана
+// получить свой: с numerator.unique перенос чужого кода не дал бы записать
+// копию вовсе, а без него завёл бы второй элемент с тем же кодом.
+func TestApplyCopyFromQuery_CatalogCodeIsReissuedWhenNumbered(t *testing.T) {
+	ent := copyTestCatalog()
+	ent.Numerator = &metadata.Numerator{Prefix: "К-", Length: 5, Unique: true}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{ent})
+
+	srcID := uuid.New()
+	if err := s.store.Upsert(ctx, ent.Name, srcID, map[string]any{
+		"Наименование": "ООО Ромашка", "Код": "К-00001",
+	}, ent); err != nil {
+		t.Fatal(err)
+	}
+
+	values := map[string]string{}
+	r := httptest.NewRequest("GET", "/ui/catalog/клиент/new?copy="+srcID.String(), nil)
+	if errText := s.applyCopyFromQuery(r.WithContext(ctx), ent, srcID.String(), values, map[string][]map[string]any{}); errText != "" {
+		t.Fatalf("applyCopyFromQuery: %s", errText)
+	}
+	if values["Код"] != "" {
+		t.Errorf("Код = %q, копия справочника с нумератором должна получить свой код при записи", values["Код"])
+	}
+	if values["Наименование"] != "ООО Ромашка" {
+		t.Errorf("остальные реквизиты должны копироваться: %#v", values)
 	}
 }
 

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -449,18 +449,26 @@ func (s *Server) applyCopyFromQuery(r *http.Request, entity *metadata.Entity, sr
 
 // skipFieldOnCopy — реквизиты, которые копия получает заново, а не от источника.
 //
-// Номер документа выдаёт запись (автонумерация), а дата нового документа —
-// текущая: форма подставила её до копирования, и копия вчерашней накладной
-// оформляется сегодняшним днём, как «Создать копированием» в 1С. Реквизиты
-// справочника (включая Код) копируются как есть: платформа их не генерирует,
-// и обнулять то, что она не умеет заполнить, значило бы ломать копию.
+// Автонумеруемый реквизит выдаёт запись, а дата нового документа — текущая:
+// форма подставила её до копирования, и копия вчерашней накладной оформляется
+// сегодняшним днём, как «Создать копированием» в 1С. Реквизит справочника без
+// нумератора (в том числе рукописный Код) копируется как есть: платформа его не
+// генерирует, и обнулять то, что она не умеет заполнить, значило бы ломать копию.
 func skipFieldOnCopy(entity *metadata.Entity, f metadata.Field) bool {
-	return isSystemDocumentNumber(entity, f) || isSystemDocumentDate(entity, f)
+	return isAutoNumberedField(entity, f) || isSystemDocumentDate(entity, f)
 }
 
-func isSystemDocumentNumber(entity *metadata.Entity, field metadata.Field) bool {
-	return entity != nil && entity.Kind == metadata.KindDocument &&
-		field.Type == metadata.FieldTypeString && strings.EqualFold(field.Name, "Номер")
+// isAutoNumberedField — реквизит, который платформа заполняет сама при записи:
+// «Номер» документа и «Код» справочника с нумератором (план 117). Спрашиваем
+// storage.AutoNumberField, а не имя реквизита: копия обязана получить своё
+// значение. С `numerator.unique: true` перенос чужого кода вообще не даст
+// записать копию, а без него — молча заведёт второй объект с тем же кодом.
+func isAutoNumberedField(entity *metadata.Entity, field metadata.Field) bool {
+	target := storage.AutoNumberField(entity)
+	if target == "" {
+		return false
+	}
+	return field.Type == metadata.FieldTypeString && strings.EqualFold(field.Name, target)
 }
 
 func isSystemDocumentDate(entity *metadata.Entity, field metadata.Field) bool {


### PR DESCRIPTION
Стык двух вещей, приехавших в main в один день: «Создать копированием» (#762, PR #766) и нумератор справочника с `numerator.unique` (план 117, этапы D–E).

## Что не так

Правило копирования выдавало заново только «Номер» **документа**
(`isSystemDocumentNumber`), а «Код» справочника считало обычным реквизитом и
переносило из источника. После плана 117 «Код» справочника с нумератором
платформа выдаёт сама (`storage.AutoNumberField`), поэтому:

- с `numerator.unique: true` копию **вообще нельзя записать** — «код занят»,
  пользователь должен вручную чистить поле, которое он не заполнял;
- без `unique` в базе молча появляется второй элемент с тем же кодом — ровно
  то, против чего этап E и делался.

## Что стало

`skipFieldOnCopy` спрашивает `storage.AutoNumberField(entity)`, а не имя
реквизита: заново выдаётся и «Номер» документа, и «Код» справочника с
нумератором. Рукописный «Код» справочника **без** нумератора по-прежнему
копируется — платформа его не генерирует, и обнулять было бы нечем (этот случай
закреплён существующим тестом).

Правило общее для обоих путей: и для подстановки значений в форму
(`applyCopyFromQuery`), и для серверной пересборки копии при записи
(`copy_item_state.go`), так что подменить код через форму тоже не выйдет.

## Проверено

`TestApplyCopyFromQuery_CatalogCodeIsReissuedWhenNumbered` — справочник с
`numerator{unique}`: «Код» в копию не переносится, остальные реквизиты
переносятся. Прежние тесты копирования (включая «Код без нумератора копируется
как есть») зелёные: `go test ./internal/ui/ -run Copy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
