### PR TITLE
fix(ui): колонки табличной части подписываются синонимом реквизита

### DIFF
--- a/internal/ui/managed_tp_titles_test.go
+++ b/internal/ui/managed_tp_titles_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Колонки табличной части подписываются синонимом реквизита (`title`/`titles`),
+// как в автогенерируемой форме. Имя реквизита остаётся идентификатором: по нему
+// идёт привязка данных SlickGrid и разбор имён полей tp.<ТЧ>.<i>.<реквизит>.
+func TestManagedTablePartColumnsUseFieldTitles(t *testing.T) {
+	ent := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{{Name: "Дата", Type: metadata.FieldTypeDate}},
+		TableParts: []metadata.TablePart{{Name: "Строки", Fields: []metadata.Field{
+			{Name: "КодКлиента", Type: metadata.FieldTypeString, Title: "Код клиента"},
+			{Name: "Количество", Type: metadata.FieldTypeNumber,
+				Titles: map[string]string{"ru": "Кол-во", "en": "Qty"}},
+			{Name: "Комментарий", Type: metadata.FieldTypeString},
+		}}},
+	}
+	form := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: ent.Name,
+		LayoutKind: metadata.FormLayoutManaged,
+		Elements: []*metadata.FormElement{{
+			Kind: metadata.FormElementTablePart, Name: "Строки", DataPath: "Объект.Строки",
+		}},
+	}
+
+	// Та же ТЧ без SlickGrid (no_grid) — второй путь отрисовки заголовков.
+	plainForm := &metadata.FormModule{
+		Name: "ФормаОбъекта", Kind: "object", EntityName: ent.Name,
+		LayoutKind: metadata.FormLayoutManaged,
+		Elements: []*metadata.FormElement{{
+			Kind: metadata.FormElementTablePart, Name: "Строки", DataPath: "Объект.Строки",
+			NoGrid: true,
+		}},
+	}
+
+	renderForm := func(f *metadata.FormModule, lang string) string {
+		var buf bytes.Buffer
+		err := tmpl.ExecuteTemplate(&buf, "page-managed-form", map[string]any{
+			"Entity": ent, "Form": f, "IsNew": true, "CanWrite": true,
+			"Values": map[string]string{}, "RefOptions": map[string]any{},
+			"EnumOptions": map[string]any{}, "TablePartRows": map[string][]map[string]any{},
+			"TPRefOptions": map[string]any{}, "TPEnumLabels": map[string]any{},
+			"Lang": lang,
+		})
+		if err != nil {
+			t.Fatalf("ExecuteTemplate: %v", err)
+		}
+		return buf.String()
+	}
+	render := func(lang string) string { return renderForm(form, lang) }
+
+	html := render("ru")
+	// SlickGrid: подпись — синоним, идентификатор — имя реквизита.
+	if !strings.Contains(html, `{"id":"КодКлиента","name":"Код клиента"`) {
+		t.Errorf("колонка SlickGrid подписана именем реквизита вместо синонима")
+	}
+	if !strings.Contains(html, `{"id":"Количество","name":"Кол-во"`) {
+		t.Errorf("локализованный синоним (titles.ru) не попал в подпись колонки")
+	}
+	// Без синонима остаётся имя реквизита.
+	if !strings.Contains(html, `{"id":"Комментарий","name":"Комментарий"`) {
+		t.Errorf("реквизит без синонима должен подписываться собственным именем")
+	}
+	// Простая таблица (no_grid) подписывается так же.
+	plain := renderForm(plainForm, "ru")
+	if !strings.Contains(plain, `<th>Код клиента</th>`) || !strings.Contains(plain, `<th>Кол-во</th>`) {
+		t.Errorf("заголовок простой таблицы ТЧ не использует синоним")
+	}
+	// Привязка данных в простой таблице остаётся по имени реквизита.
+	if !strings.Contains(plain, `КодКлиента|string`) {
+		t.Errorf("data-tp-fields должен нести имена реквизитов, а не подписи")
+	}
+
+	// Язык интерфейса выбирает перевод синонима.
+	if en := render("en"); !strings.Contains(en, `{"id":"Количество","name":"Qty"`) {
+		t.Errorf("английский синоним не подставился при Lang=en")
+	}
+}

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -276,7 +276,9 @@ const tplManagedForm = `
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПриАктивизацииСтроки")}}data-sg-rowactivate="1"{{end}}
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПриИзмененииСтроки")}}data-sg-rowchange="1"{{end}}
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПослеДобавленияСтроки")}}data-sg-rowafteradd="1"{{end}}
-       data-sg-cols='[{{range $i, $f := $tpMeta.Fields}}{{if $i}},{{end}}{"id":"{{$f.Name}}","name":"{{$f.Name}}","type":"{{$f.Type}}"{{if $f.RefEntity}},"ref":"{{$f.RefEntity}}"{{if $f.InlineCreateEnabled true}},"allowCreate":true{{end}}{{end}}{{if isEnum (str $f.Type)}},"enum":true{{end}}}{{end}}]'
+       {{/* id — имя реквизита (по нему идёт привязка данных и разбор tp.*),
+            name — только подпись колонки: синоним реквизита, как в автоформе. */}}
+       data-sg-cols='[{{range $i, $f := $tpMeta.Fields}}{{if $i}},{{end}}{"id":"{{$f.Name}}","name":"{{$f.DisplayName (str $ctx.Lang)}}","type":"{{$f.Type}}"{{if $f.RefEntity}},"ref":"{{$f.RefEntity}}"{{if $f.InlineCreateEnabled true}},"allowCreate":true{{end}}{{end}}{{if isEnum (str $f.Type)}},"enum":true{{end}}}{{end}}]'
        data-sg-ref='{{jsJSON $tpRef}}'
        data-sg-enum='{{jsJSON $tpEnum}}'
        data-sg-rows='{{jsJSON $tpRows}}'
@@ -296,7 +298,7 @@ const tplManagedForm = `
     <thead>
       <tr>
         {{if $tpCmds}}<th style="width:30px"></th>{{end}}
-        {{range $tpMeta.Fields}}<th>{{.Name}}</th>{{end}}
+        {{range $tpMeta.Fields}}<th>{{.DisplayName (str $ctx.Lang)}}</th>{{end}}
         <th style="width:40px"></th>
       </tr>
     </thead>


### PR DESCRIPTION
Closes #838 (вопрос из Q&A — #819).

## Что было

Заголовки колонок табличной части в управляемой форме показывали **имя**
реквизита: SlickGrid получал `"name"` равным `Name` (`data-sg-cols`), простая
таблица (`no_grid`) рисовала `<th>{{.Name}}</th>`. Синоним `title:` и его
переводы `titles:` не работали вовсе — при том что в автогенерируемой форме та
же колонка подписана через `DisplayName`. Одна конфигурация выглядела по-разному
в зависимости от вида формы.

## Что стало

Подпись берётся из синонима с учётом языка интерфейса. Идентификатор колонки
остаётся именем реквизита: по нему идёт привязка данных SlickGrid
(`col.field = c.id`) и разбор имён `tp.<ТЧ>.<i>.<реквизит>` при записи — данные
и сохранение не затронуты. Язык читается через `str`, чтобы шаблон не падал
там, где `Lang` в данные формы не кладут (так рендерят некоторые тесты и
служебные вызовы).

## Проверено

`TestManagedTablePartColumnsUseFieldTitles`: SlickGrid-колонка подписана
синонимом, локализованный `titles.ru` уважается, реквизит без синонима остаётся
со своим именем, простая таблица (`no_grid`) подписывается так же, а
`data-tp-fields` по-прежнему несёт имена реквизитов. При `Lang=en`
подставляется английский синоним. Убедился, что тест не пустой: с откатанной
правкой он падает. Весь пакет `go test ./internal/ui/` — зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
