### PR TITLE
fix(numerator): номер из модуля теряет префикс базы (план 117, пробел этапа D)

### DIFF
--- a/internal/dsl/interpreter/numerator_builtins.go
+++ b/internal/dsl/interpreter/numerator_builtins.go
@@ -22,12 +22,18 @@ import (
 	"time"
 
 	"github.com/ivantit66/onebase/internal/metadata"
-	"github.com/ivantit66/onebase/internal/storage"
 )
 
 // NumeratorStore — то, что объекту Нумераторы нужно от хранилища. Реализуется
 // *storage.DB. Обе операции атомарны и безопасны при конкурентных вызовах.
 type NumeratorStore interface {
+	// GenerateNumber — ЕДИНАЯ точка выдачи номера (план 117C): период, маски
+	// даты и префикс базы считаются там, а не пересобираются по месту. Пока
+	// этот объект собирал номер сам, он терял префикс базы (117D): номер,
+	// выданный из модуля, отличался от выданного через UI, и в разных базах
+	// такие номера совпадали — ровно то, ради предотвращения чего префикс и
+	// заведён.
+	GenerateNumber(ctx context.Context, entity *metadata.Entity, fields map[string]any) (string, error)
 	NextNumber(ctx context.Context, entityName, periodKey string) (int, error)
 	NextNum(ctx context.Context, entityName string) (int64, error)
 }
@@ -132,13 +138,12 @@ func (r *NumeratorsRoot) nextNumber(args []any) any {
 			}
 		}
 		// Тот же расчёт, что у UI и REST (план 117C): период выбирается
-		// детерминированно, префикс раскрывает маски даты.
-		periodKey := storage.PeriodKeyFor(entity, num, fields)
-		n, err := r.store.NextNumber(r.ctx.Ctx(), entity.Name, periodKey)
+		// детерминированно, префикс раскрывает маски даты и префикс базы.
+		value, err := r.store.GenerateNumber(r.ctx.Ctx(), entity, fields)
 		if err != nil {
 			panic(userError{Msg: "СледующийНомер: " + err.Error()})
 		}
-		return storage.FormatNumber(storage.ExpandPrefix(num.Prefix, storage.NumberPeriodDate(entity, fields)), num.Length, n)
+		return value
 	}
 	n, err := r.store.NextNum(r.ctx.Ctx(), entity.Name)
 	if err != nil {

--- a/internal/dsl/interpreter/numerator_builtins_test.go
+++ b/internal/dsl/interpreter/numerator_builtins_test.go
@@ -26,6 +26,23 @@ func (f *fakeNumStore) NextNumber(_ context.Context, entity, periodKey string) (
 	return f.seq[entity+"|"+periodKey], nil
 }
 
+// GenerateNumber в заглушке считает НАМЕРЕННО примитивно: эти тесты про разбор
+// аргументов объекта Нумераторы (область, дата, приоритет), а не про формат
+// номера. Формат — включая префикс базы, который заглушка не знает вовсе, —
+// проверяется на настоящем хранилище: см. TestDSLNumerator_UsesBasePrefix в
+// internal/ui.
+func (f *fakeNumStore) GenerateNumber(ctx context.Context, entity *metadata.Entity, fields map[string]any) (string, error) {
+	if entity == nil || entity.Numerator == nil {
+		return "", nil
+	}
+	num := entity.Numerator
+	n, err := f.NextNumber(ctx, entity.Name, storage.PeriodKeyFor(entity, num, fields))
+	if err != nil {
+		return "", err
+	}
+	return storage.FormatNumber(storage.ExpandPrefix(num.Prefix, storage.NumberPeriodDate(entity, fields)), num.Length, n), nil
+}
+
 func (f *fakeNumStore) NextNum(_ context.Context, entity string) (int64, error) {
 	if f.legacy == nil {
 		f.legacy = map[string]int64{}

--- a/internal/ui/dsl_numerator_test.go
+++ b/internal/ui/dsl_numerator_test.go
@@ -1,0 +1,114 @@
+package ui
+
+// Номер, выданный из модуля, обязан совпадать по формату с выданным платформой.
+//
+// `Нумераторы.СледующийНомер()` собирал номер сам и терял префикс базы (план
+// 117D): объект, созданный обработкой, получал «Д-000001», а такой же через
+// UI — «Ф-Д-000001». В разных базах номера, выданные из модулей, при этом
+// совпадали — ровно то, ради предотвращения чего префикс базы и заведён.
+//
+// Тест идёт через настоящее хранилище и настоящий путь DSL: заглушка стора,
+// которая собирает номер сама, проверяла бы копию формулы, а не платформу.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+func numeratorDSLServer(t *testing.T, basePrefix bool) (*Server, context.Context, *metadata.Entity) {
+	t.Helper()
+	doc := &metadata.Entity{
+		Name: "Договор", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Дата", Type: metadata.FieldTypeDate},
+		},
+		Numerator: &metadata.Numerator{Prefix: "Д-", Length: 6, Period: "none", BasePrefix: basePrefix},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{doc})
+	if err := s.store.EnsureNumeratorSchema(ctx); err != nil {
+		t.Fatalf("схема нумератора: %v", err)
+	}
+	if err := s.store.EnsureSettingsSchema(ctx); err != nil {
+		t.Fatalf("схема настроек: %v", err)
+	}
+	return s, ctx, doc
+}
+
+func nextNumberFromDSL(t *testing.T, s *Server, ctx context.Context) string {
+	t.Helper()
+	prog := mustParse(t, `Функция Проверка() Экспорт
+  Возврат Нумераторы.СледующийНомер("Договор");
+КонецФункции`)
+	var result any
+	vars, _ := s.buildDSLVarsTx(ctx, runtime.NewMovementsCollector("test", uuid.Nil))
+	if err := s.interp.RunWithResult(prog.Procedures[0], nil, &result, vars); err != nil {
+		t.Fatalf("СледующийНомер: %v", err)
+	}
+	got, _ := result.(string)
+	return got
+}
+
+// Префикс базы попадает в номер, выданный из модуля.
+func TestDSLNumerator_UsesBasePrefix(t *testing.T) {
+	s, ctx, ent := numeratorDSLServer(t, true)
+	if err := s.store.SaveBasePrefix(ctx, "Ф-"); err != nil {
+		t.Fatalf("префикс базы: %v", err)
+	}
+
+	got := nextNumberFromDSL(t, s, ctx)
+	if !strings.HasPrefix(got, "Ф-Д-") {
+		t.Errorf("номер из модуля = %q, ожидался с префиксом базы «Ф-Д-»", got)
+	}
+
+	// И совпадает по формату с тем, что выдаёт сама платформа.
+	platform, err := s.store.GenerateNumber(ctx, ent, map[string]any{})
+	if err != nil {
+		t.Fatalf("GenerateNumber: %v", err)
+	}
+	if trimNumberTail(got) != trimNumberTail(platform) {
+		t.Errorf("формат разошёлся: из модуля %q, из платформы %q", got, platform)
+	}
+}
+
+// Без base_prefix: true формат не меняется — включение префикса на базе не
+// должно молча переформатировать номера тех объектов, где он не объявлен.
+func TestDSLNumerator_WithoutBasePrefixUnchanged(t *testing.T) {
+	s, ctx, _ := numeratorDSLServer(t, false)
+	if err := s.store.SaveBasePrefix(ctx, "Ф-"); err != nil {
+		t.Fatalf("префикс базы: %v", err)
+	}
+	got := nextNumberFromDSL(t, s, ctx)
+	if !strings.HasPrefix(got, "Д-") {
+		t.Errorf("номер = %q, ожидался «Д-…» без префикса базы", got)
+	}
+}
+
+// Счётчик у модуля и платформы ОБЩИЙ: иначе два пути выдали бы один номер
+// дважды, и уникальность кода ловила бы это уже при записи.
+func TestDSLNumerator_SharesCounterWithPlatform(t *testing.T) {
+	s, ctx, ent := numeratorDSLServer(t, false)
+
+	first := nextNumberFromDSL(t, s, ctx)
+	second, err := s.store.GenerateNumber(ctx, ent, map[string]any{})
+	if err != nil {
+		t.Fatalf("GenerateNumber: %v", err)
+	}
+	if first == second {
+		t.Errorf("модуль и платформа выдали один номер %q — счётчик разошёлся", first)
+	}
+}
+
+// trimNumberTail отрезает числовой хвост, оставляя префиксную часть.
+func trimNumberTail(v string) string {
+	i := len(v)
+	for i > 0 && v[i-1] >= '0' && v[i-1] <= '9' {
+		i--
+	}
+	return v[:i]
+}


### PR DESCRIPTION
Пробел этапа 117D, найденный при проверке смежного кода. Тред — #658.

## Что не так

`Нумераторы.СледующийНомер()` собирал номер **сам** — счётчик, период, маски
даты — и не знал про префикс базы, который этап 117D добавил в единую точку
выдачи `GenerateNumber`.

| Как создан документ | Номер |
|---|---|
| через UI/REST | `Ф-Д-000001` |
| из обработки (`Нумераторы.СледующийНомер`) | `Д-000001` |

Расхождение формата внутри одной базы — полбеды. Хуже, что номера, выданные из
модулей в РАЗНЫХ базах, совпадали: префикс базы заведён именно для того, чтобы
обмен не склеивал разные объекты, и на этом пути он не работал.

Это последняя уцелевшая копия расчёта номера: план 117C сносил пять таких, а
шестая жила в DSL-объекте и разошлась с оригиналом при следующей же правке
формата — что и произошло на 117D.

## Что сделано

Объект зовёт `GenerateNumber` — ту же точку, что UI, REST и приёмка обмена.
Разбор аргументов (область нумерации, дата, приоритет) остаётся в объекте: он
специфичен для DSL и к формату отношения не имеет.

## О тестах

Заглушка стора в юнит-тестах интерпретатора собирает номер по-прежнему
примитивно — и это записано в её комментарии: те тесты про разбор аргументов, а
не про формат. Формат проверяется на **настоящем** хранилище и настоящем пути
DSL (`TestDSLNumerator_UsesBasePrefix` в `internal/ui`): заглушка, повторяющая
формулу, проверяла бы копию, а не платформу.

Проверено, что без правки этот тест падает:

```
номер из модуля = "Д-000001", ожидался с префиксом базы «Ф-Д-»
формат разошёлся: из модуля "Д-000001", из платформы "Ф-Д-000002"
```

Плюс проверено, что счётчик у модуля и платформы общий (иначе два пути выдали бы
один номер дважды) и что без `base_prefix: true` формат не меняется.

## Проверено

`go test ./...` (включая PostgreSQL), `golangci-lint`, `gofmt`.

Замечание про прогон: на чистой базе PostgreSQL часть тестов этапов падает —
это известная зависимость от порядка прогона, её снимает #851; в порядке CI всё
зелёное.
