### PR TITLE
fix(ui): ИИ-действие больше не затирает явно заданный «Номер» (Д13)

### DIFF
--- a/internal/ui/ai_actions.go
+++ b/internal/ui/ai_actions.go
@@ -516,17 +516,11 @@ func (s *Server) aiActionRun(w http.ResponseWriter, r *http.Request) {
 		obj.Set(k, s.aiTypedValue(entity.Fields, k, v))
 	}
 	obj.TablePartRows = action.TPRows
-	// Автонумерация — как при создании из формы.
-	if entity.Kind == metadata.KindDocument {
-		for _, f := range entity.Fields {
-			if f.Name == "Номер" && f.Type == metadata.FieldTypeString {
-				if v := fmt.Sprintf("%v", obj.Fields["Номер"]); v == "" || v == "<nil>" {
-					obj.Set("Номер", s.generateNumber(ctx, entity, obj.Fields))
-				}
-				break
-			}
-		}
-	}
+	// Автонумерация — та же общая точка, что при создании из формы (117C).
+	// Локальная копия здесь читала obj.Fields["Номер"] напрямую, а Object.Set
+	// хранит ключи в нижнем регистре — проверка пустоты всегда была истинной,
+	// и явно заданный пользователем номер молча затирался (Д13, issue #866).
+	s.ensureNewDocumentNumber(ctx, entity, obj)
 	// Строковый доступ (план 79): автозаполнение обязательных полей политики и
 	// проверка, что пользователь вправе записать такую строку.
 	if err := s.autoFillRowAccessFields(ctx, entity, "write", obj.Fields); err != nil {

--- a/internal/ui/ai_actions_test.go
+++ b/internal/ui/ai_actions_test.go
@@ -177,6 +177,63 @@ func TestAIActions_ReferenceLabelsHonorFieldMasking(t *testing.T) {
 	}
 }
 
+// Явно заданный «Номер» не затирается автонумерацией (Д13, issue #866):
+// локальная копия проверки пустоты читала obj.Fields["Номер"] напрямую, тогда
+// как Object.Set хранит ключи в нижнем регистре, — условие «пусто» было
+// истинным всегда, и ИИ-действие молча переписывало номер пользователя.
+func TestAIActionRun_KeepsExplicitNumber(t *testing.T) {
+	ents := aiActionsEntities()
+	s, ctx := newSubmitTestServer(t, ents)
+	contraID := uuid.New()
+	if err := s.store.Upsert(ctx, "Контрагенты", contraID, map[string]any{"Наименование": "Ромашка"}, ents[0]); err != nil {
+		t.Fatal(err)
+	}
+	action, res, _ := stageCreateOrder(t, s, map[string]any{
+		"сущность": "Заказ",
+		"поля": map[string]any{
+			"Номер":      "ЗК-777",
+			"Дата":       "2026-07-17T10:30",
+			"Контрагент": "Ромашка",
+		},
+	})
+	if res.IsError {
+		t.Fatalf("staging: %s", res.Content)
+	}
+
+	body, _ := json.Marshal(action)
+	rr := httptest.NewRecorder()
+	s.aiActionRun(rr, httptest.NewRequest("POST", "/ui/ai/action", strings.NewReader(string(body))))
+
+	var out struct {
+		OK    bool   `json:"ok"`
+		ID    string `json:"id"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("разбор ответа: %v (%s)", err, rr.Body.String())
+	}
+	if !out.OK {
+		t.Fatalf("ожидался ok, получено: %s", out.Error)
+	}
+	id, err := uuid.Parse(out.ID)
+	if err != nil {
+		t.Fatalf("нет корректного id в ответе: %q", out.ID)
+	}
+	row, err := s.store.GetByID(ctx, "Заказ", id, ents[1])
+	if err != nil {
+		t.Fatalf("документ не найден: %v", err)
+	}
+	num := ""
+	for k, v := range row {
+		if strings.EqualFold(k, "Номер") && v != nil {
+			num = fmt.Sprint(v)
+		}
+	}
+	if num != "ЗК-777" {
+		t.Fatalf("явный номер затёрт: got %q, want %q", num, "ЗК-777")
+	}
+}
+
 func TestAIActionRun_CreatesDraft(t *testing.T) {
 	ents := aiActionsEntities()
 	s, ctx := newSubmitTestServer(t, ents)


### PR DESCRIPTION
## Что не так

`aiActionRun` держал собственную копию автонумерации и проверял пустоту через `obj.Fields["Номер"]` — прямое чтение map. Но `runtime.Object.Set` нормализует ключи в нижний регистр, поэтому чтение по `"Номер"` всегда давало `nil` → «<nil>» → условие «пусто» истинно всегда → **явно заданный пользователем номер молча переписывался сгенерированным**. Это дефект Д13 плана 117 (`Plans/117-standard-code-and-base-prefix.md` цитирует ровно эту строку); PR #773 заявлял закрытие «сносом пяти копий», но эта копия жила дальше. Существующий тест проверял только «номер не пуст» и дефект не ловил.

## Что сделано

Копия снесена: `aiActionRun` зовёт общую точку `ensureNewDocumentNumber` (117C) — ту же, что путь создания из формы. Побочный бонус: ИИ-создание **справочника** теперь заполняет стандартный «Код» (общая точка умеет и Номер, и Код), частично продвигая #869.

## Тесты

`TestAIActionRun_KeepsExplicitNumber` — через публичный AI-хендлер: документ с явным «ЗК-777» сохраняет его (на старом коде тест падает — номер перегенерирован). Существующий `TestAIActionRun_CreatesDraft` (автозаполнение пустого номера) остаётся зелёным.

`go test ./internal/ui/` — зелёный.

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)