### PR TITLE
fix(cli): renumber обходит всю базу, а не первые 1000 записей

### DIFF
--- a/internal/cli/renumber.go
+++ b/internal/cli/renumber.go
@@ -136,53 +136,61 @@ func renumberTargets(proj *project.Project, only string) ([]*metadata.Entity, er
 	return out, nil
 }
 
-// renumberEntity дозаполняет пустые значения одного объекта.
+// renumberEntity дозаполняет пустые значения одного объекта. База читается
+// страницами до исчерпания: один вызов List с Limit=MaxListPageSize видел
+// только первую тысячу записей, и на большом справочнике команда молча
+// «дозаполняла» первую страницу, рапортуя успех (issue #867).
 func renumberEntity(ctx context.Context, db *storage.DB, ent *metadata.Entity, write bool) (renumberEntityReport, error) {
 	field := storage.AutoNumberField(ent)
 	rep := renumberEntityReport{Object: ent.Name, Field: field}
 
-	rows, err := db.List(ctx, ent.Name, ent, storage.ListParams{Limit: storage.MaxListPageSize})
-	if err != nil {
-		return rep, err
-	}
-	// Порядок выдачи детерминирован: сортируем по идентификатору записи, а не
-	// полагаемся на порядок выборки. Иначе повторный запуск на другой машине
-	// раздал бы те же коды другим элементам.
-	sort.Slice(rows, func(i, j int) bool {
-		return fmt.Sprintf("%v", rows[i]["id"]) < fmt.Sprintf("%v", rows[j]["id"])
-	})
-
-	for _, row := range rows {
-		if !isBlankValue(rowFieldValue(row, field)) {
-			continue // заполненное не трогаем: дозаполнение, а не перенумерация
+	for offset := 0; ; offset += storage.MaxListPageSize {
+		// Sort: "id" — принудительно. Порядок нужен детерминированный (иначе
+		// повторный запуск на другой машине раздал бы те же коды другим
+		// элементам) и УСТОЙЧИВЫЙ к самой записи: у иерархических справочников
+		// List по умолчанию сортирует по is_folder и первому строковому полю,
+		// а это обычно и есть заполняемый «Код» — страницы поплыли бы прямо
+		// под Offset-пейджингом. ORDER BY id от SetAutoNumberValue не меняется.
+		rows, err := db.List(ctx, ent.Name, ent, storage.ListParams{
+			Sort: "id", Limit: storage.MaxListPageSize, Offset: offset,
+		})
+		if err != nil {
+			return rep, err
 		}
-		rep.Empty++
-		if !write {
-			if len(rep.Samples) < 3 {
-				rep.Samples = append(rep.Samples, fmt.Sprintf("%v", row["id"]))
+		for _, row := range rows {
+			if !isBlankValue(rowFieldValue(row, field)) {
+				continue // заполненное не трогаем: дозаполнение, а не перенумерация
 			}
-			continue
+			rep.Empty++
+			if !write {
+				if len(rep.Samples) < 3 {
+					rep.Samples = append(rep.Samples, fmt.Sprintf("%v", row["id"]))
+				}
+				continue
+			}
+			value, err := db.GenerateNumber(ctx, ent, row)
+			if err != nil {
+				return rep, err
+			}
+			if value == "" {
+				continue
+			}
+			id, err := uuid.Parse(fmt.Sprintf("%v", row["id"]))
+			if err != nil {
+				return rep, fmt.Errorf("неразбираемый идентификатор %v: %w", row["id"], err)
+			}
+			if err := db.SetAutoNumberValue(ctx, ent, id, field, value); err != nil {
+				return rep, err
+			}
+			rep.Filled++
+			if len(rep.Samples) < 3 {
+				rep.Samples = append(rep.Samples, value)
+			}
 		}
-		value, err := db.GenerateNumber(ctx, ent, row)
-		if err != nil {
-			return rep, err
-		}
-		if value == "" {
-			continue
-		}
-		id, err := uuid.Parse(fmt.Sprintf("%v", row["id"]))
-		if err != nil {
-			return rep, fmt.Errorf("неразбираемый идентификатор %v: %w", row["id"], err)
-		}
-		if err := db.SetAutoNumberValue(ctx, ent, id, field, value); err != nil {
-			return rep, err
-		}
-		rep.Filled++
-		if len(rep.Samples) < 3 {
-			rep.Samples = append(rep.Samples, value)
+		if len(rows) < storage.MaxListPageSize {
+			return rep, nil
 		}
 	}
-	return rep, nil
 }
 
 // isBlankValue — пусто ли значение колонки. Отдельная функция потому, что

--- a/internal/cli/renumber_test.go
+++ b/internal/cli/renumber_test.go
@@ -8,6 +8,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,6 +154,54 @@ func TestRenumber_Idempotent(t *testing.T) {
 
 // Объект без numerator: в цели не попадает — раздача кодов всем справочникам
 // молча изменила бы данные существующих конфигураций.
+// База больше одной страницы: раньше renumberEntity делал единственный List с
+// Limit=MaxListPageSize и молча оставлял хвост пустым, рапортуя успех (#867).
+// Справочник иерархический — заодно ловим второй капкан: List без Sort сортирует
+// иерархические по is_folder и первому строковому полю, то есть по заполняемому
+// «Коду», и страницы Offset-пейджинга плыли бы прямо под записью.
+func TestRenumber_FillsBeyondFirstPage(t *testing.T) {
+	ent := renumberCatalog()
+	ent.Hierarchical = true
+	total := storage.MaxListPageSize + 100
+	seed := make([]map[string]any, 0, total)
+	for i := 0; i < total; i++ {
+		seed = append(seed, map[string]any{"Наименование": fmt.Sprintf("Элемент %04d", i)})
+	}
+	db := renumberDB(t, ent, seed)
+
+	rep, err := renumberEntity(context.Background(), db, ent, true)
+	if err != nil {
+		t.Fatalf("renumberEntity: %v", err)
+	}
+	if rep.Empty != total || rep.Filled != total {
+		t.Errorf("отчёт = %+v, ожидалось empty=filled=%d", rep, total)
+	}
+
+	rows, err := db.List(context.Background(), ent.Name, ent, storage.ListParams{Sort: "id", Limit: 0})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != total {
+		t.Fatalf("прочитано %d строк, ожидалось %d", len(rows), total)
+	}
+	uniq := map[string]bool{}
+	blank := 0
+	for _, r := range rows {
+		code := strings.TrimSpace(asAnyString(rowFieldValue(r, metadata.StandardCodeField)))
+		if code == "" {
+			blank++
+			continue
+		}
+		uniq[code] = true
+	}
+	if blank != 0 {
+		t.Errorf("остались записи без кода: %d", blank)
+	}
+	if len(uniq) != total {
+		t.Errorf("кодов %d уникальных, ожидалось %d — есть дубли", len(uniq), total)
+	}
+}
+
 func TestRenumberTargets_SkipsWithoutNumerator(t *testing.T) {
 	withNum := renumberCatalog()
 	plain := &metadata.Entity{


### PR DESCRIPTION
## Что не так

`renumberEntity` (`internal/cli/renumber.go`) читал записи единственным `db.List` с `Limit: storage.MaxListPageSize` (=1000) — без Offset и без цикла. На справочнике в 5000 элементов и dry-run, и `--write` видели только первую тысячу по id; повторный запуск читал ту же (уже заполненную) страницу и рапортовал «без значения 0», создавая ложное впечатление полного дозаполнения — при том что команда позиционируется именно для больших живых баз.

## Что сделано

Постраничный обход до исчерпания. Принудительный `Sort: "id"` — существенно: у **иерархических** справочников `List` без Sort сортирует по `is_folder` и первому строковому полю, а это обычно сам заполняемый «Код» — страницы Offset-пейджинга плыли бы прямо под записью. `ORDER BY id` детерминирован (то же свойство, ради которого раньше стоял in-memory sort — он снят) и не меняется от `SetAutoNumberValue`.

## Тест

`TestRenumber_FillsBeyondFirstPage` — иерархический справочник на `MaxListPageSize+100` записей: отчёт `empty=filled=1100`, ни одной записи без кода, все коды уникальны. На старом коде заполнялась ровно тысяча — тест падает.

`go test ./internal/cli/` — зелёный, кроме заведомо падающего локально `TestApplyStagedBlocksGenerationBoundRecovery` (self-update, падает и на чистом main — особенность среды, в CI проходит).

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)