### PR TITLE
fix(storage): Any-предикат RLS — один операнд WHERE во всех билдерах

### DIFF
--- a/internal/query/row_filters_or_test.go
+++ b/internal/query/row_filters_or_test.go
@@ -113,7 +113,15 @@ func TestCompile_RowFiltersAnyWrappedInAutoJoinON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
-	if !strings.Contains(res.SQL, "AND ((ref_категория.owner = ?) OR (ref_категория.owner = ?))") {
+	// Пунктуация нарочно не сверяется дословно: после #858 Any-группа
+	// оборачивается ещё и в корне PredicateSQL, так что скобок может быть
+	// больше одной пары. Проверяем суть: OR-группа входит в ON одним операндом
+	// (сразу после AND открывается скобка группы), а «голая» форма
+	// `AND (a) OR (b)`, у которой OR вырывается из-под JOIN, отсутствует.
+	if !strings.Contains(res.SQL, "AND ((") {
 		t.Fatalf("предикат any: в ON авто-JOIN не обёрнут в скобки:\n%s", res.SQL)
+	}
+	if strings.Contains(res.SQL, "AND (ref_категория.owner = ?) OR") {
+		t.Fatalf("предикат any: OR-ветка вырвалась из-под ON:\n%s", res.SQL)
 	}
 }

--- a/internal/storage/predicate.go
+++ b/internal/storage/predicate.go
@@ -155,7 +155,17 @@ func predicateGroupSQL(d Dialect, entity *metadata.Entity, items []Predicate, jo
 	if len(parts) == 0 {
 		return "", args, nextArg, nil
 	}
-	return strings.Join(parts, join), args, nextArg, nil
+	joined := strings.Join(parts, join)
+	if len(parts) > 1 {
+		// Группа целиком — ОДИН операнд для вызывающего. Без внешних скобок
+		// потребители, склеивающие WHERE через " AND " (List, GetMovements,
+		// GetBalances, InfoRegList), получали `фильтр AND (a) OR (b)`: OR-ветка
+		// политики вырывалась из-под остальных условий, и пользователь видел
+		// чужие строки (issue #858; в internal/query это же чинил #652 — но
+		// оборачивал результат снаружи, не тронув параллельные билдеры).
+		joined = "(" + joined + ")"
+	}
+	return joined, args, nextArg, nil
 }
 
 func qualifyPredicateColumn(qualifier, col string) string {

--- a/internal/storage/predicate_any_parens_test.go
+++ b/internal/storage/predicate_any_parens_test.go
@@ -1,0 +1,129 @@
+package storage_test
+
+// RLS-предикат Any обязан оставаться одним операндом WHERE (issue #858).
+//
+// PredicateSQL для Any-группы возвращал `(a) OR (b)` без внешних скобок, а
+// List/GetMovements/GetBalances/InfoRegList склеивают WHERE через " AND ":
+// получалось `фильтр AND (a) OR (b)` — по приоритету операторов вторая ветка
+// политики вырывалась из-под фильтра, и пользователь видел чужие строки.
+// В internal/query то же чинил #652, но оборачивал результат снаружи, не
+// тронув параллельные storage-билдеры.
+//
+// Тесты матричные: генерация SQL общая, но исполнение и приведение типов у
+// диалектов своё — dbtest.ForEachDialect гоняет SQLite и (при заданном
+// TEST_DATABASE_URL) PostgreSQL.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Поиск (AND-условие) + политика «свои ИЛИ публичные» (Any): запись, не
+// попавшая под поиск, не должна протекать в выдачу через OR-ветку политики.
+func TestListAnyPolicyStaysInsideSearchFilterMatrix(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		cat := &metadata.Entity{
+			Name: "Товар" + uuid.NewString()[:8],
+			Kind: metadata.KindCatalog,
+			Fields: []metadata.Field{
+				{Name: "Наименование", Type: metadata.FieldTypeString},
+				{Name: "Owner", Type: metadata.FieldTypeString},
+				{Name: "Public", Type: metadata.FieldTypeBool},
+			},
+		}
+		if err := db.Migrate(ctx, []*metadata.Entity{cat}); err != nil {
+			t.Fatalf("Migrate: %v", err)
+		}
+		seed := []map[string]any{
+			{"Наименование": "красный стул", "Owner": "alice", "Public": false},
+			{"Наименование": "красный стол", "Owner": "bob", "Public": true},
+			{"Наименование": "зелёный шкаф", "Owner": "bob", "Public": true},
+		}
+		for _, r := range seed {
+			if err := db.Upsert(ctx, cat.Name, uuid.New(), r, cat); err != nil {
+				t.Fatalf("upsert %v: %v", r["Наименование"], err)
+			}
+		}
+		params := storage.ListParams{
+			Search: "красный",
+			RowFilter: &storage.Predicate{Any: []storage.Predicate{
+				{Field: "Owner", Op: "eq", Value: "alice"},
+				{Field: "Public", Op: "eq", Value: true},
+			}},
+		}
+		rows, err := db.List(ctx, cat.Name, cat, params)
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(rows) != 2 {
+			t.Fatalf("rows = %d, want 2 (утечка мимо поиска через OR-ветку политики): %#v", len(rows), rows)
+		}
+		for _, r := range rows {
+			if r["Наименование"] == "зелёный шкаф" {
+				t.Fatalf("«зелёный шкаф» не под поиском, но в выдаче: %#v", rows)
+			}
+		}
+		total, err := db.CountList(ctx, cat.Name, cat, params)
+		if err != nil {
+			t.Fatalf("CountList: %v", err)
+		}
+		if total != 2 {
+			t.Fatalf("CountList = %d, want 2", total)
+		}
+	})
+}
+
+// Отбор по измерению (AND) + Any-политика в остатках регистра накопления:
+// движение чужого склада не должно попадать в остатки через OR-ветку.
+func TestBalancesAnyPolicyStaysInsideDimFilterMatrix(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		reg := &metadata.Register{
+			Name: "Остатки" + uuid.NewString()[:8],
+			Dimensions: []metadata.Field{
+				{Name: "Owner", Type: metadata.FieldTypeString},
+				{Name: "Склад", Type: metadata.FieldTypeString},
+			},
+			Resources: []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+		}
+		if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+			t.Fatalf("MigrateRegisters: %v", err)
+		}
+		period := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+		if err := db.WriteMovements(ctx, reg.Name, "Док", uuid.New(), []map[string]any{
+			{"Owner": "u1", "Склад": "Основной", "Количество": 10},
+			{"Owner": "u3", "Склад": "Резервный", "Количество": 20},
+			{"Owner": "u2", "Склад": "Основной", "Количество": 30},
+		}, reg, &period); err != nil {
+			t.Fatalf("WriteMovements: %v", err)
+		}
+		filter := storage.RegFilter{
+			Dims: map[string]string{"Склад": "Основной"},
+			RowFilter: &storage.Predicate{Any: []storage.Predicate{
+				{Field: "Owner", Op: "eq", Value: "u1"},
+				{Field: "Owner", Op: "eq", Value: "u3"},
+			}},
+		}
+		balances, err := db.GetBalances(ctx, reg.Name, reg, filter)
+		if err != nil {
+			t.Fatalf("GetBalances: %v", err)
+		}
+		if len(balances) != 1 || balances[0]["Owner"] != "u1" {
+			t.Fatalf("balances = %#v, want ровно строка u1/Основной (Резервный протёк через OR-ветку)", balances)
+		}
+		movements, err := db.GetMovements(ctx, reg.Name, reg, filter)
+		if err != nil {
+			t.Fatalf("GetMovements: %v", err)
+		}
+		if len(movements) != 1 || movements[0]["Owner"] != "u1" {
+			t.Fatalf("movements = %#v, want ровно строка u1/Основной", movements)
+		}
+	})
+}


### PR DESCRIPTION
## Что не так

`PredicateSQL` возвращал Any-группу как `(a) OR (b)` **без внешних скобок**. PR #652 (issue #625) обернул её в скобки только в `internal/query` (`rowFilterCondition`), а параллельные билдеры storage-слоя — `List` (`crud.go`), `GetMovements`/`GetBalances` (`register.go`), `InfoRegList` (`inforeg.go`) — склеивают WHERE через `" AND "`:

```sql
... AND (owner = 'я') OR (public = 1)   -- OR вырывается из-под фильтра
```

Пользователь с политикой «свои ИЛИ публичные» видел чужие строки в списках (в т.ч. мимо поиска), движениях и остатках регистров.

## Что сделано

Скобки добавлены в корне — в `predicateGroupSQL`: одна точка закрывает все четыре потребителя и любые будущие. Обёртка #652 в `internal/query` оставлена как защита в глубину; её текстовая ассерция ослаблена до сути (OR не вырывается из-под ON), так как скобок теперь может быть больше одной пары — сам файл теста ранее уже отмечал, что дословная пунктуация ломается на верном поведении.

## Тесты

Матричные (`dbtest.ForEachDialect`, SQLite + PostgreSQL), оба **воспроизводят утечку на нечиненом коде** (проверено):
- `TestListAnyPolicyStaysInsideSearchFilterMatrix` — поиск (AND) + Any-политика: запись мимо поиска не протекает через OR-ветку; `CountList` согласован;
- `TestBalancesAnyPolicyStaysInsideDimFilterMatrix` — отбор по измерению + Any-политика в `GetBalances`/`GetMovements`: движение чужого склада не попадает в остатки.

`go test ./internal/storage/ ./internal/query/ ./internal/ui/ ./internal/api/` — зелёные.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)