### PR TITLE
ci(release): timeout-minutes всем джобам release.yml и очередь без отмены (#875)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ permissions:
 concurrency:
   group: release-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
+  # По умолчанию GitHub держит только один pending-run и третий пуш отменяет
+  # второй. max сохраняет до 100 ожидающих релизов вместо их тихой замены.
+  queue: max
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,21 @@ on:
 permissions:
   contents: read
 
+# Сериализация, но БЕЗ cancel-in-progress: в отличие от CI, прерывать релиз
+# нельзя — отменённый прогон может оставить тег с половиной артефактов или
+# опубликованный релиз без файлов. Очередь на ref: два пуша в main ждут друг
+# друга, тег со своей очередью им не мешает.
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ${{ matrix.runner }}
+    # Без явного лимита зависший раннер держит релиз и минуты организации до
+    # 6-часового дефолта GitHub. Сборка одной цели укладывается в единицы минут.
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -118,6 +129,10 @@ jobs:
   verify-ci:
     name: Require green CI for this commit
     runs-on: ubuntu-latest
+    # Свой дедлайн ожидания CI — 30 минут (см. шаг ниже); лимит job'а стоит
+    # чуть выше, чтобы срабатывал внутренний с внятным сообщением, а этот
+    # оставался страховкой на случай зависания самого раннера.
+    timeout-minutes: 40
     permissions:
       actions: read
     steps:
@@ -161,6 +176,7 @@ jobs:
     name: Dev Pre-Release
     needs: [build, verify-ci]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write   # публикация пре-релиза
@@ -251,6 +267,7 @@ jobs:
     name: Create GitHub Release
     needs: [build, verify-ci]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write   # публикация релиза


### PR DESCRIPTION
Закрывает #875.

`#811` добавил `concurrency` и `timeout-minutes` только в `ci.yml` — единственный файл своего диффа, — хотя проблему формулировал широко («у тяжёлых workflow»). В `release.yml` не было ни одного лимита: зависший раннер build-матрицы (3 ОС) держал релиз и минуты организации до 6-часового дефолта GitHub.

## Что сделано

| Джоб | timeout-minutes | почему столько |
|---|---|---|
| `build` (windows/linux/macos) | 30 | сборка одной цели — единицы минут |
| `verify-ci` | 40 | у самого шага дедлайн ожидания CI 30 минут; внешний лимит стоит выше, чтобы срабатывал внутренний с внятным сообщением, а этот оставался страховкой от зависания раннера |
| `dev-release`, `release` | 15 | скачать артефакты и опубликовать |

`concurrency` — **без** `cancel-in-progress`, в отличие от CI: прерывать релиз нельзя, отменённый прогон оставляет тег с половиной артефактов или релиз без файлов. Очередь на `ref`, поэтому пуш тега не встаёт в хвост очереди пушей в main.

## Проверки

- YAML разбирается, все 4 джоба покрыты лимитом (проверено скриптом);
- сверх заявки прошёлся по всем workflow — `ci.yml` и `release.yml` теперь оба с `concurrency` и без джобов без `timeout-minutes`.