### PR TITLE
fix(launcher): сохранение подсистемы правит YAML точечно, а не пересобирает файл (#878)

### DIFF
--- a/internal/launcher/appconfig.go
+++ b/internal/launcher/appconfig.go
@@ -139,7 +139,17 @@ func updateYAMLMapping(raw []byte, docName string, edit func(doc *yaml.Node) err
 	if err := enc.Close(); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	// yaml.Encoder trusts Alias.Value and can emit an alias whose anchor was
+	// removed by edit (for example when deleting a mapping value that contained
+	// a nested anchor). Reparse the result before it can replace the user's
+	// configuration. A failed edit must be fail-closed and leave the source
+	// untouched.
+	out := buf.Bytes()
+	var verified yaml.Node
+	if err := yaml.Unmarshal(out, &verified); err != nil {
+		return nil, fmt.Errorf("%s: результат YAML-правки некорректен: %w", docName, err)
+	}
+	return out, nil
 }
 
 // validateYAMLTree отклоняет неоднозначные mapping-узлы до правки. yaml.Node
@@ -217,6 +227,17 @@ func yamlSubMap(m *yaml.Node, key string) (*yaml.Node, error) {
 		}
 		return resolved, nil
 	}
+	inherited, err := yamlMapHasMergedField(mapping, key)
+	if err != nil {
+		return nil, err
+	}
+	if inherited {
+		// Creating an empty direct mapping would shadow the inherited mapping and
+		// silently drop every field the form does not edit (pages, titles, future
+		// extension keys). Materialising an arbitrary anchored graph safely is not
+		// possible here, so reject the edit and preserve the source verbatim.
+		return nil, fmt.Errorf("yamlSubMap: ключ %q унаследован через YAML merge; точечная правка небезопасна", key)
+	}
 	sub := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 	mapping.Content = append(mapping.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, sub)
 	return sub, nil
@@ -246,6 +267,116 @@ func yamlMapField(m *yaml.Node, key string) (*yaml.Node, int, error) {
 		return nil, -1, nil
 	}
 	return resolved.Content[index+1], index, nil
+}
+
+// yamlMapHasMergedField reports whether key would be inherited through a YAML
+// merge key (<<). Removing a direct key without accounting for this would
+// merely expose the old inherited value again, so a form would report success
+// while the value selected by the user remained unchanged.
+func yamlMapHasMergedField(m *yaml.Node, key string) (bool, error) {
+	resolved, err := resolveYAMLAlias(m)
+	if err != nil {
+		return false, err
+	}
+	if resolved.Kind != yaml.MappingNode || len(resolved.Content)%2 != 0 {
+		return false, fmt.Errorf("ожидалось YAML-отображение")
+	}
+	active := make(map[*yaml.Node]struct{})
+	for i := 0; i < len(resolved.Content); i += 2 {
+		if isYAMLMergeKey(resolved.Content[i]) {
+			return yamlMergeSourceHasField(resolved.Content[i+1], key, active)
+		}
+	}
+	return false, nil
+}
+
+func yamlMergeSourceHasField(source *yaml.Node, key string, active map[*yaml.Node]struct{}) (bool, error) {
+	resolved, err := resolveYAMLAlias(source)
+	if err != nil {
+		return false, err
+	}
+	switch resolved.Kind {
+	case yaml.MappingNode:
+		return yamlMappingDefinesField(resolved, key, active)
+	case yaml.SequenceNode:
+		for _, item := range resolved.Content {
+			itemResolved, err := resolveYAMLAlias(item)
+			if err != nil {
+				return false, err
+			}
+			if itemResolved.Kind != yaml.MappingNode {
+				return false, fmt.Errorf("YAML merge ожидает отображение или последовательность отображений")
+			}
+			found, err := yamlMappingDefinesField(itemResolved, key, active)
+			if err != nil || found {
+				return found, err
+			}
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("YAML merge ожидает отображение или последовательность отображений")
+	}
+}
+
+func yamlMappingDefinesField(m *yaml.Node, key string, active map[*yaml.Node]struct{}) (bool, error) {
+	if _, ok := active[m]; ok {
+		return false, fmt.Errorf("циклический YAML merge")
+	}
+	active[m] = struct{}{}
+	defer delete(active, m)
+
+	if m.Kind != yaml.MappingNode || len(m.Content)%2 != 0 {
+		return false, fmt.Errorf("YAML merge ожидает отображение")
+	}
+	for i := 0; i < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if !isYAMLMergeKey(k) && k.Kind == yaml.ScalarNode && k.Value == key {
+			return true, nil
+		}
+	}
+	for i := 0; i < len(m.Content); i += 2 {
+		if isYAMLMergeKey(m.Content[i]) {
+			found, err := yamlMergeSourceHasField(m.Content[i+1], key, active)
+			if err != nil || found {
+				return found, err
+			}
+		}
+	}
+	return false, nil
+}
+
+func isYAMLMergeKey(n *yaml.Node) bool {
+	return n != nil && n.Kind == yaml.ScalarNode && n.Value == "<<" && n.ShortTag() == "!!merge"
+}
+
+// yamlNodeDefinesAnchor checks anchor definitions in the represented tree.
+// Alias.Alias is deliberately not traversed: an alias only references a
+// definition elsewhere and removing that alias does not remove the definition.
+func yamlNodeDefinesAnchor(n *yaml.Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.Kind != yaml.AliasNode && n.Anchor != "" {
+		return true
+	}
+	for _, child := range n.Content {
+		if yamlNodeDefinesAnchor(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func yamlNodeDescendantsDefineAnchor(n *yaml.Node) bool {
+	if n == nil {
+		return false
+	}
+	for _, child := range n.Content {
+		if yamlNodeDefinesAnchor(child) {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveYAMLAlias(n *yaml.Node) (*yaml.Node, error) {

--- a/internal/launcher/appconfig.go
+++ b/internal/launcher/appconfig.go
@@ -91,7 +91,14 @@ func readAppYAML(ctx context.Context, b *Base, v any) error {
 // как было. Пустой или отсутствующий файл — начинаем с чистого отображения;
 // битый YAML и не-отображение в корне возвращают ошибку: молча затереть чужой
 // файл хуже, чем отказать в сохранении (починить можно на вкладке «Файлы»).
-func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) {
+// updateYAMLMapping точечно правит YAML-документ, сохраняя всё, чего правка не
+// касается: неизвестные ключи, комментарии, порядок и форматирование.
+//
+// docName участвует только в тексте ошибки — функция общая для нескольких
+// файлов конфигурации (config/app.yaml, subsystems/*.yaml), и сообщение
+// «ожидалось YAML-отображение в config/app.yaml» при сохранении подсистемы
+// отправляло бы искать проблему не в том файле.
+func updateYAMLMapping(raw []byte, docName string, edit func(doc *yaml.Node) error) ([]byte, error) {
 	root := yaml.Node{Kind: yaml.DocumentNode,
 		Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}}
 	if len(bytes.TrimSpace(raw)) > 0 {
@@ -101,7 +108,7 @@ func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) 
 		}
 		if parsed.Kind != yaml.DocumentNode || len(parsed.Content) == 0 ||
 			parsed.Content[0].Kind != yaml.MappingNode {
-			return nil, fmt.Errorf("updateAppYAML: ожидалось YAML-отображение в корне config/app.yaml")
+			return nil, fmt.Errorf("%s: ожидалось YAML-отображение в корне", docName)
 		}
 		root = parsed
 	}
@@ -110,8 +117,8 @@ func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) 
 	}
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
-	// app.yaml пишут руками и держат в git — отступ по умолчанию (4) переколбасил
-	// бы все вложенные блоки при первом же сохранении.
+	// Конфигурацию пишут руками и держат в git — отступ по умолчанию (4)
+	// переколбасил бы все вложенные блоки при первом же сохранении.
 	enc.SetIndent(2)
 	if err := enc.Encode(&root); err != nil {
 		_ = enc.Close()
@@ -123,13 +130,18 @@ func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
+// updateAppYAML — прежнее имя для config/app.yaml.
+func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) {
+	return updateYAMLMapping(raw, "config/app.yaml", edit)
+}
+
 // yamlSubMap возвращает вложенное отображение по ключу, создавая пустое, если
 // ключа ещё нет. Ошибка — если ключ занят не отображением.
 func yamlSubMap(m *yaml.Node, key string) (*yaml.Node, error) {
 	for i := 0; i+1 < len(m.Content); i += 2 {
 		if m.Content[i].Value == key {
 			if m.Content[i+1].Kind != yaml.MappingNode {
-				return nil, fmt.Errorf("yamlSubMap: ключ %q в config/app.yaml — не отображение", key)
+				return nil, fmt.Errorf("yamlSubMap: ключ %q — не отображение", key)
 			}
 			return m.Content[i+1], nil
 		}

--- a/internal/launcher/appconfig.go
+++ b/internal/launcher/appconfig.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -103,12 +104,23 @@ func updateYAMLMapping(raw []byte, docName string, edit func(doc *yaml.Node) err
 		Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}}
 	if len(bytes.TrimSpace(raw)) > 0 {
 		var parsed yaml.Node
-		if err := yaml.Unmarshal(raw, &parsed); err != nil {
+		dec := yaml.NewDecoder(bytes.NewReader(raw))
+		if err := dec.Decode(&parsed); err != nil {
 			return nil, err
+		}
+		var extra yaml.Node
+		if err := dec.Decode(&extra); err != io.EOF {
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("%s: ожидался один YAML-документ", docName)
 		}
 		if parsed.Kind != yaml.DocumentNode || len(parsed.Content) == 0 ||
 			parsed.Content[0].Kind != yaml.MappingNode {
 			return nil, fmt.Errorf("%s: ожидалось YAML-отображение в корне", docName)
+		}
+		if err := validateYAMLTree(parsed.Content[0], docName); err != nil {
+			return nil, err
 		}
 		root = parsed
 	}
@@ -130,6 +142,50 @@ func updateYAMLMapping(raw []byte, docName string, edit func(doc *yaml.Node) err
 	return buf.Bytes(), nil
 }
 
+// validateYAMLTree отклоняет неоднозначные mapping-узлы до правки. yaml.Node
+// намеренно умеет представить дубли ключей, но обычная загрузка конфигурации в
+// struct затем отвергнет такой файл. Сохранить форму с кодом 200 и оставить
+// подсистему нечитаемой хуже, чем показать ошибку и не тронуть исходник.
+func validateYAMLTree(n *yaml.Node, docName string) error {
+	if n == nil {
+		return fmt.Errorf("%s: пустой YAML-узел", docName)
+	}
+	switch n.Kind {
+	case yaml.MappingNode:
+		if len(n.Content)%2 != 0 {
+			return fmt.Errorf("%s: нечётное число узлов в YAML-отображении", docName)
+		}
+		seen := make(map[string]struct{}, len(n.Content)/2)
+		for i := 0; i < len(n.Content); i += 2 {
+			key, val := n.Content[i], n.Content[i+1]
+			if key.Kind == yaml.ScalarNode {
+				identity := key.Tag + "\x00" + key.Value
+				if _, ok := seen[identity]; ok {
+					return fmt.Errorf("%s: повторяющийся YAML-ключ %q", docName, key.Value)
+				}
+				seen[identity] = struct{}{}
+			}
+			if err := validateYAMLTree(key, docName); err != nil {
+				return err
+			}
+			if err := validateYAMLTree(val, docName); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode, yaml.DocumentNode:
+		for _, child := range n.Content {
+			if err := validateYAMLTree(child, docName); err != nil {
+				return err
+			}
+		}
+	case yaml.AliasNode:
+		if n.Alias == nil {
+			return fmt.Errorf("%s: YAML-псевдоним %q без цели", docName, n.Value)
+		}
+	}
+	return nil
+}
+
 // updateAppYAML — прежнее имя для config/app.yaml.
 func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) {
 	return updateYAMLMapping(raw, "config/app.yaml", edit)
@@ -138,17 +194,96 @@ func updateAppYAML(raw []byte, edit func(doc *yaml.Node) error) ([]byte, error) 
 // yamlSubMap возвращает вложенное отображение по ключу, создавая пустое, если
 // ключа ещё нет. Ошибка — если ключ занят не отображением.
 func yamlSubMap(m *yaml.Node, key string) (*yaml.Node, error) {
-	for i := 0; i+1 < len(m.Content); i += 2 {
-		if m.Content[i].Value == key {
-			if m.Content[i+1].Kind != yaml.MappingNode {
-				return nil, fmt.Errorf("yamlSubMap: ключ %q — не отображение", key)
-			}
-			return m.Content[i+1], nil
+	mapping, err := resolveYAMLAlias(m)
+	if err != nil {
+		return nil, err
+	}
+	value, _, err := yamlMapField(m, key)
+	if err != nil {
+		return nil, err
+	}
+	if value != nil {
+		resolved, err := resolveYAMLAlias(value)
+		if err != nil {
+			return nil, fmt.Errorf("yamlSubMap: ключ %q: %w", key, err)
 		}
+		// null в старом struct-round-trip означал пустое отображение. Сохраняем
+		// эту семантику, не заставляя пользователя чинить безвредный null вручную.
+		if resolved.Kind == yaml.ScalarNode && resolved.Tag == "!!null" {
+			replaceYAMLNode(resolved, &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"})
+		}
+		if resolved.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("yamlSubMap: ключ %q — не отображение", key)
+		}
+		return resolved, nil
 	}
 	sub := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	m.Content = append(m.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, sub)
+	mapping.Content = append(mapping.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, sub)
 	return sub, nil
+}
+
+// yamlMapField возвращает значение и позицию ключа, не разворачивая alias.
+// Неоднозначный дубль отклоняется даже если функция вызвана без общего
+// validateYAMLTree.
+func yamlMapField(m *yaml.Node, key string) (*yaml.Node, int, error) {
+	resolved, err := resolveYAMLAlias(m)
+	if err != nil {
+		return nil, -1, err
+	}
+	if resolved.Kind != yaml.MappingNode || len(resolved.Content)%2 != 0 {
+		return nil, -1, fmt.Errorf("ожидалось YAML-отображение")
+	}
+	index := -1
+	for i := 0; i < len(resolved.Content); i += 2 {
+		if resolved.Content[i].Kind == yaml.ScalarNode && resolved.Content[i].Value == key {
+			if index >= 0 {
+				return nil, -1, fmt.Errorf("повторяющийся YAML-ключ %q", key)
+			}
+			index = i
+		}
+	}
+	if index < 0 {
+		return nil, -1, nil
+	}
+	return resolved.Content[index+1], index, nil
+}
+
+func resolveYAMLAlias(n *yaml.Node) (*yaml.Node, error) {
+	seen := map[*yaml.Node]struct{}{}
+	for n != nil && n.Kind == yaml.AliasNode {
+		if _, ok := seen[n]; ok {
+			return nil, fmt.Errorf("циклический YAML-псевдоним %q", n.Value)
+		}
+		seen[n] = struct{}{}
+		if n.Alias == nil {
+			return nil, fmt.Errorf("YAML-псевдоним %q без цели", n.Value)
+		}
+		n = n.Alias
+	}
+	if n == nil {
+		return nil, fmt.Errorf("пустая цель YAML-псевдонима")
+	}
+	return n, nil
+}
+
+// replaceYAMLNode меняет значение узла на месте: ссылки Alias продолжают
+// указывать на тот же объект, а комментарии/anchor и выбранный человеком стиль
+// скаляра не исчезают при сохранении формы.
+func replaceYAMLNode(dst, src *yaml.Node) {
+	anchor := dst.Anchor
+	head, line, foot := dst.HeadComment, dst.LineComment, dst.FootComment
+	style := dst.Style
+	oldKind := dst.Kind
+	*dst = *src
+	dst.Anchor = anchor
+	dst.HeadComment, dst.LineComment, dst.FootComment = head, line, foot
+	// Flow/block style у коллекций можно сохранить без смены значения. Стиль
+	// скаляра намеренно не переносим: прежний form-save код кодировал новое
+	// значение заново (и существующие тесты фиксируют эту семантику, например
+	// снятие лишних кавычек у cron schedule).
+	if oldKind == dst.Kind && oldKind != yaml.ScalarNode {
+		dst.Style = style
+	}
 }
 
 // setAppYAMLFields применяет к отображению набор «ключ → значение» по порядку.

--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -195,6 +196,15 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 		homeValue, _, err := yamlMapField(doc, "home_page")
 		if err != nil {
 			return err
+		}
+		if homeValue == nil {
+			inherited, err := yamlMapHasMergedField(doc, "home_page")
+			if err != nil {
+				return err
+			}
+			if inherited {
+				return fmt.Errorf("home_page унаследован через YAML merge; точечная правка небезопасна")
+			}
 		}
 		if homeValue != nil {
 			home, err := yamlSubMap(doc, "home_page")

--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -112,84 +112,98 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 		title = subName
 	}
 
-	type yamlContents struct {
-		Catalogs   []string `yaml:"catalogs,omitempty"`
-		Documents  []string `yaml:"documents,omitempty"`
-		Registers  []string `yaml:"registers,omitempty"`
-		InfoRegs   []string `yaml:"inforegs,omitempty"`
-		Reports    []string `yaml:"reports,omitempty"`
-		Processors []string `yaml:"processors,omitempty"`
-		Journals   []string `yaml:"journals,omitempty"`
-		Pages      []string `yaml:"pages,omitempty"`
-	}
-	type yamlSubsystem struct {
-		Name     string             `yaml:"name"`
-		Title    string             `yaml:"title"`
-		Titles   map[string]string  `yaml:"titles,omitempty"`
-		Icon     string             `yaml:"icon,omitempty"`
-		Order    int                `yaml:"order"`
-		Roles    []string           `yaml:"roles,omitempty"`
-		Contents yamlContents       `yaml:"contents"`
-		HomePage *metadata.HomePage `yaml:"home_page,omitempty"`
-	}
-
 	relPath := "subsystems/" + nameToFilename(subName) + ".yaml"
 
-	ys := yamlSubsystem{
-		Name:  subName,
-		Title: title,
-		Icon:  icon,
-		Order: order,
-	}
-	ys.Contents.Catalogs = r.Form["catalogs"]
-	ys.Contents.Documents = r.Form["documents"]
-	ys.Contents.Registers = r.Form["registers"]
-	ys.Contents.InfoRegs = r.Form["inforegs"]
-	ys.Contents.Reports = r.Form["reports"]
-	ys.Contents.Processors = r.Form["processors"]
-	ys.Contents.Journals = r.Form["journals"]
-
-	// Сохраняем переводы (titles) и метаданные рабочего стола из уже
-	// существующего файла, чтобы перезапись не теряла данные, которых нет в форме.
-	if raw, ok := h.readConfigFileRaw(r.Context(), b, relPath); ok {
-		var existing yamlSubsystem
-		if yaml.Unmarshal(raw, &existing) == nil {
-			// Страницы и роли пока не редактируются этой формой — переносим их
-			// из текущей конфигурации, чтобы сохранение состава их не затирало.
-			ys.Roles = existing.Roles
-			ys.Contents.Pages = existing.Contents.Pages
-			if formHasMapField(r, "titles") {
-				ys.Titles = parseMapForm(r, "titles")
-			} else {
-				ys.Titles = existing.Titles
+	// Точечная правка YAML вместо пересборки файла из struct.
+	//
+	// Прежде файл собирался полным yaml.Marshal локальной struct, и всё, чего в
+	// ней нет — незнакомые ключи (нынешние и будущие) и любые комментарии, —
+	// молча исчезало при первом же сохранении из конфигуратора. Ровно этот
+	// антипаттерн уже дважды чинили: в config/app.yaml (#663) и в матрице ролей
+	// (#744). Часть данных struct пыталась спасать вручную, перечитывая файл и
+	// перенося roles/pages/titles/home_page обратно, — то есть список
+	// «что не потерять» приходилось вести руками, и он неизбежно отставал (#878).
+	raw, _ := h.readConfigFileRaw(r.Context(), b, relPath)
+	out, err := updateYAMLMapping(raw, relPath, func(doc *yaml.Node) error {
+		if err := setAppYAMLFields(doc, []appYAMLField{
+			{key: "name", val: subName},
+			{key: "title", val: title},
+			{key: "icon", val: strOrNil(icon)},
+			{key: "order", val: order},
+		}); err != nil {
+			return err
+		}
+		// Переводы правим только когда форма их прислала: иначе они остаются
+		// в файле как были.
+		if formHasMapField(r, "titles") {
+			titles := parseMapForm(r, "titles")
+			var val any
+			if len(titles) > 0 {
+				val = titles
 			}
-			ys.HomePage = existing.HomePage
+			if err := setYAMLMapField(doc, "titles", val); err != nil {
+				return err
+			}
 		}
-	} else if formHasMapField(r, "titles") {
-		ys.Titles = parseMapForm(r, "titles")
-	}
 
-	// Раскладка виджетов рабочего стола из формы: режим «Авто» — отмеченные
-	// галочками виджеты одним рядом; «По рядам» — ряды из drag-конструктора.
-	// Перезаписывает rows/layout, сохраняя title/titles рабочего стола.
-	rows, layout := rowsFromForm(r)
-	if len(rows) > 0 {
-		if ys.HomePage == nil {
-			ys.HomePage = &metadata.HomePage{}
+		contents, err := yamlSubMap(doc, "contents")
+		if err != nil {
+			return err
 		}
-		ys.HomePage.Rows = rows
-		ys.HomePage.Layout = layout
-		ys.HomePage.Widgets = nil // rows и flat widgets взаимоисключающи
-	} else if ys.HomePage != nil {
-		ys.HomePage.Rows = nil
-		// Если от рабочего стола ничего не осталось — убираем секцию целиком.
-		if ys.HomePage.Title == "" && len(ys.HomePage.Titles) == 0 &&
-			ys.HomePage.Layout == "" && len(ys.HomePage.Widgets) == 0 {
-			ys.HomePage = nil
+		// pages форма не редактирует — ключ не трогаем вовсе, он останется
+		// в файле сам по себе, без переноса руками.
+		for _, sec := range []struct {
+			key   string
+			field string
+		}{
+			{"catalogs", "catalogs"},
+			{"documents", "documents"},
+			{"registers", "registers"},
+			{"inforegs", "inforegs"},
+			{"reports", "reports"},
+			{"processors", "processors"},
+			{"journals", "journals"},
+		} {
+			var val any
+			if list := r.Form[sec.field]; len(list) > 0 {
+				val = list
+			}
+			if err := setYAMLMapField(contents, sec.key, val); err != nil {
+				return err
+			}
 		}
-	}
 
-	out, err := yaml.Marshal(&ys)
+		// Раскладка виджетов рабочего стола: режим «Авто» — отмеченные
+		// галочками виджеты одним рядом; «По рядам» — ряды из drag-конструктора.
+		// Правятся только rows/layout/widgets; title и titles рабочего стола
+		// остаются как в файле.
+		rows, layout := rowsFromForm(r)
+		if len(rows) > 0 {
+			home, err := yamlSubMap(doc, "home_page")
+			if err != nil {
+				return err
+			}
+			if err := setYAMLMapField(home, "rows", rows); err != nil {
+				return err
+			}
+			if err := setYAMLMapField(home, "layout", strOrNil(layout)); err != nil {
+				return err
+			}
+			// rows и плоский список виджетов взаимоисключающи.
+			return setYAMLMapField(home, "widgets", nil)
+		}
+		if home, err := yamlSubMap(doc, "home_page"); err == nil {
+			if err := setYAMLMapField(home, "rows", nil); err != nil {
+				return err
+			}
+			// Пустой рабочий стол убираем целиком, чтобы не оставлять
+			// «home_page: {}».
+			if len(home.Content) == 0 {
+				return setYAMLMapField(doc, "home_page", nil)
+			}
+		}
+		return nil
+	})
 	if err == nil {
 		err = saveConfigFile(r, h, b, relPath, out)
 	}

--- a/internal/launcher/configurator_home_app.go
+++ b/internal/launcher/configurator_home_app.go
@@ -192,7 +192,15 @@ func (h *handler) configuratorSaveSubsystem(w http.ResponseWriter, r *http.Reque
 			// rows и плоский список виджетов взаимоисключающи.
 			return setYAMLMapField(home, "widgets", nil)
 		}
-		if home, err := yamlSubMap(doc, "home_page"); err == nil {
+		homeValue, _, err := yamlMapField(doc, "home_page")
+		if err != nil {
+			return err
+		}
+		if homeValue != nil {
+			home, err := yamlSubMap(doc, "home_page")
+			if err != nil {
+				return err
+			}
 			if err := setYAMLMapField(home, "rows", nil); err != nil {
 				return err
 			}

--- a/internal/launcher/configurator_subsystem_preserve_test.go
+++ b/internal/launcher/configurator_subsystem_preserve_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ivantit66/onebase/internal/configdb"
+	"gopkg.in/yaml.v3"
 )
 
 // Сохранение подсистемы из конфигуратора обязано быть точечной правкой, а не
@@ -114,5 +116,142 @@ home_page:
 	// И собственно правка применилась.
 	if !strings.Contains(saved, "ГТП_атс") {
 		t.Errorf("новый состав не сохранён:\n%s", saved)
+	}
+}
+
+func TestSaveSubsystem_FileModePreservesUntouchedDataAndHomePageSemantics(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config", "app.yaml"), []byte("name: Тест\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := writeCfgFileRv(t, cfgDir, "subsystems", "продажи.yaml", `# комментарий подсистемы
+name: Продажи
+title: Старый
+titles:
+  en: Sales
+icon: cart
+order: 1
+roles: [Менеджер]
+experimental_flag: true
+contents:
+  catalogs: [Старый]
+  pages: [Сводка]
+home_page:
+  title: Рабочий стол
+  titles:
+    en: Dashboard
+  layout: grid
+  widgets:
+    - name: СтарыйВиджет
+  experimental_home: keep
+`)
+
+	form := url.Values{
+		"subsystem_name": {"Продажи"},
+		"title":          {"Новый заголовок"},
+		"order":          {"7"},
+		"catalogs":       {"Новый"},
+		"home_layout":    {"rows"},
+		"home_rows":      {`[["Первый","Второй"]]`},
+	}
+	rec := postCfgRv(t, "test", "/bases/test/configurator/subsystem", form, h.configuratorSaveSubsystem)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved := string(raw)
+	for _, fragment := range []string{
+		"# комментарий подсистемы",
+		"en: Sales",
+		"roles: [Менеджер]",
+		"experimental_flag: true",
+		"pages: [Сводка]",
+		"title: Рабочий стол",
+		"en: Dashboard",
+		"experimental_home: keep",
+	} {
+		if !strings.Contains(saved, fragment) {
+			t.Errorf("после file-mode сохранения потеряно %q:\n%s", fragment, saved)
+		}
+	}
+	var got struct {
+		Title    string `yaml:"title"`
+		Icon     string `yaml:"icon"`
+		Order    int    `yaml:"order"`
+		Contents struct {
+			Catalogs []string `yaml:"catalogs"`
+			Pages    []string `yaml:"pages"`
+		} `yaml:"contents"`
+		HomePage struct {
+			Title  string `yaml:"title"`
+			Layout string `yaml:"layout"`
+			Rows   []struct {
+				Widgets []string `yaml:"widgets"`
+			} `yaml:"rows"`
+			Widgets []map[string]any `yaml:"widgets"`
+		} `yaml:"home_page"`
+	}
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("сохранённый YAML не разбирается: %v\n%s", err, saved)
+	}
+	if got.Title != "Новый заголовок" || got.Icon != "" || got.Order != 7 {
+		t.Errorf("поля формы сохранены неверно: title=%q icon=%q order=%d", got.Title, got.Icon, got.Order)
+	}
+	if len(got.Contents.Catalogs) != 1 || got.Contents.Catalogs[0] != "Новый" ||
+		len(got.Contents.Pages) != 1 || got.Contents.Pages[0] != "Сводка" {
+		t.Errorf("contents = %+v", got.Contents)
+	}
+	if got.HomePage.Title != "Рабочий стол" || got.HomePage.Layout != "rows" ||
+		len(got.HomePage.Rows) != 1 || len(got.HomePage.Rows[0].Widgets) != 2 || len(got.HomePage.Widgets) != 0 {
+		t.Errorf("home_page semantics нарушена: %+v", got.HomePage)
+	}
+}
+
+func TestSaveSubsystem_MalformedExistingYAMLIsNotOverwritten(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "duplicate keys",
+			raw:  "name: Продажи\nname: Дубль\ncontents: {}\n",
+		},
+		{
+			name: "home page is scalar",
+			raw:  "name: Продажи\ncontents: {}\nhome_page: сломано\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, cfgDir := newFileBaseHandler(t)
+			h.runner = NewRunner()
+			path := writeCfgFileRv(t, cfgDir, "subsystems", "продажи.yaml", tt.raw)
+			form := url.Values{
+				"subsystem_name": {"Продажи"},
+				"title":          {"Новый заголовок"},
+				"order":          {"2"},
+			}
+			rec := postCfgRv(t, "test", "/bases/test/configurator/subsystem", form, h.configuratorSaveSubsystem)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), `"ok":false`) {
+				t.Fatalf("обработчик не сообщил ошибку: %s", rec.Body.String())
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tt.raw {
+				t.Fatalf("ошибочный YAML был перезаписан:\n--- want\n%s--- got\n%s", tt.raw, got)
+			}
+		})
 	}
 }

--- a/internal/launcher/configurator_subsystem_preserve_test.go
+++ b/internal/launcher/configurator_subsystem_preserve_test.go
@@ -1,0 +1,118 @@
+package launcher
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/configdb"
+)
+
+// Сохранение подсистемы из конфигуратора обязано быть точечной правкой, а не
+// пересборкой файла из struct (#878).
+//
+// Прежде файл собирался полным yaml.Marshal локальной struct: всё, чего в ней
+// нет — незнакомые ключи и любые комментарии, — молча исчезало при первом же
+// сохранении. Ровно этот антипаттерн уже дважды чинили: в config/app.yaml
+// (#663) и в матрице ролей (#744). Часть данных struct пыталась спасать
+// вручную, перенося roles/pages/titles/home_page обратно, — то есть список
+// «что не потерять» вели руками, и он неизбежно отставал.
+//
+// Проверка идёт через публичный хендлер сохранения и смотрит на СЫРОЙ текст
+// файла: разбор в структуру показал бы только то, что структура и так знает.
+func TestSaveSubsystem_СохраняетКомментарииИНезнакомыеКлючи(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	store := newTestStore(t)
+	base := &Base{
+		ID:           "subsystem-preserve",
+		Name:         "Тест",
+		ConfigSource: "database",
+		DBType:       "sqlite",
+		DBPath:       filepath.Join(t.TempDir(), "config.db"),
+	}
+	if err := store.Add(base); err != nil {
+		t.Fatalf("store.Add: %v", err)
+	}
+
+	const original = `# Подсистема отдела продаж — не удалять комментарий
+name: АТС
+title: АТС
+order: 10
+# роли этой формой не редактируются
+roles: [Диспетчер]
+experimental_flag: true
+contents:
+  catalogs: [ГП_атс]
+  pages: [Сводка]
+home_page:
+  title: Рабочий стол АТС
+  widgets:
+    - name: СводкаПоАТС
+`
+
+	ctx := context.Background()
+	db, err := OpenDB(ctx, base)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	repo := configdb.New(db)
+	if err := repo.EnsureSchema(ctx); err != nil {
+		db.Close()
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	if err := repo.SaveFiles(ctx, []configdb.ConfigFile{
+		{Path: "config/app.yaml", Content: []byte("name: Тест\n")},
+		{Path: "catalogs/гп_атс.yaml", Content: []byte("name: ГП_атс\nfields: []\n")},
+		{Path: "catalogs/гтп_атс.yaml", Content: []byte("name: ГТП_атс\nfields: []\n")},
+		{Path: "subsystems/атс.yaml", Content: []byte(original)},
+	}, configdb.VersionOptions{Message: "seed"}); err != nil {
+		db.Close()
+		t.Fatalf("seed: %v", err)
+	}
+	db.Close()
+
+	h := &handler{store: store, runner: NewRunner()}
+	form := url.Values{
+		"subsystem_name": {"АТС"},
+		"title":          {"АТС"},
+		"order":          {"10"},
+		"catalogs":       {"ГП_атс", "ГТП_атс"},
+	}
+	rec := postCfgRv(t, base.ID, "/bases/"+base.ID+"/configurator/subsystem", form, h.configuratorSaveSubsystem)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("код %d: %s", rec.Code, rec.Body.String())
+	}
+
+	db, err = OpenDB(ctx, base)
+	if err != nil {
+		t.Fatalf("повторный OpenDB: %v", err)
+	}
+	defer db.Close()
+	raw, ok, err := configdb.New(db).ReadFile(ctx, "subsystems/атс.yaml")
+	if err != nil || !ok {
+		t.Fatalf("ReadFile: ok=%v err=%v", ok, err)
+	}
+	saved := string(raw)
+
+	for _, must := range []struct{ what, text string }{
+		{"комментарий шапки", "# Подсистема отдела продаж"},
+		{"комментарий про роли", "# роли этой формой не редактируются"},
+		{"незнакомый ключ", "experimental_flag"},
+		{"роли", "Диспетчер"},
+		{"страницы (форма их не редактирует)", "Сводка"},
+		{"заголовок рабочего стола", "Рабочий стол АТС"},
+		{"виджет рабочего стола", "СводкаПоАТС"},
+	} {
+		if !strings.Contains(saved, must.text) {
+			t.Errorf("после сохранения потеряно: %s (%q)\n---\n%s", must.what, must.text, saved)
+		}
+	}
+	// И собственно правка применилась.
+	if !strings.Contains(saved, "ГТП_атс") {
+		t.Errorf("новый состав не сохранён:\n%s", saved)
+	}
+}

--- a/internal/launcher/configurator_subsystem_save_test.go
+++ b/internal/launcher/configurator_subsystem_save_test.go
@@ -48,10 +48,13 @@ func TestSaveSubsystem_DBModePersistsContents(t *testing.T) {
 		{
 			Path: "subsystems/атс.yaml",
 			Content: []byte(
-				"name: АТС\n" +
+				"defaults: &defaults\n" +
+					"  icon: cart\n" +
+					"name: АТС\n" +
 					"title: АТС\n" +
 					"roles: [Диспетчер]\n" +
 					"order: 10\n" +
+					"<<: *defaults\n" +
 					"contents:\n" +
 					"  catalogs: [ГП_атс]\n",
 			),
@@ -100,6 +103,7 @@ func TestSaveSubsystem_DBModePersistsContents(t *testing.T) {
 		t.Fatalf("ReadFile: ok=%v err=%v", ok, err)
 	}
 	var saved struct {
+		Icon     string   `yaml:"icon"`
 		Roles    []string `yaml:"roles"`
 		Contents struct {
 			Catalogs []string `yaml:"catalogs"`
@@ -114,5 +118,8 @@ func TestSaveSubsystem_DBModePersistsContents(t *testing.T) {
 	}
 	if !slices.Equal(saved.Roles, []string{"Диспетчер"}) {
 		t.Fatalf("скрытый от формы whitelist roles потерян: %v", saved.Roles)
+	}
+	if saved.Icon != "" {
+		t.Fatalf("очищенное поле icon восстановилось из YAML merge: %q\n%s", saved.Icon, raw)
 	}
 }

--- a/internal/launcher/report_composition_form.go
+++ b/internal/launcher/report_composition_form.go
@@ -49,19 +49,35 @@ func applyReportComposition(raw []byte, f url.Values) ([]byte, error) {
 // точечно править одно поле документа без round-trip через типизированную
 // структуру (которая молча теряет неперечисленные в ней поля).
 func setYAMLMapField(m *yaml.Node, key string, val any) error {
-	for i := 0; i+1 < len(m.Content); i += 2 {
-		if m.Content[i].Value == key {
-			if val == nil {
-				m.Content = append(m.Content[:i], m.Content[i+2:]...)
-				return nil
+	mapping, err := resolveYAMLAlias(m)
+	if err != nil {
+		return err
+	}
+	existing, index, err := yamlMapField(mapping, key)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		if val == nil {
+			// Удаление определения anchor при живых aliases создало бы битый YAML.
+			// Alias-значение удалить безопасно: само определение находится в другом
+			// узле и остаётся на месте.
+			if existing.Kind != yaml.AliasNode && existing.Anchor != "" {
+				return fmt.Errorf("setYAMLMapField: нельзя удалить ключ %q с YAML-anchor %q", key, existing.Anchor)
 			}
-			var vn yaml.Node
-			if err := vn.Encode(val); err != nil {
-				return err
-			}
-			m.Content[i+1] = &vn
+			mapping.Content = append(mapping.Content[:index], mapping.Content[index+2:]...)
 			return nil
 		}
+		var vn yaml.Node
+		if err := vn.Encode(val); err != nil {
+			return err
+		}
+		target, err := resolveYAMLAlias(existing)
+		if err != nil {
+			return err
+		}
+		replaceYAMLNode(target, &vn)
+		return nil
 	}
 	if val == nil {
 		return nil
@@ -70,7 +86,7 @@ func setYAMLMapField(m *yaml.Node, key string, val any) error {
 	if err := vn.Encode(val); err != nil {
 		return err
 	}
-	m.Content = append(m.Content,
+	mapping.Content = append(mapping.Content,
 		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
 		&vn)
 	return nil

--- a/internal/launcher/report_composition_form.go
+++ b/internal/launcher/report_composition_form.go
@@ -45,9 +45,11 @@ func applyReportComposition(raw []byte, f url.Values) ([]byte, error) {
 }
 
 // setYAMLMapField устанавливает значение ключа в mapping-узле YAML, сохраняя
-// порядок и форматирование прочих ключей. val==nil удаляет ключ. Позволяет
-// точечно править одно поле документа без round-trip через типизированную
-// структуру (которая молча теряет неперечисленные в ней поля).
+// порядок и форматирование прочих ключей. val==nil убирает эффективное значение:
+// удаляет обычный ключ, а при наличии значения из YAML merge оставляет явный
+// null, чтобы старое значение не проявилось снова. Позволяет точечно править одно
+// поле документа без round-trip через типизированную структуру (которая молча
+// теряет неперечисленные в ней поля).
 func setYAMLMapField(m *yaml.Node, key string, val any) error {
 	mapping, err := resolveYAMLAlias(m)
 	if err != nil {
@@ -57,13 +59,32 @@ func setYAMLMapField(m *yaml.Node, key string, val any) error {
 	if err != nil {
 		return err
 	}
+	inherited, err := yamlMapHasMergedField(mapping, key)
+	if err != nil {
+		return err
+	}
 	if existing != nil {
 		if val == nil {
-			// Удаление определения anchor при живых aliases создало бы битый YAML.
-			// Alias-значение удалить безопасно: само определение находится в другом
+			if inherited {
+				// Deleting the direct value would reveal the value from << again.
+				// Keep an explicit null override instead. If the direct value is an
+				// alias, replace the alias edge itself rather than mutating its target.
+				var vn yaml.Node
+				if err := vn.Encode(nil); err != nil {
+					return err
+				}
+				if existing.Kind != yaml.AliasNode && yamlNodeDescendantsDefineAnchor(existing) {
+					return fmt.Errorf("setYAMLMapField: нельзя очистить ключ %q с вложенным YAML-anchor", key)
+				}
+				replaceYAMLNode(existing, &vn)
+				return nil
+			}
+			// Удаление любого anchor в паре (включая anchor на ключе или во
+			// вложенном значении) может оставить внешний alias без определения.
+			// Alias-значение удалить безопасно: его определение находится в другом
 			// узле и остаётся на месте.
-			if existing.Kind != yaml.AliasNode && existing.Anchor != "" {
-				return fmt.Errorf("setYAMLMapField: нельзя удалить ключ %q с YAML-anchor %q", key, existing.Anchor)
+			if yamlNodeDefinesAnchor(mapping.Content[index]) || yamlNodeDefinesAnchor(existing) {
+				return fmt.Errorf("setYAMLMapField: нельзя удалить ключ %q с YAML-anchor", key)
 			}
 			mapping.Content = append(mapping.Content[:index], mapping.Content[index+2:]...)
 			return nil
@@ -76,10 +97,25 @@ func setYAMLMapField(m *yaml.Node, key string, val any) error {
 		if err != nil {
 			return err
 		}
+		if yamlNodeDescendantsDefineAnchor(target) {
+			return fmt.Errorf("setYAMLMapField: нельзя заменить ключ %q с вложенным YAML-anchor", key)
+		}
 		replaceYAMLNode(target, &vn)
 		return nil
 	}
 	if val == nil {
+		if !inherited {
+			return nil
+		}
+		// There is no direct key, but << supplies one. An explicit null is the
+		// only non-destructive way to shadow it without rewriting the merge graph.
+		var vn yaml.Node
+		if err := vn.Encode(nil); err != nil {
+			return err
+		}
+		mapping.Content = append(mapping.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+			&vn)
 		return nil
 	}
 	var vn yaml.Node

--- a/internal/launcher/yaml_mapping_adversarial_test.go
+++ b/internal/launcher/yaml_mapping_adversarial_test.go
@@ -1,0 +1,151 @@
+package launcher
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSetYAMLMapField_DoesNotLeaveDanglingNestedAnchor(t *testing.T) {
+	const raw = `icon:
+  nested: &shared-icon cart
+mirror: *shared-icon
+contents: {}
+`
+
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
+		t.Fatal(err)
+	}
+	err := setYAMLMapField(root.Content[0], "icon", nil)
+	if err != nil {
+		return // rejecting an unsafe edit is acceptable
+	}
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded any
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("edit emitted YAML with a dangling alias: %v\n%s", err, out)
+	}
+}
+
+func TestSetYAMLMapField_DoesNotLeaveDanglingKeyAnchor(t *testing.T) {
+	const raw = `&icon-key icon: cart
+mirror: *icon-key
+contents: {}
+`
+
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
+		t.Fatal(err)
+	}
+	err := setYAMLMapField(root.Content[0], "icon", nil)
+	if err != nil {
+		return // rejecting an unsafe edit is acceptable
+	}
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded any
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("edit emitted YAML with a dangling key alias: %v\n%s", err, out)
+	}
+}
+
+func TestSetYAMLMapField_DoesNotReplaceNestedAnchorDefinition(t *testing.T) {
+	const raw = `composition:
+  nested: &shared-value old
+mirror: *shared-value
+`
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
+		t.Fatal(err)
+	}
+	err := setYAMLMapField(root.Content[0], "composition", map[string]any{"new": true})
+	if err != nil {
+		return // rejecting an unsafe edit is acceptable
+	}
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded any
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("replacement emitted YAML with a dangling alias: %v\n%s", err, out)
+	}
+}
+
+func TestSaveSubsystem_ClearsValuesInheritedThroughMergeKeys(t *testing.T) {
+	h, cfgDir := newFileBaseHandler(t)
+	h.runner = NewRunner()
+	if err := os.MkdirAll(filepath.Join(cfgDir, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config", "app.yaml"), []byte("name: Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := writeCfgFileRv(t, cfgDir, "subsystems", "sales.yaml", `defaults: &defaults
+  icon: cart
+contents_defaults: &contents_defaults
+  catalogs: [Old]
+name: Sales
+title: Old title
+order: 1
+<<: *defaults
+contents:
+  <<: *contents_defaults
+`)
+
+	form := url.Values{
+		"subsystem_name": {"Sales"},
+		"title":          {"New title"},
+		"order":          {"2"},
+	}
+	rec := postCfgRv(t, "test", "/bases/test/configurator/subsystem", form, h.configuratorSaveSubsystem)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Icon     string `yaml:"icon"`
+		Contents struct {
+			Catalogs []string `yaml:"catalogs"`
+		} `yaml:"contents"`
+	}
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("saved YAML is invalid: %v\n%s", err, raw)
+	}
+	if got.Icon != "" || len(got.Contents.Catalogs) != 0 {
+		t.Fatalf("unchecked form values survived via YAML merge: icon=%q catalogs=%v\n%s", got.Icon, got.Contents.Catalogs, raw)
+	}
+}
+
+func TestUpdateYAMLMapping_RejectsEditingWholeInheritedMapping(t *testing.T) {
+	const raw = `defaults: &defaults
+  contents:
+    catalogs: [Old]
+    pages: [Keep]
+<<: *defaults
+`
+
+	out, err := updateYAMLMapping([]byte(raw), "subsystems/test.yaml", func(doc *yaml.Node) error {
+		_, err := yamlSubMap(doc, "contents")
+		return err
+	})
+	if err == nil {
+		t.Fatalf("expected an unsafe inherited mapping edit to be rejected:\n%s", out)
+	}
+	if out != nil {
+		t.Fatalf("rejected edit returned replacement bytes: %q", out)
+	}
+}

--- a/internal/launcher/yaml_mapping_update_test.go
+++ b/internal/launcher/yaml_mapping_update_test.go
@@ -1,0 +1,118 @@
+package launcher
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestUpdateYAMLMapping_PreservesCommentsAnchorsAndAliases(t *testing.T) {
+	const raw = `# комментарий документа
+shared_contents: &shared
+  # комментарий списка
+  catalogs: [Старый] # состав
+contents: *shared
+title: &label "Старый заголовок" # заголовок
+mirror_title: *label
+experimental:
+  enabled: true
+`
+
+	out, err := updateYAMLMapping([]byte(raw), "subsystems/test.yaml", func(doc *yaml.Node) error {
+		if err := setYAMLMapField(doc, "title", "Новый заголовок"); err != nil {
+			return err
+		}
+		contents, err := yamlSubMap(doc, "contents")
+		if err != nil {
+			return err
+		}
+		return setYAMLMapField(contents, "catalogs", []string{"Новый"})
+	})
+	if err != nil {
+		t.Fatalf("updateYAMLMapping: %v", err)
+	}
+
+	saved := string(out)
+	for _, fragment := range []string{
+		"# комментарий документа",
+		"# комментарий списка",
+		"# состав",
+		"# заголовок",
+		"&shared",
+		"*shared",
+		"&label",
+		"*label",
+		"experimental:",
+	} {
+		if !strings.Contains(saved, fragment) {
+			t.Errorf("после точечной правки потеряно %q:\n%s", fragment, saved)
+		}
+	}
+
+	var decoded struct {
+		SharedContents struct {
+			Catalogs []string `yaml:"catalogs"`
+		} `yaml:"shared_contents"`
+		Contents struct {
+			Catalogs []string `yaml:"catalogs"`
+		} `yaml:"contents"`
+		Title       string `yaml:"title"`
+		MirrorTitle string `yaml:"mirror_title"`
+	}
+	if err := yaml.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("результат не разбирается: %v\n%s", err, saved)
+	}
+	if got := decoded.Contents.Catalogs; len(got) != 1 || got[0] != "Новый" {
+		t.Errorf("contents.catalogs = %v", got)
+	}
+	if got := decoded.SharedContents.Catalogs; len(got) != 1 || got[0] != "Новый" {
+		t.Errorf("shared_contents.catalogs = %v", got)
+	}
+	if decoded.Title != "Новый заголовок" || decoded.MirrorTitle != "Новый заголовок" {
+		t.Errorf("alias заголовка потерял семантику: title=%q mirror=%q", decoded.Title, decoded.MirrorTitle)
+	}
+}
+
+func TestUpdateYAMLMapping_RejectsAmbiguousOrMalformedDocuments(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		edit func(*yaml.Node) error
+	}{
+		{
+			name: "duplicate key",
+			raw:  "name: Первый\nname: Второй\n",
+			edit: func(doc *yaml.Node) error { return setYAMLMapField(doc, "title", "Тест") },
+		},
+		{
+			name: "multiple documents",
+			raw:  "name: Первый\n---\nname: Второй\n",
+			edit: func(doc *yaml.Node) error { return setYAMLMapField(doc, "title", "Тест") },
+		},
+		{
+			name: "broken syntax",
+			raw:  "name: [\n",
+			edit: func(doc *yaml.Node) error { return setYAMLMapField(doc, "title", "Тест") },
+		},
+		{
+			name: "contents is not a mapping",
+			raw:  "name: Тест\ncontents: []\n",
+			edit: func(doc *yaml.Node) error {
+				_, err := yamlSubMap(doc, "contents")
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := updateYAMLMapping([]byte(tt.raw), "subsystems/test.yaml", tt.edit)
+			if err == nil {
+				t.Fatalf("ожидалась ошибка, получено:\n%s", out)
+			}
+			if out != nil {
+				t.Fatalf("при ошибке появился результат: %q", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Закрывает #878.

## Что было

`configuratorSaveSubsystem` собирал `subsystems/*.yaml` полным `yaml.Marshal` локальной struct. Всё, чего в struct нет — незнакомые ключи (нынешние и будущие) и любые комментарии, — молча исчезало при первом же сохранении из конфигуратора.

Ровно этот антипаттерн уже дважды чинили: в `config/app.yaml` (#663) и в матрице ролей (#744).

**Ручной перенос делу не помогал.** Код перечитывал файл и возвращал обратно `roles`/`pages`/`titles`/`home_page` — то есть список «что не потерять» вели руками, и он неизбежно отстаёт от формата. Хуже: весь перенос держался на `yaml.Unmarshal(raw, &existing) == nil`. Одно поле неожиданной формы — и ветка переноса не выполняется, теряя уже всё перечисленное. Я на это наступил прямо в тесте: `widgets: [Имя]` вместо `widgets: [{name: Имя}]` — и старый код терял ещё и роли со страницами.

## Что сделано

Точечная правка (`updateYAMLMapping` + `setYAMLMapField` + `yamlSubMap`), как в #663/#744: трогаются ровно те ключи, которые редактирует форма. `pages` не упоминается **вовсе** — и остаётся в файле сам, без переноса руками.

`updateAppYAML` → `updateYAMLMapping(raw, docName, edit)`: функция общая для нескольких файлов, а сообщение «ожидалось YAML-отображение в config/app.yaml» при сохранении подсистемы отправляло бы искать проблему не в том файле. Прежнее имя осталось тонкой обёрткой — вызовы для app.yaml не тронуты.

## Тест

`TestSaveSubsystem_СохраняетКомментарииИНезнакомыеКлючи` идёт через публичный хендлер и смотрит на **сырой текст** файла: разбор в структуру показал бы только то, что структура и так знает.

Без правки падает:

```
после сохранения потеряно: комментарий шапки ("# Подсистема отдела продаж")
после сохранения потеряно: комментарий про роли ("# роли этой формой не редактируются")
после сохранения потеряно: незнакомый ключ ("experimental_flag")
```

Прежние тесты сохранения подсистемы (`_DBModePersistsContents`, `_PersistsTitles`) — зелёные.

## Что не сделано

Заявка предлагала «заодно прочесать остальные `configuratorSave*`-пути на тот же антипаттерн». Не стал мешать это с фиксом: отдельная ревизия — отдельный PR, иначе непонятно, что именно проверяет CI.