### PR TITLE
fix(backup): универсальный бэкап работает в схеме, отличной от public (#877)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
           # (round-trip на выделенной базе, чтобы разрушительный restore не
           # затронул общую onebase_test). Требует pg_dump/psql — см. шаг выше.
           go test -race -count=1 -timeout 10m -tags integration ./internal/backup \
-            -run TestPostgresBackupRestoreRoundTrip
+            -run '^(TestPostgresBackupRestoreRoundTrip|TestUniversalBackupRoundTripInNonPublicSchema)$'
           # Owner-aware image demo has a PostgreSQL-only inter-server race
           # regression. Select the exact matrix subtest so this job does not
           # expand into the full internal/ui suite.

--- a/internal/backup/universal.go
+++ b/internal/backup/universal.go
@@ -322,6 +322,12 @@ func ExportUniversal(
 }
 
 // listAppTables returns all non-system table names in the database, sorted.
+// Интроспекция каталога фильтруется по current_schema(), а не по литералу
+// 'public' — правило пакета storage (см. комментарий к ConnectWithSchema,
+// #665). Универсальный бэкап его нарушал в семи местах, поэтому база, живущая в
+// другой схеме (search_path), выгружалась и восстанавливалась МИМО своих
+// таблиц: список таблиц приходил пустым или чужим, а типы колонок брались не
+// оттуда, где лежат данные (#877).
 func listAppTables(ctx context.Context, db *storage.DB) ([]string, error) {
 	var q string
 	if db.IsSQLite() {
@@ -331,7 +337,7 @@ func listAppTables(ctx context.Context, db *storage.DB) ([]string, error) {
 			   AND name NOT LIKE 'sqlite\_%' ESCAPE '\'
 			 ORDER BY name`
 	} else {
-		q = `SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename NOT LIKE '\_%' ESCAPE '\' ORDER BY tablename`
+		q = `SELECT tablename FROM pg_tables WHERE schemaname=current_schema() AND tablename NOT LIKE '\_%' ESCAPE '\' ORDER BY tablename`
 	}
 	rows, err := db.Query(ctx, q)
 	if err != nil {
@@ -496,7 +502,7 @@ func detectByteCols(ctx context.Context, db schemaMetadataDB, tableName string) 
 		}
 	} else {
 		rows, err := db.Query(ctx,
-			`SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1 AND data_type='bytea'`,
+			`SELECT column_name FROM information_schema.columns WHERE table_schema=current_schema() AND table_name=$1 AND data_type='bytea'`,
 			tableName)
 		if err != nil {
 			return nil, fmt.Errorf("query binary columns for %s: %w", tableName, err)
@@ -524,7 +530,7 @@ func detectJSONCols(ctx context.Context, db schemaMetadataDB, tableName string) 
 	}
 	rows, err := db.Query(ctx,
 		`SELECT column_name FROM information_schema.columns
-		 WHERE table_schema='public' AND table_name=$1 AND data_type IN ('json','jsonb')`,
+		 WHERE table_schema=current_schema() AND table_name=$1 AND data_type IN ('json','jsonb')`,
 		tableName)
 	if err != nil {
 		return nil, fmt.Errorf("query JSON columns for %s: %w", tableName, err)
@@ -551,7 +557,7 @@ func detectBoolCols(ctx context.Context, db schemaMetadataDB, tableName string) 
 	}
 	rows, err := db.Query(ctx,
 		`SELECT column_name FROM information_schema.columns
-		 WHERE table_schema='public' AND table_name=$1 AND data_type='boolean'`,
+		 WHERE table_schema=current_schema() AND table_name=$1 AND data_type='boolean'`,
 		tableName)
 	if err != nil {
 		return nil, fmt.Errorf("query boolean columns for %s: %w", tableName, err)
@@ -600,7 +606,7 @@ func detectByteaCols(ctx context.Context, db schemaMetadataDB, tableName string)
 	}
 	rows, err := db.Query(ctx,
 		`SELECT column_name FROM information_schema.columns
-		 WHERE table_schema='public' AND table_name=$1 AND data_type='bytea'`,
+		 WHERE table_schema=current_schema() AND table_name=$1 AND data_type='bytea'`,
 		tableName)
 	if err != nil {
 		return nil, fmt.Errorf("query bytea columns for %s: %w", tableName, err)
@@ -2771,7 +2777,7 @@ func getTableCols(ctx context.Context, db *storage.DB, tableName string) (map[st
 		}
 	} else {
 		rows, err := db.Query(ctx,
-			`SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1`,
+			`SELECT column_name FROM information_schema.columns WHERE table_schema=current_schema() AND table_name=$1`,
 			tableName)
 		if err != nil {
 			return cols, err
@@ -2800,7 +2806,7 @@ func tableExistsChecked(ctx context.Context, db tableExistenceDB, tableName stri
 		return exists, err
 	} else {
 		err := db.QueryRow(ctx,
-			`SELECT EXISTS(SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename=$1)`, tableName,
+			`SELECT EXISTS(SELECT 1 FROM pg_tables WHERE schemaname=current_schema() AND tablename=$1)`, tableName,
 		).Scan(&exists)
 		return exists, err
 	}

--- a/internal/backup/universal_schema_pg_test.go
+++ b/internal/backup/universal_schema_pg_test.go
@@ -3,9 +3,11 @@
 package backup
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -33,53 +35,55 @@ func TestUniversalBackupRoundTripInNonPublicSchema(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	const schema = "ob_schema_877"
-	admin, err := storage.Connect(ctx, baseDSN)
-	if err != nil {
-		t.Fatalf("Connect: %v", err)
-	}
-	if _, err := admin.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`); err != nil {
-		admin.Close()
-		t.Fatalf("подготовка схемы: %v", err)
-	}
-	if _, err := admin.Exec(ctx, `CREATE SCHEMA `+schema); err != nil {
-		admin.Close()
-		t.Fatalf("CREATE SCHEMA: %v", err)
-	}
-	admin.Close()
-	t.Cleanup(func() {
-		db, err := storage.Connect(context.Background(), baseDSN)
-		if err != nil {
-			return
-		}
-		defer db.Close()
-		_, _ = db.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
-	})
-
-	client := &metadata.Entity{
-		Name:   "Контрагент",
-		Kind:   metadata.KindCatalog,
-		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
-	}
-
+	schema := storage.NewEphemeralSchemaName()
 	db, err := storage.ConnectWithSchema(ctx, baseDSN, schema)
 	if err != nil {
 		t.Fatalf("ConnectWithSchema: %v", err)
 	}
-	defer db.Close()
-	if err := db.Migrate(ctx, []*metadata.Entity{client}); err != nil {
+	if err := db.CreateSchema(ctx, schema); err != nil {
+		db.Close()
+		t.Fatalf("CreateSchema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.DropSchemaCascade(context.Background(), schema); err != nil {
+			t.Errorf("DropSchemaCascade(%s): %v", schema, err)
+		}
+		db.Close()
+	})
+
+	probe := &metadata.Entity{
+		Name:   "Schema877UniversalBackupProbe",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "ProbeValue", Type: metadata.FieldTypeString}},
+	}
+	probeTable := metadata.TableName(probe.Name)
+	// The old implementation enumerated public tables and then read them through
+	// search_path. A shared entity name could therefore make this test pass by
+	// accident even though the probe table in the active schema was never listed.
+	var existsInPublic bool
+	if err := db.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = $1
+	)`, probeTable).Scan(&existsInPublic); err != nil {
+		t.Fatalf("check public probe precondition: %v", err)
+	}
+	if existsInPublic {
+		t.Fatalf("test precondition violated: probe table %q already exists in public", probeTable)
+	}
+
+	if err := db.Migrate(ctx, []*metadata.Entity{probe}); err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}
 	id := uuid.New()
-	if err := db.Upsert(ctx, client.Name, id, map[string]any{"Наименование": "ООО Схема"}, client); err != nil {
+	if err := db.Upsert(ctx, probe.Name, id, map[string]any{"ProbeValue": "schema-877-roundtrip"}, probe); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
 
 	cfgDir := t.TempDir()
-	if err := os.MkdirAll(cfgDir+"/config", 0o750); err != nil {
+	configDir := filepath.Join(cfgDir, "config")
+	if err := os.MkdirAll(configDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(cfgDir+"/config/app.yaml", []byte("name: Тест\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(configDir, "app.yaml"), []byte("name: Тест\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -90,12 +94,32 @@ func TestUniversalBackupRoundTripInNonPublicSchema(t *testing.T) {
 	if archive.Len() == 0 {
 		t.Fatal("архив пуст")
 	}
+	zr, err := zip.NewReader(bytes.NewReader(archive.Bytes()), int64(archive.Len()))
+	if err != nil {
+		t.Fatalf("open exported archive: %v", err)
+	}
+	// Together with the public-schema precondition above, this is the direct
+	// regression assertion: the old public-only table listing omits this entry.
+	wantEntry := "data/" + probeTable + ".jsonl"
+	foundProbe := false
+	for _, entry := range zr.File {
+		if entry.Name == wantEntry {
+			foundProbe = true
+			break
+		}
+	}
+	if !foundProbe {
+		t.Fatalf("archive omitted non-public probe table %q (entry %q)", probeTable, wantEntry)
+	}
 
 	// «Авария»: данные снесены. Таблица останется — её восстановит импорт.
-	if _, err := db.Exec(ctx, `DELETE FROM `+metadata.TableName(client.Name)); err != nil {
+	if _, err := db.Exec(ctx, `DELETE FROM `+probeTable); err != nil {
 		t.Fatalf("симуляция аварии: %v", err)
 	}
-	if row, err := db.GetByID(ctx, client.Name, id, client); err == nil && row != nil {
+	if _, err := db.GetByID(ctx, probe.Name, id, probe); !storage.IsNotFound(err) {
+		if err != nil {
+			t.Fatalf("проверка симуляции аварии: %v", err)
+		}
 		t.Fatal("подготовка: запись не удалилась")
 	}
 
@@ -109,11 +133,11 @@ func TestUniversalBackupRoundTripInNonPublicSchema(t *testing.T) {
 		t.Fatal("отчёт импорта пуст")
 	}
 
-	row, err := db.GetByID(ctx, client.Name, id, client)
+	row, err := db.GetByID(ctx, probe.Name, id, probe)
 	if err != nil {
 		t.Fatalf("после импорта записи нет — бэкап прошёл мимо таблиц своей схемы: %v", err)
 	}
-	if got, _ := row["Наименование"].(string); got != "ООО Схема" {
-		t.Fatalf("после импорта Наименование = %q, ожидалось «ООО Схема»", got)
+	if got, _ := row["ProbeValue"].(string); got != "schema-877-roundtrip" {
+		t.Fatalf("после импорта ProbeValue = %q, ожидалось %q", got, "schema-877-roundtrip")
 	}
 }

--- a/internal/backup/universal_schema_pg_test.go
+++ b/internal/backup/universal_schema_pg_test.go
@@ -1,0 +1,119 @@
+//go:build integration
+
+package backup
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Универсальный бэкап обязан работать в базе, живущей НЕ в схеме public (#877).
+//
+// Правило пакета storage записано прямо в коде (ConnectWithSchema, #665): любая
+// интроспекция каталога фильтруется по current_schema(), а не по литералу
+// 'public'. Универсальный бэкап его нарушал в семи местах, поэтому база с
+// собственным search_path выгружалась и восстанавливалась МИМО своих таблиц:
+// список таблиц приходил чужим или пустым, а типы колонок брались не оттуда,
+// где лежат данные.
+//
+// Тест идёт публичным путём ExportUniversal → ImportUniversal и сверяет
+// СОДЕРЖИМОЕ, а не код возврата: пустая выгрузка «успешна» ровно так же, как
+// полная.
+func TestUniversalBackupRoundTripInNonPublicSchema(t *testing.T) {
+	baseDSN := os.Getenv("TEST_DATABASE_URL")
+	if baseDSN == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+
+	const schema = "ob_schema_877"
+	admin, err := storage.Connect(ctx, baseDSN)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if _, err := admin.Exec(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`); err != nil {
+		admin.Close()
+		t.Fatalf("подготовка схемы: %v", err)
+	}
+	if _, err := admin.Exec(ctx, `CREATE SCHEMA `+schema); err != nil {
+		admin.Close()
+		t.Fatalf("CREATE SCHEMA: %v", err)
+	}
+	admin.Close()
+	t.Cleanup(func() {
+		db, err := storage.Connect(context.Background(), baseDSN)
+		if err != nil {
+			return
+		}
+		defer db.Close()
+		_, _ = db.Exec(context.Background(), `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	})
+
+	client := &metadata.Entity{
+		Name:   "Контрагент",
+		Kind:   metadata.KindCatalog,
+		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+	}
+
+	db, err := storage.ConnectWithSchema(ctx, baseDSN, schema)
+	if err != nil {
+		t.Fatalf("ConnectWithSchema: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(ctx, []*metadata.Entity{client}); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	id := uuid.New()
+	if err := db.Upsert(ctx, client.Name, id, map[string]any{"Наименование": "ООО Схема"}, client); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	cfgDir := t.TempDir()
+	if err := os.MkdirAll(cfgDir+"/config", 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgDir+"/config/app.yaml", []byte("name: Тест\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var archive bytes.Buffer
+	if err := ExportUniversal(ctx, db, "file", cfgDir, t.TempDir(), "schema-test", &archive); err != nil {
+		t.Fatalf("ExportUniversal: %v", err)
+	}
+	if archive.Len() == 0 {
+		t.Fatal("архив пуст")
+	}
+
+	// «Авария»: данные снесены. Таблица останется — её восстановит импорт.
+	if _, err := db.Exec(ctx, `DELETE FROM `+metadata.TableName(client.Name)); err != nil {
+		t.Fatalf("симуляция аварии: %v", err)
+	}
+	if row, err := db.GetByID(ctx, client.Name, id, client); err == nil && row != nil {
+		t.Fatal("подготовка: запись не удалилась")
+	}
+
+	data := archive.Bytes()
+	report, err := ImportUniversal(ctx, db, "file", t.TempDir(), t.TempDir(),
+		bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("ImportUniversal: %v", err)
+	}
+	if report == nil {
+		t.Fatal("отчёт импорта пуст")
+	}
+
+	row, err := db.GetByID(ctx, client.Name, id, client)
+	if err != nil {
+		t.Fatalf("после импорта записи нет — бэкап прошёл мимо таблиц своей схемы: %v", err)
+	}
+	if got, _ := row["Наименование"].(string); got != "ООО Схема" {
+		t.Fatalf("после импорта Наименование = %q, ожидалось «ООО Схема»", got)
+	}
+}


### PR DESCRIPTION
Закрывает #877.

## Что было

#665 перевёл интроспекцию каталога на `current_schema()` и записал это правилом пакета прямо в коде (`ConnectWithSchema`):

> любая интроспекция каталога (`pg_tables`, `information_schema.*`, `pg_constraint`) фильтруется по `current_schema()`, а не по литералу `public`. Иначе читаем и пишем в разные места.

`internal/backup/universal.go` нарушал это правило в **семи** местах: список таблиц, три запроса типов колонок (bytea/json/boolean), проверка существования таблицы и состав колонок при импорте.

База, живущая в своей схеме (`search_path`), из-за этого выгружалась и восстанавливалась **мимо своих таблиц**. Формально операция завершалась успехом — пустая выгрузка «успешна» ровно так же, как полная.

## Тест

`TestUniversalBackupRoundTripInNonPublicSchema` — интеграционный (тег `integration`), публичным путём `ExportUniversal` → «авария» → `ImportUniversal` в схеме `ob_schema_877`, со сверкой **содержимого**, а не кода возврата.

Прогнан на локальном PostgreSQL 14:

```
# с литералом public (как было)
после импорта записи нет — бэкап прошёл мимо таблиц своей схемы:
getbyid Контрагент: no rows in result set

# с current_schema()
ok  github.com/ivantit66/onebase/internal/backup  3.801s
```

Весь пакет зелёный, включая прежний round-trip из #802.