### PR TITLE
fix(selfupdate): поколение сверяется по текущему бинарю, а не по жёсткому имени (#831)

### DIFF
--- a/internal/selfupdate/binary_name_test.go
+++ b/internal/selfupdate/binary_name_test.go
@@ -1,0 +1,73 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// privateInstallDirLocal — каталог установки, который проверка приватности
+// признаёт своим. После мержа #931 заменяется на общий installtest.
+func privateInstallDirLocal(t *testing.T) string {
+	t.Helper()
+	if root := windowsTestPrivateInstallRoot(); root != "" {
+		dir, err := os.MkdirTemp(root, "onebase-name-test-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) }) //nolint:gosec // G703: точный результат MkdirTemp внутри профиля
+		return dir
+	}
+	root := filepath.Join(t.TempDir(), "private")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o700); err != nil { //nolint:gosec // G302: 0700 и есть приватная граница
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gosec // G301: моделируем реальную установку
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Бинарь, названный не onebase[.exe], обязан работать (#831).
+//
+// Гейт поколения запускал `<каталог>/onebase[.exe] --version` по жёстко зашитому
+// имени. Для сборки под другим именем (`go build -o my-onebase`, хранение
+// версий рядом: onebase-0.9.8.exe) этого файла попросту нет — и НИ ОДНА команда
+// не выполнялась, включая check и run, которые к обновлению отношения не имеют.
+// Сообщение при этом уводило в сторону: «binary package is unavailable during
+// update recovery», хотя обновление никто не запускал.
+//
+// Проверяется именно то, ЧТО спрашивают: путь, переданный в определение версии,
+// должен быть текущим исполняемым файлом, а не именем из каталога установки.
+func TestConsumerLease_ПроверяетПоколениеТекущегоБинаря(t *testing.T) {
+	dir := privateInstallDirLocal(t)
+	self := filepath.Join(dir, "ob-2026-08-13.exe")
+
+	oldPath, oldVersion := currentBinaryPath, consumerBinaryVersion
+	t.Cleanup(func() { currentBinaryPath, consumerBinaryVersion = oldPath, oldVersion })
+
+	currentBinaryPath = func() (string, error) { return self, nil }
+	var asked string
+	consumerBinaryVersion = func(path string) (string, error) {
+		asked = path
+		return "build-1", nil
+	}
+
+	lease, err := acquireConsumerLease(dir, "build-1")
+	if err != nil {
+		t.Fatalf("лизинг не выдан бинарю под своим именем: %v", err)
+	}
+	t.Cleanup(func() { _ = lease.Release() })
+
+	if asked != self {
+		t.Fatalf("версию спросили у %q, а надо у текущего бинаря %q", asked, self)
+	}
+	if strings.HasSuffix(asked, BinaryName()) {
+		t.Errorf("гейт снова смотрит на жёстко зашитое имя %q", BinaryName())
+	}
+}

--- a/internal/selfupdate/consumer_lock.go
+++ b/internal/selfupdate/consumer_lock.go
@@ -16,6 +16,9 @@ var (
 	ErrPendingBinaryTransaction  = errors.New("selfupdate: installation has a pending binary transaction")
 	ErrConsumerGenerationChanged = errors.New("selfupdate: installed binary generation changed while this process was starting")
 	consumerBinaryVersion        = BinaryVersion
+	// currentBinaryPath — шов для тестов: они подменяют «текущий бинарь»
+	// заглушкой, не пересобирая себя.
+	currentBinaryPath = BinaryPath
 )
 
 var processConsumerState struct {
@@ -93,7 +96,15 @@ func acquireConsumerLease(targetDir, expectedVersion string) (*ConsumerLease, er
 		return nil, errors.Join(err, lock.Unlock(), intent.Unlock())
 	}
 	if expectedVersion != "" {
-		got, versionErr := consumerBinaryVersion(filepath.Join(canonical, BinaryName()))
+		// Сверяем поколение ТЕКУЩЕГО исполняемого файла, а не файла с жёстко
+		// зашитым именем в каталоге: бинарь, названный иначе (сборка
+		// ob-2026-08-13.exe, `go build -o my-onebase`), проверял бы
+		// несуществующий onebase.exe и не выполнял НИ ОДНОЙ команды (#831).
+		self, pathErr := currentBinaryPath()
+		if pathErr != nil {
+			return nil, errors.Join(pathErr, lock.Unlock(), intent.Unlock())
+		}
+		got, versionErr := consumerBinaryVersion(self)
 		if versionErr != nil {
 			return nil, errors.Join(fmt.Errorf("selfupdate: verify installed binary generation: %w", versionErr), lock.Unlock(), intent.Unlock())
 		}
@@ -217,7 +228,11 @@ func resumeProcessConsumer(consumer *ConsumerLease) error {
 		return err
 	}
 	if consumer.expectedVersion != "" {
-		got, versionErr := consumerBinaryVersion(filepath.Join(consumer.targetDir, BinaryName()))
+		self, pathErr := currentBinaryPath()
+		if pathErr != nil {
+			return pathErr
+		}
+		got, versionErr := consumerBinaryVersion(self)
 		if versionErr != nil {
 			return errors.Join(versionErr, lock.Unlock())
 		}

--- a/internal/selfupdate/policy.go
+++ b/internal/selfupdate/policy.go
@@ -167,6 +167,24 @@ func BinaryDir() (string, error) {
 	return filepath.Dir(exe), nil
 }
 
+// BinaryPath — путь ТЕКУЩЕГО исполняемого файла с разрешёнными симлинками.
+//
+// Отличается от filepath.Join(BinaryDir(), BinaryName()) именем: жёсткое имя
+// «onebase[.exe]» осмысленно только когда речь о каталоге УСТАНОВКИ (туда
+// обновление кладёт файл именно так). Для вопроса «не подменили ли бинарь, из
+// которого я загружен» имя должно быть настоящим — иначе бинарь под другим
+// именем проверяет чужой (и обычно несуществующий) файл (#831).
+func BinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("selfupdate: определить текущий бинарь: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return exe, nil
+}
+
 // CanWriteBinaryDir сообщает, может ли текущий пользователь заменить бинарь.
 //
 // Это и есть граница «кому можно обновлять платформу»: на личной установке


### PR DESCRIPTION
Закрывает #831 (заявка от @ivantit66).

## Что было

Гейт поколения запускал `<каталог>/onebase[.exe] --version` — файл с **жёстко зашитым именем**. Бинарь, названный иначе, не выполнял ни одной команды.

Воспроизвёл вживую (на приватном каталоге установки — иначе гейт пропускается и дефекта не видно):

```
$ ./ob-old check --project examples/minimal
onebase: binary package is unavailable during update recovery: selfupdate: verify
installed binary generation: не удалось определить версию бинаря onebase:
fork/exec …/bin/onebase: no such file or directory

$ ./ob-2026-08-13 check --project examples/minimal      # с правкой
OK: ошибок не найдено
```

Ломалось всё: `go build -o my-onebase ./cmd/onebase` (первое, что делает разработчик), хранение сборок рядом, `check` и `run` — команды, к обновлению отношения не имеющие. Сообщение уводило в сторону: про «update recovery», хотя обновление никто не запускал.

## Что сделано

Вопрос, на который отвечает гейт, — «не подменили ли бинарь, **из которого я загружен**». Значит и спрашивать надо у него: добавлен `BinaryPath()` (`os.Executable` + разрешение симлинков), сверка идёт по нему.

Жёсткое имя осталось там, где оно осмысленно, — в каталоге **установки**: туда обновление кладёт файл именно так.

## Тест

`TestConsumerLease_ПроверяетПоколениеТекущегоБинаря` проверяет ровно предмет: путь, у которого спрашивают версию, обязан быть текущим исполняемым файлом. Без правки падает, показывая оба пути.

Фикстуру приватного каталога пришлось написать локально: общий `internal/installtest` появится с #931 — после мержа заменю одной строкой.

## Про красные тесты пакета

`TestConsumerGenerationAttestationRejects…` и `TestConsumerRejectsPendingTarget…` падают в моей копии и на чистом main — это те самые средозависимые фикстуры, которые чинит #931.