### PR TITLE
test: cover table_part loader through managed-form HTTP path

### DIFF
--- a/internal/ui/form_tablepart_kind_test.go
+++ b/internal/ui/form_tablepart_kind_test.go
@@ -1,76 +1,90 @@
 package ui
 
 import (
-	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/go-chi/chi/v5"
+	"github.com/ivantit66/onebase/internal/project"
 )
 
-// Элемент ТЧ, описанный ключом `table_part:`, обязан отрисовываться (#830).
-//
-// Заявка пришла от человека, который наступил на это, собирая проверку по
-// другому вопросу: таблицы на форме просто нет, а `check` и `forms validate`
-// зелёные. Ключ объявлен в модели, загрузчик его читает — и на этом всё.
-//
-// Загрузчик теперь заполняет из него data_path, а этот тест держит конечный
-// результат: таблица в HTML. Проверять только загрузчик недостаточно — дефект
-// был именно в том, что модель и рендер разошлись.
+// Элемент ТЧ, описанный только ключом `table_part:`, обязан пройти весь путь
+// пользовательской конфигурации: YAML проекта → project.Load → HTTP-форма → HTML.
+// До #830 загрузчик оставлял data_path пустым, поэтому метаданные загружались,
+// но HTTP-форма молча не отрисовывала таблицу.
 func TestManagedForm_TablePartKeyRenders(t *testing.T) {
-	doc := &metadata.Entity{
-		Name: "Заказ",
-		Kind: metadata.KindDocument,
-		Fields: []metadata.Field{
-			{Name: "Номер", Type: metadata.FieldTypeString},
-		},
-		TableParts: []metadata.TablePart{{Name: "Строки", Fields: []metadata.Field{
-			{Name: "Номенклатура", Type: metadata.FieldTypeString},
-			{Name: "Количество", Type: metadata.FieldTypeNumber},
-		}}},
-	}
-	// Ровно то, что даёт загрузчик после нормализации table_part → data_path.
-	form := &metadata.FormModule{
-		Name:       "ФормаОбъекта",
-		Kind:       "object",
-		EntityName: doc.Name,
-		LayoutKind: metadata.FormLayoutManaged,
-		Title:      map[string]string{"ru": "Заказ"},
-		Elements: []*metadata.FormElement{{
-			Kind:      metadata.FormElementTablePart,
-			Name:      "Строки",
-			TablePart: "Строки",
-			DataPath:  "Объект.Строки",
-		}},
-	}
-	doc.Forms = []*metadata.FormModule{form}
-
-	data := map[string]any{
-		"Entity": doc, "Form": form, "IsNew": true,
-		"Values":        map[string]string{},
-		"RefOptions":    map[string]any{},
-		"EnumOptions":   map[string]any{},
-		"ChoiceOptions": map[string]any{},
-		"TPRefOptions":  map[string]any{},
-		"TPEnumLabels":  map[string]map[string]map[string]string{},
-		"TPEnumOrder":   map[string]map[string][]string{},
-		"TPRefMeta":     map[string]any{},
-		"TablePartRows": map[string][]map[string]any{"Строки": {}},
-		"User":          nil,
-		"Lang":          "ru",
+	dir := t.TempDir()
+	writeFixture := func(rel, body string) {
+		t.Helper()
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("создание каталога %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("запись %s: %v", path, err)
+		}
 	}
 
-	var buf bytes.Buffer
-	if err := tmpl.ExecuteTemplate(&buf, "page-managed-form", data); err != nil {
-		t.Fatalf("ExecuteTemplate: %v", err)
-	}
-	html := buf.String()
+	writeFixture("documents/заказ.yaml", `name: Заказ
+title: Заказ
+fields:
+  - name: Номер
+    type: string
+tableparts:
+  - name: Строки
+    fields:
+      - name: Номенклатура
+        type: string
+      - name: Количество
+        type: number
+`)
+	writeFixture("forms/заказ/объекта.form.yaml", `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заказ
+elements:
+  - kind: ТабличнаяЧасть
+    name: ТаблицаСтроки
+    table_part: Строки
+`)
 
-	// Колонки табличной части — признак того, что таблица действительно
-	// отрисована, а не просто заголовок элемента.
-	for _, want := range []string{"Номенклатура", "Количество"} {
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	s, _ := newSubmitTestServer(t, proj.Entities)
+	router := chi.NewRouter()
+	s.Mount(router)
+	httpServer := httptest.NewServer(router)
+	t.Cleanup(httpServer.Close)
+
+	endpoint := httpServer.URL + "/ui/document/" + url.PathEscape("Заказ") + "/new"
+	resp, err := http.Get(endpoint) //nolint:gosec,noctx // адрес тестового httptest-сервера
+	if err != nil {
+		t.Fatalf("GET %s: %v", endpoint, err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("чтение HTTP-ответа: %v", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET формы → %d: %.600s", resp.StatusCode, body)
+	}
+
+	html := string(body)
+	for _, want := range []string{`data-sg-tp="Строки"`, "Номенклатура", "Количество"} {
 		if !strings.Contains(html, want) {
-			t.Errorf("в форме нет колонки %q — таблица не отрисована:\n%.600s", want, html)
+			t.Fatalf("в HTTP-форме нет %q — table_part не дошёл до рендера:\n%.1200s", want, html)
 		}
 	}
 }

--- a/internal/ui/form_tablepart_kind_test.go
+++ b/internal/ui/form_tablepart_kind_test.go
@@ -20,18 +20,15 @@ import (
 // но HTTP-форма молча не отрисовывала таблицу.
 func TestManagedForm_TablePartKeyRenders(t *testing.T) {
 	dir := t.TempDir()
-	writeFixture := func(rel, body string) {
-		t.Helper()
-		path := filepath.Join(dir, rel)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("создание каталога %s: %v", filepath.Dir(path), err)
-		}
-		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-			t.Fatalf("запись %s: %v", path, err)
+	documentsDir := filepath.Join(dir, "documents")
+	formsDir := filepath.Join(dir, "forms", "заказ")
+	for _, path := range []string{documentsDir, formsDir} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatalf("создание каталога %s: %v", path, err)
 		}
 	}
 
-	writeFixture("documents/заказ.yaml", `name: Заказ
+	if err := os.WriteFile(filepath.Join(documentsDir, "заказ.yaml"), []byte(`name: Заказ
 title: Заказ
 fields:
   - name: Номер
@@ -43,8 +40,10 @@ tableparts:
         type: string
       - name: Количество
         type: number
-`)
-	writeFixture("forms/заказ/объекта.form.yaml", `schema: onebase.form/v1
+`), 0o644); err != nil {
+		t.Fatalf("запись метаданных документа: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(formsDir, "объекта.form.yaml"), []byte(`schema: onebase.form/v1
 form:
   name: ФормаОбъекта
   kind: object
@@ -53,7 +52,9 @@ elements:
   - kind: ТабличнаяЧасть
     name: ТаблицаСтроки
     table_part: Строки
-`)
+`), 0o644); err != nil {
+		t.Fatalf("запись формы: %v", err)
+	}
 
 	proj, err := project.Load(dir)
 	if err != nil {


### PR DESCRIPTION
Follow-up to #935.

The original regression test constructed already-normalized metadata, so it could not fail when the YAML loader omitted `table_part -> data_path` normalization. This replaces it with an end-to-end regression that exercises:

`YAML fixture -> project.Load -> mounted UI HTTP route -> rendered managed-form HTML`

It asserts both the table-part marker and its real columns. A mutation check confirmed that removing the loader normalization makes this test fail.

Local verification on fresh `main` after #932:
- exact Go 1.26.6: `go test ./... -count=1`
- focused UI and loader tests
- `go vet ./internal/ui ./internal/dsl/loader`
- `go run ./tools/i18ncheck`