### PR TITLE
fix(forms): harden virtual table-part columns after #942

### DIFF
--- a/internal/configcheck/form_virtual_column_check.go
+++ b/internal/configcheck/form_virtual_column_check.go
@@ -111,7 +111,12 @@ func checkVirtualColumn(
 	}
 	if metadata.IsReservedFormVirtualColumnName(name) {
 		add(fmt.Sprintf("виртуальная колонка %q использует служебное имя", name),
-			"выберите имя, отличное от id, _ord, _obRowClass и _obCellClasses")
+			"выберите имя, которое не занято служебными данными строки формы")
+		return
+	}
+	if vc.Name != name || !metadata.ValidIdent(name) {
+		add(fmt.Sprintf("виртуальная колонка %q не является идентификатором", vc.Name),
+			"используйте буквы, цифры и _ без пробелов; первый символ — буква или _")
 		return
 	}
 	// Имя колонки не должно совпадать с реквизитом ТЧ: одноимённая виртуальная

--- a/internal/configcheck/form_virtual_column_check.go
+++ b/internal/configcheck/form_virtual_column_check.go
@@ -25,6 +25,7 @@ func CheckFormVirtualColumns(proj *project.Project) []Issue {
 	for _, ent := range proj.Entities {
 		for _, form := range ent.Forms {
 			label := formFileLabel(ent, form)
+			formSeen := make(map[string]formVirtualColumnUse)
 			walkFormElements(form.Elements, func(el *metadata.FormElement) {
 				if len(el.VirtualColumns) == 0 {
 					return
@@ -48,11 +49,52 @@ func CheckFormVirtualColumns(proj *project.Project) []Issue {
 				seen := make(map[string]bool, len(el.VirtualColumns))
 				for _, vc := range el.VirtualColumns {
 					checkVirtualColumn(add, byName, *tp, vc, seen)
+					checkVirtualColumnAcrossViews(add, formSeen, *tp, el, vc)
 				}
 			})
 		}
 	}
 	return issues
+}
+
+type formVirtualColumnUse struct {
+	element *metadata.FormElement
+	name    string
+	path    string
+}
+
+// checkVirtualColumnAcrossViews keeps the row-map contract unambiguous when
+// the same table part is placed on a form more than once. Presentation details
+// may differ per view, but one row key cannot represent two different paths.
+func checkVirtualColumnAcrossViews(
+	add func(msg, fix string),
+	seen map[string]formVirtualColumnUse,
+	tp metadata.TablePart,
+	el *metadata.FormElement,
+	vc metadata.FormVirtualColumn,
+) {
+	exactName := vc.Name
+	name := strings.TrimSpace(exactName)
+	if name == "" || metadata.IsReservedFormVirtualColumnName(name) {
+		return
+	}
+	refName, ok := vc.RefFieldName()
+	if !ok {
+		return
+	}
+	targetName, _ := vc.TargetFieldName()
+	key := strings.ToLower(strings.TrimSpace(tp.Name)) + "\x00" + strings.ToLower(name)
+	path := strings.ToLower(refName) + "\x00" + strings.ToLower(targetName)
+	previous, exists := seen[key]
+	if !exists {
+		seen[key] = formVirtualColumnUse{element: el, name: exactName, path: path}
+		return
+	}
+	if previous.element == el || (previous.name == exactName && previous.path == path) {
+		return
+	}
+	add(fmt.Sprintf("виртуальная колонка %q конфликтует с объявлением элемента %q для той же табличной части", name, formElementName(previous.element)),
+		"используйте одинаковые name и data_path во всех представлениях табличной части либо задайте разные имена колонок")
 }
 
 func checkVirtualColumn(
@@ -65,6 +107,11 @@ func checkVirtualColumn(
 	name := strings.TrimSpace(vc.Name)
 	if name == "" {
 		add("виртуальная колонка без name", "задайте name — по нему колонка адресуется внутри формы")
+		return
+	}
+	if metadata.IsReservedFormVirtualColumnName(name) {
+		add(fmt.Sprintf("виртуальная колонка %q использует служебное имя", name),
+			"выберите имя, отличное от id, _ord, _obRowClass и _obCellClasses")
 		return
 	}
 	// Имя колонки не должно совпадать с реквизитом ТЧ: одноимённая виртуальная
@@ -132,6 +179,9 @@ func checkVirtualColumn(
 // ключ table_part или data_path «Объект.<ТЧ>». Возвращает nil, если элемент —
 // не табличная часть сущности (например таблица значений формы).
 func virtualColumnTablePart(ent *metadata.Entity, el *metadata.FormElement) *metadata.TablePart {
+	if ent == nil || el == nil || el.Kind != metadata.FormElementTablePart {
+		return nil
+	}
 	name := strings.TrimSpace(el.TablePart)
 	if name == "" {
 		if parts := strings.Split(el.DataPath, "."); len(parts) == 2 &&

--- a/internal/configcheck/form_virtual_column_check_test.go
+++ b/internal/configcheck/form_virtual_column_check_test.go
@@ -54,6 +54,8 @@ func TestCheckFormVirtualColumns(t *testing.T) {
 		{"реквизит не ссылочный", metadata.FormVirtualColumn{Name: "Код", DataPath: "Комментарий.Код"}, "не ссылочный"},
 		{"нет реквизита у цели", metadata.FormVirtualColumn{Name: "ИНН", DataPath: "Клиент.ИНН"}, "нет реквизита \"ИНН\""},
 		{"имя совпадает с реквизитом ТЧ", metadata.FormVirtualColumn{Name: "Комментарий", DataPath: "Клиент.Код"}, "совпадает с реквизитом"},
+		{"имя с пробелом", metadata.FormVirtualColumn{Name: "Код клиента", DataPath: "Клиент.Код"}, "идентификатором"},
+		{"имя с внешними пробелами", metadata.FormVirtualColumn{Name: " КодКлиента ", DataPath: "Клиент.Код"}, "идентификатором"},
 		{"без имени", metadata.FormVirtualColumn{DataPath: "Клиент.Код"}, "без name"},
 	}
 	for _, c := range cases {
@@ -102,7 +104,10 @@ func TestCheckFormVirtualColumns_НеТабличнаяЧасть(t *testing.T) 
 }
 
 func TestCheckFormVirtualColumns_СлужебныеИмена(t *testing.T) {
-	for _, name := range []string{" id ", "_OrD", "_obROWclass", "_OBCELlClasses"} {
+	for _, name := range []string{
+		" id ", "_OrD", "_obROWclass", "_OBCELlClasses",
+		"_FORM_ROW_CLASS", "_form_cell_classes", "__Proto__",
+	} {
 		t.Run(name, func(t *testing.T) {
 			issues := CheckFormVirtualColumns(virtualColumnProject(
 				metadata.FormVirtualColumn{Name: name, DataPath: "Клиент.Код"},

--- a/internal/configcheck/form_virtual_column_check_test.go
+++ b/internal/configcheck/form_virtual_column_check_test.go
@@ -92,11 +92,68 @@ func TestCheckFormVirtualColumns_Дубль(t *testing.T) {
 func TestCheckFormVirtualColumns_НеТабличнаяЧасть(t *testing.T) {
 	proj := virtualColumnProject()
 	proj.Entities[1].Forms[0].Elements = []*metadata.FormElement{{
-		Kind: metadata.FormElementField, Name: "Комментарий", DataPath: "Объект.Комментарий",
+		Kind: metadata.FormElementField, Name: "ЛожнаяТаблица", DataPath: "Объект.Строки",
 		VirtualColumns: []metadata.FormVirtualColumn{{Name: "КодКлиента", DataPath: "Клиент.Код"}},
 	}}
 	issues := CheckFormVirtualColumns(proj)
 	if len(issues) != 1 || !strings.Contains(issues[0].Message, "не на табличной части") {
 		t.Fatalf("ожидалась ошибка размещения, получено: %+v", issues)
+	}
+}
+
+func TestCheckFormVirtualColumns_СлужебныеИмена(t *testing.T) {
+	for _, name := range []string{" id ", "_OrD", "_obROWclass", "_OBCELlClasses"} {
+		t.Run(name, func(t *testing.T) {
+			issues := CheckFormVirtualColumns(virtualColumnProject(
+				metadata.FormVirtualColumn{Name: name, DataPath: "Клиент.Код"},
+			))
+			if len(issues) != 1 || !strings.Contains(issues[0].Message, "служебное имя") {
+				t.Fatalf("служебное имя %q принято: %+v", name, issues)
+			}
+		})
+	}
+}
+
+func TestCheckFormVirtualColumns_КонфликтМеждуПредставлениями(t *testing.T) {
+	proj := virtualColumnProject(
+		metadata.FormVirtualColumn{Name: "КодКлиента", DataPath: "Клиент.Код"},
+	)
+	proj.Entities[1].Forms[0].Elements = append(proj.Entities[1].Forms[0].Elements, &metadata.FormElement{
+		Kind: metadata.FormElementTablePart, Name: "СтрокиИтоги", DataPath: "Объект.Строки",
+		VirtualColumns: []metadata.FormVirtualColumn{{Name: "КодКлиента", DataPath: "Клиент.Наименование"}},
+	})
+	issues := CheckFormVirtualColumns(proj)
+	if len(issues) != 1 || !strings.Contains(issues[0].Message, "конфликтует") {
+		t.Fatalf("конфликт одного row-key с разными путями принят: %+v", issues)
+	}
+}
+
+func TestCheckFormVirtualColumns_ОдинаковоеОбъявлениеВПредставлениях(t *testing.T) {
+	proj := virtualColumnProject(
+		metadata.FormVirtualColumn{Name: "КодКлиента", DataPath: "Клиент.Код", Width: 90},
+	)
+	proj.Entities[1].Forms[0].Elements = append(proj.Entities[1].Forms[0].Elements, &metadata.FormElement{
+		Kind: metadata.FormElementTablePart, Name: "СтрокиИтоги", DataPath: "Объект.Строки",
+		VirtualColumns: []metadata.FormVirtualColumn{{
+			Name: "КодКлиента", DataPath: " клиент . код ", Width: 180,
+			TitleMap: map[string]string{"ru": "Другой заголовок"},
+		}},
+	})
+	if issues := CheckFormVirtualColumns(proj); len(issues) != 0 {
+		t.Fatalf("одно и то же объявление с разными presentation-настройками отклонено: %+v", issues)
+	}
+}
+
+func TestCheckFormVirtualColumns_РегистрИмениМеждуПредставлениями(t *testing.T) {
+	proj := virtualColumnProject(
+		metadata.FormVirtualColumn{Name: "КодКлиента", DataPath: "Клиент.Код"},
+	)
+	proj.Entities[1].Forms[0].Elements = append(proj.Entities[1].Forms[0].Elements, &metadata.FormElement{
+		Kind: metadata.FormElementTablePart, Name: "СтрокиИтоги", DataPath: "Объект.Строки",
+		VirtualColumns: []metadata.FormVirtualColumn{{Name: "кодклиента", DataPath: "Клиент.Код"}},
+	})
+	issues := CheckFormVirtualColumns(proj)
+	if len(issues) != 1 || !strings.Contains(issues[0].Message, "конфликтует") {
+		t.Fatalf("разный регистр одного row-key принят: %+v", issues)
 	}
 }

--- a/internal/metadata/form_module.go
+++ b/internal/metadata/form_module.go
@@ -237,7 +237,8 @@ type FormVirtualColumn struct {
 // must not be allowed to overwrite identity, stable-order or styling metadata.
 func IsReservedFormVirtualColumnName(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "id", "_ord", "_obrowclass", "_obcellclasses":
+	case "id", "_ord", "_obrowclass", "_obcellclasses",
+		"_form_row_class", "_form_cell_classes", "__proto__":
 		return true
 	default:
 		return false

--- a/internal/metadata/form_module.go
+++ b/internal/metadata/form_module.go
@@ -232,6 +232,18 @@ type FormVirtualColumn struct {
 	Width    int               `yaml:"width,omitempty"`
 }
 
+// IsReservedFormVirtualColumnName reports names occupied by the managed-form
+// table runtime. A virtual column is copied into the same JS row object, so it
+// must not be allowed to overwrite identity, stable-order or styling metadata.
+func IsReservedFormVirtualColumnName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "id", "_ord", "_obrowclass", "_obcellclasses":
+		return true
+	default:
+		return false
+	}
+}
+
 // ColumnTitle — подпись колонки для языка с откатом на ru и на имя колонки.
 func (c FormVirtualColumn) ColumnTitle(lang string) string {
 	if c.TitleMap != nil {

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -40,12 +40,50 @@ function obManagedTableBodies(id, metadataAttr) {
   return matches;
 }
 
-function obManagedWritableTableBody(id, metadataAttr) {
+function obManagedWritableTableBody(id, metadataAttr, elementName) {
   var bodies = obManagedTableBodies(id, metadataAttr);
+  var legacyFallback = null;
   for (var i = 0; i < bodies.length; i++) {
-    if (!obManagedTableReadOnly(bodies[i])) return bodies[i];
+    if (obManagedTableReadOnly(bodies[i])) continue;
+    if (!elementName) return bodies[i];
+    var table = bodies[i].closest && bodies[i].closest('table[data-ob-dom-table]');
+    var bodyElement = table && table.getAttribute ? table.getAttribute('data-ob-element') : '';
+    if (bodyElement === elementName) return bodies[i];
+    // Preserve compatibility with custom/old templates that have no element
+    // identity at all, while never choosing another explicitly named view.
+    if (!bodyElement && !legacyFallback) legacyFallback = bodies[i];
   }
-  return null;
+  return legacyFallback;
+}
+
+function obManagedIsReservedVirtualColumnName(name) {
+  var normalized = String(name == null ? '' : name).trim().toLowerCase();
+  return normalized === 'id' || normalized === '_ord' ||
+    normalized === '_obrowclass' || normalized === '_obcellclasses';
+}
+
+function obManagedEscapeHTML(value) {
+  var entities = {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'};
+  return String(value).replace(/[&<>"']/g, function(ch) { return entities[ch]; });
+}
+
+function obManagedVirtualColumnNames(tbody) {
+  var raw = tbody && tbody.getAttribute ? tbody.getAttribute('data-tp-virtual-cols') : '';
+  if (!raw) return [];
+  try {
+    var parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    var seen = Object.create(null);
+    return parsed.filter(function(name) {
+      if (typeof name !== 'string' || name.trim() === '' || obManagedIsReservedVirtualColumnName(name)) return false;
+      var key = name.trim().toLowerCase();
+      if (seen[key]) return false;
+      seen[key] = true;
+      return true;
+    });
+  } catch (e) {
+    return [];
+  }
 }
 
 // Shared by the managed-form response renderer and the separate SlickGrid
@@ -304,6 +342,7 @@ window.obManagedSetTablePartJSON = obManagedSetTablePartJSON;
         if (refIdx >= 0) return { name: name, type: rest.slice(0, refIdx), ref: rest.slice(refIdx + 1) };
         return { name: name, type: rest, ref: '' };
       });
+      const virtualNames = obManagedVirtualColumnNames(tbody);
       const rows = tps[tpName] || [];
       const refOpts = (window._tpRefOpts && window._tpRefOpts[tpName]) || {};
       const tpEnumLabels = (window._tpEnumLabels && window._tpEnumLabels[tpName]) || {};
@@ -398,6 +437,13 @@ window.obManagedSetTablePartJSON = obManagedSetTablePartJSON;
             inp.disabled = readOnly;
             td.appendChild(inp);
           }
+          tr.appendChild(td);
+        });
+        virtualNames.forEach(function(name){
+          const td = document.createElement('td');
+          td.setAttribute('data-ob-virtual-col', name);
+          const value = Object.prototype.hasOwnProperty.call(row, name) ? row[name] : '';
+          td.textContent = value == null ? '' : String(value);
           tr.appendChild(td);
         });
         const tdDel = document.createElement('td');
@@ -952,12 +998,13 @@ function obManagedParseFieldMeta(raw) {
 
 function obManagedAddTpRow(btn) {
   var tpName = btn.getAttribute('data-ob-add-tp') || '';
-  var tbody = obManagedWritableTableBody('tp-body-' + tpName, 'data-tp-fields');
+  var elementName = btn.getAttribute('data-ob-element') || '';
+  var tbody = obManagedWritableTableBody('tp-body-' + tpName, 'data-tp-fields', elementName);
   if (!tpName || !tbody || typeof addTpRow !== 'function') return;
   var meta = obManagedParseFieldMeta(tbody.getAttribute('data-tp-fields') || '');
   var fields = meta.map(function (f) { return f.name; });
   var nums = meta.filter(function (f) { return f.type === 'number'; }).map(function (f) { return f.name; });
-  addTpRow(tpName, fields, nums, tbody.rows.length, tbody);
+  addTpRow(tpName, fields, nums, tbody.rows.length, tbody, obManagedVirtualColumnNames(tbody));
   var table = tbody.closest && tbody.closest('table[data-ob-dom-table]');
   if (table && window.obDOMNotifyMutation) window.obDOMNotifyMutation(table, 'add');
 }
@@ -1599,7 +1646,7 @@ obManagedReady(obManagedInitDelegates);
         if (c.width) col.width = c.width;
         col.formatter = function(row, cell, value) {
           if (value == null || value === "") return "";
-          return "<span style='color:#64748b'>" + String(value) + "</span>";
+          return "<span style='color:#64748b'>" + obManagedEscapeHTML(value) + "</span>";
         };
         columns.push(col);
         continue;
@@ -2152,6 +2199,9 @@ obManagedReady(obManagedInitDelegates);
     // создавался и не регистрировался, из-за чего add/удаление/подбор тихо не
     // работали именно в новых документах.
     var colsRaw = JSON.parse(div.getAttribute("data-sg-cols") || "[]") || [];
+    colsRaw = colsRaw.filter(function(c) {
+      return !(c && c.virtual && obManagedIsReservedVirtualColumnName(c.id));
+    });
     var refOpts = JSON.parse(div.getAttribute("data-sg-ref") || "null") || {};
     var enumLabels = JSON.parse(div.getAttribute("data-sg-enum") || "null") || {};
     var rowsRaw = JSON.parse(div.getAttribute("data-sg-rows") || "[]") || [];

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -59,7 +59,9 @@ function obManagedWritableTableBody(id, metadataAttr, elementName) {
 function obManagedIsReservedVirtualColumnName(name) {
   var normalized = String(name == null ? '' : name).trim().toLowerCase();
   return normalized === 'id' || normalized === '_ord' ||
-    normalized === '_obrowclass' || normalized === '_obcellclasses';
+    normalized === '_obrowclass' || normalized === '_obcellclasses' ||
+    normalized === '_form_row_class' || normalized === '_form_cell_classes' ||
+    normalized === '__proto__';
 }
 
 function obManagedEscapeHTML(value) {
@@ -996,10 +998,19 @@ function obManagedParseFieldMeta(raw) {
   }).filter(function (f) { return f.name !== ''; });
 }
 
+function obManagedAdjacentTableBody(btn, tpName, metadataAttr) {
+  var table = btn && btn.previousElementSibling;
+  if (!table || !table.getAttribute || !table.querySelector ||
+      table.getAttribute('data-ob-dom-table') !== tpName) return null;
+  var tbody = table.querySelector('tbody[' + metadataAttr + ']');
+  return tbody && !obManagedTableReadOnly(tbody) ? tbody : null;
+}
+
 function obManagedAddTpRow(btn) {
   var tpName = btn.getAttribute('data-ob-add-tp') || '';
   var elementName = btn.getAttribute('data-ob-element') || '';
-  var tbody = obManagedWritableTableBody('tp-body-' + tpName, 'data-tp-fields', elementName);
+  var tbody = obManagedAdjacentTableBody(btn, tpName, 'data-tp-fields') ||
+    obManagedWritableTableBody('tp-body-' + tpName, 'data-tp-fields', elementName);
   if (!tpName || !tbody || typeof addTpRow !== 'function') return;
   var meta = obManagedParseFieldMeta(tbody.getAttribute('data-tp-fields') || '');
   var fields = meta.map(function (f) { return f.name; });

--- a/internal/ui/static/managed_duplicate_grid_behavior_test.js
+++ b/internal/ui/static/managed_duplicate_grid_behavior_test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 
 const source = fs.readFileSync('static/managed.js', 'utf8');
-const helperStart = source.indexOf('function obManagedSetTablePartJSON');
+const helperStart = source.indexOf('function obManagedIsReservedVirtualColumnName');
 const helperEndMarker = 'window.obManagedSetTablePartJSON = obManagedSetTablePartJSON;';
 const helperEndAt = source.indexOf(helperEndMarker, helperStart);
 const start = source.indexOf('// SlickGrid initializer for managed-form table parts');
@@ -17,7 +17,7 @@ function eventSlot() {
   return {handlers: [], subscribe(fn) { this.handlers.push(fn); }};
 }
 
-function host(readOnly) {
+function host(readOnly, overrides) {
   const attrs = {
     'data-sg-tp': 'Lines',
     'data-sg-el': readOnly ? 'ReadonlyLines' : 'WritableLines',
@@ -26,6 +26,7 @@ function host(readOnly) {
     'data-sg-enum': 'null',
     'data-sg-rows': '[]'
   };
+  Object.assign(attrs, overrides || {});
   if (readOnly) attrs['data-sg-ro'] = '1';
   else attrs['data-sg-rowadd'] = '1';
   return {
@@ -37,9 +38,9 @@ function host(readOnly) {
   };
 }
 
-function run(order) {
-  const readonly = host(true);
-  const writable = host(false);
+function run(order, overrides) {
+  const readonly = host(true, overrides);
+  const writable = host(false, overrides);
   const hosts = order === 'readonly-first' ? [readonly, writable] : [writable, readonly];
   const created = [];
   const fired = [];
@@ -94,13 +95,43 @@ function run(order) {
     addEventListener() {},
     contains() { return true; }
   };
-  global.Slick = {Data: {DataView}, Grid};
+  global.Slick = {Data: {DataView}, Grid, Editors: {Text: function TextEditor() {}}};
   global.formGridItemMetadata = function() {};
   global.copyFormGridStyleKeys = function() {};
 
   eval(runtime);
   return {readonly, writable, created, fired, hidden, requestedFields, window: global.window};
 }
+
+test('virtual SlickGrid formatter escapes HTML', () => {
+  const state = run('writable-first', {
+    'data-sg-cols': JSON.stringify([{
+      id: 'Virtual', name: 'Virtual', type: 'string', virtual: true
+    }])
+  });
+  const formatter = state.created[0].columns[0].formatter;
+  const attack = `<img src=x onerror=alert(1)>&"'`;
+  assert.equal(
+    formatter(0, 0, attack),
+    "<span style='color:#64748b'>&lt;img src=x onerror=alert(1)&gt;&amp;&quot;&#39;</span>"
+  );
+});
+
+test('reserved virtual column cannot overwrite stable row order', () => {
+  const state = run('writable-first', {
+    'data-sg-cols': JSON.stringify([
+      {id: 'Value', name: 'Value', type: 'string'},
+      {id: '_ord', name: 'Order', type: 'string', virtual: true}
+    ]),
+    'data-sg-rows': JSON.stringify([
+      {Value: 'first', _ord: 100},
+      {Value: 'second', _ord: -1}
+    ])
+  });
+  assert.deepEqual(state.created[0].columns.map(column => column.id), ['Value']);
+  state.window.obGridSync();
+  assert.deepEqual(JSON.parse(state.hidden.value), [{Value: 'first'}, {Value: 'second'}]);
+});
 
 for (const order of ['readonly-first', 'writable-first']) {
   test(`duplicate SlickGrid keeps writable authority (${order})`, () => {

--- a/internal/ui/static/managed_duplicate_grid_behavior_test.js
+++ b/internal/ui/static/managed_duplicate_grid_behavior_test.js
@@ -117,14 +117,17 @@ test('virtual SlickGrid formatter escapes HTML', () => {
   );
 });
 
-test('reserved virtual column cannot overwrite stable row order', () => {
+test('reserved virtual columns cannot enter the SlickGrid row contract', () => {
   const state = run('writable-first', {
     'data-sg-cols': JSON.stringify([
       {id: 'Value', name: 'Value', type: 'string'},
-      {id: '_ord', name: 'Order', type: 'string', virtual: true}
+      {id: '_ord', name: 'Order', type: 'string', virtual: true},
+      {id: '_form_row_class', name: 'Row class', type: 'string', virtual: true},
+      {id: '_form_cell_classes', name: 'Cell classes', type: 'string', virtual: true},
+      {id: '__Proto__', name: 'Prototype', type: 'string', virtual: true}
     ]),
     'data-sg-rows': JSON.stringify([
-      {Value: 'first', _ord: 100},
+      {Value: 'first', _ord: 100, _form_row_class: 'wrong'},
       {Value: 'second', _ord: -1}
     ])
   });

--- a/internal/ui/static/managed_file_reader_behavior_test.js
+++ b/internal/ui/static/managed_file_reader_behavior_test.js
@@ -631,6 +631,41 @@ test('NoGrid add uses the clicked duplicate view schema', () => {
   assert.deepEqual(call.virtuals, ['Второй']);
 });
 
+test('NoGrid add uses its adjacent table when element names are ambiguous', () => {
+  resetDOM();
+  const first = installTableBody('tp-body-Строки', {
+    'data-tp-fields': 'Значение|string', 'data-tp-virtual-cols': '["Первый"]'
+  });
+  const second = installTableBody('tp-body-Строки', {
+    'data-tp-fields': 'Значение|string', 'data-tp-virtual-cols': '["Второй"]'
+  });
+  first.closest = second.closest = () => ({getAttribute() { return ''; }});
+  const adjacentTable = {
+    getAttribute(name) { return name === 'data-ob-dom-table' ? 'Строки' : null; },
+    querySelector(selector) { return selector === 'tbody[data-tp-fields]' ? second : null; }
+  };
+  let call = null;
+  const realAddTpRow = global.addTpRow;
+  global.addTpRow = function(_name, _fields, _nums, _index, target, virtuals) {
+    call = {target, virtuals};
+  };
+  try {
+    obManagedAddTpRow({
+      previousElementSibling: adjacentTable,
+      getAttribute(name) {
+        if (name === 'data-ob-add-tp') return 'Строки';
+        if (name === 'data-ob-element') return '';
+        return null;
+      }
+    });
+  } finally {
+    global.addTpRow = realAddTpRow;
+  }
+  assert.equal(call.target, second);
+  assert.deepEqual(call.virtuals, ['Второй']);
+  assert.equal(first.children.length, 0);
+});
+
 for (const order of ['readonly-first', 'writable-first']) {
   test(`ValueTable add targets writable duplicate (${order})`, () => {
     resetDOM();

--- a/internal/ui/static/managed_file_reader_behavior_test.js
+++ b/internal/ui/static/managed_file_reader_behavior_test.js
@@ -250,6 +250,11 @@ global.fetch = async (_url, options) => {
 resetDOM();
 const managedSource = fs.readFileSync(path.join(__dirname, 'managed.js'), 'utf8');
 vm.runInThisContext(managedSource, {filename: 'managed.js'});
+const uiSource = fs.readFileSync(path.join(__dirname, 'ui.js'), 'utf8');
+const addTpStart = uiSource.indexOf('function obTPRefOpts');
+const addTpEnd = uiSource.indexOf('function recalcTpRow', addTpStart);
+if (addTpStart < 0 || addTpEnd < 0) throw new Error('ui.js addTpRow slice not found');
+vm.runInThisContext(uiSource.slice(addTpStart, addTpEnd), {filename: 'ui-add-tp-row.js'});
 // DOMContentLoaded is intentionally not dispatched: initialise the real
 // delegated handlers directly, without running unrelated UI widgets.
 obManagedInitDelegates();
@@ -549,6 +554,82 @@ for (const order of ['readonly-first', 'writable-first']) {
     assert.equal(addTarget, writable, 'NoGrid add action targeted the first readonly duplicate');
   });
 }
+
+test('NoGrid repaint restores virtual cells for each view', () => {
+  resetDOM();
+  window._obGrids = {};
+  window._tpRefOpts = {};
+  window._tpEnumLabels = {};
+  window._tpEnumOrder = {};
+  const summary = installTableBody('tp-body-Строки', {
+    'data-ob-table-readonly': '1',
+    'data-tp-fields': 'Значение|string',
+    'data-tp-virtual-cols': '["Код"]'
+  });
+  const editor = installTableBody('tp-body-Строки', {
+    'data-tp-fields': 'Значение|string',
+    'data-tp-virtual-cols': '["Дата","Номер"]'
+  });
+
+  window.applyTableParts({Строки: [{Значение: 'stored', Код: '<safe text>', Дата: 'D', Номер: 'N'}]});
+
+  assert.equal(summary.children[0].children.length, 3, 'summary lost stored/virtual/delete shape');
+  assert.equal(summary.children[0].children[1].getAttribute('data-ob-virtual-col'), 'Код');
+  assert.equal(summary.children[0].children[1].textContent, '<safe text>');
+  assert.equal(editor.children[0].children.length, 4, 'editor lost stored/virtual/delete shape');
+  assert.equal(editor.children[0].children[1].textContent, 'D');
+  assert.equal(editor.children[0].children[2].textContent, 'N');
+  assert.equal(editor.children[0].children[3].children[0].className, 'del-btn');
+});
+
+test('NoGrid add inserts empty virtual cells before delete', () => {
+  resetDOM();
+  window._tpRefOpts = {};
+  window._tpRefMeta = {};
+  const body = installTableBody('tp-body-Строки', {
+    'data-tp-fields': 'Значение|string',
+    'data-tp-virtual-cols': '["Код","Дата"]'
+  });
+
+  obManagedAddTpRow({getAttribute(name) {
+    return name === 'data-ob-add-tp' ? 'Строки' : null;
+  }});
+
+  const row = body.children[0];
+  assert.equal(row.children.length, 4);
+  assert.equal(row.children[1].getAttribute('data-ob-virtual-col'), 'Код');
+  assert.equal(row.children[2].getAttribute('data-ob-virtual-col'), 'Дата');
+  assert.equal(row.children[1].children.length, 0);
+  assert.equal(row.children[3].children[0].className, 'del-btn');
+});
+
+test('NoGrid add uses the clicked duplicate view schema', () => {
+  resetDOM();
+  const first = installTableBody('tp-body-Строки', {
+    'data-tp-fields': 'Значение|string', 'data-tp-virtual-cols': '["Первый"]'
+  });
+  const second = installTableBody('tp-body-Строки', {
+    'data-tp-fields': 'Значение|string', 'data-tp-virtual-cols': '["Второй"]'
+  });
+  first.closest = () => ({getAttribute(name) { return name === 'data-ob-element' ? 'ПервоеПредставление' : null; }});
+  second.closest = () => ({getAttribute(name) { return name === 'data-ob-element' ? 'ВтороеПредставление' : null; }});
+  let call = null;
+  const realAddTpRow = global.addTpRow;
+  global.addTpRow = function(_name, _fields, _nums, _index, target, virtuals) {
+    call = {target, virtuals};
+  };
+  try {
+    obManagedAddTpRow({getAttribute(name) {
+      if (name === 'data-ob-add-tp') return 'Строки';
+      if (name === 'data-ob-element') return 'ВтороеПредставление';
+      return null;
+    }});
+  } finally {
+    global.addTpRow = realAddTpRow;
+  }
+  assert.equal(call.target, second);
+  assert.deepEqual(call.virtuals, ['Второй']);
+});
 
 for (const order of ['readonly-first', 'writable-first']) {
   test(`ValueTable add targets writable duplicate (${order})`, () => {

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -2449,7 +2449,7 @@ function obTPRefMeta() {
   return window._tpRefMeta || {};
 }
 
-function addTpRow(tpName, fields, numFields, idx, tbodyOverride) {
+function addTpRow(tpName, fields, numFields, idx, tbodyOverride, virtualFields) {
   var tbody = tbodyOverride || document.getElementById('tp-body-' + tpName);
   var table = tbody && tbody.closest ? tbody.closest('table[data-ob-dom-table]') : null;
   var domWritable = !!(table && !obDOMTableReadOnly(table));
@@ -2518,6 +2518,12 @@ function addTpRow(tpName, fields, numFields, idx, tbodyOverride) {
       }
       td.appendChild(inp);
     }
+    tr.appendChild(td);
+  });
+  (Array.isArray(virtualFields) ? virtualFields : []).forEach(function (name) {
+    var td = document.createElement('td');
+    td.setAttribute('data-ob-virtual-col', name);
+    td.textContent = '';
     tr.appendChild(td);
   });
   var tdDel = document.createElement('td');

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -810,6 +810,7 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			return template.JS(b) //nolint:gosec // G203: значение получено json.Marshal — он экранирует < > & в \u-последовательности, поэтому «</script>» из данных не разорвёт тег
 		},
 		"managedTPColumnsJSON": func(fields []metadata.Field, virtual []metadata.FormVirtualColumn, lang string) template.JS {
+			virtual = filterVirtualTPColumns(fields, virtual)
 			cols := make([]managedTPColumnJSON, 0, len(fields)+len(virtual))
 			for _, field := range fields {
 				cols = append(cols, managedTPColumnJSON{
@@ -842,22 +843,11 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			}
 			return template.JS(b) //nolint:gosec // G203: JSON сформирован encoding/json
 		},
-		"managedTPVirtualColumns": func(virtual []metadata.FormVirtualColumn) []metadata.FormVirtualColumn {
-			filtered := make([]metadata.FormVirtualColumn, 0, len(virtual))
-			for _, vc := range virtual {
-				if strings.TrimSpace(vc.Name) == "" || metadata.IsReservedFormVirtualColumnName(vc.Name) {
-					continue
-				}
-				filtered = append(filtered, vc)
-			}
-			return filtered
-		},
+		"managedTPVirtualColumns": filterVirtualTPColumns,
 		"managedTPVirtualNamesJSON": func(virtual []metadata.FormVirtualColumn) string {
-			names := make([]string, 0, len(virtual))
-			for _, vc := range virtual {
-				if strings.TrimSpace(vc.Name) == "" || metadata.IsReservedFormVirtualColumnName(vc.Name) {
-					continue
-				}
+			filtered := filterVirtualTPColumns(nil, virtual)
+			names := make([]string, 0, len(filtered))
+			for _, vc := range filtered {
 				names = append(names, vc.Name)
 			}
 			b, err := json.Marshal(names)

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -825,7 +825,7 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 			// менять нельзя, по нему пользователи ориентируются и его же ожидает
 			// перенос данных из буфера.
 			for _, vc := range virtual {
-				if vc.Name == "" {
+				if strings.TrimSpace(vc.Name) == "" || metadata.IsReservedFormVirtualColumnName(vc.Name) {
 					continue
 				}
 				cols = append(cols, managedTPColumnJSON{
@@ -841,6 +841,30 @@ func templateFuncs(bundle *i18n.Bundle) template.FuncMap {
 				return template.JS("[]")
 			}
 			return template.JS(b) //nolint:gosec // G203: JSON сформирован encoding/json
+		},
+		"managedTPVirtualColumns": func(virtual []metadata.FormVirtualColumn) []metadata.FormVirtualColumn {
+			filtered := make([]metadata.FormVirtualColumn, 0, len(virtual))
+			for _, vc := range virtual {
+				if strings.TrimSpace(vc.Name) == "" || metadata.IsReservedFormVirtualColumnName(vc.Name) {
+					continue
+				}
+				filtered = append(filtered, vc)
+			}
+			return filtered
+		},
+		"managedTPVirtualNamesJSON": func(virtual []metadata.FormVirtualColumn) string {
+			names := make([]string, 0, len(virtual))
+			for _, vc := range virtual {
+				if strings.TrimSpace(vc.Name) == "" || metadata.IsReservedFormVirtualColumnName(vc.Name) {
+					continue
+				}
+				names = append(names, vc.Name)
+			}
+			b, err := json.Marshal(names)
+			if err != nil {
+				return "[]"
+			}
+			return string(b)
 		},
 		"wcell":            widgetCell,
 		"echartsJSON":      echartsJSON,

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -249,6 +249,7 @@ const tplManagedForm = `
   {{$tpEnum := index $ctx.TPEnumLabels $tpName}}
   {{$tpCmds := tpCommandButtons $el}}
   {{$tpReadOnly := or $ro (not $ctx.CanWrite)}}
+  {{$tpVirtualCols := managedTPVirtualColumns $el.VirtualColumns}}
   <h3 style="margin:18px 0 8px;font-size:14px">{{fieldTitleRU $el.TitleMap (or (tablePartTitle $tpMeta) $tpName)}}</h3>
   {{if $tpMeta}}
   {{if $tpCmds}}
@@ -278,7 +279,7 @@ const tplManagedForm = `
 	   {{if and (not $tpReadOnly) (hasHandler $el "ПослеДобавленияСтроки")}}data-sg-rowafteradd="1"{{end}}
        {{/* id — имя реквизита (по нему идёт привязка данных и разбор tp.*),
             name — только подпись колонки: синоним реквизита, как в автоформе. */}}
-       data-sg-cols='{{managedTPColumnsJSON $tpMeta.Fields $el.VirtualColumns (str $ctx.Lang)}}'
+       data-sg-cols='{{managedTPColumnsJSON $tpMeta.Fields $tpVirtualCols (str $ctx.Lang)}}'
        data-sg-ref='{{jsJSON $tpRef}}'
        data-sg-enum='{{jsJSON $tpEnum}}'
        data-sg-rows='{{jsJSON $tpRows}}'
@@ -299,11 +300,11 @@ const tplManagedForm = `
       <tr>
         {{if $tpCmds}}<th style="width:30px"></th>{{end}}
         {{range $tpMeta.Fields}}<th>{{.DisplayName (str $ctx.Lang)}}</th>{{end}}
-        {{range $el.VirtualColumns}}<th>{{.ColumnTitle (str $ctx.Lang)}}</th>{{end}}
+        {{range $tpVirtualCols}}<th>{{.ColumnTitle (str $ctx.Lang)}}</th>{{end}}
         <th style="width:40px"></th>
       </tr>
     </thead>
-    <tbody id="tp-body-{{$tpName}}" {{if $tpCmds}}data-tp-cmd="1" {{end}}{{if $tpReadOnly}}data-ob-table-readonly="1" {{end}}data-tp-fields="{{range $i, $f := $tpMeta.Fields}}{{if $i}},{{end}}{{$f.Name}}|{{$f.Type}}{{if $f.RefEntity}}:{{$f.RefEntity}}{{end}}{{end}}">
+    <tbody id="tp-body-{{$tpName}}" {{if $tpCmds}}data-tp-cmd="1" {{end}}{{if $tpReadOnly}}data-ob-table-readonly="1" {{end}}data-tp-fields="{{range $i, $f := $tpMeta.Fields}}{{if $i}},{{end}}{{$f.Name}}|{{$f.Type}}{{if $f.RefEntity}}:{{$f.RefEntity}}{{end}}{{end}}" data-tp-virtual-cols="{{managedTPVirtualNamesJSON $tpVirtualCols}}">
     {{range $i, $row := $tpRows}}
       <tr{{with formRowClass $row}} class="{{.}}"{{end}} tabindex="-1" aria-selected="false">
         {{if $tpCmds}}<td style="text-align:center"><input type="checkbox" class="_tp-sel"{{if $tpReadOnly}} disabled{{end}}></td>{{end}}
@@ -330,18 +331,18 @@ const tplManagedForm = `
         {{end}}
         {{/* Виртуальная колонка — только текст: значение не хранится, и поля
              ввода у неё быть не должно, иначе правка выглядела бы сохраняемой. */}}
-        {{range $vc := $el.VirtualColumns}}<td data-ob-virtual-col="{{$vc.Name}}">{{index $row $vc.Name}}</td>{{end}}
+        {{range $vc := $tpVirtualCols}}<td data-ob-virtual-col="{{$vc.Name}}">{{index $row $vc.Name}}</td>{{end}}
         <td><button type="button" class="del-btn"{{if $tpReadOnly}} disabled{{else}} data-ob-remove-row title="Delete" aria-keyshortcuts="Delete"{{end}}>×</button></td>
       </tr>
     {{end}}
     </tbody>
     <tfoot id="tp-foot-{{$tpName}}" class="tp-footer" style="display:none"><tr>
       {{if $tpCmds}}<td></td>{{end}}
-      {{range $f := $tpMeta.Fields}}{{if eq (str $f.Type) "number"}}<td class="tp-total" data-tp-total="{{$tpName}}.{{$f.Name}}" style="text-align:right;font-variant-numeric:tabular-nums">0</td>{{else}}<td></td>{{end}}{{end}}{{range $el.VirtualColumns}}<td></td>{{end}}<td></td>
+      {{range $f := $tpMeta.Fields}}{{if eq (str $f.Type) "number"}}<td class="tp-total" data-tp-total="{{$tpName}}.{{$f.Name}}" style="text-align:right;font-variant-numeric:tabular-nums">0</td>{{else}}<td></td>{{end}}{{end}}{{range $tpVirtualCols}}<td></td>{{end}}<td></td>
     </tr></tfoot>
   </table>
   <button type="button" class="btn btn-sm" style="background:#e2e8f0;color:#475569;margin:0 0 12px"{{if $tpReadOnly}} disabled{{else}}
-    data-ob-add-tp="{{$tpName}}" title="Insert" aria-keyshortcuts="Insert"{{end}}>
+    data-ob-add-tp="{{$tpName}}" data-ob-element="{{$el.Name}}" title="Insert" aria-keyshortcuts="Insert"{{end}}>
     + Добавить строку
   </button>
 {{end}}

--- a/internal/ui/templates_managed.go
+++ b/internal/ui/templates_managed.go
@@ -249,9 +249,9 @@ const tplManagedForm = `
   {{$tpEnum := index $ctx.TPEnumLabels $tpName}}
   {{$tpCmds := tpCommandButtons $el}}
   {{$tpReadOnly := or $ro (not $ctx.CanWrite)}}
-  {{$tpVirtualCols := managedTPVirtualColumns $el.VirtualColumns}}
   <h3 style="margin:18px 0 8px;font-size:14px">{{fieldTitleRU $el.TitleMap (or (tablePartTitle $tpMeta) $tpName)}}</h3>
   {{if $tpMeta}}
+  {{$tpVirtualCols := managedTPVirtualColumns $tpMeta.Fields $el.VirtualColumns}}
   {{if $tpCmds}}
   <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:6px">
     {{range $tpCmds}}

--- a/internal/ui/virtual_tp_columns.go
+++ b/internal/ui/virtual_tp_columns.go
@@ -33,6 +33,7 @@ func (s *Server) applyVirtualTPColumns(
 	if entity == nil || form == nil || len(tpRows) == 0 {
 		return
 	}
+	seen := make(map[string]bool)
 	form.Walk(func(el *metadata.FormElement) bool {
 		if len(el.VirtualColumns) == 0 {
 			return true
@@ -46,7 +47,17 @@ func (s *Server) applyVirtualTPColumns(
 			return true
 		}
 		for _, vc := range el.VirtualColumns {
-			s.fillVirtualColumn(ctx, *tp, vc, rows)
+			name := strings.TrimSpace(vc.Name)
+			if name == "" || metadata.IsReservedFormVirtualColumnName(name) {
+				continue
+			}
+			key := strings.ToLower(strings.TrimSpace(tp.Name)) + "\x00" + strings.ToLower(name)
+			if seen[key] {
+				continue
+			}
+			if s.fillVirtualColumn(ctx, *tp, vc, rows) {
+				seen[key] = true
+			}
 		}
 		return true
 	})
@@ -57,10 +68,10 @@ func (s *Server) fillVirtualColumn(
 	tp metadata.TablePart,
 	vc metadata.FormVirtualColumn,
 	rows []map[string]any,
-) {
+) bool {
 	refName, ok := vc.RefFieldName()
 	if !ok {
-		return
+		return false
 	}
 	targetName, _ := vc.TargetFieldName()
 
@@ -73,11 +84,11 @@ func (s *Server) fillVirtualColumn(
 		}
 	}
 	if !found {
-		return
+		return false
 	}
 	target := s.reg.GetEntity(refField.RefEntity)
 	if target == nil {
-		return
+		return false
 	}
 	var targetField metadata.Field
 	found = false
@@ -88,7 +99,7 @@ func (s *Server) fillVirtualColumn(
 		}
 	}
 	if !found {
-		return
+		return false
 	}
 
 	idsByString := map[string]uuid.UUID{}
@@ -100,7 +111,7 @@ func (s *Server) fillVirtualColumn(
 		}
 	}
 	if len(idsByString) == 0 {
-		return
+		return true
 	}
 	ids := make([]uuid.UUID, 0, len(idsByString))
 	for _, id := range idsByString {
@@ -118,7 +129,7 @@ func (s *Server) fillVirtualColumn(
 			// Отказ в доступе или ошибка чтения оставляют колонку пустой. Пустая
 			// колонка честнее частичной: иначе пользователь не отличил бы «нет
 			// значения» от «часть батча не прочиталась».
-			return
+			return true
 		}
 		for idStr, refRow := range refRows {
 			s.maskRecord(ctx, target, refRow)
@@ -145,11 +156,15 @@ func (s *Server) fillVirtualColumn(
 			row[vc.Name] = val
 		}
 	}
+	return true
 }
 
 // formElementTablePart — табличная часть сущности, к которой привязан элемент
 // формы (ключ table_part или data_path «Объект.<ТЧ>»).
 func formElementTablePart(entity *metadata.Entity, el *metadata.FormElement) *metadata.TablePart {
+	if entity == nil || el == nil || el.Kind != metadata.FormElementTablePart {
+		return nil
+	}
 	name := el.TablePart
 	if name == "" {
 		if parts := strings.Split(el.DataPath, "."); len(parts) == 2 && strings.EqualFold(parts[0], "Объект") {

--- a/internal/ui/virtual_tp_columns.go
+++ b/internal/ui/virtual_tp_columns.go
@@ -47,10 +47,10 @@ func (s *Server) applyVirtualTPColumns(
 			return true
 		}
 		for _, vc := range el.VirtualColumns {
-			name := strings.TrimSpace(vc.Name)
-			if name == "" || metadata.IsReservedFormVirtualColumnName(name) {
+			if !usableVirtualTPColumnName(tp.Fields, vc.Name) {
 				continue
 			}
+			name := strings.TrimSpace(vc.Name)
 			key := strings.ToLower(strings.TrimSpace(tp.Name)) + "\x00" + strings.ToLower(name)
 			if seen[key] {
 				continue
@@ -63,12 +63,51 @@ func (s *Server) applyVirtualTPColumns(
 	})
 }
 
+// usableVirtualTPColumnName protects the shared row-map contract even when a
+// project is started without running `onebase check` first. In particular, a
+// virtual column must never overwrite a stored table-part value: the browser
+// would otherwise serialize the projected value back into that stored field.
+func usableVirtualTPColumnName(fields []metadata.Field, name string) bool {
+	trimmed := strings.TrimSpace(name)
+	if name != trimmed || !metadata.ValidIdent(name) || metadata.IsReservedFormVirtualColumnName(name) {
+		return false
+	}
+	for _, field := range fields {
+		if strings.EqualFold(field.Name, name) {
+			return false
+		}
+	}
+	return true
+}
+
+func filterVirtualTPColumns(fields []metadata.Field, virtual []metadata.FormVirtualColumn) []metadata.FormVirtualColumn {
+	filtered := make([]metadata.FormVirtualColumn, 0, len(virtual))
+	seen := make(map[string]bool, len(virtual))
+	for _, vc := range virtual {
+		name := strings.TrimSpace(vc.Name)
+		key := strings.ToLower(name)
+		if !usableVirtualTPColumnName(fields, vc.Name) || seen[key] {
+			continue
+		}
+		seen[key] = true
+		filtered = append(filtered, vc)
+	}
+	return filtered
+}
+
 func (s *Server) fillVirtualColumn(
 	ctx context.Context,
 	tp metadata.TablePart,
 	vc metadata.FormVirtualColumn,
 	rows []map[string]any,
 ) bool {
+	// The virtual key may already be present after a form event. Clear it before
+	// every validation/read exit so a broken reference or denied batch cannot
+	// leave a stale or handler-supplied value visible as a trusted projection.
+	for _, row := range rows {
+		row[vc.Name] = ""
+	}
+
 	refName, ok := vc.RefFieldName()
 	if !ok {
 		return false
@@ -143,7 +182,6 @@ func (s *Server) fillVirtualColumn(
 		// Пустая или битая ссылка даёт пустую ячейку без маркера: строка ТЧ с
 		// незаполненной ссылкой — рабочее состояние ввода, и «—» в такой ячейке
 		// читался бы как значение.
-		row[vc.Name] = ""
 		_, v, ok := lookupMapCI(row, refField.Name)
 		if !ok || v == nil {
 			continue

--- a/internal/ui/virtual_tp_columns_test.go
+++ b/internal/ui/virtual_tp_columns_test.go
@@ -234,3 +234,82 @@ func TestVirtualTPColumn_СтрокаЗакрытаяПолитикойНеПо�
 		t.Fatalf("реквизит недоступной строки показан: %v", got)
 	}
 }
+
+func TestVirtualTPColumn_NoGridPublishesVirtualSchema(t *testing.T) {
+	s, order, orderID := virtualColumnFixture(t)
+	order.Forms[0].Elements[0].NoGrid = true
+	htmlOut := virtualColumnFormHTML(t, s, order, orderID)
+
+	const prefix = `data-tp-virtual-cols="`
+	start := strings.Index(htmlOut, prefix)
+	if start < 0 {
+		t.Fatal("no_grid tbody не содержит схему виртуальных колонок")
+	}
+	start += len(prefix)
+	end := strings.Index(htmlOut[start:], `"`)
+	if end < 0 {
+		t.Fatal("атрибут data-tp-virtual-cols не закрыт")
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(html.UnescapeString(htmlOut[start:start+end])), &names); err != nil {
+		t.Fatalf("data-tp-virtual-cols содержит невалидный JSON: %v", err)
+	}
+	if len(names) != 1 || names[0] != "КодКлиента" {
+		t.Fatalf("неверная схема виртуальных колонок: %#v", names)
+	}
+	if !strings.Contains(htmlOut, `data-ob-virtual-col="КодКлиента">К-000042</td>`) {
+		t.Fatal("начальный no_grid render потерял значение виртуальной колонки")
+	}
+}
+
+func TestFormElementTablePartRequiresTablePartKind(t *testing.T) {
+	entity := &metadata.Entity{TableParts: []metadata.TablePart{{Name: "Строки"}}}
+	el := &metadata.FormElement{
+		Kind: metadata.FormElementField, DataPath: "Объект.Строки",
+	}
+	if got := formElementTablePart(entity, el); got != nil {
+		t.Fatalf("элемент kind=%q принят как табличная часть: %+v", el.Kind, got)
+	}
+}
+
+func TestApplyVirtualTPColumns_SkipsReservedNames(t *testing.T) {
+	s, order, orderID := virtualColumnFixture(t)
+	loaded := parseManagedTPRows(t, virtualColumnFormHTML(t, s, order, orderID))
+	rows := map[string][]map[string]any{
+		"Строки": {{"Клиент": loaded[0]["Клиент"]}},
+	}
+	form := &metadata.FormModule{Elements: []*metadata.FormElement{{
+		Kind: metadata.FormElementTablePart, DataPath: "Объект.Строки",
+		VirtualColumns: []metadata.FormVirtualColumn{{Name: "_OrD", DataPath: "Клиент.Код"}},
+	}}}
+	s.applyVirtualTPColumns(context.Background(), order, form, rows)
+	if _, exists := rows["Строки"][0]["_OrD"]; exists {
+		t.Fatalf("runtime материализовал служебную колонку: %#v", rows["Строки"][0])
+	}
+}
+
+func TestApplyVirtualTPColumns_FirstValidBindingWinsAcrossViews(t *testing.T) {
+	s, order, orderID := virtualColumnFixture(t)
+	loaded := parseManagedTPRows(t, virtualColumnFormHTML(t, s, order, orderID))
+	rows := map[string][]map[string]any{
+		"Строки": {{"Клиент": loaded[0]["Клиент"]}},
+	}
+	form := &metadata.FormModule{Elements: []*metadata.FormElement{
+		{
+			Kind: metadata.FormElementTablePart, Name: "НекорректныйВид", DataPath: "Объект.Строки",
+			VirtualColumns: []metadata.FormVirtualColumn{{Name: "Проекция", DataPath: "Нет.Код"}},
+		},
+		{
+			Kind: metadata.FormElementTablePart, Name: "ОсновнойВид", DataPath: "Объект.Строки",
+			VirtualColumns: []metadata.FormVirtualColumn{{Name: "Проекция", DataPath: "Клиент.Код"}},
+		},
+		{
+			Kind: metadata.FormElementTablePart, Name: "КонфликтующийВид", DataPath: "Объект.Строки",
+			VirtualColumns: []metadata.FormVirtualColumn{{Name: "Проекция", DataPath: "Клиент.Наименование"}},
+		},
+	}}
+	s.applyVirtualTPColumns(context.Background(), order, form, rows)
+	if got := rows["Строки"][0]["Проекция"]; got != "К-000042" {
+		t.Fatalf("последующее представление перезаписало первый валидный binding: %v", got)
+	}
+}

--- a/internal/ui/virtual_tp_columns_test.go
+++ b/internal/ui/virtual_tp_columns_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"html"
 	"net/http"
 	"net/http/httptest"
@@ -275,16 +276,64 @@ func TestFormElementTablePartRequiresTablePartKind(t *testing.T) {
 func TestApplyVirtualTPColumns_SkipsReservedNames(t *testing.T) {
 	s, order, orderID := virtualColumnFixture(t)
 	loaded := parseManagedTPRows(t, virtualColumnFormHTML(t, s, order, orderID))
+	for _, name := range []string{
+		"_OrD", "_obRowClass", "_obCellClasses",
+		"_form_row_class", "_form_cell_classes", "__Proto__",
+	} {
+		t.Run(name, func(t *testing.T) {
+			rows := map[string][]map[string]any{
+				"Строки": {{"Клиент": loaded[0]["Клиент"]}},
+			}
+			form := &metadata.FormModule{Elements: []*metadata.FormElement{{
+				Kind: metadata.FormElementTablePart, DataPath: "Объект.Строки",
+				VirtualColumns: []metadata.FormVirtualColumn{{Name: name, DataPath: "Клиент.Код"}},
+			}}}
+			s.applyVirtualTPColumns(context.Background(), order, form, rows)
+			if _, exists := rows["Строки"][0][name]; exists {
+				t.Fatalf("runtime материализовал служебную колонку: %#v", rows["Строки"][0])
+			}
+		})
+	}
+}
+
+func TestVirtualTPColumn_StoredFieldCollisionFailsClosed(t *testing.T) {
+	s, order, orderID := virtualColumnFixture(t)
+	order.Forms[0].Elements[0].VirtualColumns = []metadata.FormVirtualColumn{
+		{Name: "Сумма", DataPath: "Клиент.Код"},
+		{Name: " Невалидная ", DataPath: "Клиент.Код"},
+		{Name: "_form_row_class", DataPath: "Клиент.Код"},
+		{Name: "КодКлиента", DataPath: "Клиент.Код"},
+		{Name: "кодклиента", DataPath: "Клиент.Наименование"},
+	}
+
+	htmlOut := virtualColumnFormHTML(t, s, order, orderID)
+	cols := parseManagedTPColumns(t, htmlOut)
+	ids := make([]string, 0, len(cols))
+	for _, col := range cols {
+		ids = append(ids, col.ID)
+	}
+	if strings.Join(ids, ",") != "Клиент,Сумма,КодКлиента" {
+		t.Fatalf("коллизионная виртуальная колонка попала в схему: %v", ids)
+	}
+	rows := parseManagedTPRows(t, htmlOut)
+	if got := rows[0]["Сумма"]; fmt.Sprint(got) != "100" {
+		t.Fatalf("проекция перезаписала хранимый реквизит ТЧ: %v", got)
+	}
+}
+
+func TestApplyVirtualTPColumns_ClearsStaleProjectionOnEarlyExit(t *testing.T) {
+	s, order, _ := virtualColumnFixture(t)
 	rows := map[string][]map[string]any{
-		"Строки": {{"Клиент": loaded[0]["Клиент"]}},
+		"Строки": {{"Клиент": nil, "КодКлиента": "STALE"}},
 	}
 	form := &metadata.FormModule{Elements: []*metadata.FormElement{{
 		Kind: metadata.FormElementTablePart, DataPath: "Объект.Строки",
-		VirtualColumns: []metadata.FormVirtualColumn{{Name: "_OrD", DataPath: "Клиент.Код"}},
+		VirtualColumns: []metadata.FormVirtualColumn{{Name: "КодКлиента", DataPath: "Клиент.Код"}},
 	}}}
+
 	s.applyVirtualTPColumns(context.Background(), order, form, rows)
-	if _, exists := rows["Строки"][0]["_OrD"]; exists {
-		t.Fatalf("runtime материализовал служебную колонку: %#v", rows["Строки"][0])
+	if got := rows["Строки"][0]["КодКлиента"]; got != "" {
+		t.Fatalf("ранний выход сохранил устаревшую проекцию: %v", got)
 	}
 }
 


### PR DESCRIPTION
Follow-up hardening for #942.

## Почему нужен follow-up

После внешнего merge #942 независимый review обнаружил обходы защитного контракта виртуальных колонок табличной части: сохранённый XSS в SlickGrid formatter, потерю виртуальных ячеек при `no_grid` rebuild/add/event, коллизии со служебными и хранимыми полями и неоднозначность нескольких представлений одной табличной части.

## Исправление

- экранирует HTML виртуальных значений в SlickGrid;
- запрещает `id`, `_ord`, style/form keys и `__proto__` на уровне metadata/configcheck/runtime/template/JS;
- отбрасывает virtual name, совпадающий с хранимым полем, даже если startup check не запускался;
- требует корректный identifier и фактический `tablepart` element kind;
- не допускает разные `data_path` под одним virtual name в нескольких views;
- очищает stale/handler-supplied projection до всех ранних выходов чтения;
- сохраняет virtual schema при event response, rebuild и добавлении строки;
- привязывает `no_grid` add к соседней или точно именованной writable-таблице, не к случайному duplicate view.

## Проверки

- `go test ./... -count=1`;
- `go vet ./internal/configcheck ./internal/metadata ./internal/ui`;
- 34/34 Node behavior tests;
- `node --check` для `managed.js` и `ui.js`;
- `git diff --check`;
- негативные мутации каждого guard краснят соответствующие regression tests.