### PR TITLE
test(ci): gate PostgreSQL review regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,12 @@ jobs:
           # Без этой строки postgres-подтесты матричных тестов пакета
           # пропускались: TEST_DATABASE_URL задан только в этом джобе.
           go test -race -count=1 -timeout 15m -tags integration ./internal/dsl/interpreter
+          # Матрица doctor намеренно не имеет build tag: обычный unit-job
+          # исполняет SQLite-половину, а PostgreSQL-половина без этой строки
+          # молча Skip-ается, потому что TEST_DATABASE_URL есть только здесь.
+          # Гоним весь пакет, чтобы новый матричный тест нельзя было добавить
+          # рядом с checks_matrix_test.go и случайно оставить вне PG-гейта.
+          go test -race -count=1 -timeout 15m ./internal/dbcheck
           # Table-part shape compatibility is dialect-matrix tested in
           # internal/exchange. The regular unit job has no TEST_DATABASE_URL,
           # so explicitly gate the PostgreSQL half here.

--- a/internal/dbcheck/refs_resources_matrix_test.go
+++ b/internal/dbcheck/refs_resources_matrix_test.go
@@ -1,0 +1,132 @@
+package dbcheck
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// #910: storage.CheckRefs учитывает ссылочные ресурсы обоих регистров, поэтому
+// doctor обязан уметь объяснить, какая именно ссылка блокирует удаление.
+// Ресурс регистра накопления можно очистить с пересчётом итогов; ресурс
+// бухрегистра не трогаем автоматически — это изменило бы уже проведённую
+// операцию. Обе ветки раньше не имели даже SQLite-теста, а тип колонки на
+// PostgreSQL отличается (uuid вместо TEXT), поэтому проверяем их матрично.
+func TestRefsRegisterResourcesMatrix(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		suffix := uuid.NewString()[:8]
+		partner := &metadata.Entity{
+			Name: "Контрагенты" + suffix,
+			Kind: metadata.KindCatalog,
+			Fields: []metadata.Field{{
+				Name: "Наименование", Type: metadata.FieldTypeString,
+			}},
+		}
+		refType := metadata.FieldType("reference:" + partner.Name)
+		regResource := metadata.Field{
+			Name: "Куратор", Type: refType, RefEntity: partner.Name,
+		}
+		reg := &metadata.Register{
+			Name:      "Назначения" + suffix,
+			Resources: []metadata.Field{regResource},
+		}
+		accountResource := metadata.Field{
+			Name: "Аудитор", Type: refType, RefEntity: partner.Name,
+		}
+		account := &metadata.AccountRegister{
+			Name:      "БухУчёт" + suffix,
+			Resources: []metadata.Field{accountResource},
+		}
+
+		if err := db.Migrate(ctx, []*metadata.Entity{partner}); err != nil {
+			t.Fatalf("Migrate: %v", err)
+		}
+		if err := db.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+			t.Fatalf("MigrateRegisters: %v", err)
+		}
+		if err := db.MigrateAccountRegisters(ctx, []*metadata.AccountRegister{account}); err != nil {
+			t.Fatalf("MigrateAccountRegisters: %v", err)
+		}
+
+		live := uuid.New()
+		broken := uuid.New()
+		if err := db.Upsert(ctx, partner.Name, live,
+			map[string]any{"Наименование": "Живой"}, partner); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		period := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+		if err := db.WriteMovements(ctx, reg.Name, "Документ", uuid.New(), []map[string]any{
+			{"Куратор": live},
+			{"Куратор": broken},
+		}, reg, &period); err != nil {
+			t.Fatalf("WriteMovements: %v", err)
+		}
+		if err := db.WriteAccountMovements(ctx, account.Name, "Документ", uuid.New(), []map[string]any{
+			{"счётдт": "50", "счёткт": "51", "Аудитор": live},
+			{"счётдт": "50", "счёткт": "51", "Аудитор": broken},
+		}, account, &period); err != nil {
+			t.Fatalf("WriteAccountMovements: %v", err)
+		}
+
+		env := &Env{
+			DB: db, Entities: []*metadata.Entity{partner},
+			Registers:        []*metadata.Register{reg},
+			AccountRegisters: []*metadata.AccountRegister{account},
+		}
+		res := findResult(t, Run(ctx, env, []Check{refsCheck{}}, nil), "refs")
+		if res.Severity != SeverityError || len(res.Findings) != 2 {
+			t.Fatalf("ссылочные ресурсы регистров не найдены: %+v", res)
+		}
+		findings := make(map[string]Finding, len(res.Findings))
+		for _, finding := range res.Findings {
+			findings[finding.Object] = finding
+		}
+		regFinding, ok := findings[reg.Name+"."+regResource.Name]
+		if !ok || regFinding.Count != 1 {
+			t.Fatalf("нет одной битой ссылки в ресурсе регистра накопления: %+v", res.Findings)
+		}
+		accountFinding, ok := findings[account.Name+"."+accountResource.Name]
+		if !ok || accountFinding.Count != 1 || !strings.Contains(accountFinding.Detail, "ресурс бухрегистра") {
+			t.Fatalf("ресурс бухрегистра не назван ручной находкой: %+v", res.Findings)
+		}
+
+		fixed := findResult(t, Run(ctx, env, []Check{refsCheck{}}, map[string]bool{"refs": true}), "refs")
+		if fixed.Fixed != 1 {
+			t.Fatalf("ресурс регистра накопления не очищен: %+v", fixed)
+		}
+		if !strings.Contains(fixed.Error, "ресурс бухрегистра") {
+			t.Fatalf("ручная находка бухрегистра потеряна при --fix: %q", fixed.Error)
+		}
+
+		var regBroken, regLive int
+		regTable := metadata.RegisterTableName(reg.Name)
+		regColumn := metadata.ColumnName(regResource)
+		if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+regTable+" WHERE "+regColumn+" IS NULL").Scan(&regBroken); err != nil {
+			t.Fatalf("проверка очищенного ресурса: %v", err)
+		}
+		if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+regTable+" WHERE "+regColumn+" IS NOT NULL").Scan(&regLive); err != nil {
+			t.Fatalf("проверка живого ресурса: %v", err)
+		}
+		if regBroken != 1 || regLive != 1 {
+			t.Fatalf("очистка ресурса регистра затронула не те строки: NULL=%d, non-NULL=%d", regBroken, regLive)
+		}
+
+		var accountRefs int
+		accountTable := metadata.AccountRegTableName(account.Name)
+		accountColumn := metadata.ColumnName(accountResource)
+		if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM "+accountTable+" WHERE "+accountColumn+" IS NOT NULL").Scan(&accountRefs); err != nil {
+			t.Fatalf("проверка ресурса бухрегистра: %v", err)
+		}
+		if accountRefs != 2 {
+			t.Fatalf("--fix изменил ресурс бухрегистра: непустых ссылок %d из 2", accountRefs)
+		}
+	})
+}

--- a/internal/query/row_filters_or_matrix_test.go
+++ b/internal/query/row_filters_or_matrix_test.go
@@ -2,6 +2,7 @@ package query_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/google/uuid"
@@ -151,6 +152,112 @@ func TestRowFilterAnyWithUserOrMatrix(t *testing.T) {
 		}
 		// «общий» политика пропускает, «чужой» — нет, несмотря на ИЛИ.
 		assertNames(t, runNames(t, db, res), "ТоварМатрица-общий")
+	})
+}
+
+// #625 затрагивал не только виртуальные таблицы, но и ON автоматически
+// добавленного JOIN по ссылочному полю. Правая OR-ветвь политики не должна
+// присоединять разрешённую, но никак не связанную запись справочника.
+func TestRowFilterAnyInAutoJoinMatrix(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		category := &metadata.Entity{
+			Name: "КатегорияСсылкиМатрица",
+			Kind: metadata.KindCatalog,
+			Fields: []metadata.Field{
+				{Name: "Наименование", Type: metadata.FieldTypeString},
+				{Name: "Owner", Type: metadata.FieldTypeString},
+			},
+		}
+		product := &metadata.Entity{
+			Name: "ТоварСсылкиМатрица",
+			Kind: metadata.KindCatalog,
+			Fields: []metadata.Field{
+				{Name: "Наименование", Type: metadata.FieldTypeString},
+				{Name: "Категория", Type: metadata.FieldTypeString, RefEntity: category.Name},
+			},
+		}
+		entities := []*metadata.Entity{category, product}
+		if err := db.Migrate(ctx, entities); err != nil {
+			t.Fatalf("Migrate: %v", err)
+		}
+
+		allowedA := uuid.New()
+		allowedB := uuid.New()
+		foreign := uuid.New()
+		for _, row := range []struct {
+			id    uuid.UUID
+			name  string
+			owner string
+		}{
+			{allowedA, "разрешённая-A", "A"},
+			{allowedB, "разрешённая-B", "B"},
+			{foreign, "чужая", "чужой"},
+		} {
+			if err := db.Upsert(ctx, category.Name, row.id,
+				map[string]any{"Наименование": row.name, "Owner": row.owner}, category); err != nil {
+				t.Fatalf("Upsert category %s: %v", row.name, err)
+			}
+		}
+		for _, row := range []struct {
+			name       string
+			categoryID uuid.UUID
+		}{
+			{"товар-свой", allowedA},
+			{"товар-чужой", foreign},
+		} {
+			if err := db.Upsert(ctx, product.Name, uuid.New(),
+				map[string]any{"Наименование": row.name, "Категория": row.categoryID}, product); err != nil {
+				t.Fatalf("Upsert product %s: %v", row.name, err)
+			}
+		}
+
+		res, err := query.Compile(
+			`ВЫБРАТЬ Т.Наименование, Т.Категория.Наименование
+			 ИЗ Справочник.ТоварСсылкиМатрица КАК Т
+			 УПОРЯДОЧИТЬ ПО Т.Наименование`,
+			query.CompileOpts{
+				Entities: entities,
+				Dialect:  db.Dialect(),
+				RowFilters: map[query.SourceRef]*storage.Predicate{
+					{Kind: "catalog", Name: category.Name}: {Any: []storage.Predicate{
+						{Field: "Owner", Op: "eq", Value: "A"},
+						{Field: "Owner", Op: "eq", Value: "B"},
+					}},
+				},
+			})
+		if err != nil {
+			t.Fatalf("компиляция: %v", err)
+		}
+		rows, err := db.Query(ctx, res.SQL, res.Args...)
+		if err != nil {
+			t.Fatalf("выполнение: %v\n%s", err, res.SQL)
+		}
+		defer rows.Close()
+		got := make(map[string]sql.NullString)
+		for rows.Next() {
+			var name string
+			var categoryName sql.NullString
+			if err := rows.Scan(&name, &categoryName); err != nil {
+				t.Fatalf("чтение: %v", err)
+			}
+			if _, duplicate := got[name]; duplicate {
+				t.Fatalf("товар %q размножен JOIN-ом; политика вырвалась из-под ON\nSQL: %s", name, res.SQL)
+			}
+			got[name] = categoryName
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("товары = %v, ожидались две исходные строки\nSQL: %s", got, res.SQL)
+		}
+		if own := got["товар-свой"]; !own.Valid || own.String != "разрешённая-A" {
+			t.Fatalf("представление разрешённой ссылки = %+v", own)
+		}
+		if foreignName := got["товар-чужой"]; foreignName.Valid {
+			t.Fatalf("чужая ссылка раскрыта как %q; политика не удержалась в ON", foreignName.String)
+		}
 	})
 }
 


### PR DESCRIPTION
Follow-up coverage for #943, #944 and #948.

## Проблема

Review обнаружил, что PostgreSQL-половина doctor matrix фактически не являлась gate: `TEST_DATABASE_URL` задаётся только в `postgres-integration`, но этот job не запускал пакет `internal/dbcheck`, поэтому PostgreSQL subtests молча skip-ались. Одновременно production-фиксы ссылочных resources и группировки RLS не имели полного поведенческого покрытия на обоих диалектах.

## Исправление

- обязательный `postgres-integration` теперь запускает весь `./internal/dbcheck`, поэтому любые новые `ForEachDialect` doctor tests автоматически получают PostgreSQL gate;
- dialect matrix проверяет ссылочные resources регистра накопления и бухрегистра, включая разные правила `--fix`: битая ссылка accumulation очищается, проведённая бухгалтерская запись остаётся ручной находкой;
- dialect matrix проверяет RLS `Any` в обычном `WHERE`, UNION branches, группировке и auto-generated `LEFT JOIN ... ON`;
- auto-JOIN regression доказывает, что политика не размножает строки и не раскрывает presentation запрещённой ссылки.

Production-код не меняется: PR содержит только CI и regression tests.

## Проверки

- `go test ./internal/dbcheck ./internal/query -count=1`;
- `go vet ./internal/dbcheck ./internal/query`;
- `actionlint 1.7.12 .github/workflows/ci.yml`;
- `git diff --check`;
- негативные мутации reference-resource обходов и RLS grouping краснят новые tests.

Локально PostgreSQL отсутствует, поэтому merge намеренно зависит от зелёного exact-head `postgres-integration`.