### PR TITLE
ci: harden merged PowerShell and fuzz checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,11 +301,19 @@ jobs:
       # ставит бинарь, исполнять его в CI незачем. Синтаксис — это всё, что
       # можно проверить дёшево и без побочных эффектов.
       - name: PowerShell syntax check (install.ps1)
-        shell: pwsh
+        # Установщик поддерживает штатный Windows PowerShell 5.1, а pwsh на
+        # runner'е — PowerShell 7. Проверяем минимальную поддержанную версию,
+        # чтобы CI не пропустил, например, PS7-only операторы.
+        shell: powershell
         run: |
           $errors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path ./install.ps1), [ref]$null, [ref]$errors) | Out-Null
+          # install.ps1 хранится как UTF-8 без BOM и штатно приходит строкой
+          # через `irm ... | iex`. Явное чтение UTF-8 воспроизводит этот путь:
+          # ParseFile в Windows PowerShell 5.1 иначе считает файл ANSI.
+          $source = [IO.File]::ReadAllText(
+            (Resolve-Path ./install.ps1), [Text.Encoding]::UTF8)
+          [System.Management.Automation.Language.Parser]::ParseInput(
+            $source, [ref]$null, [ref]$errors) | Out-Null
           if ($errors -and $errors.Count -gt 0) {
             foreach ($e in $errors) {
               Write-Host "::error file=install.ps1,line=$($e.Extent.StartLineNumber)::$($e.Message)"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,9 +38,13 @@ jobs:
       # -run='^$' отключает обычные тесты: иначе они выполнятся перед fuzz и
       # съедят часть бюджета времени.
       - name: Fuzz ParseProgram
+        env:
+          # Не интерполировать workflow_dispatch input прямо в run: иначе
+          # shell-метасимволы в значении превращаются в команды раннера.
+          FUZZTIME: ${{ github.event.inputs.fuzztime || '10m' }}
         run: |
           go test -run='^$' -fuzz=FuzzParseProgram \
-            -fuzztime=${{ github.event.inputs.fuzztime || '10m' }} \
+            "-fuzztime=$FUZZTIME" \
             ./internal/dsl/parser/
 
       # Корпус пишется в testdata/fuzz только когда прогон нашёл падение —


### PR DESCRIPTION
## Почему

#950 и #951 были влиты внешним процессом до доставки обязательных исправлений ревью. В `main` остались две проблемы: проверка установщика выполнялась только PowerShell 7, хотя поддерживается Windows PowerShell 5.1, а `workflow_dispatch` input ночного fuzz напрямую интерполировался в shell-команду.

## Что исправлено

- `install.ps1` разбирается штатным Windows PowerShell 5.1 через явное UTF-8 чтение и `Parser.ParseInput`; PS7-only синтаксис больше не пройдёт CI незамеченным.
- `fuzztime` передаётся через environment и один quoted argv, без прямой подстановки GitHub expression в shell source.
- PostgreSQL doctor gate из #956 сохранён без изменений.

## Проверки

- `actionlint v1.7.12` на `ci.yml` и `fuzz.yml`;
- реальный Windows PowerShell 5.1: валидный UTF-8 installer принимается, повреждённая скобка и PS7-only `??` отклоняются;
- 522 hostile/random значений `fuzztime` сохраняются одним argv; duration grammar (`1h30m`, `1.5s`, `250ms`, `100x`) не меняется;
- `git diff --check`.