### PR TITLE
fix(check): проверять расписание регламентного задания (#965)

### DIFF
--- a/internal/configcheck/check.go
+++ b/internal/configcheck/check.go
@@ -112,6 +112,10 @@ func annotateIssue(is Issue) Issue {
 		set("dsl.unknown-function", "Проверьте имя процедуры/функции, импортируемый модуль или используйте существенный builtin из `onebase ai-guide`.")
 	case strings.HasSuffix(lowFile, ".os") || strings.Contains(lowKind, "dsl"):
 		set("dsl.syntax", "Проверьте синтаксис модуля около указанной строки и колонки.")
+	// Расписание разбирается до YAML-ветки: сам YAML тут корректен, неверно
+	// значение, и совет «исправьте синтаксис и отступы» увёл бы не туда.
+	case strings.Contains(lowMsg, "расписание") && strings.Contains(lowMsg, "не разбирается"):
+		set("scheduled.schedule-invalid", "Расписание задаётся пятью полями «минуты часы день месяц день_недели» (например `0 9 * * 1-5`) либо сокращением `@daily`/`@every 30m`. До #965 такая опечатка проходила проверку и роняла запуск сервера.")
 	case strings.Contains(lowMsg, "yaml:") || strings.Contains(lowMsg, "cannot unmarshal") || strings.Contains(lowMsg, "unmarshal errors") || strings.Contains(lowMsg, "did not find expected"):
 		set("yaml.invalid", "Исправьте YAML-синтаксис, отступы и тип значения в указанном файле.")
 	case strings.Contains(lowKind, "запрос") || strings.Contains(lowMsg, "compile query") || strings.Contains(lowMsg, "no such table") || strings.Contains(lowMsg, "ambiguous column"):

--- a/internal/configcheck/scheduled_schedule_test.go
+++ b/internal/configcheck/scheduled_schedule_test.go
@@ -1,0 +1,97 @@
+package configcheck
+
+// Проверка расписания регламентного задания (#965).
+//
+// Идёт публичным путём — через CheckDir, то есть тем же кодом, что и
+// `onebase check`, а не вызовом metadata.ValidateSchedule напрямую (правило
+// #611). Повод конкретный: расписание уже умел разбирать планировщик, но на
+// пути `check` этого разбора не было — и именно этот разрыв заявка и чинит.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeJob(t *testing.T, dir, file, schedule string) {
+	t.Helper()
+	jobs := filepath.Join(dir, "scheduled")
+	if err := os.MkdirAll(jobs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "name: Задание\ntitle: Задание\nschedule: \"" + schedule + "\"\nprocessor: Обработка\nenabled: true\n"
+	mustWrite(t, filepath.Join(jobs, file), body)
+}
+
+func scheduleIssues(t *testing.T, dir string) []Issue {
+	t.Helper()
+	issues, _ := CheckDir(dir)
+	var out []Issue
+	for _, is := range issues {
+		if strings.Contains(is.Message, "расписание") {
+			out = append(out, is)
+		}
+	}
+	return out
+}
+
+// Тот самый случай из заявки: семь полей вместо пяти. Раньше `check` отвечал
+// «ошибок не найдено», а `run` не поднимал базу вовсе.
+func TestCheckDir_БитоеРасписаниеЛовится(t *testing.T) {
+	dir := t.TempDir()
+	writeJob(t, dir, "битое.yaml", "*/5 * * * * * *")
+
+	found := scheduleIssues(t, dir)
+	if len(found) == 0 {
+		t.Fatal("check пропустил заведомо неверное расписание — ровно то поведение, из-за которого сервер не стартовал")
+	}
+	is := found[0]
+	if !strings.Contains(is.File, "битое.yaml") {
+		t.Errorf("проблема не привязана к файлу: %+v", is)
+	}
+	// Разработчику нужно видеть само значение, иначе искать опечатку он будет
+	// глазами по всем заданиям.
+	if !strings.Contains(is.Message, "*/5 * * * * * *") {
+		t.Errorf("в сообщении нет самого расписания: %q", is.Message)
+	}
+}
+
+// Опечатки, которые реально делают руками.
+func TestCheckDir_ТипичныеОпечаткиВРасписании(t *testing.T) {
+	for _, schedule := range []string{
+		"*/5 * * *",  // потеряно поле
+		"0 25 * * *", // часа 25 не бывает
+		"@evry 5m",   // опечатка в сокращении
+		"каждый час", // не cron вовсе
+	} {
+		t.Run(schedule, func(t *testing.T) {
+			dir := t.TempDir()
+			writeJob(t, dir, "job.yaml", schedule)
+			if len(scheduleIssues(t, dir)) == 0 {
+				t.Fatalf("расписание %q принято, хотя планировщик его не разберёт", schedule)
+			}
+		})
+	}
+}
+
+// Рабочие расписания обязаны проходить: проверка, которая ругается на верное,
+// хуже отсутствующей — её отключат.
+func TestCheckDir_ВерныеРасписанияПроходят(t *testing.T) {
+	for _, schedule := range []string{
+		"0 9 * * 1-5",
+		"*/15 * * * *",
+		"0 0 1 * *",
+		"@daily",
+		"@every 30m",
+		"", // задание без расписания: запускается только по требованию
+	} {
+		t.Run("«"+schedule+"»", func(t *testing.T) {
+			dir := t.TempDir()
+			writeJob(t, dir, "job.yaml", schedule)
+			if found := scheduleIssues(t, dir); len(found) > 0 {
+				t.Fatalf("верное расписание %q отвергнуто: %+v", schedule, found)
+			}
+		})
+	}
+}

--- a/internal/metadata/scheduled.go
+++ b/internal/metadata/scheduled.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	cron "github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -49,7 +50,40 @@ func LoadScheduledFile(path string) (*ScheduledJob, error) {
 	if job.Timeout == 0 {
 		job.Timeout = 3600
 	}
+	if err := ValidateSchedule(job.Schedule); err != nil {
+		// Имя файла, а не полный путь: `check` добавляет к сообщению свой
+		// префикс с путём и строкой, и полный путь дублировался бы в выводе.
+		return nil, fmt.Errorf("задание %s: %w", filepath.Base(path), err)
+	}
 	return &job, nil
+}
+
+// ValidateSchedule разбирает расписание тем же парсером, что и планировщик
+// (#965).
+//
+// Раньше расписание не проверялось нигде, кроме самого планировщика, и
+// опечатка в нём проходила `onebase check` со словами «ошибок не найдено», а
+// потом не давала серверу запуститься вовсе — падал не сбойный джоб, а вся
+// база вместе с UI, REST и остальными заданиями. Проверять здесь важно именно
+// потому, что зелёный check — основной сигнал «конфигурацию можно катить».
+//
+// Парсер тот же: cron.New() внутри использует standardParser, а ParseStandard
+// это он и есть. Разойтись они не могут по построению — иначе check снова
+// начал бы пропускать то, на чём падает рантайм.
+func ValidateSchedule(schedule string) error {
+	trimmed := strings.TrimSpace(schedule)
+	if trimmed == "" {
+		// Пустое расписание — законный способ описать задание, которое
+		// запускают только по требованию (кнопкой админки или из кода).
+		// Планировщик такое задание в cron просто не заводит.
+		return nil
+	}
+	if _, err := cron.ParseStandard(trimmed); err != nil {
+		return fmt.Errorf("расписание %q не разбирается: %w "+
+			"(ожидается пять полей «минуты часы день месяц день_недели» либо @every/@daily и т.п.)",
+			schedule, err)
+	}
+	return nil
 }
 
 func LoadScheduledDir(dir string) ([]*ScheduledJob, error) {


### PR DESCRIPTION
Fixes #965.

## Проблема

Опечатка в `schedule` проходила `onebase check`, а потом не давала серверу запуститься. Падала не сбойная задача, а вся база — вместе с UI, REST и остальными заданиями:

```
$ onebase check --project .
OK: ошибок не найдено

$ onebase run --project . --sqlite base.db
Ошибка запуска onebase: scheduler: invalid schedule for БитоеРасписание:
expected exactly 5 fields, found 7
```

Разрыв был в том, что расписание разбирал **только планировщик**: `robfig/cron` импортировался ровно в одном месте, а валидация YAML заданий проверяла состав ключей, но не значение `schedule`. Между «проверено» и «разобрано» лежал весь путь до старта сервера.

Обиднее всего это для сценария «поправил конфигурацию, прогнал check, перезапустил»: check молчит, сервер после перезапуска не встаёт. `check` — основной сигнал «конфигурацию можно катить», и он давал ложное «всё хорошо» ровно в том классе ошибок, ради которого его и запускают.

## Решение

Расписание разбирается в `metadata.LoadScheduledFile` — то есть и в `check`, и при загрузке проекта, **тем же парсером, что и планировщик**. Это не совпадение и не копия: `cron.New()` внутри использует `standardParser`, а `ParseStandard` — это он и есть, так что разойтись они не могут по построению. Иначе `check` со временем снова начал бы пропускать то, на чём падает рантайм.

**Поведение рантайма намеренно не меняется.** Тихо не выполняющееся регламентное задание хуже явного отказа: пользователь думает, что обмен идёт, а он не идёт. Меняется момент и внятность — ошибка приходит раньше и называет файл, а не только имя задания:

```
load project: project: load scheduled: задание битое.yaml:
расписание "*/5 * * * * * *" не разбирается: expected exactly 5 fields, found 7
(ожидается пять полей «минуты часы день месяц день_недели» либо @every/@daily и т.п.)
```

Пустое расписание остаётся законным — так описывают задание, которое запускают только по требованию (кнопкой админки или, после #742, из кода). Планировщик такое в cron и не заводит.

## Категория ошибки

В `check` заведена своя категория `scheduled.schedule-invalid`, разбираемая **до** YAML-ветки. Иначе подсказка советовала бы «исправьте YAML-синтаксис и отступы», хотя YAML совершенно корректен, а неверно значение — и человек искал бы не там.

## Тесты

Публичным путём, через `CheckDir` — тем же кодом, что и `onebase check` (правило #611). Повод конкретный: расписание уже умел разбирать планировщик, но на пути `check` этого разбора не было, и именно этот разрыв заявка чинит.

- тот самый случай из заявки (семь полей вместо пяти), с проверкой, что в сообщении есть и файл, и само значение;
- четыре типичные опечатки: потерянное поле, 25-й час, `@evry` вместо `@every`, текст вместо cron;
- верные расписания не отвергаются: `0 9 * * 1-5`, `*/15 * * * *`, `@daily`, `@every 30m` и пустое. Проверка, которая ругается на верное, хуже отсутствующей — её просто отключат.

## Проверки

`go build ./...`, `go test ./internal/...` — 76 пакетов зелёные (с реальным PostgreSQL). `golangci-lint` по затронутым пакетам — 0 issues. Обе конфигурации в `examples/` проходят `check` как раньше.