### PR TITLE
refactor(entityservice): consumer-side порты вместо *storage.DB (шаг 2 ARCH-01)

### DIFF
--- a/internal/entityservice/ports.go
+++ b/internal/entityservice/ports.go
@@ -1,0 +1,126 @@
+package entityservice
+
+// Порты хранилища (шаг 2 ARCH-01, issue #787).
+//
+// Интерфейсы объявлены на стороне потребителя: здесь перечислена ровно та
+// поверхность *storage.DB, которой пользуется сам сервис, — 22 метода из 314.
+// internal/storage о них не знает и не меняется, *storage.DB удовлетворяет им
+// как есть (см. compile-time проверку в конце файла).
+//
+// Зачем: раньше поле Service.Store имело тип *storage.DB, и сигнатура ничего не
+// сообщала о контракте — чтобы узнать, что сервису нужно от базы, приходилось
+// читать сервис целиком. Теперь набор виден объявлением, а изменение любого из
+// остальных 292 методов storage.DB сервиса не задевает.
+//
+// Роли объявлены раздельно, чтобы будущие потребители могли зависеть от узкой
+// части; поле Store пока держит совокупный Storage — это оставляет все точки
+// сборки (*storage.DB присваивается в поле-интерфейс) без единой правки.
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// EntityStore — CRUD объектов и их табличных частей: всё, что относится к
+// строке сущности, включая проверки перед удалением.
+type EntityStore interface {
+	// GetByID читает объект по id (для документов — вместе с posted).
+	GetByID(ctx context.Context, entityName string, id uuid.UUID, entity *metadata.Entity) (map[string]any, error)
+	// Upsert пишет поля объекта (обычная запись, версия инкрементируется).
+	Upsert(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity) error
+	// UpsertProvisional вставляет предварительную строку родителя внутри
+	// транзакции, чтобы хук нового объекта мог создать потомков по FK.
+	UpsertProvisional(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity) error
+	// UpsertPreserveVersion — финальная запись такой предварительной строки
+	// без продвижения _version (наружу объект остаётся версии 1).
+	UpsertPreserveVersion(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity) error
+	// UpsertVersioned пишет с проверкой ожидаемой версии; при расхождении —
+	// storage.ErrVersionConflict, и ничего не записано.
+	UpsertVersioned(ctx context.Context, entityName string, id uuid.UUID, fields map[string]any, entity *metadata.Entity, expectedVersion *int64) error
+	// GetTablePartRows читает строки табличной части родителя.
+	GetTablePartRows(ctx context.Context, entityName, tpName string, parentID uuid.UUID, tp metadata.TablePart) ([]map[string]any, error)
+	// UpsertTablePartRows заменяет все строки табличной части родителя.
+	UpsertTablePartRows(ctx context.Context, entityName, tpName string, parentID uuid.UUID, rows []map[string]any, tp metadata.TablePart) error
+	// Delete удаляет строку сущности (предопределённые — ошибка).
+	Delete(ctx context.Context, entityName string, id uuid.UUID) error
+	// SetPosted выставляет признак проведения документа.
+	SetPosted(ctx context.Context, entityName string, id uuid.UUID, posted bool) error
+	// IsMarkedForDeletion сообщает, помечен ли объект на удаление.
+	IsMarkedForDeletion(ctx context.Context, entityName string, id uuid.UUID) (bool, error)
+	// CheckRefs возвращает ссылки на объект из сущностей, ТЧ и регистров —
+	// предохранитель перед удалением (fail-closed).
+	CheckRefs(ctx context.Context, entityName string, id uuid.UUID, src storage.RefSources) ([]storage.RefInfo, error)
+}
+
+// MovementStore — запись движений документа во все три вида регистров.
+// Пустой rows означает отмену проведения: движения регистратора снимаются.
+type MovementStore interface {
+	// WriteMovements перезаписывает движения документа в регистре накопления.
+	WriteMovements(ctx context.Context, regName, recorderType string, recorderID uuid.UUID, rows []map[string]any, reg *metadata.Register, period *time.Time) error
+	// WriteInfoMovements перезаписывает движения документа в регистре сведений.
+	WriteInfoMovements(ctx context.Context, regName, recorderType string, recorderID uuid.UUID, rows []map[string]any, ir *metadata.InfoRegister, period *time.Time) error
+	// WriteAccountMovements перезаписывает проводки документа в бухрегистре
+	// (вместе с итогами в той же транзакции).
+	WriteAccountMovements(ctx context.Context, regName, docType string, docID uuid.UUID, rows []map[string]any, ar *metadata.AccountRegister, period *time.Time) error
+}
+
+// TxManager — управление транзакцией вокруг записи и проведения.
+type TxManager interface {
+	// WithTxScope делает fn атомарным даже внутри чужой транзакции
+	// (верхний уровень — транзакция, вложенный — savepoint).
+	WithTxScope(ctx context.Context, fn func(context.Context) error) error
+	// WithTx выполняет fn в транзакции: ошибка — откат, успех — фиксация.
+	WithTx(ctx context.Context, fn func(context.Context) error) error
+}
+
+// Locker — advisory-блокировки на время транзакции (на SQLite — no-op).
+type Locker interface {
+	// AdvisoryXactLock берёт блокировки по логическим ключам до конца транзакции.
+	AdvisoryXactLock(ctx context.Context, keys []string) error
+}
+
+// NumberGenerator — нумерация документов и кодов справочников.
+type NumberGenerator interface {
+	// GenerateNumber выдаёт следующий номер по блоку numerator сущности.
+	GenerateNumber(ctx context.Context, entity *metadata.Entity, fields map[string]any) (string, error)
+	// NextNum атомарно увеличивает и возвращает счётчик сущности.
+	NextNum(ctx context.Context, entityName string) (int64, error)
+}
+
+// PostingLockReader — дата запрета проведения (закрытый период).
+type PostingLockReader interface {
+	// GetPostingLockDate возвращает дату запрета и признак её наличия.
+	GetPostingLockDate(ctx context.Context) (time.Time, bool)
+}
+
+// RawExecutor — сырой SQL. Нужен ровно в одном месте: удаление строк табличных
+// частей перед удалением родителя, потому что в storage нет метода вида
+// DeleteTablePartRows. Как только он появится, этот порт удаляется целиком —
+// это единственное место, где сервис ходит мимо CRUD-слоя.
+type RawExecutor interface {
+	// Exec выполняет не-выборку, уважая транзакцию в ctx.
+	Exec(ctx context.Context, sqlText string, args ...any) (storage.CommandTag, error)
+	// Dialect отдаёт диалект SQL — нужен для расстановки плейсхолдеров.
+	Dialect() storage.Dialect
+}
+
+// Storage — совокупный порт, который держит Service в поле Store.
+type Storage interface {
+	EntityStore
+	MovementStore
+	TxManager
+	Locker
+	NumberGenerator
+	PostingLockReader
+	RawExecutor
+}
+
+// *storage.DB обязан удовлетворять порту без единой правки в internal/storage.
+// Если сигнатура там разойдётся с портом, сломается эта строка с внятным
+// сообщением, а не полсотни мест вызова.
+var _ Storage = (*storage.DB)(nil)

--- a/internal/entityservice/service.go
+++ b/internal/entityservice/service.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
-	"github.com/ivantit66/onebase/internal/exchange"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
@@ -54,7 +53,9 @@ func SetPeriodFromFields(mc *runtime.MovementsCollector, entity *metadata.Entity
 
 // Service выполняет сохранение объектов вместе с побочными эффектами.
 type Service struct {
-	Store  *storage.DB
+	// Store — порт хранилища (ports.go), а не *storage.DB: сервису нужны 22
+	// метода из 314, и объявлены здесь только они.
+	Store  Storage
 	Reg    *runtime.Registry
 	Interp *interpreter.Interpreter
 
@@ -85,6 +86,13 @@ type Service struct {
 	// получает obj напрямую, что для документов без ТЧ тоже работает. ctxSrc
 	// передаёт живой контекст DSL-транзакции объектным методам.
 	MakeThis func(ctx context.Context, ctxSrc interpreter.CtxSource, obj *runtime.Object, entity *metadata.Entity) interpreter.This
+
+	// RegisterExchangeSave регистрирует запись объекта в планах обмена
+	// (план 86); deletion=true приходит из пути пометки на удаление.
+	// Шов симметричен RegisterExchangeDelete: exchange принимает конкретный
+	// *storage.DB, поэтому сервис, знающий только порт Storage, зовёт его через
+	// замыкание ui-слоя. nil = обмен не настроен.
+	RegisterExchangeSave func(ctx context.Context, entity *metadata.Entity, id uuid.UUID, deletion bool) error
 
 	// RegisterExchangeDelete регистрирует удаление в планах обмена (план 86).
 	// Вынесено швом, потому что exchange живёт в ui-слое; nil = обмен не
@@ -1157,14 +1165,14 @@ func IsBadRequest(err error) bool {
 // nil-Reg и отсутствие планов — быстрый выход без обращения к БД (обмен не
 // настроен). deletion=true передаётся из пути пометки на удаление.
 func (s *Service) registerExchange(ctx context.Context, entity *metadata.Entity, id uuid.UUID, deletion bool) error {
-	if s.Reg == nil {
+	if s.Reg == nil || s.RegisterExchangeSave == nil {
 		return nil
 	}
 	plans := s.Reg.ExchangePlans()
 	if len(plans) == 0 {
 		return nil
 	}
-	return exchange.RegisterOnSave(ctx, s.Store, plans, entity, id, deletion)
+	return s.RegisterExchangeSave(ctx, entity, id, deletion)
 }
 
 // Repost перепроводит уже записанный документ: перечитывает его из БД, запускает

--- a/internal/entityservice/webhook_test.go
+++ b/internal/entityservice/webhook_test.go
@@ -47,7 +47,10 @@ func (h *hookSink) handler() http.HandlerFunc {
 	}
 }
 
-func newWebhookSvc(t *testing.T, entities []*metadata.Entity, hooks []webhook.Config) (*Service, *webhook.Dispatcher) {
+// Третьим значением отдаётся сам *storage.DB: поле Service.Store — узкий порт
+// (ports.go), а тесту нужен BeginTx, которого в порту нет и который сервису не
+// нужен.
+func newWebhookSvc(t *testing.T, entities []*metadata.Entity, hooks []webhook.Config) (*Service, *webhook.Dispatcher, *storage.DB) {
 	t.Helper()
 	ctx := context.Background()
 	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "wh.db"))
@@ -66,7 +69,7 @@ func newWebhookSvc(t *testing.T, entities []*metadata.Entity, hooks []webhook.Co
 		defer cancel()
 		_ = d.Close(ctx)
 	})
-	return &Service{Store: db, Reg: registry, Interp: interpreter.New(), Hooks: d}, d
+	return &Service{Store: db, Reg: registry, Interp: interpreter.New(), Hooks: d}, d, db
 }
 
 func TestSave_DispatchesCatalogSaveWebhook(t *testing.T) {
@@ -78,7 +81,7 @@ func TestSave_DispatchesCatalogSaveWebhook(t *testing.T) {
 		Name: "Товары", Kind: metadata.KindCatalog,
 		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
 	}
-	svc, d := newWebhookSvc(t, []*metadata.Entity{cat}, []webhook.Config{{
+	svc, d, _ := newWebhookSvc(t, []*metadata.Entity{cat}, []webhook.Config{{
 		Name: "n8n", On: "catalog.save", URL: srv.URL,
 		Body: `{"event":"{{entity}}","name":"{{Наименование}}","id":"{{id}}"}`,
 	}})
@@ -111,7 +114,7 @@ func TestSave_DispatchesDocumentPostWebhook(t *testing.T) {
 		Name: "Реализация", Kind: metadata.KindDocument, Posting: true,
 		Fields: []metadata.Field{{Name: "Номер", Type: metadata.FieldTypeString}},
 	}
-	svc, d := newWebhookSvc(t, []*metadata.Entity{doc}, []webhook.Config{
+	svc, d, _ := newWebhookSvc(t, []*metadata.Entity{doc}, []webhook.Config{
 		{Name: "post-hook", On: "document.post", URL: srv.URL, Body: `{"n":"{{Номер}}"}`},
 		{Name: "save-hook", On: "document.save", URL: srv.URL, Body: `{"saved":"{{Номер}}"}`},
 	})
@@ -144,7 +147,7 @@ func TestSave_NoWebhookOnDSLError(t *testing.T) {
 		Name: "Товары", Kind: metadata.KindCatalog,
 		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
 	}
-	svc, d := newWebhookSvc(t, []*metadata.Entity{cat}, []webhook.Config{{
+	svc, d, _ := newWebhookSvc(t, []*metadata.Entity{cat}, []webhook.Config{{
 		Name: "x", On: "catalog.save", URL: srv.URL, Body: "{}",
 	}})
 	// OnWrite с ошибкой — сохранение отменяется бизнес-правилом
@@ -185,11 +188,11 @@ func TestSave_DefersWebhookUntilExplicitTransactionCommit(t *testing.T) {
 		Name: "Товары", Kind: metadata.KindCatalog,
 		Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
 	}
-	svc, d := newWebhookSvc(t, []*metadata.Entity{cat}, []webhook.Config{{
+	svc, d, db := newWebhookSvc(t, []*metadata.Entity{cat}, []webhook.Config{{
 		Name: "tx-hook", On: "catalog.save", URL: srv.URL, Body: `{"id":"{{id}}"}`,
 	}})
 
-	tx, txCtx, err := svc.Store.BeginTx(context.Background())
+	tx, txCtx, err := db.BeginTx(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +215,7 @@ func TestSave_DefersWebhookUntilExplicitTransactionCommit(t *testing.T) {
 		t.Fatalf("webhook dispatched for rolled-back save: %d", got)
 	}
 
-	tx, txCtx, err = svc.Store.BeginTx(context.Background())
+	tx, txCtx, err = db.BeginTx(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ui/dsl_catalogs.go
+++ b/internal/ui/dsl_catalogs.go
@@ -21,8 +21,17 @@ import (
 // MakeThis — обёртка с методами ТЧ. Используется и полным сервером (New), и
 // offline-запуском обработок (RunProcessorOffline).
 func (s *Server) newEntityService(hooks *webhook.Dispatcher) *entityservice.Service {
+	// Пустое хранилище кладём нетипизированным nil. Server штатно поднимается
+	// без БД (ui.New(reg, nil, ...)), а интерфейс, обёрнутый вокруг
+	// (*storage.DB)(nil), сам по себе не равен nil — прямое присваивание молча
+	// обезвредило бы проверки `s.Store == nil` внутри сервиса, и вместо
+	// внятной ошибки получилась бы паника на первом же обращении к базе.
+	var store entityservice.Storage
+	if s.store != nil {
+		store = s.store
+	}
 	return &entityservice.Service{
-		Store:        s.store,
+		Store:        store,
 		Reg:          s.reg,
 		Interp:       s.interp,
 		PrepareHook:  s.enrichHeaderRefs,
@@ -30,6 +39,12 @@ func (s *Server) newEntityService(hooks *webhook.Dispatcher) *entityservice.Serv
 		BuildVars:    s.buildDSLVarsWithMessagesTx,
 		MakeThis: func(ctx context.Context, ctxSrc interpreter.CtxSource, obj *runtime.Object, e *metadata.Entity) interpreter.This {
 			return s.newFormObjectThisLive(ctx, ctxSrc, obj, e, nil, false)
+		},
+		// Регистрация записи в планах обмена (план 86): exchange принимает
+		// конкретный *storage.DB, а сервис знает только порт Storage, поэтому
+		// вызов попадает в него швом — симметрично удалению ниже.
+		RegisterExchangeSave: func(ctx context.Context, e *metadata.Entity, id uuid.UUID, deletion bool) error {
+			return exchange.RegisterOnSave(ctx, s.store, s.reg.ExchangePlans(), e, id, deletion)
 		},
 		// Регистрация удаления в планах обмена (план 86): exchange живёт в
 		// ui-слое, поэтому в сервис попадает швом.

--- a/internal/ui/entity_service_nil_store_test.go
+++ b/internal/ui/entity_service_nil_store_test.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+// Сервер штатно поднимается без БД (ui.New(reg, nil, ...) — см. тесты
+// обработчиков событий), и сборка сервиса обязана положить в поле-порт
+// нетипизированный nil.
+//
+// Грабля, ради которой существует тест: Service.Store — интерфейс
+// (entityservice.Storage), а интерфейс, хранящий nil-указатель *storage.DB, сам
+// по себе НЕ равен nil. Прямое `Store: s.store` компилируется, выглядит
+// правильно и молча обезвреживает проверки `s.Store == nil` внутри сервиса —
+// вместо внятной ошибки «не задано хранилище» получается паника на первом
+// обращении к базе. Компилятор такое не ловит, поэтому ловит тест.
+func TestNewEntityServiceKeepsNilStoreUntyped(t *testing.T) {
+	s := &Server{reg: runtime.NewRegistry(), interp: interpreter.New()}
+
+	svc := s.newEntityService(nil)
+
+	if svc.Store != nil {
+		t.Fatal("Store != nil при сервере без БД: в поле-порт попал типизированный nil, " +
+			"проверки хранилища внутри сервиса перестали срабатывать")
+	}
+}

--- a/internal/ui/exchange_save_seam_test.go
+++ b/internal/ui/exchange_save_seam_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/entityservice"
+	"github.com/ivantit66/onebase/internal/runtime"
+)
+
+// Запись объекта через entityservice.Save обязана регистрировать изменение в
+// планах обмена (план 86): без строки в очереди узлы разъезжаются молча —
+// приёмник просто никогда не узнает о новом объекте.
+//
+// Тест идёт публичным путём — s.entityService().Save, то есть через ту самую
+// сборку сервиса, которой пользуется сервер (newEntityService). Это
+// принципиально: соседние ui-тесты подменяют s.entitySvc собственным литералом
+// и регистрацию обмена не задействуют вовсе, поэтому проводку «сервис →
+// exchange» до сих пор не покрывал ни один тест — её можно было оборвать, не
+// уронив ни одной проверки.
+func TestEntityServiceSaveRegistersExchangeChange(t *testing.T) {
+	db, reg, ctx, ent := newExchangeBaseDB(t)
+	// База участвует в плане как узел center; в плоском плане обмена изменение
+	// регистрируется всем остальным узлам, то есть fil01.
+	if err := db.SaveExchangeThisNode(ctx, "Обмен", "center"); err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{
+		store:    db,
+		reg:      reg,
+		interp:   interpreter.New(),
+		lockMgr:  runtime.NewLockManager(),
+		messages: NewMessageStore(),
+	}
+
+	id := uuid.New()
+	if _, err := s.entityService().Save(ctx, entityservice.SaveRequest{
+		Entity: ent,
+		ID:     id,
+		IsNew:  true,
+		Fields: map[string]any{"Наименование": "Гвоздь"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	changes, err := db.PendingExchangeChanges(ctx, "Обмен", "fil01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("очередь обмена для fil01: получено %d строк, ожидалась 1: %+v", len(changes), changes)
+	}
+	if got := changes[0].ObjectID; got != id.String() {
+		t.Errorf("ObjectID = %q, ожидался %q", got, id.String())
+	}
+	if got := changes[0].ObjectType; got != ent.Name {
+		t.Errorf("ObjectType = %q, ожидался %q", got, ent.Name)
+	}
+	if changes[0].Deletion {
+		t.Error("Deletion = true, ожидалось false: это обычная запись, а не пометка удаления")
+	}
+}


### PR DESCRIPTION
Шаг 2 из трёх по **ARCH-01** (#787) — самый дешёвый и полностью обратимый.

## Что не так было

Поле `Service.Store` имело тип `*storage.DB` — объекта на **314 методов**, который импортируют 22 пакета. Сигнатура не сообщала ничего: чтобы узнать, что сервису нужно от базы, приходилось читать сервис целиком, а подменить хранилище в тесте было нельзя вовсе.

## Что сделано

`internal/entityservice/ports.go` объявляет ровно ту поверхность, которой сервис пользуется, — **22 метода из 314**, разложенные по ролям: `EntityStore` (CRUD и табличные части), `MovementStore` (движения), `TxManager`, `Locker`, `NumberGenerator`, `PostingLockReader`, `RawExecutor`.

Интерфейсы объявлены **на стороне потребителя**, поэтому пакет `storage` не меняется ни на строку: `*storage.DB` удовлетворяет им как есть. Это закреплено compile-time проверкой

```go
var _ Storage = (*storage.DB)(nil)
```

— при расхождении сигнатур ломается она одна с внятным сообщением, а не полсотни мест вызова.

Поле `Store` держит совокупный `Storage`, а не отдельные поля по ролям: так все **37 точек сборки** сервиса (прод и тесты) продолжают присваивать `*storage.DB` без единой правки. **Тела методов не изменены нигде** — правка целиком в объявлениях. Это же свойство сделало мёрж свежего `main` (6 коммитов, включая #982, правивший тот же `service.go`) чистым.

## Два следствия, потребовавшие правок

**1. Транзитивная утечка через `exchange`.** `exchange.RegisterOnSave` принимает конкретный `*storage.DB` — единственная ошибка компиляции при замене. Вызов переехал на шов `RegisterExchangeSave`, симметрично уже существовавшему `RegisterExchangeDelete`; замыкание живёт в `ui` рядом с ним. Пакеты `exchange` и `storage` не тронуты.

**2. Типизированный nil.** Интерфейс, обёрнутый вокруг `(*storage.DB)(nil)`, не равен `nil`, а сервер штатно поднимается без БД (`ui.New(reg, nil, …)`). Прямое `Store: s.store` собралось бы, выглядело правильно и молча обезвредило проверки `s.Store == nil` внутри сервиса — вместо внятной ошибки вышла бы паника на первом обращении к базе. Поэтому `newEntityService` кладёт в поле-порт нетипизированный nil.

## Тесты

Оба риска закрыты тестами, и каждый **проверен в обе стороны** — зелёный на целом коде, красный при искусственном разрыве:

- `TestEntityServiceSaveRegistersExchangeChange` — идёт публичным путём `s.entityService().Save`, а не дёргает шов напрямую. Это принципиально: соседние ui-тесты подменяют `s.entitySvc` собственным литералом и регистрацию обмена не задействуют, поэтому проводку «сервис → обмен» до сих пор **не покрывал ни один тест** — её можно было оборвать, не уронив ни одной проверки. Тест закоммичен отдельно и **до** рефакторинга, чтобы страховать сам переезд.
- `TestNewEntityServiceKeepsNilStoreUntyped` — на типизированный nil; компилятор такое не ловит.

## Проверено

- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./internal/entityservice/`
- `go test ./...` — без единого падения
- `golangci-lint run ./internal/entityservice/... ./internal/ui/...` — 0 issues
- интеграционные тесты `entityservice` и `storage` на локальном PostgreSQL 14

## Обратимость

Откат = удалить `ports.go` и вернуть три хунка в `service.go` плюс два в `ui/dsl_catalogs.go`. Промежуточных состояний, где что-то компилируется наполовину, нет.

Closes часть #787 (шаг 2). Шаги 1 (`internal/app` с `Build/Run/Close`) и 3 (развязка API↔UI) — отдельными PR; шаг 1 не стоит начинать до появления сквозного smoke-теста сборки без тега `integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
