### PR TITLE
fix(launcher): со страницы отчёта об ошибке есть выход на каждом шаге

### DIFF
--- a/internal/launcher/report_problem.go
+++ b/internal/launcher/report_problem.go
@@ -87,6 +87,24 @@ func (h *handler) reportProblemPreview(w http.ResponseWriter, r *http.Request) {
 	h.renderReportProblem(w, r, vm)
 }
 
+// reportProblemEdit возвращает с предпросмотра к форме, не теряя написанного:
+// описание приезжает обратно скрытыми полями. Раньше «Изменить описание» вело
+// ссылкой на пустой бланк, и текст приходилось набирать заново.
+func (h *handler) reportProblemEdit(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, reportMaxTextBytes)
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	h.renderReportProblem(w, r, reportVM{
+		Did:       r.FormValue("did"),
+		Expected:  r.FormValue("expected"),
+		Got:       r.FormValue("got"),
+		BaseID:    strings.TrimSpace(r.FormValue("base")),
+		AttachLog: r.FormValue("attach_log") == "1",
+	})
+}
+
 // reportInput собирает данные отчёта по состоянию формы.
 func (h *handler) reportInput(r *http.Request, vm reportVM) bugreport.Input {
 	in := bugreport.Input{
@@ -126,6 +144,11 @@ func (h *handler) reportProblemSave(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	vm := reportVM{
+		// Описание держим и после сохранения: страница остаётся на экране, и
+		// «Изменить описание» с неё должно открывать заполненную форму.
+		Did:       r.FormValue("did"),
+		Expected:  r.FormValue("expected"),
+		Got:       r.FormValue("got"),
 		BaseID:    strings.TrimSpace(r.FormValue("base")),
 		AttachLog: r.FormValue("attach_log") == "1",
 	}

--- a/internal/launcher/report_problem_test.go
+++ b/internal/launcher/report_problem_test.go
@@ -60,6 +60,24 @@ func TestLauncherReportProblem_PreviewIsEditable(t *testing.T) {
 	}
 }
 
+// Со страницы отчёта должен быть выход на каждом шаге. Тулбара лаунчера на ней
+// нет, а в нативном окне нет и браузерного «назад»: единственный путь обратно —
+// тот, что нарисован на самой странице. Раньше его не было ни в предпросмотре,
+// ни на экране «пакет сохранён» — пользователь оставался в тупике.
+func TestLauncherReportProblem_EveryStepHasWayBack(t *testing.T) {
+	steps := map[string]map[string]any{
+		"форма":             nil,
+		"предпросмотр":      {"Preview": "# отчёт", "BaseID": "b1"},
+		"пакет сохранён":    {"Preview": "# отчёт", "SavedPath": `C:\Users\u\.onebase\reports\r.zip`},
+		"ошибка сохранения": {"Preview": "# отчёт", "Error": "нет места на диске"},
+	}
+	for step, data := range steps {
+		if !strings.Contains(renderReportProblemPage(t, data), `href="/"`) {
+			t.Errorf("шаг %q: со страницы не вернуться к списку баз", step)
+		}
+	}
+}
+
 func TestLauncherReportProblem_ShowsSavedPathAndError(t *testing.T) {
 	ok := renderReportProblemPage(t, map[string]any{"SavedPath": `C:\Users\u\.onebase\reports\r.zip`})
 	if !strings.Contains(ok, `C:\Users\u\.onebase\reports\r.zip`) {
@@ -82,6 +100,51 @@ func TestLauncherReportProblem_ToolbarHasLink(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "/report-problem") {
 		t.Error("в тулбаре лаунчера нет кнопки «Сообщить об ошибке»")
+	}
+}
+
+// «Изменить описание» возвращает форму заполненной. Раньше это была ссылка на
+// пустой бланк: единственный путь назад стирал написанное, и вернуться «просто
+// посмотреть» было нельзя.
+func TestLauncherReportProblem_EditKeepsDescription(t *testing.T) {
+	h := &handler{store: newTestStore(t)}
+	form := url.Values{
+		"did": {"открыл список"}, "expected": {"список открылся"}, "got": {"пустой экран"},
+		"attach_log": {"1"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/report-problem", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.reportProblemPreview(rec, req)
+
+	// Предпросмотр несёт описание скрытыми полями и шлёт их на /edit — иначе
+	// возвращать в форму будет нечего.
+	preview := rec.Body.String()
+	for _, want := range []string{
+		`name="did" value="открыл список"`,
+		`name="expected" value="список открылся"`,
+		`name="got" value="пустой экран"`,
+		`formaction="/report-problem/edit"`,
+	} {
+		if !strings.Contains(preview, want) {
+			t.Errorf("в предпросмотре нет %s", want)
+		}
+	}
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/report-problem/edit", strings.NewReader(form.Encode()))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	h.reportProblemEdit(rec2, req2)
+
+	back := rec2.Body.String()
+	if strings.Contains(back, `id="rp-text"`) {
+		t.Fatal("«Изменить описание» вернуло предпросмотр вместо формы")
+	}
+	for _, want := range []string{"открыл список", "список открылся", "пустой экран"} {
+		if !strings.Contains(back, want) {
+			t.Errorf("форма открылась без %q — текст пришлось бы набирать заново", want)
+		}
 	}
 }
 
@@ -163,7 +226,11 @@ func TestLauncherReportProblem_EndToEnd(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	edited := "# мой отчёт\nбез лишнего\n"
-	save := url.Values{"report": {edited}, "base": {"b1"}, "attach_log": {"1"}}
+	save := url.Values{
+		"report": {edited}, "base": {"b1"}, "attach_log": {"1"},
+		// Скрытые поля предпросмотра уходят вместе с отчётом.
+		"did": {"нажал «Провести»"}, "expected": {"документ проведён"}, "got": {"ошибка"},
+	}
 	rec2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest("POST", "/report-problem/save", strings.NewReader(save.Encode()))
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -174,6 +241,13 @@ func TestLauncherReportProblem_EndToEnd(t *testing.T) {
 	}
 	if strings.Contains(rec2.Body.String(), "Не удалось сохранить") {
 		t.Fatalf("страница сообщила об ошибке сохранения:\n%s", rec2.Body.String())
+	}
+	// Пакет собран — работа кончилась, и уйти со страницы должно быть чем.
+	if !strings.Contains(rec2.Body.String(), `href="/"`) {
+		t.Error("с экрана «пакет сохранён» не вернуться к списку баз")
+	}
+	if !strings.Contains(rec2.Body.String(), `name="did" value="нажал «Провести»"`) {
+		t.Error("после сохранения описание потерялось — «Изменить описание» откроет пустой бланк")
 	}
 
 	found, err := filepath.Glob(filepath.Join(home, ".onebase", "reports", "*.zip"))

--- a/internal/launcher/server.go
+++ b/internal/launcher/server.go
@@ -255,6 +255,7 @@ func (s *Server) ListenAndServe() error {
 	// «Сообщить об ошибке» (план 116): форма → предпросмотр → пакет на диск.
 	r.Get("/report-problem", s.h.reportProblem)
 	r.Post("/report-problem", s.h.reportProblemPreview)
+	r.Post("/report-problem/edit", s.h.reportProblemEdit)
 	r.Post("/report-problem/save", s.h.reportProblemSave)
 	r.Get("/bases/new", s.h.newForm)
 	r.Post("/bases", s.h.create)

--- a/internal/launcher/tpl_report_problem.go
+++ b/internal/launcher/tpl_report_problem.go
@@ -26,12 +26,20 @@ const tplReportProblem = `
   <form method="post" action="/report-problem/save">
     <input type="hidden" name="base" value="{{.BaseID}}">
     <input type="hidden" name="attach_log" value="{{if .AttachLog}}1{{end}}">
+    {{/* Описание едет с собой скрытыми полями: «Изменить описание» обязано
+         вернуть форму заполненной, иначе текст пришлось бы набирать заново. */}}
+    <input type="hidden" name="did" value="{{.Did}}">
+    <input type="hidden" name="expected" value="{{.Expected}}">
+    <input type="hidden" name="got" value="{{.Got}}">
     <textarea id="rp-text" name="report" rows="20" spellcheck="false"
       style="width:100%;padding:8px;border:1px solid #ACA899;border-radius:2px;font-family:Consolas,monospace;font-size:12px;line-height:1.5">{{.Preview}}</textarea>
     <div style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;align-items:center">
       <button class="btn-ok" type="submit">{{t $.Lang "Сохранить пакет…"}}</button>
       <button class="btn-cancel" type="button" id="rp-copy">{{t $.Lang "Скопировать текст"}}</button>
-      <a class="btn-cancel" href="/report-problem{{if .BaseID}}?base={{.BaseID}}{{end}}">{{t $.Lang "Изменить описание"}}</a>
+      <button class="btn-cancel" type="submit" formaction="/report-problem/edit">{{t $.Lang "Изменить описание"}}</button>
+      {{/* Выход отсюда есть только свой: страница отчёта рисуется без тулбара
+           лаунчера, а нативное окно не даёт браузерного «назад». */}}
+      <a class="btn-cancel" href="/">← {{t $.Lang "Назад к списку баз"}}</a>
       <span id="rp-copied" style="color:#166534;font-size:12px;display:none">{{t $.Lang "Скопировано"}}</span>
     </div>
     <div style="margin-top:8px;font-size:12px;color:#777">


### PR DESCRIPTION
## Проблема

Страница «Сообщить об ошибке» в лаунчере рисуется голой карточкой, без тулбара
(`internal/launcher/tpl_report_problem.go`), а нативное окно лаунчера не даёт
браузерного «назад». Кнопка `← Назад` была только в ветке формы: как только
пользователь нажимал «Сформировать отчёт», страница переключалась на
предпросмотр, где ссылок наружу нет вовсе. После «Сохранить пакет…» — тот же
экран плюс плашка «Пакет сохранён»: работа сделана, а вернуться к списку баз
нечем.

Обходной путь был один — «Изменить описание» → `← Назад`. Причём платный:
«Изменить описание» вело ссылкой на `GET /report-problem`, который заполняет
только `base`, поэтому форма открывалась пустой и написанное пропадало.

Пользователь описал это так: «после формирования пакета назад в лаунчер не
вернуться никак».

## Что сделано

- В предпросмотре появилась ссылка `← Назад к списку баз` на `/` — выход есть
  на каждом шаге, включая экран «пакет сохранён» и экран ошибки сохранения.
- «Изменить описание» стало кнопкой отправки той же формы на новый
  `POST /report-problem/edit`: описание едет через предпросмотр скрытыми полями
  и возвращается в форму заполненным. Оно же сохраняется в `reportProblemSave`,
  поэтому переживает и сохранение пакета.
- Новых строк интерфейса не добавилось: оба ключа («Изменить описание»,
  «Назад к списку баз») уже есть в словарях.

## Проверка

- `go test ./internal/launcher/ ./internal/i18n/...` — зелёные; `go vet`,
  `go run ./tools/i18ncheck` — чисто.
- Новые тесты проверялись на сборке **до** правки — падают ровно на том, что
  чинится (предпросмотр, «пакет сохранён», ошибка сохранения — выхода нет;
  описание после сохранения потеряно).
- Вживую: лаунчер с изолированным профилем, полный путь формы —
  форма → предпросмотр → «Изменить описание» (поля вернулись заполненными) →
  «Сохранить пакет…» → пакет на диске, на экране путь, кнопка возврата и
  описание на месте. Заодно это проверило регистрацию маршрута `/edit`,
  которую юнит-тестами не поймать: роутер лаунчера собирается внутри
  `ListenAndServe`.

## Осталось за скобками

В Предприятии (`internal/ui/tpl_report_problem.go`) «Изменить описание» тоже
открывает пустой бланк. Там это не запирает пользователя — страница идёт с
общей навигацией, — поэтому в этот PR не тянул; отдельная мелкая правка по той
же схеме.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
