### PR TITLE
fix(ui): keep stage route curves inside chart

### DIFF
--- a/internal/ui/stages.go
+++ b/internal/ui/stages.go
@@ -166,7 +166,7 @@ func stageChartJSON(v any) template.JS {
 		links = append(links, map[string]any{
 			"source":    view.Nodes[fi].Label,
 			"target":    view.Nodes[ti].Label,
-			"lineStyle": map[string]any{"color": "#94a3b8", "curveness": curvenessFor(fi, ti)},
+			"lineStyle": map[string]any{"color": "#94a3b8", "curveness": curvenessFor(fi, ti, len(view.Nodes))},
 		})
 	}
 	opt := map[string]any{
@@ -189,14 +189,25 @@ func stageChartJSON(v any) template.JS {
 	return template.JS(b) //nolint:gosec // G203: значение получено json.Marshal — он экранирует < > & в \u-последовательности
 }
 
-// curvenessFor выгибает обратные переходы (возврат «Отклонена → Черновик»),
-// чтобы они не ложились поверх прямой стрелки.
-func curvenessFor(from, to int) float64 {
-	if to < from {
-		return -0.35
+// curvenessFor выгибает обратные и пропускающие этапы переходы, чтобы они не
+// ложились поверх прямых стрелок. ECharts умножает curveness на экранную длину
+// ребра: прежние постоянные -0.35/0.25 выбрасывали длинные дуги за верхнюю
+// границу невысокого canvas. Нормализация по доле маршрута оставляет примерно
+// одинаковый вертикальный прогиб для коротких и длинных переходов.
+func curvenessFor(from, to, total int) float64 {
+	if from == to || total < 2 {
+		return 0
 	}
-	if to-from > 1 {
-		return 0.25
+	span := to - from
+	if span < 0 {
+		span = -span
+	}
+	scale := float64(total-1) / float64(span)
+	if to < from {
+		return -min(0.35, 0.06*scale)
+	}
+	if span > 1 {
+		return min(0.25, 0.05*scale)
 	}
 	return 0
 }

--- a/internal/ui/stages_ui_test.go
+++ b/internal/ui/stages_ui_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"html"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -116,6 +117,70 @@ func TestStageChartJSONBuildsGraphSeries(t *testing.T) {
 	}
 	if highlighted != 1 {
 		t.Fatalf("подсвечено узлов: %d, ожидался ровно 1", highlighted)
+	}
+}
+
+// Длинные и обратные переходы не должны получать постоянную большую кривизну:
+// ECharts масштабирует её вместе с длиной ребра, и дуга уходит за canvas.
+func TestStageChartJSONNormalizesCurvenessBySpan(t *testing.T) {
+	view := &stageRouteView{
+		Nodes: []stageNodeView{
+			{Name: "draft", Label: "Черновик"},
+			{Name: "review", Label: "На согласовании"},
+			{Name: "approved", Label: "Утверждена"},
+			{Name: "rejected", Label: "Отклонена"},
+		},
+		Edges: [][2]string{
+			{"draft", "review"},
+			{"review", "rejected"},
+			{"rejected", "draft"},
+		},
+	}
+	var opt struct {
+		Series []struct {
+			Links []struct {
+				Source    string `json:"source"`
+				Target    string `json:"target"`
+				LineStyle struct {
+					Curveness float64 `json:"curveness"`
+				} `json:"lineStyle"`
+			} `json:"links"`
+		} `json:"series"`
+	}
+	if err := json.Unmarshal([]byte(stageChartJSON(view)), &opt); err != nil {
+		t.Fatalf("option не разбирается: %v", err)
+	}
+	if len(opt.Series) != 1 || len(opt.Series[0].Links) != 3 {
+		t.Fatalf("неожиданные серии/рёбра: %+v", opt.Series)
+	}
+	want := []float64{0, 0.075, -0.06}
+	for i, link := range opt.Series[0].Links {
+		if math.Abs(link.LineStyle.Curveness-want[i]) > 1e-9 {
+			t.Errorf("ребро %s → %s: curveness=%v, ожидалось %v", link.Source, link.Target, link.LineStyle.Curveness, want[i])
+		}
+	}
+}
+
+func TestStageCurvenessCapsShortDetours(t *testing.T) {
+	tests := []struct {
+		name     string
+		from, to int
+		total    int
+		want     float64
+	}{
+		{name: "same node", from: 1, to: 1, total: 4, want: 0},
+		{name: "invalid total", from: 1, to: 0, total: 1, want: 0},
+		{name: "adjacent forward", from: 1, to: 2, total: 4, want: 0},
+		{name: "adjacent reverse capped", from: 10, to: 9, total: 20, want: -0.35},
+		{name: "short forward jump capped", from: 0, to: 2, total: 20, want: 0.25},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := curvenessFor(tt.from, tt.to, tt.total)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("curvenessFor(%d, %d, %d)=%v, ожидалось %v", tt.from, tt.to, tt.total, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize ECharts edge curvature by the transition span and total stage count
- keep adjacent forward transitions straight and retain bounded curves for skips/returns
- add regression coverage for the four-stage callcenter route and curvature caps

## Why
ECharts scales `lineStyle.curveness` with the rendered edge length. The fixed values `0.25` and `-0.35` pushed long forward and reverse transitions outside the 90/110 px canvas on wide screens, so the process diagram looked cropped.

## Verification
- `go test ./internal/ui -run TestStage -count=1`
- `go test ./internal/ui -count=1`
- built `./cmd/onebase` with Go 1.26.6
- visually checked `/ui/stages/заявка` in Edge/Playwright at 1600×900: 1286×110 chart, complete forward and reverse arcs, no page errors