### PR TITLE
fix: закрыть подтверждённые открытые дефекты форм, renumber и Windows CI

### DIFF
--- a/internal/cli/renumber.go
+++ b/internal/cli/renumber.go
@@ -143,6 +143,18 @@ func renumberTargets(proj *project.Project, only string) ([]*metadata.Entity, er
 func renumberEntity(ctx context.Context, db *storage.DB, ent *metadata.Entity, write bool) (renumberEntityReport, error) {
 	field := storage.AutoNumberField(ent)
 	rep := renumberEntityReport{Object: ent.Name, Field: field}
+	// Частично выполненная миграция — основной сценарий этой команды: гейт
+	// уникальности мог остановить схему на одном объекте, а следующие таблицы
+	// ещё не созданы. Для такого объекта дозаполнять нечего. Проверяем наличие
+	// явно, не распознаём текст ошибки List: TableExists отделяет «нет таблицы»
+	// от настоящего сбоя соединения на обоих диалектах (#1080).
+	exists, err := db.TableExists(ctx, metadata.TableName(ent.Name))
+	if err != nil {
+		return rep, err
+	}
+	if !exists {
+		return rep, nil
+	}
 
 	lastRows, err := db.List(ctx, ent.Name, ent, storage.ListParams{
 		Sort: "id", Dir: "desc", Limit: 1,

--- a/internal/cli/renumber_contract_test.go
+++ b/internal/cli/renumber_contract_test.go
@@ -29,6 +29,12 @@ func renumberContractFixture(t *testing.T) (dir, dbPath string) {
 	writeProcrunFixture(t, dir, "config/app.yaml", "name: renumber-contract\nversion: \"1.0\"\n")
 	writeProcrunFixture(t, dir, "catalogs/Контрагенты.yaml",
 		"name: Контрагенты\nnumerator:\n  prefix: \"К-\"\n  length: 6\nfields:\n  - name: Наименование\n    type: string\n")
+	// Конфигурация уже знает следующий объект, но его таблицы ещё нет: ровно
+	// такое состояние оставляет миграция, остановленная гейтом уникальности на
+	// Контрагентах (#1080). Публичная команда и вызывающий её лаунчер должны
+	// считать это «дозаполнять нечего», а не падать с no such table.
+	writeProcrunFixture(t, dir, "catalogs/НовыйОбъект.yaml",
+		"name: НовыйОбъект\nnumerator:\n  prefix: \"Н-\"\n  length: 6\nfields:\n  - name: Наименование\n    type: string\n")
 
 	ent := renumberCatalog()
 	dbPath = filepath.Join(t.TempDir(), "contract.db")

--- a/internal/scheduler/scheduled_admin_switch_test.go
+++ b/internal/scheduler/scheduled_admin_switch_test.go
@@ -39,9 +39,7 @@ func TestТикУважаетАдминистративноеВключение(
 		t.Fatal(err)
 	}
 
-	runCtx, stop := context.WithCancel(ctx)
-	go func() { _ = sched.Run(runCtx) }()
-	defer stop()
+	runSchedulerUntilCleanup(t, sched, ctx)
 
 	// Выключенное в конфигурации не тикает.
 	assert.Never(t, func() bool { return runCount(t, db, "Молчун") > 0 },
@@ -81,9 +79,7 @@ func TestТикУважаетАдминистративноеВыключени�
 		t.Fatal(err)
 	}
 
-	runCtx, stop := context.WithCancel(ctx)
-	go func() { _ = sched.Run(runCtx) }()
-	defer stop()
+	runSchedulerUntilCleanup(t, sched, ctx)
 
 	assert.Never(t, func() bool { return runCount(t, db, "АвтоОтчёт") > 0 },
 		2500*time.Millisecond, 200*time.Millisecond,
@@ -98,9 +94,7 @@ func TestТикГейтитНативноеЗадание(t *testing.T) {
 	assert.NoError(t, sched.RegisterGoJob("НативноеЗадание", "", "@every 1s",
 		func(context.Context) error { return nil }))
 
-	runCtx, stop := context.WithCancel(ctx)
-	go func() { _ = sched.Run(runCtx) }()
-	defer stop()
+	runSchedulerUntilCleanup(t, sched, ctx)
 
 	assert.Never(t, func() bool { return runCount(t, db, "НативноеЗадание") > 0 },
 		2500*time.Millisecond, 200*time.Millisecond,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -29,6 +29,38 @@ func openSchedulerTestDB(t *testing.T) (*storage.DB, context.Context) {
 	return db, ctx
 }
 
+// runSchedulerUntilCleanup starts the same blocking Run path as production and
+// registers a cleanup that not only cancels it, but also waits for graceful
+// shutdown. A bare defer cancel() lets the test return first; the earlier
+// db.Close cleanup then races the scheduler's final status write (#1062).
+func runSchedulerUntilCleanup(t *testing.T, sched *Scheduler, parent context.Context) {
+	t.Helper()
+	runCtx, cancel := context.WithCancel(parent)
+	ready := make(chan struct{})
+	done := make(chan error, 1)
+	go func() { done <- sched.RunReady(runCtx, ready) }()
+	select {
+	case <-ready:
+	case err := <-done:
+		cancel()
+		t.Fatalf("scheduler stopped before ready: %v", err)
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("scheduler did not become ready")
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("scheduler shutdown: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("scheduler did not stop before database cleanup")
+		}
+	})
+}
+
 func TestShutdownDrainsRunningGoJob(t *testing.T) {
 	db, ctx := openSchedulerTestDB(t)
 	sched := New(db, nil, nil)

--- a/internal/ui/detail_panel_test.go
+++ b/internal/ui/detail_panel_test.go
@@ -8,6 +8,7 @@ import (
 	"html"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -297,6 +298,44 @@ func TestDetailPanel_HandlerHonorsExplicitComposition(t *testing.T) {
 	}
 }
 
+// Пункт 1 #1083: после записи панель обязана читать текущий снимок из БД, а не
+// пустые/устаревшие значения строки, с которой открыли форму. Проверка идёт
+// публичными submitEdit → detailPanelRecord, как пользовательский путь.
+func TestDetailPanel_AfterEditShowsSavedValues_1083(t *testing.T) {
+	ent := &metadata.Entity{
+		Name: "Номенклатура", Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Наименование", Type: metadata.FieldTypeString},
+			{Name: "Вес", Type: metadata.FieldTypeNumber},
+		},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{ent})
+	id := uuid.New()
+	if err := s.store.Upsert(ctx, ent.Name, id, map[string]any{
+		"Наименование": "До правки", "Вес": "1",
+	}, ent); err != nil {
+		t.Fatal(err)
+	}
+
+	request := reqWithChi(http.MethodPost, "/ui/catalog/Номенклатура/"+id.String(), url.Values{
+		"Наименование": {"После правки"},
+		"Вес":          {"12,4"},
+	}, map[string]string{"kind": "catalog", "entity": ent.Name, "id": id.String()})
+	response := httptest.NewRecorder()
+	s.submitEdit(response, request)
+	if response.Code != http.StatusSeeOther {
+		t.Fatalf("submitEdit: статус=%d, body=%s", response.Code, response.Body.String())
+	}
+
+	panel := fetchDetailPanel(t, s, ent, id)
+	if got, ok := detailPanelValueByLabel(panel, "Наименование"); !ok || got != "После правки" {
+		t.Fatalf("панель не показала сохранённое наименование: %+v", panel)
+	}
+	if got, ok := detailPanelValueByLabel(panel, "Вес"); !ok || got != "12.4" {
+		t.Fatalf("панель не показала сохранённый вес: %+v", panel)
+	}
+}
+
 // fetchDetailPanel зовёт публичный хендлер панели и разбирает ответ.
 func fetchDetailPanel(t *testing.T, s *Server, ent *metadata.Entity, id uuid.UUID) detailPanelData {
 	t.Helper()
@@ -404,6 +443,9 @@ func TestDetailPanel_ClientRuntime(t *testing.T) {
 	}
 	if !strings.Contains(js, "if (typeof obDetailInvalidate === 'function') obDetailInvalidate()") {
 		t.Error("live refresh не инвалидирует кэш панели деталей")
+	}
+	if !strings.Contains(js, "ob-detail-field-image") || !strings.Contains(js, "object-fit:contain") {
+		t.Error("картинка панели не получает отдельную компоновку с автоподгоном")
 	}
 }
 

--- a/internal/ui/dsl_reference_tx_test.go
+++ b/internal/ui/dsl_reference_tx_test.go
@@ -19,7 +19,11 @@ import (
 // must rebind it to the current transaction; otherwise ПолучитьОбъект() waits
 // for a second connection forever because SQLite deliberately uses a pool of 1.
 func TestDocWriterOnWriteRebindsTablePartReferenceToTransaction(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// Это предохранитель от исходного deadlock, а не performance assertion.
+	// Две секунды оказались меньше честного времени на загруженном Windows
+	// runner: исторический отказ #1062 завершился за 5.28s, тогда как тот же код
+	// в соседних прогонах проходил. Настоящий deadlock по-прежнему ограничен.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "test.db"))

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -698,26 +698,11 @@ func parseFormNumber(raw string) (decimal.Decimal, error) {
 	return result, nil
 }
 
-// checkFormNumberFields валидирует числовые реквизиты до запуска hook-ов и
-// транзакции записи, чтобы пользователь получил понятный ответ формы, а не
-// техническую ошибку драйвера PostgreSQL.
-func checkFormNumberFields(r *http.Request, entity *metadata.Entity) error {
-	for _, f := range entity.Fields {
-		if f.Type != metadata.FieldTypeNumber {
-			continue
-		}
-		raw := r.FormValue(f.Name)
-		if strings.TrimSpace(raw) == "" {
-			continue
-		}
-		if _, err := parseFormNumber(raw); err != nil {
-			return i18nerr.Errorf("поле %q: %v", f.Name, err)
-		}
-	}
-	return nil
-}
-
-func formToFields(r *http.Request, entity *metadata.Entity) map[string]any {
+// formToFields приводит каждый присланный реквизит шапки к объявленному типу
+// до границы storage. Табличные части идут через tablePartFieldValue; шапка
+// обязана пользоваться тем же закрытым разбором даты, иначе SQLite принимает
+// произвольный текст в TEXT-колонку даты, а PostgreSQL отвечает 500 (#1085).
+func formToFields(r *http.Request, entity *metadata.Entity) (map[string]any, error) {
 	fields := make(map[string]any)
 	for _, f := range entity.Fields {
 		val := r.FormValue(f.Name)
@@ -726,35 +711,27 @@ func formToFields(r *http.Request, entity *metadata.Entity) map[string]any {
 			continue
 		}
 		switch f.Type {
-		case metadata.FieldTypeDate:
-			parsed := false
-			for _, layout := range []string{"2006-01-02T15:04:05", "2006-01-02T15:04", "2006-01-02"} {
-				if t, err := time.ParseInLocation(layout, val, time.Local); err == nil {
-					fields[f.Name] = t
-					parsed = true
-					break
-				}
-			}
-			if !parsed {
-				fields[f.Name] = val
-			}
-		case metadata.FieldTypeBool:
-			fields[f.Name] = val == "true"
-		case metadata.FieldTypeNumber:
-			if n, err := parseFormNumber(val); err == nil {
-				fields[f.Name] = n
-			} else {
-				fields[f.Name] = val
-			}
 		case metadata.FieldTypeRichText:
 			// Санитизация на ЗАПИСИ: вырезаем script/on*/внешние src ещё до
 			// сохранения (на выводе санитизируем повторно — defense-in-depth).
 			fields[f.Name] = richtext.Sanitize(val)
+		case metadata.FieldTypeNumber:
+			value, err := parseFormNumber(val)
+			if err != nil {
+				return nil, i18nerr.Errorf("поле %q: %v", f.Name, err)
+			}
+			fields[f.Name] = value
+		case metadata.FieldTypeDate, metadata.FieldTypeBool:
+			value, err := typedFormFieldValue(f, val)
+			if err != nil {
+				return nil, i18nerr.Errorf("поле %q: %v", f.Name, err)
+			}
+			fields[f.Name] = value
 		default:
 			fields[f.Name] = val
 		}
 	}
-	return fields
+	return fields, nil
 }
 
 // checkRichTextLimits проверяет, что ни одно richtext-поле формы не превышает

--- a/internal/ui/handlers_entity.go
+++ b/internal/ui/handlers_entity.go
@@ -580,16 +580,12 @@ func (s *Server) parseSubmitForm(w http.ResponseWriter, r *http.Request, entity 
 		http.Error(w, s.errText(r, err), 400)
 		return
 	}
-	if err := checkFormNumberFields(r, entity); err != nil {
-		http.Error(w, s.errText(r, err), http.StatusBadRequest)
-		return
-	}
-	fields = formToFields(r, entity)
-	if form := pickManagedForm(entity, "object"); form != nil {
+	form := pickManagedForm(entity, "object")
+	if form != nil {
 		var parseErr error
 		tpRows, parseErr = parseTablePartRowsForManagedForm(r, entity, form, true)
 		if parseErr != nil {
-			http.Error(w, s.errText(r, parseErr), http.StatusBadRequest)
+			s.renderObjectFormBadRequest(w, r, entity, existingID == nil, parseErr.Error(), tpRows)
 			return
 		}
 		// ValueTable attributes are form-local and are not persisted by
@@ -598,7 +594,7 @@ func (s *Server) parseSubmitForm(w http.ResponseWriter, r *http.Request, entity 
 		// through the hooks; Save still writes only entity.TableParts.
 		valueTables, parseErr := parseValueTableRowsForManagedForm(r, form, entity, true)
 		if parseErr != nil {
-			http.Error(w, s.errText(r, parseErr), http.StatusBadRequest)
+			s.renderObjectFormBadRequest(w, r, entity, existingID == nil, parseErr.Error(), tpRows)
 			return
 		}
 		for name, rows := range valueTables {
@@ -608,9 +604,19 @@ func (s *Server) parseSubmitForm(w http.ResponseWriter, r *http.Request, entity 
 		var parseErr error
 		tpRows, parseErr = parseTablePartRows(r, entity)
 		if parseErr != nil {
-			http.Error(w, s.errText(r, parseErr), http.StatusBadRequest)
+			s.renderObjectFormBadRequest(w, r, entity, existingID == nil, parseErr.Error(), tpRows)
 			return
 		}
+	}
+
+	// Разбираем шапку после табличных частей: при ошибке типа форма
+	// перерисовывается с теми же строками, а не выбрасывает весь введённый
+	// документ на отдельную текстовую страницу (#1083).
+	var fieldsErr error
+	fields, fieldsErr = formToFields(r, entity)
+	if fieldsErr != nil {
+		s.renderObjectFormBadRequest(w, r, entity, existingID == nil, fieldsErr.Error(), tpRows)
+		return
 	}
 
 	if entity.Hierarchical {
@@ -688,6 +694,14 @@ func (s *Server) renderObjectFormError(w http.ResponseWriter, r *http.Request, e
 		data["IsPopup"] = r.FormValue("_popup") == "1" //nolint:gosec // G120: предел тела ставит вызывающий обработчик; gosec видит только присваивание r.Body в той же функции
 	}
 	s.renderEntityForm(w, r, "object", data)
+}
+
+func (s *Server) renderObjectFormBadRequest(w http.ResponseWriter, r *http.Request, entity *metadata.Entity, isNew bool, errMsg string, tpRows map[string][]map[string]any) {
+	// render() выставляет тот же заголовок, но после WriteHeader менять его уже
+	// поздно. Ответ остаётся настоящим 400 и при этом является HTML-формой.
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusBadRequest)
+	s.renderObjectFormError(w, r, entity, isNew, errMsg, nil, tpRows)
 }
 
 func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
@@ -2243,6 +2257,17 @@ func parseManagedTablePartRows(
 // nil дал бы «<nil>», поэтому проверка на nil там добавлена явно — иначе
 // полностью пустые строки перестали бы отсеиваться.
 func tablePartFieldValue(f metadata.Field, raw string) (any, error) {
+	value, err := typedFormFieldValue(f, raw)
+	if err != nil {
+		return nil, fmt.Errorf("реквизит %q: %v", f.Name, err)
+	}
+	return value, nil
+}
+
+// typedFormFieldValue — общий разбор скалярных типов для шапки и табличных
+// частей. Ошибка здесь не содержит имени реквизита: каждый публичный путь
+// добавляет своё понятие (поле формы или реквизит строки) сам.
+func typedFormFieldValue(f metadata.Field, raw string) (any, error) {
 	switch f.Type {
 	case metadata.FieldTypeNumber:
 		if raw == "" {
@@ -2250,7 +2275,7 @@ func tablePartFieldValue(f metadata.Field, raw string) (any, error) {
 		}
 		number, err := strconv.ParseFloat(raw, 64)
 		if err != nil {
-			return nil, fmt.Errorf("реквизит %q: %q не число", f.Name, raw)
+			return nil, fmt.Errorf("%q не число", raw)
 		}
 		return number, nil
 	case metadata.FieldTypeBool:
@@ -2261,7 +2286,7 @@ func tablePartFieldValue(f metadata.Field, raw string) (any, error) {
 		}
 		canonical, ok := canonicalFormDate(raw)
 		if !ok {
-			return nil, fmt.Errorf("реквизит %q: %q не дата", f.Name, raw)
+			return nil, fmt.Errorf("%q не дата", raw)
 		}
 		return canonical, nil
 	}

--- a/internal/ui/handlers_managed_events.go
+++ b/internal/ui/handlers_managed_events.go
@@ -683,7 +683,10 @@ func buildObjectFromForm(
 	form *metadata.FormModule,
 	canWrite bool,
 ) (*runtime.Object, error) {
-	fields := formToFields(r, entity)
+	fields, err := formToFields(r, entity)
+	if err != nil {
+		return nil, err
+	}
 	tpRows, err := parseTablePartRowsForManagedForm(r, entity, form, canWrite)
 	if err != nil {
 		return nil, err

--- a/internal/ui/header_date_write_test.go
+++ b/internal/ui/header_date_write_test.go
@@ -1,0 +1,79 @@
+package ui
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Регрессия #1085 идёт публичным путём POST формы и одной матрицей держит
+// SQLite/PostgreSQL. До фикса SQLite подтверждал запись произвольного текста в
+// колонку даты ответом 303, а PostgreSQL падал с 500.
+func TestHeaderDateWrite_ПриводитсяКТипуДоЗаписи_1085(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		entity := &metadata.Entity{
+			Name: "ДатаШапки" + strings.ReplaceAll(uuid.NewString()[:8], "-", ""),
+			Kind: metadata.KindCatalog,
+			Fields: []metadata.Field{
+				{Name: "Наименование", Type: metadata.FieldTypeString},
+				{Name: "ДатаПоставки", Type: metadata.FieldTypeDate},
+			},
+		}
+		ts := tpw1074Server(t, db, []*metadata.Entity{entity})
+		client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}}
+		post := func(value string) (int, string) {
+			t.Helper()
+			resp, err := client.PostForm(ts.URL+"/ui/catalog/"+url.PathEscape(entity.Name)+"/new", url.Values{
+				"Наименование": {"Проба"},
+				"ДатаПоставки": {value},
+			}) //nolint:noctx // локальный httptest.Server
+			if err != nil {
+				t.Fatalf("POST формы: %v", err)
+			}
+			defer resp.Body.Close() //nolint:errcheck // тест читает тело сразу
+			body, _ := io.ReadAll(resp.Body)
+			return resp.StatusCode, string(body)
+		}
+
+		status, body := post("не дата")
+		if status != http.StatusBadRequest {
+			t.Fatalf("неверная дата: статус=%d, ожидался 400; body=%s", status, body)
+		}
+		if !strings.Contains(body, "не дата") || !strings.Contains(body, "<form") {
+			t.Fatalf("ошибка показана не в форме: %s", body)
+		}
+		rows, err := db.List(context.Background(), entity.Name, entity, storage.ListParams{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 0 {
+			t.Fatalf("неверная дата попала в базу: %#v", rows)
+		}
+
+		status, body = post("14.03.1985")
+		if status != http.StatusSeeOther {
+			t.Fatalf("допустимая дата: статус=%d, ожидался 303; body=%s", status, body)
+		}
+		rows, err = db.List(context.Background(), entity.Name, entity, storage.ListParams{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("записей=%d, ожидалась одна", len(rows))
+		}
+		if got := tpw1074Day(t, rows[0]["ДатаПоставки"]); got != "1985-03-14" {
+			t.Fatalf("ДатаПоставки=%v (%s), ожидался день 1985-03-14", rows[0]["ДатаПоставки"], got)
+		}
+	})
+}

--- a/internal/ui/number_input_test.go
+++ b/internal/ui/number_input_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -93,8 +94,15 @@ func TestParseSubmitForm_InvalidNumberReturnsWarningBeforeStorage(t *testing.T) 
 	if response.Code != http.StatusBadRequest {
 		t.Fatalf("статус = %d, ожидался 400", response.Code)
 	}
-	if body := response.Body.String(); !strings.Contains(body, "поле \"Значение\": некорректное число") {
+	if body := html.UnescapeString(response.Body.String()); !strings.Contains(body, "поле \"Значение\": некорректное число") {
 		t.Errorf("нет понятного предупреждения: %q", body)
+	} else {
+		if !strings.Contains(body, "<form") {
+			t.Errorf("ошибка показана отдельной текстовой страницей, а не в форме: %q", body)
+		}
+		if !strings.Contains(body, `value="12,3x"`) {
+			t.Errorf("форма потеряла введённое значение: %q", body)
+		}
 	}
 }
 

--- a/internal/ui/richtext_test.go
+++ b/internal/ui/richtext_test.go
@@ -32,7 +32,10 @@ func TestFormToFields_SanitizesRichText(t *testing.T) {
 	req := httptest.NewRequest("POST", "/", nil)
 	req.PostForm = body
 
-	fields := formToFields(req, richtextEntity())
+	fields, err := formToFields(req, richtextEntity())
+	if err != nil {
+		t.Fatal(err)
+	}
 	got, _ := fields["Результат"].(string)
 	if got == "" {
 		t.Fatalf("Результат пуст, ожидался санитизированный HTML")

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -3777,6 +3777,7 @@ function obDetailRender() {
         label.textContent = f.label;
         wrap.appendChild(label);
         if (f.kind === 'image' && f.value) {
+          wrap.className += ' ob-detail-field-image';
           var img = document.createElement('img');
           img.className = 'ob-detail-image';
           img.src = '/ui/_image/' + encodeURIComponent(f.value);
@@ -3874,7 +3875,10 @@ function initDetailPanel() {
     '.ob-detail-field{display:flex;gap:8px;padding:4px 0;border-bottom:1px solid #f1f5f9;font-size:13px}' +
     '.ob-detail-label{flex:0 0 42%;color:#64748b}' +
     '.ob-detail-value{flex:1 1 auto;word-break:break-word}' +
-    '.ob-detail-image{max-width:100%;border-radius:6px;margin-top:4px}' +
+    '.ob-detail-field-image{display:block;overflow:hidden}' +
+    '.ob-detail-field-image .ob-detail-label{display:block;margin-bottom:6px}' +
+    '.ob-detail-image{display:block;width:100%;height:auto;max-width:100%;max-height:calc(100vh - 260px);' +
+    'object-fit:contain;object-position:center;border-radius:6px}' +
     '.ob-detail-empty{color:#94a3b8;font-size:13px;margin:4px 0 0}' +
     /* Узкий экран: третья колонка недопустима — панель уходит под список. */
     '@media(max-width:820px){.ob-list-wrap{flex-direction:column}.ob-detail{width:auto!important;max-height:none}}';


### PR DESCRIPTION
## Что исправлено

- `onebase renumber` пропускает объекты, чьи таблицы ещё не успела создать оборванная миграция; разведка лаунчера снова доходит до кнопки дозаполнения кодов.
- Реквизиты даты в шапке приводятся к типу до записи. Некорректные дата/число возвращают заполненную форму с баннером ошибки вместо отдельной текстовой страницы.
- Изображение в панели деталей использует всю ширину панели и вписывается по ширине/высоте; публичный регрессионный тест подтверждает актуальные значения после редактирования.
- Scheduler-тесты дожидаются graceful shutdown до закрытия БД; deadline теста транзакционной ссылки остаётся предохранителем от deadlock, но не случайным performance-гейтом Windows.

## Проверка

- `go test ./...`
- `go test ./internal/scheduler -count=3`
- `go test ./internal/ui -run '^TestDocWriterOnWriteRebindsTablePartReferenceToTransaction$' -count=40`

Fixes #1062
Fixes #1080
Fixes #1083
Fixes #1085