### PR TITLE
fix(http): isolate personalized service cache responses

### DIFF
--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -178,7 +178,7 @@ func (s *Server) serviceDispatch(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Accept-Encoding")
 		if clientAcceptsGzip(r) {
 			gzw := newGzipResponseWriter(w)
-			defer gzw.Close()
+			defer gzw.closeAfterHandler()
 			w = gzw
 		}
 	}
@@ -266,7 +266,7 @@ func (s *Server) serviceDispatch(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		out := w
-		capture := newCacheCapture()
+		capture := newCacheCapture(out, svc.Cache.BodyLimit())
 		defer func() {
 			// Паника обработчика раскручивает стек через этот defer: capture в
 			// этот момент — нетронутый 200 с пустым телом, и без проверки он
@@ -275,7 +275,7 @@ func (s *Server) serviceDispatch(w http.ResponseWriter, r *http.Request) {
 			if rec := recover(); rec != nil {
 				panic(rec)
 			}
-			if capture.cacheable(svc.Cache.BodyLimit()) {
+			if capture.cacheable(svc) {
 				resp := capture.toCachedResponse()
 				s.svcCache.Put(key, svc.RootURL, resp, time.Duration(svc.Cache.TTL)*time.Second)
 				s.svcCache.forgetUncacheable(key)

--- a/internal/ui/services_cache.go
+++ b/internal/ui/services_cache.go
@@ -296,8 +296,9 @@ func (c *serviceCache) removeElement(el *list.Element) {
 
 // serviceCacheKey строит ключ запроса.
 //
-// Параметры запроса сортируются: без этого «?a=1&b=2» и «?b=2&a=1» дали бы две
-// записи с одинаковым содержимым.
+// Имена параметров запроса сортируются: без этого «?a=1&b=2» и «?b=2&a=1»
+// дали бы две записи с одинаковым содержимым. Значения одного имени сохраняют
+// исходный порядок: DSL читает первое значение, поэтому переставлять их нельзя.
 func serviceCacheKey(svc *httpservice.Service, r *http.Request, lang string) string {
 	var b strings.Builder
 	b.WriteString(svc.RootURL)
@@ -331,9 +332,7 @@ func sortedQuery(q url.Values) string {
 	sort.Strings(keys)
 	var b strings.Builder
 	for _, k := range keys {
-		vals := append([]string(nil), q[k]...)
-		sort.Strings(vals)
-		for _, v := range vals {
+		for _, v := range q[k] {
 			b.WriteString(url.QueryEscape(k))
 			b.WriteByte('=')
 			b.WriteString(url.QueryEscape(v))
@@ -348,38 +347,159 @@ func computeETag(body []byte) string {
 	return `W/"` + hex.EncodeToString(sum[:8]) + `"`
 }
 
-// cacheCapture собирает ответ обработчика в память вместо отправки клиенту.
+// cacheCapture собирает ответ обработчика в память до limit. Если очередная
+// запись пересекает предел, уже собранный префикс и все последующие байты сразу
+// уходят в out: max_body остаётся настоящим пределом памяти, а клиент не теряет
+// ни статус, ни заголовки, ни начало тела.
 type cacheCapture struct {
-	header http.Header
-	status int
-	body   []byte
+	out         http.ResponseWriter
+	header      http.Header
+	status      int
+	body        []byte
+	limit       int64
+	wroteHeader bool
+	passthrough bool
 }
 
-func newCacheCapture() *cacheCapture {
-	return &cacheCapture{header: make(http.Header), status: http.StatusOK}
+func newCacheCapture(out http.ResponseWriter, limit int64) *cacheCapture {
+	return &cacheCapture{out: out, header: make(http.Header), status: http.StatusOK, limit: limit}
 }
 
 func (c *cacheCapture) Header() http.Header { return c.header }
 
-func (c *cacheCapture) WriteHeader(status int) { c.status = status }
+func (c *cacheCapture) WriteHeader(status int) {
+	if c.wroteHeader {
+		return
+	}
+	c.wroteHeader = true
+	c.status = status
+}
 
 func (c *cacheCapture) Write(p []byte) (int, error) {
+	if c.passthrough {
+		return c.out.Write(p) //nolint:gosec // тело формирует обработчик сервиса
+	}
+	if !c.wroteHeader {
+		c.WriteHeader(http.StatusOK)
+	}
+	remaining := c.limit - int64(len(c.body))
+	if remaining >= 0 && int64(len(p)) <= remaining {
+		c.appendBody(p)
+		return len(p), nil
+	}
+
+	c.passthrough = true
+	copyCapturedHeaders(c.out.Header(), c.header)
+	c.out.WriteHeader(c.status)
+	if len(c.body) > 0 {
+		if _, err := c.out.Write(c.body); err != nil { //nolint:gosec // тело формирует обработчик сервиса
+			c.body = nil
+			return 0, err
+		}
+		c.body = nil
+	}
+	return c.out.Write(p) //nolint:gosec // тело формирует обработчик сервиса
+}
+
+// appendBody растит буфер геометрически, но его capacity никогда не превышает
+// max_body. Это важно: проверка только len оставила бы скрытый перерасход из-за
+// запаса, который append выделяет самостоятельно.
+func (c *cacheCapture) appendBody(p []byte) {
+	newLen := len(c.body) + len(p)
+	if newLen > cap(c.body) {
+		newCap := cap(c.body)
+		if newCap == 0 {
+			newCap = 512
+			if int64(newCap) > c.limit {
+				newCap = newLen
+			}
+		}
+		for newCap < newLen {
+			grown := newCap + newCap/2
+			if grown <= newCap || int64(grown) > c.limit {
+				newCap = newLen
+				break
+			}
+			newCap = grown
+		}
+		next := make([]byte, len(c.body), newCap)
+		copy(next, c.body)
+		c.body = next
+	}
 	c.body = append(c.body, p...)
-	return len(p), nil
+}
+
+func copyCapturedHeaders(dst, src http.Header) {
+	for k, vals := range src {
+		for _, v := range vals {
+			dst.Add(k, v)
+		}
+	}
 }
 
 // cacheable решает, можно ли сохранить собранный ответ.
 //
-// Только 200 и только без Set-Cookie: «404 залип на час» — типовой инцидент
-// CMS, а кэшированный Set-Cookie раздал бы одну сессию нескольким клиентам.
-func (c *cacheCapture) cacheable(limit int64) bool {
-	if c.status != http.StatusOK {
+// Помимо 200 запрещены Set-Cookie, приватные cache directives и Vary, который
+// внутренний ключ не умеет воспроизвести. Иначе один клиент мог бы наполнить
+// общую запись персонализированным ответом для всех остальных.
+func (c *cacheCapture) cacheable(svc *httpservice.Service) bool {
+	if c.passthrough || c.status != http.StatusOK {
 		return false
 	}
-	if len(c.header.Values("Set-Cookie")) > 0 {
+	if len(c.header.Values("Set-Cookie")) > 0 ||
+		(c.out != nil && len(c.out.Header().Values("Set-Cookie")) > 0) {
 		return false
 	}
-	return int64(len(c.body)) <= limit
+	if cacheControlDisallowsStorage(c.header) ||
+		(c.out != nil && cacheControlDisallowsStorage(c.out.Header())) {
+		return false
+	}
+	if !handlerVarySupported(c.header, svc) {
+		return false
+	}
+	return int64(len(c.body)) <= c.limit
+}
+
+func cacheControlDisallowsStorage(h http.Header) bool {
+	for _, value := range h.Values("Cache-Control") {
+		for _, raw := range strings.Split(value, ",") {
+			name, directiveValue, hasValue := strings.Cut(strings.TrimSpace(raw), "=")
+			switch strings.ToLower(strings.TrimSpace(name)) {
+			case "no-store", "private", "no-cache":
+				return true
+			case "max-age", "s-maxage":
+				if !hasValue {
+					continue
+				}
+				directiveValue = strings.Trim(strings.TrimSpace(directiveValue), `"`)
+				seconds, err := strconv.ParseUint(directiveValue, 10, 64)
+				if err == nil && seconds == 0 {
+					// Внутренний кэш не умеет revalidation: немедленно
+					// протухший ответ нельзя подменять его собственным TTL.
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// handlerVarySupported проверяет только Vary, заданный самим обработчиком.
+// Vary: Accept-Encoding, который ставит внешний слой компрессии, сюда не
+// попадает: в кэше хранится несжатое тело, а кодирование выбирается при выдаче.
+func handlerVarySupported(h http.Header, svc *httpservice.Service) bool {
+	for _, value := range h.Values("Vary") {
+		for _, raw := range strings.Split(value, ",") {
+			name := strings.ToLower(strings.TrimSpace(raw))
+			if name == "" {
+				continue
+			}
+			if name != "accept-language" || !svc.Cache.VaryBy("lang") {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (c *cacheCapture) toCachedResponse() *cachedResponse {
@@ -423,12 +543,11 @@ func writeCachedResponse(w http.ResponseWriter, r *http.Request, resp *cachedRes
 
 // flushCapture отдаёт некэшируемый ответ клиенту как есть.
 func flushCapture(w http.ResponseWriter, c *cacheCapture) {
-	h := w.Header()
-	for k, vals := range c.header {
-		for _, v := range vals {
-			h.Add(k, v)
-		}
+	if c.passthrough {
+		return
 	}
+	h := w.Header()
+	copyCapturedHeaders(h, c.header)
 	w.WriteHeader(c.status)
 	_, _ = w.Write(c.body) //nolint:gosec // G705: ответ уже сформирован обработчиком сервиса
 }
@@ -445,6 +564,15 @@ func (s *Server) serviceCacheUsable(svc *httpservice.Service, r *http.Request) b
 	}
 	if !svc.CacheUsable() {
 		warnCacheIgnoredOnce(svc)
+		return false
+	}
+	// Даже auth: none может получить Cookie/Authorization, а DSL видит все
+	// заголовки запроса. Не даём такому клиенту наполнить общую запись своим
+	// персонализированным ответом. no-cache/no-store на запросе тоже требуют
+	// полного обхода локального кэша: механизм revalidation здесь отсутствует.
+	if r.Header.Get("Cookie") != "" || r.Header.Get("Authorization") != "" ||
+		r.Header.Get("Proxy-Authorization") != "" || cacheControlDisallowsStorage(r.Header) ||
+		strings.EqualFold(strings.TrimSpace(r.Header.Get("Pragma")), "no-cache") {
 		return false
 	}
 	return true

--- a/internal/ui/services_cache_test.go
+++ b/internal/ui/services_cache_test.go
@@ -6,6 +6,7 @@ package ui
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -49,6 +50,24 @@ const cacheHandlersSrc = `
     Отв = Новый HTTPСервисОтвет(200);
     Отв.УстановитьЗаголовок("Set-Cookie", "sid=abc");
     Отв.УстановитьТелоИзСтроки("сессия");
+    Возврат Отв;
+КонецФункции
+
+Функция Персональный(Запрос) Экспорт
+    Возврат ОтветТекст(200, Запрос.ПолучитьЗаголовок("Cookie") + Запрос.ПолучитьЗаголовок("Authorization"));
+КонецФункции
+
+Функция УправлениеКэшем(Запрос) Экспорт
+    Отв = Новый HTTPСервисОтвет(200);
+    Отв.УстановитьЗаголовок("Cache-Control", Запрос.ПолучитьЗаголовок("X-Cache-Policy"));
+    Отв.УстановитьТелоИзСтроки(Запрос.ПолучитьЗаголовок("X-Client"));
+    Возврат Отв;
+КонецФункции
+
+Функция ПоАрендатору(Запрос) Экспорт
+    Отв = Новый HTTPСервисОтвет(200);
+    Отв.УстановитьЗаголовок("Vary", "X-Tenant");
+    Отв.УстановитьТелоИзСтроки(Запрос.ПолучитьЗаголовок("X-Tenant"));
     Возврат Отв;
 КонецФункции
 
@@ -146,6 +165,9 @@ func newCacheTestServer(t *testing.T) *cacheTestServer {
 		{Template: "/page", Methods: map[string]string{"GET": "Страница", "POST": "Страница"}},
 		{Template: "/missing", Methods: map[string]string{"GET": "Ошибка404"}},
 		{Template: "/cookie", Methods: map[string]string{"GET": "Куки"}},
+		{Template: "/personal", Methods: map[string]string{"GET": "Персональный"}},
+		{Template: "/cache-policy", Methods: map[string]string{"GET": "УправлениеКэшем"}},
+		{Template: "/tenant", Methods: map[string]string{"GET": "ПоАрендатору"}},
 		{Template: "/big", Methods: map[string]string{"GET": "Большая"}},
 		{Template: "/boom", Methods: map[string]string{"GET": "Бум"}},
 		{Template: "/slow404", Methods: map[string]string{"GET": "ОтказСМодулем"}},
@@ -351,6 +373,22 @@ func TestServiceCache_VaryQuery(t *testing.T) {
 	}
 }
 
+// Значения одного query-параметра не взаимозаменяемы: DSL берёт первое.
+// Имена параметров можно канонизировать, но сортировка значений склеила бы
+// семантически разные запросы в одну запись.
+func TestServiceCache_VaryQueryPreservesRepeatedValueOrder(t *testing.T) {
+	c := newCacheTestServer(t)
+	c.get(t, "/hs/pub/page?role=user&role=admin")
+	c.get(t, "/hs/pub/page?role=admin&role=user")
+	if got := c.calls(); got != 2 {
+		t.Fatalf("разный порядок повторяющихся значений склеен в один cache key, вызовов=%d", got)
+	}
+	c.get(t, "/hs/pub/page?role=user&role=admin")
+	if got := c.calls(); got != 2 {
+		t.Fatalf("точный повтор первого запроса не дал hit, вызовов=%d", got)
+	}
+}
+
 // Пустой vary — осознанный режим «одна страница для всех».
 func TestServiceCache_VaryEmptyIgnoresQuery(t *testing.T) {
 	c := newCacheTestServer(t)
@@ -401,6 +439,105 @@ func TestServiceCache_NoCacheForErrorsAndCookies(t *testing.T) {
 	}
 }
 
+// Даже сервис auth:none видит Cookie и Authorization через объект Запрос.
+// Такие запросы не должны наполнять общий кэш: иначе ответ первого клиента
+// станет ответом второго, даже если обработчик не выставил Vary сам.
+func TestServiceCache_SensitiveRequestHeadersKeepClientsIsolated(t *testing.T) {
+	for _, tc := range []struct {
+		name, header, first, second, path string
+	}{
+		{"cookie", "Cookie", "client=alice", "client=bob", "/hs/pub/personal?kind=cookie"},
+		{"authorization", "Authorization", "Bearer alice", "Bearer bob", "/hs/pub/personal?kind=auth"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newCacheTestServer(t)
+			first := c.get(t, tc.path, tc.header, tc.first)
+			second := c.get(t, tc.path, tc.header, tc.second)
+			if got := first.Body.String(); got != tc.first {
+				t.Fatalf("первый клиент получил %q, ожидалось %q", got, tc.first)
+			}
+			if got := second.Body.String(); got != tc.second {
+				t.Fatalf("второй клиент получил %q, ожидалось %q", got, tc.second)
+			}
+			if size := c.cache.Size(); size != 0 {
+				t.Fatalf("персонализированный ответ попал в общий кэш: size=%d", size)
+			}
+		})
+	}
+}
+
+func TestServiceCache_ResponseCacheControlKeepsClientsIsolated(t *testing.T) {
+	for _, policy := range []string{
+		"no-store", "private, max-age=60", "no-cache", "max-age=0", `s-maxage="0"`,
+	} {
+		t.Run(policy, func(t *testing.T) {
+			c := newCacheTestServer(t)
+			first := c.get(t, "/hs/pub/cache-policy", "X-Cache-Policy", policy, "X-Client", "alice")
+			second := c.get(t, "/hs/pub/cache-policy", "X-Cache-Policy", policy, "X-Client", "bob")
+			if got := first.Body.String(); got != "alice" {
+				t.Fatalf("первый клиент получил %q", got)
+			}
+			if got := second.Body.String(); got != "bob" {
+				t.Fatalf("директива %q не изолировала второго клиента: тело=%q", policy, got)
+			}
+			if got := second.Header().Get("Cache-Control"); got != policy {
+				t.Fatalf("Cache-Control потерян: %q", got)
+			}
+			if size := c.cache.Size(); size != 0 {
+				t.Fatalf("ответ с Cache-Control %q попал в кэш: size=%d", policy, size)
+			}
+		})
+	}
+}
+
+func TestServiceCache_RequestZeroMaxAgeBypassesReadAndWrite(t *testing.T) {
+	for _, directive := range []string{"max-age=0", `s-maxage="0"`} {
+		t.Run(directive, func(t *testing.T) {
+			c := newCacheTestServer(t)
+			path := "/hs/pub/page?request-cache-control=" + url.QueryEscape(directive)
+
+			// Холодный запрос с обязательной ревалидацией не должен наполнять
+			// кэш: следующий обычный запрос обязан снова дойти до origin.
+			c.get(t, path, "Cache-Control", directive)
+			c.get(t, path)
+			if got := c.calls(); got != 2 {
+				t.Fatalf("первый запрос с %q попал в кэш, вызовов origin=%d", directive, got)
+			}
+
+			// Обычный запрос выше уже прогрел запись; точный повтор даёт hit.
+			c.get(t, path)
+			if got := c.calls(); got != 2 {
+				t.Fatalf("обычная запись не дала hit, вызовов origin=%d", got)
+			}
+
+			// Но клиент с max-age=0/s-maxage=0 не может получить эту запись
+			// без origin revalidation, которой внутренний кэш не реализует.
+			c.get(t, path, "Cache-Control", directive)
+			if got := c.calls(); got != 3 {
+				t.Fatalf("запрос с %q прочитал готовую запись без origin, вызовов=%d", directive, got)
+			}
+		})
+	}
+}
+
+func TestServiceCache_UnsupportedHandlerVaryKeepsClientsIsolated(t *testing.T) {
+	c := newCacheTestServer(t)
+	first := c.get(t, "/hs/pub/tenant", "X-Tenant", "alpha")
+	second := c.get(t, "/hs/pub/tenant", "X-Tenant", "beta")
+	if got := first.Body.String(); got != "alpha" {
+		t.Fatalf("первый tenant получил %q", got)
+	}
+	if got := second.Body.String(); got != "beta" {
+		t.Fatalf("неподдерживаемый Vary склеил клиентов: второй tenant получил %q", got)
+	}
+	if got := strings.Join(second.Header().Values("Vary"), ","); !strings.Contains(got, "X-Tenant") {
+		t.Fatalf("Vary обработчика потерян: %q", got)
+	}
+	if size := c.cache.Size(); size != 0 {
+		t.Fatalf("ответ с неподдерживаемым Vary попал в кэш: size=%d", size)
+	}
+}
+
 func TestServiceCache_MaxBody(t *testing.T) {
 	c := newCacheTestServer(t)
 	first := c.get(t, "/hs/pub/big")
@@ -413,6 +550,45 @@ func TestServiceCache_MaxBody(t *testing.T) {
 	c.get(t, "/hs/pub/big")
 	if c.calls() != 2 {
 		t.Fatalf("ответ больше max_body попал в кэш, вызовов=%d", c.calls())
+	}
+}
+
+func TestCacheCapture_MaxBodySwitchesToPassthroughWithoutLoss(t *testing.T) {
+	out := httptest.NewRecorder()
+	capture := newCacheCapture(out, 5)
+	capture.Header().Set("X-Capture", "kept")
+	capture.WriteHeader(http.StatusCreated)
+
+	if n, err := capture.Write([]byte("1234")); err != nil || n != 4 {
+		t.Fatalf("первая запись: n=%d err=%v", n, err)
+	}
+	if got := out.Body.String(); got != "" {
+		t.Fatalf("до достижения max_body данные ушли клиенту: %q", got)
+	}
+	if got := cap(capture.body); got > 5 {
+		t.Fatalf("capture выделил %d байт при max_body=5", got)
+	}
+
+	if n, err := capture.Write([]byte("567")); err != nil || n != 3 {
+		t.Fatalf("переход в passthrough: n=%d err=%v", n, err)
+	}
+	if n, err := capture.Write([]byte("89")); err != nil || n != 2 {
+		t.Fatalf("запись после перехода: n=%d err=%v", n, err)
+	}
+	if !capture.passthrough {
+		t.Fatal("превышение max_body не включило passthrough")
+	}
+	if len(capture.body) != 0 || cap(capture.body) != 0 {
+		t.Fatalf("capture удерживает тело после перехода: len=%d cap=%d", len(capture.body), cap(capture.body))
+	}
+	if out.Code != http.StatusCreated {
+		t.Fatalf("status=%d, ожидался %d", out.Code, http.StatusCreated)
+	}
+	if got := out.Header().Get("X-Capture"); got != "kept" {
+		t.Fatalf("заголовок потерян: %q", got)
+	}
+	if got := out.Body.String(); got != "123456789" {
+		t.Fatalf("тело потеряно/дублировано при переходе: %q", got)
 	}
 }
 

--- a/internal/ui/services_compress.go
+++ b/internal/ui/services_compress.go
@@ -11,6 +11,7 @@ package ui
 
 import (
 	"compress/gzip"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -159,6 +160,34 @@ func (w *gzipResponseWriter) Close() {
 		if err := w.gz.Close(); err != nil {
 			oblog.Component("http").Warn("сжатие ответа: не удалось закрыть поток", "error", err)
 		}
+		gzipWriterPool.Put(w.gz)
+		w.gz = nil
+	}
+}
+
+// closeAfterHandler завершает поток только при нормальном возврате. Если
+// обработчик запаниковал до отправки заголовков, буфер надо отбросить: иначе
+// обычный defer Close зафиксировал бы неявный 200 раньше внешнего Recoverer.
+// После commit исправить статус уже невозможно, поэтому начатый gzip-поток
+// всё же закрываем, чтобы не отдавать клиенту заведомо битое тело.
+func (w *gzipResponseWriter) closeAfterHandler() {
+	rec := recover()
+	if rec == nil {
+		w.Close()
+		return
+	}
+	if w.headersOut {
+		w.Close()
+	} else {
+		w.abort()
+	}
+	panic(rec)
+}
+
+func (w *gzipResponseWriter) abort() {
+	w.buf = nil
+	if w.gz != nil {
+		w.gz.Reset(io.Discard)
 		gzipWriterPool.Put(w.gz)
 		w.gz = nil
 	}

--- a/internal/ui/services_compress_test.go
+++ b/internal/ui/services_compress_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ivantit66/onebase/internal/dsl/lexer"
 	"github.com/ivantit66/onebase/internal/dsl/parser"
 	"github.com/ivantit66/onebase/internal/httpservice"
+	"github.com/ivantit66/onebase/internal/incident"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
 	"github.com/ivantit66/onebase/internal/websec"
@@ -63,6 +64,10 @@ const compressHandlersSrc = `
     Отв.УстановитьТелоИзСтроки(т);
     Возврат Отв;
 КонецФункции
+
+Функция Бум(Запрос) Экспорт
+    Возврат Утилиты.Бах(Запрос);
+КонецФункции
 `
 
 // newCompressTestServer поднимает сервер с тремя сервисами: публичный (сжатие
@@ -97,6 +102,7 @@ func newCompressTestServer(t *testing.T) *Server {
 		{Template: "/small", Methods: map[string]string{"GET": "Маленький"}},
 		{Template: "/png", Methods: map[string]string{"GET": "Картинка"}},
 		{Template: "/precompressed", Methods: map[string]string{"GET": "Готовый"}},
+		{Template: "/boom", Methods: map[string]string{"GET": "Бум"}},
 	}
 	yes := true
 	pub := &httpservice.Service{Name: "Pub", RootURL: "pub", Auth: "none", Templates: tmpl}
@@ -222,6 +228,29 @@ func TestCompress_BelowThreshold(t *testing.T) {
 	}
 	if got := w.Body.String(); got != "мало" {
 		t.Errorf("тело=%q, ожидалось «мало»", got)
+	}
+}
+
+func TestCompress_PanicBeforeCommitReachesRecoverer(t *testing.T) {
+	s := newCompressTestServer(t)
+	s.interp.LookupModuleProc = func(module, name string) *ast.ProcedureDecl {
+		panic("паника до commit")
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/hs/pub/boom", nil)
+	r.Header.Set("Accept-Encoding", "gzip")
+	h := incident.Recoverer(nil, nil)(http.HandlerFunc(s.serviceDispatch))
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("gzip defer преждевременно зафиксировал status=%d, ожидался 500; body=%q", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("Recoverer получил незавершённый Content-Encoding=%q", got)
+	}
+	if !strings.Contains(w.Body.String(), incident.Message("")) {
+		t.Fatalf("ответ Recoverer не дошёл до клиента: %q", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Что исправлено

- запросы с Cookie/Authorization и директивами revalidation обходят общий response cache;
- ответы `no-store`, `private`, `no-cache`, `max-age=0`, `s-maxage=0`, `Set-Cookie` и неподдерживаемый `Vary` не сохраняются;
- `cache.max_body` реально ограничивает capture memory и безопасно переходит в passthrough;
- порядок повторных query-параметров сохраняется в cache key;
- panic до commit при gzip больше не фиксирует ложный HTTP 200.

## Проверки

- `go test ./internal/ui -count=1`
- `go test ./internal/httpservice ./internal/configcheck -count=1`
- профильные regression tests после rebase на `main`
- `git diff --check`