### PR TITLE
fix(jobqueue): fence attempts and preserve parameter types

### DIFF
--- a/internal/jobqueue/pool.go
+++ b/internal/jobqueue/pool.go
@@ -148,7 +148,7 @@ type Pool struct {
 	mu         sync.Mutex
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
-	inflight   map[uuid.UUID]*inflightTask
+	inflight   map[storage.JobTaskLease]*inflightTask
 	stopping   bool
 }
 
@@ -157,6 +157,8 @@ type inflightTask struct {
 	cancel      context.CancelFunc
 	cancelled   bool // отмену запросил пользователь
 	interrupted bool // прервана остановкой сервера
+	leaseLost   bool // попытку уже изъял и заново захватил другой исполнитель
+	lease       storage.JobTaskLease
 }
 
 // New собирает пул. Обращений к базе не делает: схему заводит Run (и
@@ -183,7 +185,7 @@ func New(db *storage.DB, exec Executor, cfg Config) *Pool {
 		worker:   workerID(),
 		degraded: degraded,
 		nudge:    make(chan struct{}, 1),
-		inflight: make(map[uuid.UUID]*inflightTask),
+		inflight: make(map[storage.JobTaskLease]*inflightTask),
 	}
 	if cfg.Workers > 0 {
 		p.sem = make(chan struct{}, cfg.Workers)
@@ -281,7 +283,7 @@ func (p *Pool) Cancel(ctx context.Context, id uuid.UUID) (string, error) {
 		return "", err
 	}
 	if state == "cancelling" {
-		p.cancelLocal(id)
+		p.cancelLocalByID(id)
 	}
 	return state, nil
 }
@@ -422,7 +424,8 @@ func (p *Pool) start(task storage.JobTask) {
 		return
 	}
 	taskCtx, cancel := context.WithCancel(p.rootCtx)
-	p.inflight[task.ID] = &inflightTask{cancel: cancel}
+	lease := task.Lease()
+	p.inflight[lease] = &inflightTask{cancel: cancel, lease: lease}
 	p.wg.Add(1)
 	p.mu.Unlock()
 
@@ -441,13 +444,20 @@ func (p *Pool) start(task storage.JobTask) {
 func (p *Pool) execute(ctx context.Context, task storage.JobTask) {
 	started := time.Now()
 	output, err := p.exec.ExecuteJobOnce(ctx, task.JobName, task.Params)
-	state := p.finishInflight(task.ID)
+	state := p.finishInflight(task.Lease())
 	duration := time.Since(started)
 
 	switch {
+	case state.leaseLost:
+		// Heartbeat proved that this execution no longer owns the row. It may
+		// finish local cleanup, but any durable write would corrupt the newer
+		// attempt that reclaimed the task.
+		p.log.Warn("очередь: результат устаревшей попытки отброшен",
+			"job", task.JobName, "task", task.ID.String(), "attempt", task.Attempts)
 	case state.cancelled:
-		p.finalize(task, storage.JobTaskCancelled, output, "отменена пользователем")
-		p.log.Info("очередь: задача отменена", "job", task.JobName, "task", task.ID.String())
+		if p.finalize(task, storage.JobTaskCancelled, output, "отменена пользователем") == storage.JobTaskCancelled {
+			p.log.Info("очередь: задача отменена", "job", task.JobName, "task", task.ID.String())
+		}
 	case state.interrupted:
 		// Прервана остановкой сервера: попытка потрачена не по вине задачи,
 		// поэтому она возвращается в очередь немедленно (или уходит в карантин,
@@ -456,9 +466,14 @@ func (p *Pool) execute(ctx context.Context, task storage.JobTask) {
 	case err != nil:
 		p.retryOrQuarantine(task, output, err, p.backoff(task.Attempts))
 	default:
-		p.finalize(task, storage.JobTaskDone, output, "")
-		p.log.Info("очередь: задача выполнена", "job", task.JobName, "task", task.ID.String(),
-			"duration_ms", duration.Milliseconds(), "attempt", task.Attempts)
+		switch p.finalize(task, storage.JobTaskDone, output, "") {
+		case storage.JobTaskDone:
+			p.log.Info("очередь: задача выполнена", "job", task.JobName, "task", task.ID.String(),
+				"duration_ms", duration.Milliseconds(), "attempt", task.Attempts)
+		case storage.JobTaskCancelled:
+			p.log.Info("очередь: задача отменена до записи успешного результата",
+				"job", task.JobName, "task", task.ID.String())
+		}
 	}
 }
 
@@ -466,8 +481,20 @@ func (p *Pool) retryOrQuarantine(task storage.JobTask, output string, runErr err
 	if task.Attempts < task.MaxAttempts {
 		ctx, cancel := context.WithTimeout(context.Background(), finalizeTimeout)
 		defer cancel()
-		if err := p.db.RetryJobTask(ctx, task.ID, time.Now().Add(delay).UnixMilli(), runErr.Error()); err != nil {
+		now := time.Now()
+		actual, err := p.db.RetryJobTask(ctx, task.Lease(), now.Add(delay).UnixMilli(), now.UnixMilli(), runErr.Error())
+		if err != nil {
+			if errors.Is(err, storage.ErrJobLeaseLost) {
+				p.log.Warn("очередь: повтор устаревшей попытки отброшен",
+					"task", task.ID.String(), "attempt", task.Attempts)
+				return
+			}
 			p.log.Error("очередь: не удалось вернуть задачу в очередь", "task", task.ID.String(), "err", err)
+			return
+		}
+		if actual == storage.JobTaskCancelled {
+			p.log.Info("очередь: отмена выиграла гонку с повтором",
+				"job", task.JobName, "task", task.ID.String(), "attempt", task.Attempts)
 			return
 		}
 		p.log.Warn("очередь: задача упала, будет повтор", "job", task.JobName, "task", task.ID.String(),
@@ -477,22 +504,35 @@ func (p *Pool) retryOrQuarantine(task storage.JobTask, output string, runErr err
 		}
 		return
 	}
-	p.finalize(task, storage.JobTaskDead, output, runErr.Error())
-	p.log.Error("очередь: задача в карантине — попытки исчерпаны", "job", task.JobName,
-		"task", task.ID.String(), "attempts", task.Attempts, "err", runErr)
+	switch p.finalize(task, storage.JobTaskDead, output, runErr.Error()) {
+	case storage.JobTaskDead:
+		p.log.Error("очередь: задача в карантине — попытки исчерпаны", "job", task.JobName,
+			"task", task.ID.String(), "attempts", task.Attempts, "err", runErr)
+	case storage.JobTaskCancelled:
+		p.log.Info("очередь: отмена выиграла гонку с карантином",
+			"job", task.JobName, "task", task.ID.String(), "attempt", task.Attempts)
+	}
 }
 
 // finalize пишет терминальный статус на отдельном ограниченном контексте:
 // контекст задачи к этому моменту может быть уже отменён (таймаут, остановка),
 // а результат обязан дойти до базы — иначе задача останется running до
 // истечения аренды и будет исполнена повторно без причины.
-func (p *Pool) finalize(task storage.JobTask, status, output, errText string) {
+func (p *Pool) finalize(task storage.JobTask, status, output, errText string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), finalizeTimeout)
 	defer cancel()
-	if err := p.db.FinishJobTask(ctx, task.ID, status, output, errText, nowMs()); err != nil {
+	actual, err := p.db.FinishJobTask(ctx, task.Lease(), status, output, errText, nowMs())
+	if err != nil {
+		if errors.Is(err, storage.ErrJobLeaseLost) {
+			p.log.Warn("очередь: результат устаревшей попытки отброшен",
+				"task", task.ID.String(), "attempt", task.Attempts, "status", status)
+			return ""
+		}
 		p.log.Error("очередь: не удалось записать результат задачи",
 			"task", task.ID.String(), "status", status, "err", err)
+		return ""
 	}
+	return actual
 }
 
 // requeueUnstarted возвращает в очередь задачу, которую захватили, но так и не
@@ -506,7 +546,8 @@ func (p *Pool) finalize(task storage.JobTask, status, output, errText string) {
 func (p *Pool) requeueUnstarted(task storage.JobTask, reason string) {
 	ctx, cancel := context.WithTimeout(context.Background(), finalizeTimeout)
 	defer cancel()
-	if err := p.db.RetryJobTask(ctx, task.ID, nowMs(), reason); err != nil {
+	now := nowMs()
+	if _, err := p.db.RetryJobTask(ctx, task.Lease(), now, now, reason); err != nil {
 		p.log.Error("очередь: не удалось вернуть незапущенную задачу", "task", task.ID.String(), "err", err)
 	}
 }
@@ -545,19 +586,22 @@ func (p *Pool) heartbeatLoop(ctx context.Context) {
 }
 
 func (p *Pool) heartbeat(ctx context.Context) {
-	ids := p.inflightIDs()
-	if len(ids) == 0 {
+	leases := p.inflightLeases()
+	if len(leases) == 0 {
 		return
 	}
-	cancelled, err := p.db.RenewJobLeases(ctx, ids, time.Now().Add(p.cfg.Lease).UnixMilli())
+	cancelled, lost, err := p.db.RenewJobLeases(ctx, leases, time.Now().Add(p.cfg.Lease).UnixMilli())
 	if err != nil {
 		if ctx.Err() == nil {
-			p.log.Warn("очередь: не удалось продлить аренду задач", "count", len(ids), "err", err)
+			p.log.Warn("очередь: не удалось продлить аренду задач", "count", len(leases), "err", err)
 		}
 		return
 	}
-	for _, id := range cancelled {
-		p.cancelLocal(id)
+	for _, lease := range cancelled {
+		p.cancelLocal(lease)
+	}
+	for _, lease := range lost {
+		p.loseLocalLease(lease)
 	}
 }
 
@@ -674,9 +718,9 @@ func (p *Pool) interruptInflight() int {
 	return len(tasks)
 }
 
-func (p *Pool) cancelLocal(id uuid.UUID) {
+func (p *Pool) cancelLocal(lease storage.JobTaskLease) {
 	p.mu.Lock()
-	task := p.inflight[id]
+	task := p.inflight[lease]
 	if task != nil {
 		task.cancelled = true
 	}
@@ -686,26 +730,53 @@ func (p *Pool) cancelLocal(id uuid.UUID) {
 	}
 }
 
+func (p *Pool) cancelLocalByID(id uuid.UUID) {
+	p.mu.Lock()
+	tasks := make([]*inflightTask, 0, 1)
+	for lease, task := range p.inflight {
+		if lease.ID == id {
+			task.cancelled = true
+			tasks = append(tasks, task)
+		}
+	}
+	p.mu.Unlock()
+	for _, task := range tasks {
+		task.cancel()
+	}
+}
+
+func (p *Pool) loseLocalLease(lease storage.JobTaskLease) {
+	p.mu.Lock()
+	task := p.inflight[lease]
+	if task != nil {
+		task.leaseLost = true
+	}
+	p.mu.Unlock()
+	if task != nil {
+		task.cancel()
+	}
+}
+
 // finishInflight снимает задачу с учёта и отдаёт её финальное состояние.
-func (p *Pool) finishInflight(id uuid.UUID) inflightTask {
+func (p *Pool) finishInflight(lease storage.JobTaskLease) inflightTask {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	task := p.inflight[id]
-	delete(p.inflight, id)
+	task := p.inflight[lease]
+	delete(p.inflight, lease)
 	if task == nil {
 		return inflightTask{}
 	}
 	return *task
 }
 
-func (p *Pool) inflightIDs() []uuid.UUID {
+func (p *Pool) inflightLeases() []storage.JobTaskLease {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	ids := make([]uuid.UUID, 0, len(p.inflight))
-	for id := range p.inflight {
-		ids = append(ids, id)
+	leases := make([]storage.JobTaskLease, 0, len(p.inflight))
+	for lease := range p.inflight {
+		leases = append(leases, lease)
 	}
-	return ids
+	return leases
 }
 
 func (p *Pool) isStopping() bool {

--- a/internal/jobqueue/pool_internal_test.go
+++ b/internal/jobqueue/pool_internal_test.go
@@ -1,0 +1,54 @@
+package jobqueue
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func TestPool_ПопыткиОднойЗадачиУчитываютсяРаздельно(t *testing.T) {
+	id := uuid.New()
+	oldLease := storage.JobTaskLease{ID: id, Worker: "worker/1", Attempt: 1, Token: "old-token"}
+	newLease := storage.JobTaskLease{ID: id, Worker: "worker/1", Attempt: 2, Token: "new-token"}
+	oldCtx, cancelOld := context.WithCancel(context.Background())
+	newCtx, cancelNew := context.WithCancel(context.Background())
+	defer cancelOld()
+	defer cancelNew()
+	p := &Pool{inflight: map[storage.JobTaskLease]*inflightTask{
+		oldLease: {cancel: cancelOld, lease: oldLease},
+		newLease: {cancel: cancelNew, lease: newLease},
+	}}
+
+	p.loseLocalLease(oldLease)
+	select {
+	case <-oldCtx.Done():
+	default:
+		t.Fatal("потерявшая аренду попытка не остановлена")
+	}
+	select {
+	case <-newCtx.Done():
+		t.Fatal("потеря старой аренды остановила новую попытку")
+	default:
+	}
+	oldState := p.finishInflight(oldLease)
+	if !oldState.leaseLost {
+		t.Fatal("старая попытка не помечена как потерявшая аренду")
+	}
+	if p.InFlight() != 1 {
+		t.Fatalf("завершение старой попытки сняло новую с учёта: active=%d", p.InFlight())
+	}
+
+	p.cancelLocal(newLease)
+	select {
+	case <-newCtx.Done():
+	default:
+		t.Fatal("текущая попытка не получила отмену")
+	}
+	newState := p.finishInflight(newLease)
+	if !newState.cancelled {
+		t.Fatal("текущая попытка не сохранила состояние отмены")
+	}
+}

--- a/internal/jobqueue/pool_test.go
+++ b/internal/jobqueue/pool_test.go
@@ -336,6 +336,52 @@ func TestPool_ОтменаСнимаетОжидающуюИПрерываетИ
 	})
 }
 
+func TestPool_УдаленнаяОтменаВыигрываетГонкуДоHeartbeat(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		for _, tc := range []struct {
+			name   string
+			runErr error
+		}{
+			{name: "ошибка ведёт к RetryJobTask", runErr: errors.New("узел не ответил")},
+			{name: "успех ведёт к FinishJobTask"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				release := make(chan struct{})
+				exec := newFakeExec(func(context.Context, map[string]any) (string, error) {
+					<-release
+					return "результат", tc.runErr
+				})
+				cfg := testConfig(1)
+				cfg.Lease = 30 * time.Second // heartbeat не успеет увидеть отмену
+				cfg.MaxAttempts = 3
+				pool, stop := startPool(t, db, exec, cfg)
+
+				task, _, err := pool.Enqueue(context.Background(), "ОбменСУзлом", nil, "")
+				if err != nil {
+					t.Fatalf("Enqueue: %v", err)
+				}
+				waitStarts(t, exec, 1)
+				state, err := db.RequestJobTaskCancel(context.Background(), task.ID, time.Now().UnixMilli(), "отменена другим сервером")
+				if err != nil || state != "cancelling" {
+					t.Fatalf("RequestJobTaskCancel: state=%q err=%v", state, err)
+				}
+				close(release)
+
+				cancelled := waitStatus(t, pool, task.ID, storage.JobTaskCancelled)
+				if cancelled.Attempts != 1 || cancelled.Error != "отменена другим сервером" {
+					t.Fatalf("удаленная отмена потерялась: %+v", cancelled)
+				}
+				if got := exec.attempts(); got != 1 {
+					t.Fatalf("после отмены задача стартовала %d раз", got)
+				}
+				if err := stop(); err != nil {
+					t.Fatalf("stop: %v", err)
+				}
+			})
+		}
+	})
+}
+
 func TestPool_ОстановкаДожидаетсяВзятыхЗадач(t *testing.T) {
 	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
 		exec := newFakeExec(func(context.Context, map[string]any) (string, error) {

--- a/internal/storage/jobqueue.go
+++ b/internal/storage/jobqueue.go
@@ -21,10 +21,13 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 // Статусы задачи. Терминальных три; отдельного «error» нет намеренно: упавшая
@@ -41,23 +44,45 @@ const (
 
 // JobTask — задача очереди.
 type JobTask struct {
-	ID          uuid.UUID      `json:"id"`
-	JobName     string         `json:"job_name"`
-	Params      map[string]any `json:"params,omitempty"`
-	Key         string         `json:"key,omitempty"`
-	Status      string         `json:"status"`
-	Attempts    int            `json:"attempts"`
-	MaxAttempts int            `json:"max_attempts"`
-	AvailableAt int64          `json:"available_at"`
-	CreatedAt   int64          `json:"created_at"`
-	StartedAt   int64          `json:"started_at,omitempty"`
-	FinishedAt  int64          `json:"finished_at,omitempty"`
-	LeaseUntil  int64          `json:"lease_until,omitempty"`
-	Worker      string         `json:"worker,omitempty"`
-	Cancel      bool           `json:"cancel_requested,omitempty"`
-	Error       string         `json:"error,omitempty"`
-	Output      string         `json:"output,omitempty"`
+	ID           uuid.UUID      `json:"id"`
+	JobName      string         `json:"job_name"`
+	Params       map[string]any `json:"params,omitempty"`
+	Key          string         `json:"key,omitempty"`
+	Status       string         `json:"status"`
+	Attempts     int            `json:"attempts"`
+	AttemptToken string         `json:"-"`
+	MaxAttempts  int            `json:"max_attempts"`
+	AvailableAt  int64          `json:"available_at"`
+	CreatedAt    int64          `json:"created_at"`
+	StartedAt    int64          `json:"started_at,omitempty"`
+	FinishedAt   int64          `json:"finished_at,omitempty"`
+	LeaseUntil   int64          `json:"lease_until,omitempty"`
+	Worker       string         `json:"worker,omitempty"`
+	Cancel       bool           `json:"cancel_requested,omitempty"`
+	Error        string         `json:"error,omitempty"`
+	Output       string         `json:"output,omitempty"`
 }
+
+// JobTaskLease identifies one concrete execution attempt. ID alone is not an
+// ownership proof: once a lease expires, another worker can claim the same row
+// with an incremented attempt. Every write made by an executor must therefore
+// carry this fencing tuple.
+type JobTaskLease struct {
+	ID      uuid.UUID
+	Worker  string
+	Attempt int
+	Token   string
+}
+
+// Lease returns the fencing tuple assigned by ClaimJobTasks.
+func (t JobTask) Lease() JobTaskLease {
+	return JobTaskLease{ID: t.ID, Worker: t.Worker, Attempt: t.Attempts, Token: t.AttemptToken}
+}
+
+// ErrJobLeaseLost means that the row still may exist, but the caller no longer
+// owns its running attempt. Treating it as a generic "not found" error is
+// dangerous: retrying the UPDATE would overwrite the worker that reclaimed it.
+var ErrJobLeaseLost = errors.New("job queue: lease ownership lost")
 
 // DurationMs — длительность последней попытки; 0, пока задача не завершилась.
 func (t JobTask) DurationMs() int64 {
@@ -72,7 +97,7 @@ func (t JobTask) Terminal() bool {
 	return t.Status == JobTaskDone || t.Status == JobTaskDead || t.Status == JobTaskCancelled
 }
 
-const jobTaskColumns = `id, job_name, params, key, status, attempts, max_attempts,
+const jobTaskColumns = `id, job_name, params, key, status, attempts, attempt_token, max_attempts,
 	available_at, created_at, started_at, finished_at, lease_until, worker,
 	cancel_requested, error, output`
 
@@ -87,6 +112,7 @@ func (db *DB) EnsureJobQueueSchema(ctx context.Context) error {
 			key              TEXT    NOT NULL DEFAULT '',
 			status           TEXT    NOT NULL DEFAULT 'pending',
 			attempts         INTEGER NOT NULL DEFAULT 0,
+			attempt_token    TEXT    NOT NULL DEFAULT '',
 			max_attempts     INTEGER NOT NULL DEFAULT 1,
 			available_at     BIGINT  NOT NULL DEFAULT 0,
 			created_at       BIGINT  NOT NULL DEFAULT 0,
@@ -100,6 +126,22 @@ func (db *DB) EnsureJobQueueSchema(ctx context.Context) error {
 		)`, d.TypeUUID(), d.TypeBool(), boolFalseLit(d))
 	if _, err := db.Exec(ctx, ddl); err != nil {
 		return fmt.Errorf("job queue: create _job_queue: %w", err)
+	}
+	// Таблица появилась до fencing-токена, поэтому CREATE IF NOT EXISTS сам
+	// существующие базы не обновит. Повторная проверка после ошибки ALTER
+	// закрывает гонку двух одновременно стартующих серверов.
+	hasAttemptToken, err := d.ColumnExists(ctx, db, "_job_queue", "attempt_token")
+	if err != nil {
+		return fmt.Errorf("job queue: inspect attempt_token: %w", err)
+	}
+	if !hasAttemptToken {
+		if _, alterErr := db.Exec(ctx,
+			`ALTER TABLE _job_queue ADD COLUMN attempt_token TEXT NOT NULL DEFAULT ''`); alterErr != nil {
+			hasAttemptToken, err = d.ColumnExists(ctx, db, "_job_queue", "attempt_token")
+			if err != nil || !hasAttemptToken {
+				return fmt.Errorf("job queue: add attempt_token: %w", alterErr)
+			}
+		}
 	}
 	// Драйвер SQLite исполняет по одному стейтменту за Exec, поэтому индексы
 	// заводятся отдельными вызовами (как в _scheduled_runs).
@@ -160,7 +202,7 @@ func (db *DB) EnqueueJobTask(ctx context.Context, task JobTask) (JobTask, bool, 
 
 	paramsJSON := ""
 	if len(task.Params) > 0 {
-		raw, err := json.Marshal(task.Params)
+		raw, err := marshalJobTaskParams(task.Params)
 		if err != nil {
 			return JobTask{}, false, fmt.Errorf("job queue: параметры задачи не сериализуются: %w", err)
 		}
@@ -217,6 +259,7 @@ func (db *DB) ClaimJobTasks(ctx context.Context, worker string, limit int, nowMs
 		return nil, nil
 	}
 	d := db.dialect
+	attemptToken := uuid.NewString()
 	skipLocked := ""
 	if d.Name() == "postgres" {
 		skipLocked = " FOR UPDATE SKIP LOCKED"
@@ -225,6 +268,7 @@ func (db *DB) ClaimJobTasks(ctx context.Context, worker string, limit int, nowMs
 		UPDATE _job_queue SET
 			status = 'running',
 			attempts = attempts + 1,
+			attempt_token = %s,
 			started_at = %s,
 			finished_at = 0,
 			lease_until = %s,
@@ -237,9 +281,9 @@ func (db *DB) ClaimJobTasks(ctx context.Context, worker string, limit int, nowMs
 			LIMIT %s%s
 		)
 		RETURNING %s`,
-		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), boolFalseLit(d),
-		d.Placeholder(4), d.Placeholder(5), skipLocked, jobTaskColumns)
-	rows, err := db.Query(ctx, q, nowMs, leaseUntilMs, worker, nowMs, limit)
+		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4), boolFalseLit(d),
+		d.Placeholder(5), d.Placeholder(6), skipLocked, jobTaskColumns)
+	rows, err := db.Query(ctx, q, attemptToken, nowMs, leaseUntilMs, worker, nowMs, limit)
 	if err != nil {
 		return nil, fmt.Errorf("job queue: захват задач: %w", err)
 	}
@@ -255,82 +299,137 @@ func (db *DB) ClaimJobTasks(ctx context.Context, worker string, limit int, nowMs
 	return out, rows.Err()
 }
 
-// RenewJobLeases продлевает аренду взятых задач и возвращает те из них, для
-// которых запрошена отмена. Обе вещи делает один запрос намеренно: heartbeat —
-// единственный момент, когда исполнитель гарантированно смотрит в базу, и
-// разносить их значило бы либо второй запрос на том же такте, либо задержку
-// отмены на целый цикл.
-func (db *DB) RenewJobLeases(ctx context.Context, ids []uuid.UUID, leaseUntilMs int64) ([]uuid.UUID, error) {
-	if len(ids) == 0 {
-		return nil, nil
+// RenewJobLeases продлевает только те попытки, которыми вызывающий всё ещё
+// владеет, и возвращает отдельно запрошенные отмены и потерянные аренды.
+//
+// Проверка worker+attempt+token — fencing: после reclaim та же строка получает
+// новый случайный token, и старый heartbeat не имеет права продлевать уже
+// чужую работу. Отдельный token нужен потому, что Replay сбрасывает Attempts.
+func (db *DB) RenewJobLeases(ctx context.Context, leases []JobTaskLease, leaseUntilMs int64) (cancelled, lost []JobTaskLease, err error) {
+	if len(leases) == 0 {
+		return nil, nil, nil
 	}
 	d := db.dialect
-	args := make([]any, 0, len(ids)+1)
+	args := make([]any, 0, 1+len(leases)*4)
 	args = append(args, leaseUntilMs)
-	placeholders := make([]string, len(ids))
-	for i, id := range ids {
-		placeholders[i] = d.Placeholder(i + 2)
-		args = append(args, id.String())
+	predicates := make([]string, 0, len(leases))
+	expected := make(map[JobTaskLease]struct{}, len(leases))
+	for _, lease := range leases {
+		base := len(args) + 1
+		predicates = append(predicates, fmt.Sprintf("(id = %s AND worker = %s AND attempts = %s AND attempt_token = %s)",
+			d.Placeholder(base), d.Placeholder(base+1), d.Placeholder(base+2), d.Placeholder(base+3)))
+		args = append(args, lease.ID.String(), lease.Worker, lease.Attempt, lease.Token)
+		expected[lease] = struct{}{}
 	}
 	q := fmt.Sprintf(`UPDATE _job_queue SET lease_until = %s
-		WHERE status = 'running' AND id IN (%s)
-		RETURNING id, cancel_requested`,
-		d.Placeholder(1), strings.Join(placeholders, ", "))
+		WHERE status = 'running' AND (%s)
+		RETURNING id, worker, attempts, attempt_token, cancel_requested`, d.Placeholder(1), strings.Join(predicates, " OR "))
 	rows, err := db.Query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("job queue: продление аренды: %w", err)
+		return nil, nil, fmt.Errorf("job queue: продление аренды: %w", err)
 	}
 	defer rows.Close()
-	var cancelled []uuid.UUID
+	seen := make(map[JobTaskLease]struct{}, len(leases))
 	for rows.Next() {
-		var id uuid.UUID
+		var lease JobTaskLease
 		var cancel bool
-		if err := rows.Scan(&id, &cancel); err != nil {
-			return nil, fmt.Errorf("job queue: продление аренды: %w", err)
+		if err := rows.Scan(&lease.ID, &lease.Worker, &lease.Attempt, &lease.Token, &cancel); err != nil {
+			return nil, nil, fmt.Errorf("job queue: продление аренды: %w", err)
 		}
+		seen[lease] = struct{}{}
 		if cancel {
-			cancelled = append(cancelled, id)
+			cancelled = append(cancelled, lease)
 		}
 	}
-	return cancelled, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	for lease := range expected {
+		if _, ok := seen[lease]; !ok {
+			lost = append(lost, lease)
+		}
+	}
+	return cancelled, lost, nil
 }
 
-// FinishJobTask переводит задачу в терминальный статус.
-func (db *DB) FinishJobTask(ctx context.Context, id uuid.UUID, status, output, errText string, finishedAtMs int64) error {
+// FinishJobTask переводит задачу в терминальный статус и возвращает фактически
+// записанный статус. Запрошенная параллельно отмена имеет приоритет даже если
+// обработчик успел успешно завершиться до следующего heartbeat.
+func (db *DB) FinishJobTask(ctx context.Context, lease JobTaskLease, status, output, errText string, finishedAtMs int64) (string, error) {
 	d := db.dialect
 	q := fmt.Sprintf(`UPDATE _job_queue SET
-			status = %s, finished_at = %s, output = %s, error = %s,
+			status = CASE WHEN cancel_requested THEN 'cancelled' ELSE %s END,
+			finished_at = %s, output = %s,
+			error = CASE WHEN cancel_requested THEN error ELSE %s END,
 			lease_until = 0, cancel_requested = %s
-		WHERE id = %s`,
+		WHERE id = %s AND status = 'running' AND worker = %s AND attempts = %s AND attempt_token = %s
+		RETURNING status`,
 		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), d.Placeholder(4),
-		boolFalseLit(d), d.Placeholder(5))
-	tag, err := db.Exec(ctx, q, status, finishedAtMs, output, errText, id.String())
+		boolFalseLit(d), d.Placeholder(5), d.Placeholder(6), d.Placeholder(7), d.Placeholder(8))
+	actual, err := db.jobTaskTransition(ctx, q, status, finishedAtMs, output, errText,
+		lease.ID.String(), lease.Worker, lease.Attempt, lease.Token)
 	if err != nil {
-		return fmt.Errorf("job queue: завершение задачи: %w", err)
+		if errors.Is(err, ErrJobLeaseLost) {
+			return "", fmt.Errorf("%w: завершение задачи %s (worker=%q attempt=%d)",
+				ErrJobLeaseLost, lease.ID, lease.Worker, lease.Attempt)
+		}
+		return "", fmt.Errorf("job queue: завершение задачи: %w", err)
 	}
-	if tag.RowsAffected != 1 {
-		return fmt.Errorf("job queue: завершение задачи %s: строка не найдена", id)
-	}
-	return nil
+	return actual, nil
 }
 
 // RetryJobTask возвращает упавшую задачу в очередь с отложенным стартом.
 // Счётчик попыток не трогается: его нарастил захват.
-func (db *DB) RetryJobTask(ctx context.Context, id uuid.UUID, availableAtMs int64, errText string) error {
+// Если отмена пришла раньше этого UPDATE, она выигрывает гонку: задача сразу
+// становится cancelled и уже не может вернуться в pending.
+func (db *DB) RetryJobTask(ctx context.Context, lease JobTaskLease, availableAtMs, finishedAtMs int64, errText string) (string, error) {
 	d := db.dialect
+	// CAST is required on PostgreSQL: inside CASE the untyped ELSE 0 otherwise
+	// makes the finished-at placeholder int4 before assignment to the BIGINT
+	// column, so epoch milliseconds fail to encode.
 	q := fmt.Sprintf(`UPDATE _job_queue SET
-			status = 'pending', available_at = %s, error = %s,
-			lease_until = 0, worker = '', finished_at = 0, cancel_requested = %s
-		WHERE id = %s`,
-		d.Placeholder(1), d.Placeholder(2), boolFalseLit(d), d.Placeholder(3))
-	tag, err := db.Exec(ctx, q, availableAtMs, errText, id.String())
+			status = CASE WHEN cancel_requested THEN 'cancelled' ELSE 'pending' END,
+			available_at = %s,
+			error = CASE WHEN cancel_requested THEN error ELSE %s END,
+			lease_until = 0, worker = '',
+			finished_at = CASE WHEN cancel_requested THEN CAST(%s AS BIGINT) ELSE 0 END,
+			cancel_requested = %s
+		WHERE id = %s AND status = 'running' AND worker = %s AND attempts = %s AND attempt_token = %s`,
+		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), boolFalseLit(d), d.Placeholder(4),
+		d.Placeholder(5), d.Placeholder(6), d.Placeholder(7))
+	q += " RETURNING status"
+	actual, err := db.jobTaskTransition(ctx, q, availableAtMs, errText, finishedAtMs,
+		lease.ID.String(), lease.Worker, lease.Attempt, lease.Token)
 	if err != nil {
-		return fmt.Errorf("job queue: повтор задачи: %w", err)
+		if errors.Is(err, ErrJobLeaseLost) {
+			return "", fmt.Errorf("%w: повтор задачи %s (worker=%q attempt=%d)",
+				ErrJobLeaseLost, lease.ID, lease.Worker, lease.Attempt)
+		}
+		return "", fmt.Errorf("job queue: повтор задачи: %w", err)
 	}
-	if tag.RowsAffected != 1 {
-		return fmt.Errorf("job queue: повтор задачи %s: строка не найдена", id)
+	return actual, nil
+}
+
+func (db *DB) jobTaskTransition(ctx context.Context, query string, args ...any) (string, error) {
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return "", err
 	}
-	return nil
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return "", err
+		}
+		return "", ErrJobLeaseLost
+	}
+	var status string
+	if err := rows.Scan(&status); err != nil {
+		return "", err
+	}
+	if rows.Next() {
+		return "", errors.New("job queue: переход изменил больше одной задачи")
+	}
+	return status, rows.Err()
 }
 
 // ReclaimExpiredJobTasks изымает задачи, чья аренда истекла: процесс исполнителя
@@ -340,21 +439,33 @@ func (db *DB) RetryJobTask(ctx context.Context, id uuid.UUID, availableAtMs int6
 // класс дефекта, что и брошенные прогоны из #966.
 func (db *DB) ReclaimExpiredJobTasks(ctx context.Context, nowMs int64, reason string) (requeued, dead int64, err error) {
 	d := db.dialect
+	// Отмена, которую исполнитель не успел увидеть до потери аренды, всё равно
+	// должна победить. Иначе reclaim вернул бы строку в pending, а следующий
+	// Claim сбросил cancel_requested и выполнил отменённую работу заново.
+	cancelQ := fmt.Sprintf(`UPDATE _job_queue SET
+			status = 'cancelled', finished_at = %s, lease_until = 0,
+			cancel_requested = %s
+		WHERE status = 'running' AND cancel_requested = %s
+		  AND lease_until > 0 AND lease_until < %s`,
+		d.Placeholder(1), boolFalseLit(d), boolTrueLit(d), d.Placeholder(2))
+	if _, err := db.Exec(ctx, cancelQ, nowMs, nowMs); err != nil {
+		return 0, 0, fmt.Errorf("job queue: изъятие отменённых задач: %w", err)
+	}
 	deadQ := fmt.Sprintf(`UPDATE _job_queue SET
 			status = 'dead', finished_at = %s, error = %s, lease_until = 0
 		WHERE status = 'running' AND lease_until > 0 AND lease_until < %s
-		  AND attempts >= max_attempts`,
-		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3))
+		  AND cancel_requested = %s AND attempts >= max_attempts`,
+		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), boolFalseLit(d))
 	deadTag, err := db.Exec(ctx, deadQ, nowMs, reason, nowMs)
 	if err != nil {
 		return 0, 0, fmt.Errorf("job queue: изъятие зависших (карантин): %w", err)
 	}
 	requeueQ := fmt.Sprintf(`UPDATE _job_queue SET
 			status = 'pending', available_at = %s, error = %s,
-			lease_until = 0, worker = ''
+			lease_until = 0, worker = '', attempt_token = ''
 		WHERE status = 'running' AND lease_until > 0 AND lease_until < %s
-		  AND attempts < max_attempts`,
-		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3))
+		  AND cancel_requested = %s AND attempts < max_attempts`,
+		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3), boolFalseLit(d))
 	requeueTag, err := db.Exec(ctx, requeueQ, nowMs, reason, nowMs)
 	if err != nil {
 		return 0, deadTag.RowsAffected, fmt.Errorf("job queue: изъятие зависших (возврат): %w", err)
@@ -366,29 +477,41 @@ func (db *DB) ReclaimExpiredJobTasks(ctx context.Context, nowMs int64, reason st
 // "cancelled" — снята до начала исполнения, "cancelling" — исполнителю
 // выставлена пометка (он увидит её на ближайшем heartbeat), "" — задача
 // терминальна или неизвестна.
+// Pending и running обрабатываются одним UPDATE: иначе Retry/Reclaim мог бы
+// перевести running в pending между двумя запросами, и отмена потерялась бы.
 func (db *DB) RequestJobTaskCancel(ctx context.Context, id uuid.UUID, nowMs int64, reason string) (string, error) {
 	d := db.dialect
-	pendingQ := fmt.Sprintf(`UPDATE _job_queue SET
-			status = 'cancelled', finished_at = %s, error = %s, lease_until = 0
-		WHERE id = %s AND status = 'pending'`,
-		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3))
-	tag, err := db.Exec(ctx, pendingQ, nowMs, reason, id.String())
+	q := fmt.Sprintf(`UPDATE _job_queue SET
+			status = CASE WHEN status = 'pending' THEN 'cancelled' ELSE status END,
+			finished_at = CASE WHEN status = 'pending' THEN %s ELSE finished_at END,
+			error = %s,
+			lease_until = CASE WHEN status = 'pending' THEN 0 ELSE lease_until END,
+			cancel_requested = CASE WHEN status = 'running' THEN %s ELSE cancel_requested END
+		WHERE id = %s AND status IN ('pending','running')
+		RETURNING status`,
+		d.Placeholder(1), d.Placeholder(2), boolTrueLit(d), d.Placeholder(3))
+	rows, err := db.Query(ctx, q, nowMs, reason, id.String())
 	if err != nil {
 		return "", fmt.Errorf("job queue: отмена задачи: %w", err)
 	}
-	if tag.RowsAffected == 1 {
-		return JobTaskCancelled, nil
+	defer rows.Close()
+	if !rows.Next() {
+		return "", rows.Err()
 	}
-	runningQ := fmt.Sprintf(`UPDATE _job_queue SET cancel_requested = %s
-		WHERE id = %s AND status = 'running'`, boolTrueLit(d), d.Placeholder(1))
-	tag, err = db.Exec(ctx, runningQ, id.String())
-	if err != nil {
-		return "", fmt.Errorf("job queue: отмена исполняемой задачи: %w", err)
+	var status string
+	if err := rows.Scan(&status); err != nil {
+		return "", fmt.Errorf("job queue: отмена задачи: %w", err)
 	}
-	if tag.RowsAffected == 1 {
+	if rows.Next() {
+		return "", errors.New("job queue: отмена изменила больше одной задачи")
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("job queue: отмена задачи: %w", err)
+	}
+	if status == JobTaskRunning {
 		return "cancelling", nil
 	}
-	return "", nil
+	return JobTaskCancelled, nil
 }
 
 // ReplayJobTask возвращает задачу из карантина в очередь со сброшенным счётчиком
@@ -399,7 +522,7 @@ func (db *DB) ReplayJobTask(ctx context.Context, id uuid.UUID, availableAtMs int
 	q := fmt.Sprintf(`UPDATE _job_queue SET
 			status = 'pending', attempts = 0, available_at = %s,
 			error = '', worker = '', started_at = 0, finished_at = 0,
-			lease_until = 0, cancel_requested = %s
+			lease_until = 0, attempt_token = '', cancel_requested = %s
 		WHERE id = %s AND status IN ('dead','cancelled')`,
 		d.Placeholder(1), boolFalseLit(d), d.Placeholder(2))
 	tag, err := db.Exec(ctx, q, availableAtMs, id.String())
@@ -519,16 +642,113 @@ func (db *DB) PruneJobTasks(ctx context.Context, nowMs, maxAgeMs int64) (int64, 
 	return tag.RowsAffected, nil
 }
 
+const jobTaskParamTypesKey = "$onebase:param-types:v1"
+
+// marshalJobTaskParams keeps the historical JSON object shape and adds a
+// sidecar describing values whose JSON representation loses the DSL type.
+// This matters during a rolling update: an old worker ignores the unknown
+// sidecar and still receives all ordinary parameters (plus decimal/date in the
+// same string form it understood before), while a new worker restores them.
+func marshalJobTaskParams(params map[string]any) ([]byte, error) {
+	if _, reserved := params[jobTaskParamTypesKey]; reserved {
+		return nil, fmt.Errorf("имя %q зарезервировано платформой", jobTaskParamTypesKey)
+	}
+	persisted := make(map[string]any, len(params)+1)
+	types := make(map[string]string)
+	for name, value := range params {
+		switch typed := value.(type) {
+		case decimal.Decimal:
+			persisted[name] = typed.String()
+			types[name] = "decimal"
+		case time.Time:
+			persisted[name] = typed.Format(time.RFC3339Nano)
+			types[name] = "date"
+		default:
+			persisted[name] = value
+		}
+	}
+	// Empty sidecar is intentional: it distinguishes a new RFC3339-looking
+	// string from an old date that was persisted as an untagged string.
+	persisted[jobTaskParamTypesKey] = types
+	return json.Marshal(persisted)
+}
+
+func unmarshalJobTaskParams(raw []byte) (map[string]any, error) {
+	var encoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil, err
+	}
+	typesRaw, tagged := encoded[jobTaskParamTypesKey]
+	if tagged {
+		delete(encoded, jobTaskParamTypesKey)
+		var types map[string]string
+		if err := json.Unmarshal(typesRaw, &types); err != nil {
+			return nil, fmt.Errorf("служебная карта типов: %w", err)
+		}
+		params := make(map[string]any, len(encoded))
+		for name, rawValue := range encoded {
+			value, err := unmarshalJobTaskParam(rawValue, types[name])
+			if err != nil {
+				return nil, fmt.Errorf("параметр %q: %w", name, err)
+			}
+			params[name] = value
+		}
+		return params, nil
+	}
+
+	// Rows written before the typed sidecar must keep their historical execution
+	// types. An RFC3339-looking string may be either an old DSL date or an
+	// intentional string, and storage cannot distinguish them safely. The UI
+	// keeps its legacy display conversion at restoreTaskParam; execution gets the
+	// same string that an old worker would have received.
+	var legacy map[string]any
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		return nil, err
+	}
+	return legacy, nil
+}
+
+func unmarshalJobTaskParam(raw json.RawMessage, kind string) (any, error) {
+	if kind == "decimal" || kind == "date" {
+		var text string
+		if err := json.Unmarshal(raw, &text); err != nil {
+			return nil, err
+		}
+		if kind == "decimal" {
+			value, err := decimal.NewFromString(text)
+			if err != nil {
+				return nil, fmt.Errorf("неверное число %q: %w", text, err)
+			}
+			return value, nil
+		}
+		value, err := time.Parse(time.RFC3339Nano, text)
+		if err != nil {
+			return nil, fmt.Errorf("неверная дата %q: %w", text, err)
+		}
+		return value, nil
+	}
+	if kind != "" {
+		return nil, fmt.Errorf("неизвестный тип %q", kind)
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
 func scanJobTask(rows Rows) (JobTask, error) {
 	var t JobTask
 	var params, key, worker, errText, output *string
-	if err := rows.Scan(&t.ID, &t.JobName, &params, &key, &t.Status, &t.Attempts, &t.MaxAttempts,
+	if err := rows.Scan(&t.ID, &t.JobName, &params, &key, &t.Status, &t.Attempts, &t.AttemptToken, &t.MaxAttempts,
 		&t.AvailableAt, &t.CreatedAt, &t.StartedAt, &t.FinishedAt, &t.LeaseUntil, &worker,
 		&t.Cancel, &errText, &output); err != nil {
 		return JobTask{}, fmt.Errorf("job queue: разбор строки задачи: %w", err)
 	}
 	if params != nil && strings.TrimSpace(*params) != "" {
-		if err := json.Unmarshal([]byte(*params), &t.Params); err != nil {
+		var err error
+		t.Params, err = unmarshalJobTaskParams([]byte(*params))
+		if err != nil {
 			return JobTask{}, fmt.Errorf("job queue: параметры задачи %s не читаются: %w", t.ID, err)
 		}
 	}

--- a/internal/storage/jobqueue_matrix_test.go
+++ b/internal/storage/jobqueue_matrix_test.go
@@ -11,12 +11,15 @@ package storage_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/dbtest"
 	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/shopspring/decimal"
 )
 
 func TestJobQueue_ПостановкаЗахватИЗавершение(t *testing.T) {
@@ -80,7 +83,7 @@ func TestJobQueue_ПостановкаЗахватИЗавершение(t *test
 			t.Fatalf("вторая попытка захвата взяла %d задач, ожидался 0", len(again))
 		}
 
-		if err := db.FinishJobTask(ctx, task.ID, storage.JobTaskDone, "готово", "", now+5_000); err != nil {
+		if _, err := db.FinishJobTask(ctx, claimed[0].Lease(), storage.JobTaskDone, "готово", "", now+5_000); err != nil {
 			t.Fatalf("FinishJobTask: %v", err)
 		}
 		stored, err = db.JobTaskByID(ctx, task.ID)
@@ -92,6 +95,113 @@ func TestJobQueue_ПостановкаЗахватИЗавершение(t *test
 		}
 		if got := stored.DurationMs(); got != 5_000 {
 			t.Fatalf("длительность = %d мс, ожидалось 5000", got)
+		}
+	})
+}
+
+func TestJobQueue_ПараметрыСохраняютЧислоДатуИСтроку(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		now := time.Now().UnixMilli()
+		amount := decimal.RequireFromString("1234567890.010203")
+		moment := time.Date(2026, 8, 22, 14, 35, 17, 123456000, time.FixedZone("MSK", 3*60*60))
+		dateLikeString := moment.Format(time.RFC3339Nano)
+
+		task, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
+			JobName: "Типы", Params: map[string]any{
+				"Сумма": amount, "Момент": moment, "Строка": dateLikeString,
+			},
+			MaxAttempts: 1, AvailableAt: now, CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("EnqueueJobTask: %v", err)
+		}
+		stored, err := db.JobTaskByID(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("JobTaskByID: %v", err)
+		}
+		gotAmount, ok := stored.Params["Сумма"].(decimal.Decimal)
+		if !ok || !gotAmount.Equal(amount) {
+			t.Fatalf("Сумма = %#v (%T), ожидалось Decimal %s", stored.Params["Сумма"], stored.Params["Сумма"], amount)
+		}
+		gotMoment, ok := stored.Params["Момент"].(time.Time)
+		if !ok || !gotMoment.Equal(moment) {
+			t.Fatalf("Момент = %#v (%T), ожидалась дата %s", stored.Params["Момент"], stored.Params["Момент"], moment)
+		}
+		if got, ok := stored.Params["Строка"].(string); !ok || got != dateLikeString {
+			t.Fatalf("RFC3339-строка = %#v (%T), строковый тип потерян", stored.Params["Строка"], stored.Params["Строка"])
+		}
+	})
+}
+
+func TestJobQueue_СхемаДобавляетТокенПопыткиВСуществующуюТаблицу(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		d := db.Dialect()
+		if _, err := db.Exec(ctx, `DROP TABLE _job_queue`); err != nil {
+			t.Fatalf("DROP TABLE: %v", err)
+		}
+		oldDDL := fmt.Sprintf(`CREATE TABLE _job_queue (
+			id %s PRIMARY KEY, job_name TEXT NOT NULL, params TEXT NOT NULL DEFAULT '',
+			key TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'pending',
+			attempts INTEGER NOT NULL DEFAULT 0, max_attempts INTEGER NOT NULL DEFAULT 1,
+			available_at BIGINT NOT NULL DEFAULT 0, created_at BIGINT NOT NULL DEFAULT 0,
+			started_at BIGINT NOT NULL DEFAULT 0, finished_at BIGINT NOT NULL DEFAULT 0,
+			lease_until BIGINT NOT NULL DEFAULT 0, worker TEXT NOT NULL DEFAULT '',
+			cancel_requested %s NOT NULL DEFAULT FALSE,
+			error TEXT NOT NULL DEFAULT '', output TEXT NOT NULL DEFAULT '')`, d.TypeUUID(), d.TypeBool())
+		if _, err := db.Exec(ctx, oldDDL); err != nil {
+			t.Fatalf("создание старой схемы: %v", err)
+		}
+		id := uuid.New()
+		insert := fmt.Sprintf(`INSERT INTO _job_queue (id, job_name) VALUES (%s, %s)`,
+			d.Placeholder(1), d.Placeholder(2))
+		if _, err := db.Exec(ctx, insert, id.String(), "СтараяЗадача"); err != nil {
+			t.Fatalf("вставка строки старой схемы: %v", err)
+		}
+
+		if err := db.EnsureJobQueueSchema(ctx); err != nil {
+			t.Fatalf("EnsureJobQueueSchema после обновления: %v", err)
+		}
+		if err := db.EnsureJobQueueSchema(ctx); err != nil {
+			t.Fatalf("повторный EnsureJobQueueSchema: %v", err)
+		}
+		if has, err := d.ColumnExists(ctx, db, "_job_queue", "attempt_token"); err != nil || !has {
+			t.Fatalf("attempt_token: exists=%v err=%v", has, err)
+		}
+		claimed, err := db.ClaimJobTasks(ctx, "worker/1", 1, 0, 60_000)
+		if err != nil || len(claimed) != 1 || claimed[0].ID != id {
+			t.Fatalf("ClaimJobTasks после миграции: claimed=%+v err=%v", claimed, err)
+		}
+		if claimed[0].AttemptToken == "" {
+			t.Fatal("ClaimJobTasks не назначил fencing-токен")
+		}
+	})
+}
+
+func TestJobQueue_LegacyRFC3339СтрокаНеМеняетТипПриЧтении(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		id := uuid.New()
+		d := db.Dialect()
+		q := fmt.Sprintf(`INSERT INTO _job_queue (id, job_name, params) VALUES (%s, %s, %s)`,
+			d.Placeholder(1), d.Placeholder(2), d.Placeholder(3))
+		if _, err := db.Exec(ctx, q, id.String(), "СтараяЗадача",
+			`{"Момент":"2026-08-22T14:35:17+03:00","Сумма":"41.25"}`); err != nil {
+			t.Fatalf("вставка старой строки очереди: %v", err)
+		}
+
+		stored, err := db.JobTaskByID(ctx, id)
+		if err != nil {
+			t.Fatalf("JobTaskByID: %v", err)
+		}
+		if got, ok := stored.Params["Момент"].(string); !ok || got != "2026-08-22T14:35:17+03:00" {
+			t.Fatalf("старая RFC3339-строка = %#v (%T), тип изменился", stored.Params["Момент"], stored.Params["Момент"])
+		}
+		// Без type-sidecar ни старый decimal, ни дата неотличимы от намеренных
+		// строк. Их безопаснее оставить строками, чем менять поведение задачи.
+		if got, ok := stored.Params["Сумма"].(string); !ok || got != "41.25" {
+			t.Fatalf("старая числовая строка = %#v (%T)", stored.Params["Сумма"], stored.Params["Сумма"])
 		}
 	})
 }
@@ -126,7 +236,8 @@ func TestJobQueue_КлючИдемпотентностиНеПлодитДубл
 
 		// Захват не освобождает ключ: продюсер, тикающий раз в минуту, не должен
 		// дублировать работу, которая уже исполняется.
-		if _, err := db.ClaimJobTasks(ctx, "host/1", 10, now, now+60_000); err != nil {
+		claimed, err := db.ClaimJobTasks(ctx, "host/1", 10, now, now+60_000)
+		if err != nil {
 			t.Fatalf("ClaimJobTasks: %v", err)
 		}
 		duringRun, created := enqueue()
@@ -136,7 +247,7 @@ func TestJobQueue_КлючИдемпотентностиНеПлодитДубл
 
 		// А терминальная задача ключ отпускает — иначе ту же работу нельзя было
 		// бы повторить ни завтра, ни вообще.
-		if err := db.FinishJobTask(ctx, first.ID, storage.JobTaskDone, "", "", now+1_000); err != nil {
+		if _, err := db.FinishJobTask(ctx, claimed[0].Lease(), storage.JobTaskDone, "", "", now+1_000); err != nil {
 			t.Fatalf("FinishJobTask: %v", err)
 		}
 		next, created := enqueue()
@@ -157,10 +268,11 @@ func TestJobQueue_ПовторИКарантинПоИсчерпаниюПопы
 			t.Fatalf("EnqueueJobTask: %v", err)
 		}
 
-		if _, err := db.ClaimJobTasks(ctx, "host/1", 1, now, now+60_000); err != nil {
+		firstAttempt, err := db.ClaimJobTasks(ctx, "host/1", 1, now, now+60_000)
+		if err != nil {
 			t.Fatalf("ClaimJobTasks: %v", err)
 		}
-		if err := db.RetryJobTask(ctx, task.ID, now+30_000, "узел не ответил"); err != nil {
+		if _, err := db.RetryJobTask(ctx, firstAttempt[0].Lease(), now+30_000, now, "узел не ответил"); err != nil {
 			t.Fatalf("RetryJobTask: %v", err)
 		}
 		stored, err := db.JobTaskByID(ctx, task.ID)
@@ -191,7 +303,7 @@ func TestJobQueue_ПовторИКарантинПоИсчерпаниюПопы
 		if len(claimed) != 1 || claimed[0].Attempts != 2 {
 			t.Fatalf("вторая попытка не состоялась: %+v", claimed)
 		}
-		if err := db.FinishJobTask(ctx, task.ID, storage.JobTaskDead, "", "узел не ответил", now+31_000); err != nil {
+		if _, err := db.FinishJobTask(ctx, claimed[0].Lease(), storage.JobTaskDead, "", "узел не ответил", now+31_000); err != nil {
 			t.Fatalf("FinishJobTask(dead): %v", err)
 		}
 
@@ -273,6 +385,217 @@ func TestJobQueue_ИзъятиеЗадачиСИстёкшейАрендой(t *
 	})
 }
 
+func TestJobQueue_УстаревшаяПопыткаНеПродлеваетИНеПерезаписываетНовую(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		now := time.Now().UnixMilli()
+		task, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
+			JobName: "ОбменСУзлом", MaxAttempts: 3, AvailableAt: now, CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("EnqueueJobTask: %v", err)
+		}
+		first, err := db.ClaimJobTasks(ctx, "старый-worker", 1, now, now+1_000)
+		if err != nil || len(first) != 1 {
+			t.Fatalf("первый ClaimJobTasks: claimed=%+v err=%v", first, err)
+		}
+		if requeued, dead, err := db.ReclaimExpiredJobTasks(ctx, now+2_000, "аренда истекла"); err != nil {
+			t.Fatalf("ReclaimExpiredJobTasks: %v", err)
+		} else if requeued != 1 || dead != 0 {
+			t.Fatalf("reclaim: requeued=%d dead=%d, ожидалось 1/0", requeued, dead)
+		}
+		secondLeaseUntil := now + 120_000
+		second, err := db.ClaimJobTasks(ctx, "новый-worker", 1, now+2_000, secondLeaseUntil)
+		if err != nil || len(second) != 1 || second[0].Attempts != 2 {
+			t.Fatalf("повторный ClaimJobTasks: claimed=%+v err=%v", second, err)
+		}
+
+		renewedLeaseUntil := now + 180_000
+		cancelled, lost, err := db.RenewJobLeases(ctx,
+			[]storage.JobTaskLease{first[0].Lease(), second[0].Lease()}, renewedLeaseUntil)
+		if err != nil {
+			t.Fatalf("stale RenewJobLeases: %v", err)
+		}
+		if len(cancelled) != 0 || len(lost) != 1 || lost[0] != first[0].Lease() {
+			t.Fatalf("stale heartbeat: cancelled=%v lost=%v", cancelled, lost)
+		}
+		if _, err := db.FinishJobTask(ctx, first[0].Lease(), storage.JobTaskDone, "старый результат", "", now+3_000); !errors.Is(err, storage.ErrJobLeaseLost) {
+			t.Fatalf("stale FinishJobTask = %v, ожидался ErrJobLeaseLost", err)
+		}
+		if _, err := db.RetryJobTask(ctx, first[0].Lease(), now+4_000, now+3_000, "старый отказ"); !errors.Is(err, storage.ErrJobLeaseLost) {
+			t.Fatalf("stale RetryJobTask = %v, ожидался ErrJobLeaseLost", err)
+		}
+
+		stored, err := db.JobTaskByID(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("JobTaskByID: %v", err)
+		}
+		if stored.Status != storage.JobTaskRunning || stored.Worker != "новый-worker" ||
+			stored.Attempts != 2 || stored.LeaseUntil != renewedLeaseUntil || stored.Output != "" {
+			t.Fatalf("устаревшая попытка изменила новую: %+v", stored)
+		}
+		if _, err := db.FinishJobTask(ctx, second[0].Lease(), storage.JobTaskDone, "новый результат", "", now+5_000); err != nil {
+			t.Fatalf("новый владелец не смог завершить задачу: %v", err)
+		}
+	})
+}
+
+func TestJobQueue_ТокенПопыткиНеПовторяетсяПослеReplay(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		now := time.Now().UnixMilli()
+		task, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
+			JobName: "ОбменСУзлом", MaxAttempts: 1, AvailableAt: now, CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("EnqueueJobTask: %v", err)
+		}
+		first, err := db.ClaimJobTasks(ctx, "worker/1", 1, now, now+60_000)
+		if err != nil || len(first) != 1 || first[0].AttemptToken == "" {
+			t.Fatalf("первый ClaimJobTasks: claimed=%+v err=%v", first, err)
+		}
+		if _, err := db.FinishJobTask(ctx, first[0].Lease(), storage.JobTaskDead, "", "ошибка", now+100); err != nil {
+			t.Fatalf("FinishJobTask(dead): %v", err)
+		}
+		if err := db.ReplayJobTask(ctx, task.ID, now+200); err != nil {
+			t.Fatalf("ReplayJobTask: %v", err)
+		}
+		second, err := db.ClaimJobTasks(ctx, "worker/1", 1, now+200, now+60_000)
+		if err != nil || len(second) != 1 || second[0].Attempts != 1 {
+			t.Fatalf("второй ClaimJobTasks: claimed=%+v err=%v", second, err)
+		}
+		if second[0].AttemptToken == "" || second[0].AttemptToken == first[0].AttemptToken {
+			t.Fatalf("fencing-токен повторился после replay: first=%q second=%q",
+				first[0].AttemptToken, second[0].AttemptToken)
+		}
+		if _, err := db.FinishJobTask(ctx, first[0].Lease(), storage.JobTaskDone, "старый результат", "", now+300); !errors.Is(err, storage.ErrJobLeaseLost) {
+			t.Fatalf("FinishJobTask со старым токеном = %v, ожидался ErrJobLeaseLost", err)
+		}
+		if _, err := db.RetryJobTask(ctx, first[0].Lease(), now+400, now+300, "старая ошибка"); !errors.Is(err, storage.ErrJobLeaseLost) {
+			t.Fatalf("RetryJobTask со старым токеном = %v, ожидался ErrJobLeaseLost", err)
+		}
+		if _, err := db.FinishJobTask(ctx, second[0].Lease(), storage.JobTaskDone, "новый результат", "", now+400); err != nil {
+			t.Fatalf("FinishJobTask с новым токеном: %v", err)
+		}
+	})
+}
+
+func TestJobQueue_ОтменаВыигрываетГонкуСПовторомИЗавершением(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		now := time.Now().UnixMilli()
+
+		retryTask, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
+			JobName: "ОбменСУзлом", MaxAttempts: 3, AvailableAt: now, CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("EnqueueJobTask(retry): %v", err)
+		}
+		retryAttempt, err := db.ClaimJobTasks(ctx, "worker/1", 1, now, now+60_000)
+		if err != nil || len(retryAttempt) != 1 {
+			t.Fatalf("ClaimJobTasks(retry): claimed=%+v err=%v", retryAttempt, err)
+		}
+		if state, err := db.RequestJobTaskCancel(ctx, retryTask.ID, now+100, "отменена во время ошибки"); err != nil {
+			t.Fatalf("RequestJobTaskCancel(retry): %v", err)
+		} else if state != "cancelling" {
+			t.Fatalf("RequestJobTaskCancel(retry) = %q", state)
+		}
+		actual, err := db.RetryJobTask(ctx, retryAttempt[0].Lease(), now+30_000, now+200, "ошибка обработки")
+		if err != nil {
+			t.Fatalf("RetryJobTask после отмены: %v", err)
+		}
+		if actual != storage.JobTaskCancelled {
+			t.Fatalf("RetryJobTask после отмены записал %q вместо cancelled", actual)
+		}
+		stored, err := db.JobTaskByID(ctx, retryTask.ID)
+		if err != nil {
+			t.Fatalf("JobTaskByID(retry): %v", err)
+		}
+		if stored.Status != storage.JobTaskCancelled || stored.Cancel ||
+			stored.FinishedAt != now+200 || stored.Error != "отменена во время ошибки" {
+			t.Fatalf("отмена потерялась при RetryJobTask: %+v", stored)
+		}
+		if claimed, err := db.ClaimJobTasks(ctx, "worker/2", 1, now+30_000, now+90_000); err != nil {
+			t.Fatalf("ClaimJobTasks после отмены: %v", err)
+		} else if len(claimed) != 0 {
+			t.Fatalf("отменённая задача вернулась в pending и захвачена: %+v", claimed)
+		}
+
+		finishTask, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
+			JobName: "ОбменСУзлом", MaxAttempts: 1, AvailableAt: now, CreatedAt: now + 1,
+		})
+		if err != nil {
+			t.Fatalf("EnqueueJobTask(finish): %v", err)
+		}
+		finishAttempt, err := db.ClaimJobTasks(ctx, "worker/1", 1, now, now+60_000)
+		if err != nil || len(finishAttempt) != 1 || finishAttempt[0].ID != finishTask.ID {
+			t.Fatalf("ClaimJobTasks(finish): claimed=%+v err=%v", finishAttempt, err)
+		}
+		if _, err := db.RequestJobTaskCancel(ctx, finishTask.ID, now+300, "отменена перед результатом"); err != nil {
+			t.Fatalf("RequestJobTaskCancel(finish): %v", err)
+		}
+		actual, err = db.FinishJobTask(ctx, finishAttempt[0].Lease(), storage.JobTaskDone, "готово", "", now+400)
+		if err != nil {
+			t.Fatalf("FinishJobTask после отмены: %v", err)
+		}
+		if actual != storage.JobTaskCancelled {
+			t.Fatalf("FinishJobTask после отмены записал %q вместо cancelled", actual)
+		}
+		stored, err = db.JobTaskByID(ctx, finishTask.ID)
+		if err != nil {
+			t.Fatalf("JobTaskByID(finish): %v", err)
+		}
+		if stored.Status != storage.JobTaskCancelled || stored.Cancel ||
+			stored.FinishedAt != now+400 || stored.Error != "отменена перед результатом" {
+			t.Fatalf("отмена потерялась при FinishJobTask: %+v", stored)
+		}
+	})
+}
+
+func TestJobQueue_ОтменаВыигрываетГонкуСИзъятиемИстекшейАренды(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+		now := time.Now().UnixMilli()
+
+		task, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
+			JobName: "ОбменСУзлом", MaxAttempts: 3, AvailableAt: now, CreatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("EnqueueJobTask: %v", err)
+		}
+		claimed, err := db.ClaimJobTasks(ctx, "worker/1", 1, now, now+1_000)
+		if err != nil || len(claimed) != 1 {
+			t.Fatalf("ClaimJobTasks: claimed=%+v err=%v", claimed, err)
+		}
+		if state, err := db.RequestJobTaskCancel(ctx, task.ID, now+100, "отменена до reclaim"); err != nil {
+			t.Fatalf("RequestJobTaskCancel: %v", err)
+		} else if state != "cancelling" {
+			t.Fatalf("RequestJobTaskCancel = %q", state)
+		}
+
+		requeued, dead, err := db.ReclaimExpiredJobTasks(ctx, now+2_000, "аренда истекла")
+		if err != nil {
+			t.Fatalf("ReclaimExpiredJobTasks: %v", err)
+		}
+		if requeued != 0 || dead != 0 {
+			t.Fatalf("отменённая задача была повторена или карантинирована: requeued=%d dead=%d", requeued, dead)
+		}
+		stored, err := db.JobTaskByID(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("JobTaskByID: %v", err)
+		}
+		if stored.Status != storage.JobTaskCancelled || stored.Cancel ||
+			stored.FinishedAt != now+2_000 || stored.Error != "отменена до reclaim" {
+			t.Fatalf("reclaim потерял отмену: %+v", stored)
+		}
+		if claimed, err := db.ClaimJobTasks(ctx, "worker/2", 1, now+3_000, now+60_000); err != nil {
+			t.Fatalf("ClaimJobTasks после reclaim: %v", err)
+		} else if len(claimed) != 0 {
+			t.Fatalf("отменённая задача снова захвачена: %+v", claimed)
+		}
+	})
+}
+
 func TestJobQueue_ОтменаАрендаИУборка(t *testing.T) {
 	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
 		ctx := context.Background()
@@ -285,10 +608,13 @@ func TestJobQueue_ОтменаАрендаИУборка(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EnqueueJobTask: %v", err)
 		}
+		var runningAttempt storage.JobTask
 		if claimed, err := db.ClaimJobTasks(ctx, "host/1", 1, now, now+60_000); err != nil {
 			t.Fatalf("ClaimJobTasks: %v", err)
 		} else if len(claimed) != 1 || claimed[0].ID != running.ID {
 			t.Fatalf("захвачена не та задача: %+v", claimed)
+		} else {
+			runningAttempt = claimed[0]
 		}
 		waiting, _, err := db.EnqueueJobTask(ctx, storage.JobTask{
 			JobName: "ОбменСУзлом", MaxAttempts: 3, AvailableAt: now, CreatedAt: now + 1,
@@ -315,11 +641,14 @@ func TestJobQueue_ОтменаАрендаИУборка(t *testing.T) {
 
 		// Heartbeat продлевает аренду и приносит исполнителю пометку отмены —
 		// это единственный момент, когда он смотрит в базу.
-		cancelled, err := db.RenewJobLeases(ctx, []uuid.UUID{running.ID}, now+120_000)
+		cancelled, lost, err := db.RenewJobLeases(ctx, []storage.JobTaskLease{runningAttempt.Lease()}, now+120_000)
 		if err != nil {
 			t.Fatalf("RenewJobLeases: %v", err)
 		}
-		if len(cancelled) != 1 || cancelled[0] != running.ID {
+		if len(lost) != 0 {
+			t.Fatalf("heartbeat потерял живую аренду: %v", lost)
+		}
+		if len(cancelled) != 1 || cancelled[0] != runningAttempt.Lease() {
 			t.Fatalf("heartbeat не принёс отмену: %v", cancelled)
 		}
 		stored, err := db.JobTaskByID(ctx, running.ID)
@@ -330,7 +659,7 @@ func TestJobQueue_ОтменаАрендаИУборка(t *testing.T) {
 			t.Fatalf("аренда не продлена: %d", stored.LeaseUntil)
 		}
 
-		if err := db.FinishJobTask(ctx, running.ID, storage.JobTaskCancelled, "", "отменена", now+1_000); err != nil {
+		if _, err := db.FinishJobTask(ctx, runningAttempt.Lease(), storage.JobTaskCancelled, "", "отменена", now+1_000); err != nil {
 			t.Fatalf("FinishJobTask: %v", err)
 		}
 		stats, err := db.JobQueueStats(ctx)
@@ -348,7 +677,11 @@ func TestJobQueue_ОтменаАрендаИУборка(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EnqueueJobTask: %v", err)
 		}
-		if err := db.FinishJobTask(ctx, dead.ID, storage.JobTaskDead, "", "сдалась", now+1_000); err != nil {
+		deadAttempt, err := db.ClaimJobTasks(ctx, "host/1", 1, now, now+60_000)
+		if err != nil || len(deadAttempt) != 1 || deadAttempt[0].ID != dead.ID {
+			t.Fatalf("ClaimJobTasks(dead): claimed=%+v err=%v", deadAttempt, err)
+		}
+		if _, err := db.FinishJobTask(ctx, deadAttempt[0].Lease(), storage.JobTaskDead, "", "сдалась", now+1_000); err != nil {
 			t.Fatalf("FinishJobTask(dead): %v", err)
 		}
 		removed, err := db.PruneJobTasks(ctx, now+100_000, 10_000)

--- a/internal/ui/dsl_jobqueue.go
+++ b/internal/ui/dsl_jobqueue.go
@@ -241,10 +241,9 @@ func taskParamValue(name string, value any) any {
 	case decimal.Decimal:
 		return typed
 	case time.Time:
-		// Дата едет строкой RFC3339 и возвращается датой при чтении задачи —
-		// тем же способом, каким шаблоны {{today}} превращаются в даты на пути
-		// params регламентного задания.
-		return typed.Format(time.RFC3339)
+		// Storage сохраняет тип даты в служебной карте: строкой её здесь делать
+		// нельзя, иначе обработка очереди получит RFC3339 вместо DSL Даты.
+		return typed
 	}
 	interpreter.RaiseUserError("ФоновыеЗадания.Поставить: параметр «" + name +
 		"» имеет неподдерживаемый тип — допустимы строка, число, булево и дата " +
@@ -276,8 +275,9 @@ func jobTaskStruct(task *storage.JobTask) any {
 	return st
 }
 
-// restoreTaskParam возвращает значение параметра в DSL-виде: строка в формате
-// RFC3339 снова становится датой (см. taskParamValue).
+// restoreTaskParam сохраняет совместимость со строковыми датами в задачах,
+// поставленных до появления типизированной сериализации. Новые задачи storage
+// уже возвращает с time.Time и этот эвристический путь не используют.
 func restoreTaskParam(value any) any {
 	if text, ok := value.(string); ok {
 		if parsed, err := time.Parse(time.RFC3339, text); err == nil {

--- a/internal/ui/dsl_jobqueue_test.go
+++ b/internal/ui/dsl_jobqueue_test.go
@@ -8,11 +8,13 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
 	"github.com/ivantit66/onebase/internal/dsl/lexer"
@@ -42,7 +44,7 @@ func queueTestServer(t *testing.T, jobName, procBody string) *Server {
 		t.Fatal(err)
 	}
 
-	src := "Процедура Выполнить(Узел = \"\")\n" + procBody + "\nКонецПроцедуры"
+	src := "Процедура Выполнить(Узел = \"\", Сумма = 0, Момент = Неопределено)\n" + procBody + "\nКонецПроцедуры"
 	prog, err := parser.New(lexer.New(src, "фоновая.proc.os")).ParseProgram()
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +56,11 @@ func queueTestServer(t *testing.T, jobName, procBody string) *Server {
 		Title: "Фоновая",
 		// Параметр объявлен: очередь перекрывает params задания поимённо, а
 		// runProcessor отдаёт обработке только объявленные параметры.
-		Params: []processor.Param{{Name: "Узел", Type: "string"}},
+		Params: []processor.Param{
+			{Name: "Узел", Type: "string"},
+			{Name: "Сумма", Type: "number"},
+			{Name: "Момент", Type: "date"},
+		},
 	}})
 
 	interp := interpreter.New()
@@ -169,6 +175,64 @@ func TestФоновыеЗадания_ПоставитьИсполняетЗад
 	// 360 задач круга отличаются ровно узлом.
 	if !strings.Contains(done[1], "обмен с узлом N-042") {
 		t.Fatalf("вывод задачи = %q, ожидался обмен с узлом N-042", done[1])
+	}
+}
+
+func TestФоновыеЗадания_ЧислоИДатаДоходятДоФактическогоВыполненияСТипами(t *testing.T) {
+	s := queueTestServer(t, "ТипизированнаяЗадача", `
+		Сообщить(ТипЗнч(Сумма));
+		Сообщить(ТипЗнч(Момент));
+		Сообщить(Сумма + 0.75);
+		Если Момент = Дата(2026, 8, 22, 14, 35, 17) Тогда
+			Сообщить("дата совпала");
+		Иначе
+			Сообщить("дата потеряна");
+		КонецЕсли;`)
+
+	msgs, err := runQueueDSL(t, s, `
+		Параметры = Новый Структура;
+		Параметры.Вставить("Сумма", 41.25);
+		Параметры.Вставить("Момент", Дата(2026, 8, 22, 14, 35, 17));
+		Сообщить(ФоновыеЗадания.Поставить("ТипизированнаяЗадача", Параметры));`)
+	if err != nil {
+		t.Fatalf("Поставить: %v", err)
+	}
+	if len(msgs) != 1 || strings.TrimSpace(msgs[0]) == "" {
+		t.Fatalf("Поставить вернул %v, ожидался идентификатор задачи", msgs)
+	}
+
+	done := ждёмСтатусЗадачи(t, s, msgs[0], storage.JobTaskDone)
+	if got, want := done[1], "Число\nДата\n42\nдата совпала"; got != want {
+		t.Fatalf("типизированные параметры дошли как %q, ожидалось %q", got, want)
+	}
+}
+
+func TestФоновыеЗадания_LegacyRFC3339СтрокаОстаётсяСтрокойПриВыполнении(t *testing.T) {
+	const (
+		jobName = "LegacyСтроковаяДата"
+		value   = "2026-08-22T14:35:17+03:00"
+	)
+	s := queueTestServer(t, jobName, `
+		Сообщить(ТипЗнч(Момент));
+		Сообщить(Момент);`)
+	ctx := context.Background()
+	if err := s.store.EnsureJobQueueSchema(ctx); err != nil {
+		t.Fatalf("EnsureJobQueueSchema: %v", err)
+	}
+
+	// Имитируем задачу, записанную версией до type-sidecar. RFC3339 сам по
+	// себе не доказывает тип Дата: пользователь мог намеренно передать строку.
+	id := uuid.New()
+	d := s.store.Dialect()
+	q := fmt.Sprintf(`INSERT INTO _job_queue (id, job_name, params) VALUES (%s, %s, %s)`,
+		d.Placeholder(1), d.Placeholder(2), d.Placeholder(3))
+	if _, err := s.store.Exec(ctx, q, id.String(), jobName, `{"Момент":"`+value+`"}`); err != nil {
+		t.Fatalf("вставка legacy-задачи: %v", err)
+	}
+
+	done := ждёмСтатусЗадачи(t, s, id.String(), storage.JobTaskDone)
+	if got, want := done[1], "Строка\n"+value; got != want {
+		t.Fatalf("legacy-параметр дошёл как %q, ожидалось %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## ??? ??????????

- ??? renew/retry/finalize ????? ?????? ?? fencing tuple: task ID + worker + attempt + UUID token;
- ???????????? _job_queue ??????????? ????????????, ????????? ?????? ? replay ???????? ????? token;
- ?????? ???????? ?????????? ????? ? retry, finalize ? reclaim;
- pool ????????? ????????? ????????????? ??????? ?????? task ID ? ??????????? ????????? ?????????? ??????;
- Decimal ? Date ????????? ??? ????? JSON sidecar; legacy RFC3339-?????? ?? ???????????????????? ??? ??????????.

## ????????

- go test ./internal/storage ./internal/jobqueue ./internal/ui ./internal/scheduler -count=1
- targeted storage/UI regressions x10
- ??? ??????????? code review: approve, blockers ???

## Rollout

????? ???????? ????? ?????? ????? ??????????? workers ?????? ??????: ?? SQL ??? ?? ???????? fencing token, ??????? mixed-version ?????????? ????? ??????? ???????????.