### PR TITLE
fix(ui): F5 в режиме вкладок восстанавливает активную вкладку, а не первую

### DIFF
--- a/internal/ui/static/tabs_behavior_test.js
+++ b/internal/ui/static/tabs_behavior_test.js
@@ -1,0 +1,335 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const htmlPath = process.env.ONEBASE_TABS_HTML;
+assert.ok(htmlPath, 'ONEBASE_TABS_HTML must point to the rendered app shell');
+const html = fs.readFileSync(htmlPath, 'utf8');
+const source = Array.from(html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi), match => match[1])
+  .find(script => script.includes("var STORE='obTabs'"));
+assert.ok(source, 'rendered app shell must contain the tabs runtime');
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.names = new Set();
+  }
+
+  reset(value) {
+    this.names = new Set(String(value || '').split(/\s+/).filter(Boolean));
+  }
+
+  toggle(name, force) {
+    const enabled = force === undefined ? !this.names.has(name) : Boolean(force);
+    if (enabled) this.names.add(name);
+    else this.names.delete(name);
+    this.element._className = Array.from(this.names).join(' ');
+    return enabled;
+  }
+
+  contains(name) {
+    return this.names.has(name);
+  }
+}
+
+class Element {
+  constructor(tagName, id = '') {
+    this.tagName = String(tagName).toUpperCase();
+    this.id = id;
+    this.children = [];
+    this.parentElement = null;
+    this.style = {};
+    this.handlers = new Map();
+    this.attributes = new Map();
+    this._className = '';
+    this.classList = new ClassList(this);
+    this.textContent = '';
+    this.title = '';
+    this.src = '';
+    if (this.tagName === 'IFRAME') this.contentWindow = {};
+  }
+
+  set className(value) {
+    this._className = String(value);
+    this.classList.reset(value);
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  appendChild(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  remove() {
+    if (!this.parentElement) return;
+    const index = this.parentElement.children.indexOf(this);
+    if (index >= 0) this.parentElement.children.splice(index, 1);
+    this.parentElement = null;
+  }
+
+  addEventListener(type, listener) {
+    if (!this.handlers.has(type)) this.handlers.set(type, []);
+    this.handlers.get(type).push(listener);
+  }
+
+  dispatch(type, values = {}) {
+    const event = Object.assign({
+      target: this,
+      button: 0,
+      defaultPrevented: false,
+      preventDefault() { this.defaultPrevented = true; },
+      stopPropagation() {}
+    }, values);
+    for (const listener of this.handlers.get(type) || []) listener(event);
+    return event;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(String(name), String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(String(name)) ? this.attributes.get(String(name)) : null;
+  }
+
+  scrollIntoView() {}
+}
+
+class FakeStorage {
+  constructor(entries = {}, faults = {}) {
+    this.values = new Map(Object.entries(entries).map(([key, value]) => [key, String(value)]));
+    this.faults = faults;
+  }
+
+  getItem(key) {
+    if (this.faults.get) throw new Error('sessionStorage get blocked');
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    if (this.faults.set) throw new Error('sessionStorage set blocked');
+    this.values.set(String(key), String(value));
+  }
+
+  removeItem(key) {
+    if (this.faults.remove) throw new Error('sessionStorage remove blocked');
+    this.values.delete(String(key));
+  }
+}
+
+function shell(storage, search = '') {
+  const elements = {};
+  for (const id of ['ob-tabstrip', 'ob-tabbody', 'ob-tabempty', 'ob-tabhome']) {
+    elements[id] = new Element('div', id);
+  }
+  const documentListeners = new Map();
+  const windowListeners = new Map();
+  const document = {
+    body: new Element('body'),
+    getElementById(id) { return elements[id] || null; },
+    createElement(tagName) { return new Element(tagName); },
+    addEventListener(type, listener) {
+      if (!documentListeners.has(type)) documentListeners.set(type, []);
+      documentListeners.get(type).push(listener);
+    }
+  };
+  let uuid = 0;
+  const context = {
+    document,
+    sessionStorage: storage,
+    location: {search, origin: 'http://127.0.0.1:8080', href: '/ui/app'},
+    URL,
+    URLSearchParams,
+    crypto: {
+      randomUUID() {
+        uuid++;
+        return '00000000-0000-4000-8000-' + String(uuid).padStart(12, '0');
+      }
+    },
+    setTimeout() { return 1; },
+    confirm() { return true; },
+    addEventListener(type, listener) {
+      if (!windowListeners.has(type)) windowListeners.set(type, []);
+      windowListeners.get(type).push(listener);
+    }
+  };
+  context.window = context;
+  vm.runInNewContext(source, context, {filename: 'rendered-tabs-runtime.js'});
+
+  const strip = elements['ob-tabstrip'];
+  return {
+    open(url, title, options) { return context.obOpenTab(url, title, options); },
+    count() { return strip.children.length; },
+    activeIndex() { return strip.children.findIndex(button => button.classList.contains('active')); },
+    titles() { return strip.children.map(button => button.title); },
+    click(index) { strip.children[index].dispatch('click'); },
+    close(index) { strip.children[index].children[2].dispatch('click'); }
+  };
+}
+
+function savedTabs(storage) {
+  return JSON.parse(storage.getItem('obTabs'));
+}
+
+function savedActive(storage) {
+  const raw = storage.getItem('obTabsActive');
+  return raw ? JSON.parse(raw) : null;
+}
+
+function openThree(storage) {
+  const app = shell(storage);
+  app.open('/ui/a', 'A');
+  app.open('/ui/b', 'B');
+  app.open('/ui/c', 'C');
+  return app;
+}
+
+test('F5 restores the selected middle tab without hydration overwriting it', () => {
+  const storage = new FakeStorage();
+  let app = openThree(storage);
+  app.click(1);
+  const before = savedActive(storage);
+  assert.equal(before.url, '/ui/b');
+  assert.equal(app.activeIndex(), 1);
+
+  app = shell(storage);
+  assert.equal(app.count(), 3);
+  assert.equal(app.activeIndex(), 1);
+  assert.deepEqual(savedActive(storage), before);
+});
+
+test('duplicate URLs keep separate stable IDs and restore the active copy', () => {
+  const storage = new FakeStorage();
+  let app = shell(storage);
+  app.open('/ui/document/new', 'first');
+  app.open('/ui/document/new', 'second', {allowDup: true});
+
+  const beforeTabs = savedTabs(storage);
+  const beforeActive = savedActive(storage);
+  assert.equal(app.count(), 2);
+  assert.equal(app.activeIndex(), 1);
+  assert.equal(new Set(beforeTabs.map(tab => tab.id)).size, 2);
+  assert.equal(beforeActive.id, beforeTabs[1].id);
+
+  app = shell(storage);
+  assert.equal(app.count(), 2);
+  assert.equal(app.activeIndex(), 1);
+  assert.deepEqual(app.titles(), ['first', 'second']);
+  assert.deepEqual(savedTabs(storage).map(tab => tab.id), beforeTabs.map(tab => tab.id));
+  assert.deepEqual(savedActive(storage), beforeActive);
+});
+
+test('home view preserves the previous active tab across navigation', () => {
+  const storage = new FakeStorage();
+  let app = openThree(storage);
+  app.click(1);
+  const before = storage.getItem('obTabsActive');
+
+  app = shell(storage, '?home=1');
+  assert.equal(app.activeIndex(), -1);
+  assert.equal(storage.getItem('obTabsActive'), before);
+
+  app = shell(storage);
+  assert.equal(app.activeIndex(), 1);
+  assert.equal(storage.getItem('obTabsActive'), before);
+});
+
+test('missing active ID falls back to the first tab', () => {
+  const storage = new FakeStorage({
+    obTabs: JSON.stringify([
+      {id: 'tab:a', url: '/ui/a', title: 'A'},
+      {id: 'tab:b', url: '/ui/b', title: 'B'},
+      {id: 'tab:c', url: '/ui/c', title: 'C'}
+    ]),
+    // The stale new-format ID is authoritative. Its URL deliberately matches
+    // the second tab and must not select that different instance.
+    obTabsActive: JSON.stringify({id: 'tab:closed', url: '/ui/b'})
+  });
+
+  const app = shell(storage);
+  assert.equal(app.activeIndex(), 0);
+  assert.deepEqual(savedActive(storage), {id: 'tab:a', url: '/ui/a'});
+});
+
+test('legacy URL-only state is upgraded and remains restorable', () => {
+  const storage = new FakeStorage({
+    obTabs: JSON.stringify([
+      {url: '/ui/a', title: 'A'},
+      {url: '/ui/b', title: 'B'},
+      {url: '/ui/c', title: 'C'}
+    ]),
+    obTabsActive: '/ui/b'
+  });
+
+  let app = shell(storage);
+  assert.equal(app.activeIndex(), 1);
+  const upgraded = savedTabs(storage);
+  assert.equal(upgraded.every(tab => typeof tab.id === 'string' && tab.id.length > 0), true);
+  assert.equal(new Set(upgraded.map(tab => tab.id)).size, 3);
+  assert.equal(savedActive(storage).id, upgraded[1].id);
+  assert.equal(savedActive(storage).url, '/ui/b');
+
+  app = shell(storage);
+  assert.equal(app.activeIndex(), 1);
+  assert.deepEqual(savedTabs(storage).map(tab => tab.id), upgraded.map(tab => tab.id));
+});
+
+test('closing the active tab persists its neighbor and closing the last clears active state', () => {
+  const storage = new FakeStorage();
+  let app = openThree(storage);
+  app.click(1);
+  app.close(1);
+  assert.equal(app.count(), 2);
+  assert.equal(app.activeIndex(), 1);
+  assert.equal(savedActive(storage).url, '/ui/c');
+
+  app = shell(storage);
+  assert.equal(app.count(), 2);
+  assert.equal(app.activeIndex(), 1);
+  app.close(1);
+  app.close(0);
+  assert.equal(app.count(), 0);
+  assert.equal(storage.getItem('obTabsActive'), null);
+});
+
+test('duplicate or corrupt stored IDs cannot collapse tabs or crash startup', () => {
+  const duplicateIDs = new FakeStorage({
+    obTabs: JSON.stringify([
+      {id: 'tab:same', url: '/ui/a', title: 'A'},
+      {id: 'tab:same', url: '/ui/a', title: 'A copy'}
+    ]),
+    obTabsActive: JSON.stringify({id: 'tab:same', url: '/ui/a'})
+  });
+  const duplicates = shell(duplicateIDs);
+  assert.equal(duplicates.count(), 2);
+  assert.equal(duplicates.activeIndex(), 0);
+  assert.equal(new Set(savedTabs(duplicateIDs).map(tab => tab.id)).size, 2);
+
+  const malformed = new FakeStorage({obTabs: '{', obTabsActive: 'not-a-tab'});
+  assert.doesNotThrow(() => shell(malformed));
+  assert.equal(shell(malformed).count(), 0);
+
+  const unavailable = new FakeStorage({}, {get: true, set: true, remove: true});
+  assert.doesNotThrow(() => shell(unavailable));
+});
+
+test('independent sessionStorage areas do not leak tab state', () => {
+  const firstBase = new FakeStorage();
+  const secondBase = new FakeStorage();
+  const first = shell(firstBase);
+  const second = shell(secondBase);
+  first.open('/ui/base-one', 'One');
+  second.open('/ui/base-two', 'Two');
+
+  assert.equal(savedActive(firstBase).url, '/ui/base-one');
+  assert.equal(savedActive(secondBase).url, '/ui/base-two');
+  assert.equal(shell(firstBase).titles()[0], 'One');
+  assert.equal(shell(secondBase).titles()[0], 'Two');
+});

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -71,29 +71,57 @@ const tplAppShell = `{{define "page-app-shell"}}
   var body=document.getElementById('ob-tabbody');
   var empty=document.getElementById('ob-tabempty');
   var home=document.getElementById('ob-tabhome');
-  var tabs=[]; var active=null; var STORE='obTabs'; var STORE_ACTIVE='obTabsActive';
+  var tabs=[]; var active=null; var tabSeq=0; var STORE='obTabs'; var STORE_ACTIVE='obTabsActive';
   var SHOW_HOME=false;
   try{ SHOW_HOME = new URLSearchParams(location.search).get('home')==='1'; }catch(e){}
 
-  function persist(){ try{ sessionStorage.setItem(STORE, JSON.stringify(tabs.map(function(t){return {url:t.url,title:t.title};}))); }catch(e){} }
+  function tabByID(id){ for(var i=0;i<tabs.length;i++){ if(tabs[i].id===id)return tabs[i]; } return null; }
+  function freshTabID(){
+    var id='';
+    do{
+      try{ if(window.crypto && typeof window.crypto.randomUUID==='function') id='tab:'+window.crypto.randomUUID(); }catch(e){ id=''; }
+      if(!id){ tabSeq++; id='tab:'+Date.now().toString(36)+':'+tabSeq.toString(36)+':'+Math.random().toString(36).slice(2); }
+    }while(tabByID(id));
+    return id;
+  }
+  function uniqueTabID(value){
+    var id=(value===undefined||value===null)?'':String(value);
+    return id && !tabByID(id) ? id : freshTabID();
+  }
+  function readSavedActive(){
+    var raw='';
+    try{ raw=String(sessionStorage.getItem(STORE_ACTIVE)||''); }catch(e){}
+    if(!raw)return {id:'',url:''};
+    try{
+      var saved=JSON.parse(raw);
+      if(saved && typeof saved==='object')return {id:saved.id?String(saved.id):'',url:saved.url?String(saved.url):''};
+    }catch(e){}
+    // До появления стабильных id ключ содержал голый URL.
+    return {id:'',url:raw};
+  }
+  function persist(){ try{ sessionStorage.setItem(STORE, JSON.stringify(tabs.map(function(t){return {id:t.id,url:t.url,title:t.title};}))); }catch(e){} }
+  function persistActive(t){ try{ sessionStorage.setItem(STORE_ACTIVE, JSON.stringify({id:t.id,url:t.url})); }catch(e){} }
+  function clearPersistedActive(){ try{ sessionStorage.removeItem(STORE_ACTIVE); }catch(e){} }
   function syncEmpty(){ if(empty) empty.style.display = (!home && !tabs.length) ? '' : 'none'; }
   function setActive(t){
     active=t||null;
     tabs.forEach(function(x){ x.btn.classList.toggle('active',x===t); x.frame.classList.toggle('active',x===t); });
     if(home) home.style.display = t ? 'none' : '';
     if(active && active.btn.scrollIntoView) active.btn.scrollIntoView({inline:'nearest',block:'nearest'}); // фаза 4: активная вкладка в видимую область
-    // Активная вкладка запоминается отдельно от списка: перезагрузка оболочки
-    // (F5) не должна сбрасывать пользователя на первую вкладку. Пишем только
-    // при реальном выборе вкладки — показ рабочего стола (?home=1) ключ не
-    // стирает, поэтому возврат на /ui/app без home откроет прежнюю вкладку.
-    if(active){ try{ sessionStorage.setItem(STORE_ACTIVE, String(active.url)); }catch(e){} }
+    // id отличает несколько экземпляров одного URL. setActive(null) при
+    // ?home=1 намеренно не стирает выбор: возврат открывает прежнюю вкладку.
+    if(active)persistActive(active);
     syncEmpty();
   }
   function closeTab(t){
     var i=tabs.indexOf(t); if(i<0)return;
     if(t.dirty && !window.confirm('В этой вкладке есть несохранённые изменения. Закрыть вкладку?'))return; // фаза 3
     t.btn.remove(); t.frame.remove(); tabs.splice(i,1);
-    if(active===t) setActive(tabs[Math.min(i,tabs.length-1)]||null);
+    if(active===t){
+      var next=tabs[Math.min(i,tabs.length-1)]||null;
+      setActive(next);
+      if(!next)clearPersistedActive();
+    }
     persist();
   }
   // Фаза 4: управление множеством вкладок — контекст-меню по правому клику.
@@ -111,19 +139,20 @@ const tplAppShell = `{{define "page-app-shell"}}
   }
   function openTab(url,title,opts){
     opts=opts||{};
-    if(!opts.allowDup){ for(var i=0;i<tabs.length;i++){ if(tabs[i].url===url){ setActive(tabs[i]); return tabs[i]; } } }
+    if(!opts.allowDup){ for(var i=0;i<tabs.length;i++){ if(tabs[i].url===url){ if(!opts.restoring)setActive(tabs[i]); return tabs[i]; } } }
     var btn=document.createElement('div'); btn.className='ob-tab'; btn.setAttribute('role','tab'); btn.title=title||'Форма'; // фаза 4: тултип полного заголовка
     var lab=document.createElement('span'); lab.className='ob-tab-label'; lab.textContent=title||'Форма'; btn.appendChild(lab);
     var dup=document.createElement('span'); dup.className='ob-tab-dup'; dup.textContent='⧉'; dup.title='Открыть ещё один экземпляр'; btn.appendChild(dup);
     var cl=document.createElement('span'); cl.className='ob-tab-close'; cl.textContent='✕'; cl.title='Закрыть'; btn.appendChild(cl);
     var frame=document.createElement('iframe'); frame.src=url;
-    var t={url:url,title:title,btn:btn,frame:frame,label:lab};
+    var t={id:uniqueTabID(opts.id),url:url,title:title,btn:btn,frame:frame,label:lab};
     btn.addEventListener('click',function(e){ if(e.target===cl||e.target===dup)return; setActive(t); });
     btn.addEventListener('mousedown',function(e){ if(e.button===1){ e.preventDefault(); closeTab(t); } });
     cl.addEventListener('click',function(e){ e.stopPropagation(); closeTab(t); });
     dup.addEventListener('click',function(e){ e.stopPropagation(); openTab(t.url, t.title, {allowDup:true}); }); // #130
     btn.addEventListener('contextmenu',function(e){ e.preventDefault(); setActive(t); tabMenu(t,e.clientX,e.clientY); }); // фаза 4
-    strip.appendChild(btn); body.appendChild(frame); tabs.push(t); setActive(t); persist();
+    strip.appendChild(btn); body.appendChild(frame); tabs.push(t);
+    if(!opts.restoring){ setActive(t); persist(); }
     return t;
   }
   window.obOpenTab=openTab;
@@ -171,16 +200,20 @@ const tplAppShell = `{{define "page-app-shell"}}
     openTab(href,(a.getAttribute('title')||a.textContent||'').replace(/\s+/g,' ').trim()||'Форма');
   });
 
+  // Снимок читаем ДО openTab: восстановление само создаёт вкладки и не должно
+  // успеть заменить сохранённый выбор последней добавленной вкладкой.
+  var savedActive=readSavedActive();
   try{
     var saved=JSON.parse(sessionStorage.getItem(STORE)||'[]');
-    saved.forEach(function(s){ if(s&&s.url) openTab(String(s.url), s.title?String(s.title):'Форма'); });
-    // Восстановить АКТИВНУЮ вкладку прошлого сеанса по сохранённому URL;
-    // если её уже нет (закрыта в другом окне/список сменился) — первая, как было.
-    var savedActive='';
-    try{ savedActive=String(sessionStorage.getItem(STORE_ACTIVE)||''); }catch(e){}
+    // restoring не активирует/не сохраняет промежуточные вкладки; allowDup
+    // сохраняет отдельные экземпляры одного URL (#130).
+    saved.forEach(function(s){ if(s&&s.url) openTab(String(s.url), s.title?String(s.title):'Форма', {allowDup:true,id:s.id,restoring:true}); });
     var restore=null;
-    for(var i=0;i<tabs.length;i++){ if(tabs[i].url===savedActive){ restore=tabs[i]; break; } }
+    if(savedActive.id)restore=tabByID(savedActive.id);
+    // Backward compatibility: старые версии хранили в obTabsActive только URL.
+    if(!restore && !savedActive.id && savedActive.url){ for(var i=0;i<tabs.length;i++){ if(tabs[i].url===savedActive.url){ restore=tabs[i]; break; } } }
     if(tabs.length && !SHOW_HOME) setActive(restore||tabs[0]); else setActive(null);
+    persist(); // добавить id в legacy obTabs и убрать невалидные записи
   }catch(e){}
   syncEmpty();
 

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -71,7 +71,7 @@ const tplAppShell = `{{define "page-app-shell"}}
   var body=document.getElementById('ob-tabbody');
   var empty=document.getElementById('ob-tabempty');
   var home=document.getElementById('ob-tabhome');
-  var tabs=[]; var active=null; var STORE='obTabs';
+  var tabs=[]; var active=null; var STORE='obTabs'; var STORE_ACTIVE='obTabsActive';
   var SHOW_HOME=false;
   try{ SHOW_HOME = new URLSearchParams(location.search).get('home')==='1'; }catch(e){}
 
@@ -82,6 +82,11 @@ const tplAppShell = `{{define "page-app-shell"}}
     tabs.forEach(function(x){ x.btn.classList.toggle('active',x===t); x.frame.classList.toggle('active',x===t); });
     if(home) home.style.display = t ? 'none' : '';
     if(active && active.btn.scrollIntoView) active.btn.scrollIntoView({inline:'nearest',block:'nearest'}); // фаза 4: активная вкладка в видимую область
+    // Активная вкладка запоминается отдельно от списка: перезагрузка оболочки
+    // (F5) не должна сбрасывать пользователя на первую вкладку. Пишем только
+    // при реальном выборе вкладки — показ рабочего стола (?home=1) ключ не
+    // стирает, поэтому возврат на /ui/app без home откроет прежнюю вкладку.
+    if(active){ try{ sessionStorage.setItem(STORE_ACTIVE, String(active.url)); }catch(e){} }
     syncEmpty();
   }
   function closeTab(t){
@@ -169,7 +174,13 @@ const tplAppShell = `{{define "page-app-shell"}}
   try{
     var saved=JSON.parse(sessionStorage.getItem(STORE)||'[]');
     saved.forEach(function(s){ if(s&&s.url) openTab(String(s.url), s.title?String(s.title):'Форма'); });
-    if(tabs.length && !SHOW_HOME) setActive(tabs[0]); else setActive(null);
+    // Восстановить АКТИВНУЮ вкладку прошлого сеанса по сохранённому URL;
+    // если её уже нет (закрыта в другом окне/список сменился) — первая, как было.
+    var savedActive='';
+    try{ savedActive=String(sessionStorage.getItem(STORE_ACTIVE)||''); }catch(e){}
+    var restore=null;
+    for(var i=0;i<tabs.length;i++){ if(tabs[i].url===savedActive){ restore=tabs[i]; break; } }
+    if(tabs.length && !SHOW_HOME) setActive(restore||tabs[0]); else setActive(null);
   }catch(e){}
   syncEmpty();
 

--- a/internal/ui/tabs_node_test.go
+++ b/internal/ui/tabs_node_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestTabsBehaviorInNode executes the real app-shell script in a deterministic
+// DOM. Presence-only assertions cannot detect hydration overwriting the saved
+// active tab or duplicate URLs collapsing into one tab.
+func TestTabsBehaviorInNode(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required for the tabs behavior regression test")
+	}
+
+	data := map[string]any{
+		"Cfg":              Config{AppName: "Test"},
+		"Lang":             "ru",
+		"Subsystems":       []any{},
+		"CurrentSubsystem": "",
+		"Nav":              []any{},
+		"CollapsibleNav":   false,
+		"IsAdmin":          false,
+	}
+	var rendered bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&rendered, "page-app-shell", data); err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+
+	htmlPath := filepath.Join(t.TempDir(), "app-shell.html")
+	if err := os.WriteFile(htmlPath, rendered.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(node, "--test", "static/tabs_behavior_test.js") //nolint:gosec // test-only executable resolved by exec.LookPath
+	cmd.Env = append(os.Environ(), "ONEBASE_TABS_HTML="+htmlPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node tabs behavior test: %v\n%s", err, output)
+	}
+}

--- a/internal/ui/tabs_test.go
+++ b/internal/ui/tabs_test.go
@@ -48,7 +48,7 @@ func TestAppShell_Render(t *testing.T) {
 		`#ob-tabhome a[href]`,      // ссылки рабочего стола открываются через shell
 		// F5 в режиме вкладок не должен сбрасывать на первую: активная вкладка
 		// запоминается отдельным ключом и восстанавливается, если ещё жива.
-		`'obTabsActive'`,   // ключ sessionStorage с URL активной вкладки
+		`'obTabsActive'`,   // ключ sessionStorage с id/URL активной вкладки
 		`restore||tabs[0]`, // fallback на первую, когда сохранённая закрыта/нет
 	} {
 		if !strings.Contains(html, want) {

--- a/internal/ui/tabs_test.go
+++ b/internal/ui/tabs_test.go
@@ -46,6 +46,10 @@ func TestAppShell_Render(t *testing.T) {
 		`scrollIntoView`,           // автоскролл активной вкладки
 		`shellHomeURL`,             // переход по подсистемам строит URL через searchParams
 		`#ob-tabhome a[href]`,      // ссылки рабочего стола открываются через shell
+		// F5 в режиме вкладок не должен сбрасывать на первую: активная вкладка
+		// запоминается отдельным ключом и восстанавливается, если ещё жива.
+		`'obTabsActive'`,   // ключ sessionStorage с URL активной вкладки
+		`restore||tabs[0]`, // fallback на первую, когда сохранённая закрыта/нет
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("оболочка вкладок не содержит %q", want)


### PR DESCRIPTION
## Проблема

Оболочка вкладок (`/ui/app`) сохраняла в sessionStorage только **список** вкладок (`obTabs`), но не активность. После перезагрузки окна (F5) активной всегда становилась **первая** вкладка — пользователь «улетал» с документа, который только что читал:

```js
if(tabs.length && !SHOW_HOME) setActive(tabs[0]); else setActive(null);
```

## Решение

- Активная вкладка запоминается отдельным ключом `obTabsActive` (URL) при каждом выборе (`setActive`).
- После перезагрузки восстановление ищет живую вкладку по сохранённому URL и делает активной её; закрыта/список сменился — прежний fallback на первую (`restore||tabs[0]`).
- Показ рабочего стола (`?home=1`) ключ **не стирает**: `setActive(null)` не пишет, поэтому возврат на `/ui/app` без `home` открывает прежнюю вкладку.

## Тесты

- `TestAppShell_Render` дополнен проверками на `'obTabsActive'` и fallback `restore||tabs[0]` (TDD: тест падал до фикса).
- Полный пакет `internal/ui` — зелёный (`go test ./internal/ui -count=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)