### PR TITLE
fix(tests): гонка в тесте остановки сервера роняла test-windows

### DIFF
--- a/internal/ui/server_lifecycle_test.go
+++ b/internal/ui/server_lifecycle_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,17 +21,52 @@ func TestServerShutdownCancelsAndDrainsBackgroundJobs(t *testing.T) {
 		t.Fatal("background job rejected before shutdown")
 	}
 	jobCtx, releaseCtx := s.backgroundRequestContext(context.Background())
+	cancelled := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
+	// Фоновую задачу надо отпустить и при провале теста: t.Cleanup(s.Close)
+	// ждёт её без дедлайна, и падение превратилось бы в таймаут всего пакета
+	// вместо внятного FAIL. Cleanup'ы идут LIFO, поэтому этот сработает раньше
+	// зарегистрированного выше s.Close.
+	t.Cleanup(releaseWorker)
 	workerDone := make(chan struct{})
 	go func() {
-		defer close(workerDone)
+		// jobDone объявлен первым, а выполняется последним: Shutdown ждёт
+		// именно его (backgroundWG.Wait), поэтому к возврату Shutdown канал
+		// workerDone гарантированно закрыт. Обратный порядок оставлял гонку —
+		// Shutdown мог вернуться раньше close(workerDone), и неблокирующая
+		// проверка ниже краснела на исправном коде (флейк test-windows).
 		defer jobDone()
+		defer close(workerDone)
 		defer releaseCtx()
 		<-jobCtx.Done()
+		close(cancelled)
+		<-release
 	}()
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// Задачу держим незавершённой, пока не убедимся, что Shutdown её ждёт:
+	// иначе тест не отличал бы «дождался» от «вернулся сразу», а именно это
+	// он и обязан проверять. Запас по дедлайну большой — ждём мы не наступления
+	// таймаута, а того, что Shutdown НЕ вернулся раньше времени.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := s.Shutdown(shutdownCtx); err != nil {
+	shutdownErr := make(chan error, 1)
+	go func() { shutdownErr <- s.Shutdown(shutdownCtx) }()
+
+	select {
+	case <-cancelled:
+	case err := <-shutdownErr:
+		t.Fatalf("Shutdown returned before the background job observed cancellation: %v", err)
+	}
+	select {
+	case err := <-shutdownErr:
+		t.Fatalf("Shutdown returned while a background job was still running: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseWorker()
+
+	if err := <-shutdownErr; err != nil {
 		t.Fatal(err)
 	}
 	select {


### PR DESCRIPTION
## Что было

`TestServerShutdownCancelsAndDrainsBackgroundJobs` падал на **исправном коде** —
«background worker was not drained» (`server_lifecycle_test.go:39`). Это тот
самый флейк `test-windows`, из-за которого краснел обязательный гейт примерно
раз на тридцать прогонов; последний раз — на PR #1117, где изменены только
файлы документации.

Причина — порядок `defer` в рабочей горутине теста:

```go
defer close(workerDone)  // выполняется ПОСЛЕДНИМ
defer jobDone()          // ...а Shutdown ждёт именно его
defer releaseCtx()
```

`Shutdown` ждёт `backgroundWG.Wait()`, то есть `jobDone()`. Он мог вернуться
раньше, чем отработает `close(workerDone)`, — а проверка сделана неблокирующим
`select ... default`. Окно узкое (основная горутина успевает выйти из `select`,
пройти `closeOnce.Do` и дойти до проверки), поэтому на обычной машине не
воспроизводится; на загруженном раннере Windows вытеснение в это окно попадает.

Диагноз проверен подстановкой паузы ровно на место вытеснения — старый порядок
даёт то же самое сообщение, новый проходит.

## Что стало

1. **Порядок `defer` развёрнут**: `jobDone` объявлен первым и выполняется
   последним — к возврату `Shutdown` канал закрыт гарантированно.

2. **Тест перестал быть зелёным при сломанном коде.** Раньше он не отличал
   «Shutdown дождался задачи» от «Shutdown вернулся сразу»: рабочая горутина
   завершалась по отмене контекста, и оба исхода выглядели одинаково. Теперь
   задача держится незавершённой до явного сигнала, а тест проверяет, что
   `Shutdown` всё это время не вернулся. Проверено регрессией: если убрать из
   `Shutdown` ожидание `backgroundWG`, тест падает за 0.00s.

3. **Отпускание задачи продублировано в `t.Cleanup`.** Без этого любой провал
   теста превращался бы в таймаут пакета: `t.Cleanup(s.Close)` ждёт фоновые
   задачи без дедлайна. Cleanup'ы идут LIFO, поэтому освобождение зарегистрировано
   после `s.Close` и срабатывает раньше него.

Дедлайн `shutdownCtx` поднят с 1 с до 5 с: тест ждёт не наступления таймаута,
а того, что `Shutdown` НЕ вернулся раньше времени, и запас тут в безопасную
сторону. Поведение по дедлайну проверяет соседний
`TestServerShutdownHonorsDeadlineForUncooperativeJob` — он не тронут.

## Проверки

- `go test ./internal/ui -run TestServerShutdown -count=300` — зелено; то же с
  `GOMAXPROCS=1`.
- Полный `go test ./internal/ui` — зелено.
- `go vet`, `gofmt`, `golangci-lint run ./internal/ui/...` — 0 issues.
- Регрессия (`Shutdown` без ожидания `backgroundWG`) — тест падает с внятным
  сообщением, а не виснет.

Продуктового кода не касается, в `docs/features.md` не идёт.