### PR TITLE
fix(forms): конструктор показывает ТЧ без явных колонок как «все», а не как пустую

### DIFF
--- a/internal/launcher/forms_canvas.go
+++ b/internal/launcher/forms_canvas.go
@@ -180,8 +180,15 @@ func renderCanvasElement(buf *bytes.Buffer, en *formdoc.ElementNode, selectedID 
 		// редактировать состав (follow-up #164, слайсы D1/D2).
 		fmt.Fprintf(buf, `<div class="%s" data-node-id="%s" data-kind="%s"><div class="fc-tp fc-pick">▦ %s</div><div class="fc-cols">`,
 			elWrapClass("fc-table", id, selectedID), id, kind, title)
-		if len(en.Children) == 0 {
-			buf.WriteString(`<span class="fc-cols-empty">колонки не выбраны</span>`)
+		// Без явных колонок рантайм показывает ВСЕ реквизиты ТЧ
+		// (managedTPColumnPlan: «ничего не выбрано» = «показать всё»). Холст
+		// метаданных сущности не знает и перечислить их не может, но обязан
+		// назвать состояние верно: прежнее «колонки не выбраны» читалось как
+		// «ТЧ пустая» и толкало поставить галочку — а первая же галочка
+		// переключает смысл с «все» на «только отмеченные» и убирает
+		// остальные колонки (#1123).
+		if !hasColumnChild(en) {
+			buf.WriteString(`<span class="fc-cols-empty" title="Состав не задан: показываются все реквизиты табличной части. Задать состав явно можно галочками в свойствах.">все колонки (по умолчанию)</span>`)
 		}
 		for _, c := range en.Children {
 			if c == nil || c.El == nil {
@@ -198,15 +205,34 @@ func renderCanvasElement(buf *bytes.Buffer, en *formdoc.ElementNode, selectedID 
 	}
 }
 
+// hasColumnChild — есть ли у элемента хоть один ребёнок kind: Колонка. Считаем
+// именно их, а не всех детей: рантайм (managedTPColumnPlan) переходит в режим
+// «показать выбранное» тоже только по ним, и холст обязан говорить о том же
+// признаке, иначе состояния разъезжаются на ТЧ с посторонним ребёнком.
+func hasColumnChild(en *formdoc.ElementNode) bool {
+	for _, c := range en.Children {
+		if c != nil && c.El != nil && c.El.Kind == metadata.FormElementColumn {
+			return true
+		}
+	}
+	return false
+}
+
 // canvasElementInfo — редактируемые поля элемента для панели свойств клиента.
 // Плоская карта node-id → info отдаётся вместе с холстом, чтобы клик по элементу
 // открывал панель без повторного парсинга YAML в браузере.
 type canvasElementInfo struct {
-	NodeID    string `json:"nodeId"`
-	Kind      string `json:"kind"`
-	Name      string `json:"name"`
-	TitleRU   string `json:"titleRu"`
-	DataPath  string `json:"dataPath"`
+	NodeID   string `json:"nodeId"`
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	TitleRU  string `json:"titleRu"`
+	DataPath string `json:"dataPath"`
+	// Field — ключ `field:` элемента. Рантайм сопоставляет колонку реквизиту по
+	// data_path, field ИЛИ имени (managedTPFieldIndexForColumn), а в модель
+	// холста поле не попадало вовсе — поэтому колонка, объявленная как
+	// `field: Цена`, в рантайме была видна, а в панели свойств стояла без
+	// галочки (#1123).
+	Field     string `json:"field"`
 	Required  bool   `json:"required"`
 	ReadOnly  bool   `json:"readonly"`
 	Hint      string `json:"hint"`
@@ -252,6 +278,7 @@ func canvasModel(doc *formdoc.Doc) (map[string]canvasElementInfo, error) {
 				Kind:        string(el.Kind),
 				Name:        el.Name,
 				DataPath:    el.DataPath,
+				Field:       el.FieldName,
 				Required:    el.Required,
 				ReadOnly:    el.ReadOnly,
 				Hint:        el.Hint,

--- a/internal/launcher/forms_canvas_test.go
+++ b/internal/launcher/forms_canvas_test.go
@@ -534,7 +534,7 @@ elements:
 				DataPath: "Объект.Номер",
 			}},
 		}},
-	})
+	}, nil)
 	if !strings.Contains(preview, "group-horizontal") {
 		t.Errorf("предпросмотр не получил класс горизонтальной группы:\n%s", preview)
 	}

--- a/internal/launcher/forms_editop.go
+++ b/internal/launcher/forms_editop.go
@@ -24,7 +24,7 @@ import (
 
 // editOpRequest — разобранная команда правки формы.
 type editOpRequest struct {
-	Op       string // render | setProp | delProp | insert | move | delete | setOptions
+	Op       string // render | setProp | delProp | insert | insertColumns | move | delete | setOptions
 	Node     string // node-id цели (setProp, move); "form" = корневые свойства формы
 	Key      string // setProp/delProp: имя свойства (может быть вложенным, "title.ru")
 	Value    string // setProp: значение (сырое; bool-свойства приводятся)
@@ -35,6 +35,14 @@ type editOpRequest struct {
 	DataPath string // insert: data_path нового элемента
 	TitleRU  string // insert: ru-заголовок нового элемента
 	Options  string // setOptions: JSON-массив [{value,label}] набора значений
+	Columns  string // insertColumns: JSON-массив [{name,title,data_path}] колонок ТЧ
+}
+
+// columnSpec — одна колонка табличной части в команде insertColumns.
+type columnSpec struct {
+	Name     string `json:"name"`
+	Title    string `json:"title"`
+	DataPath string `json:"data_path"`
 }
 
 // editOpResult — результат применения команды к YAML.
@@ -214,6 +222,42 @@ func applyEditOp(yamlSrc []byte, req editOpRequest) (editOpResult, error) {
 		}
 		selected = newID
 
+	case "insertColumns":
+		// Материализация состава колонок ТЧ одной командой (#1123).
+		//
+		// Нужна ровно там, где явного состава ещё нет: пустой список детей
+		// означает «показать все реквизиты», поэтому «спрятать одну колонку» —
+		// это не одна правка, а «объявить все остальные». Серией из N запросов
+		// с клиента это делать нельзя: обрыв на середине оставил бы ТЧ с ЯВНЫМ
+		// составом, урезанным до случайного места обрыва, — то есть тихо
+		// спрятал бы колонки, которых никто не снимал.
+		if strings.TrimSpace(req.Parent) == "" {
+			return editOpResult{}, fmt.Errorf("insertColumns: не указан parent")
+		}
+		var cols []columnSpec
+		if err := json.Unmarshal([]byte(req.Columns), &cols); err != nil {
+			return editOpResult{}, fmt.Errorf("insertColumns: разбор columns: %w", err)
+		}
+		if len(cols) == 0 {
+			return editOpResult{}, fmt.Errorf("insertColumns: пустой список колонок")
+		}
+		for _, c := range cols {
+			fields := map[string]any{"kind": string(metadata.FormElementColumn)}
+			if strings.TrimSpace(c.Name) != "" {
+				fields["name"] = c.Name
+			}
+			if strings.TrimSpace(c.DataPath) != "" {
+				fields["data_path"] = c.DataPath
+			}
+			if strings.TrimSpace(c.Title) != "" {
+				fields["title"] = map[string]string{"ru": c.Title}
+			}
+			if _, err := doc.InsertElement(req.Parent, 9999, fields); err != nil {
+				return editOpResult{}, err
+			}
+		}
+		selected = req.Parent
+
 	case "move":
 		if err := doc.Move(req.Node, req.Parent, req.Index); err != nil {
 			return editOpResult{}, err
@@ -298,6 +342,7 @@ func (h *handler) configuratorFormsEditOp(w http.ResponseWriter, r *http.Request
 		DataPath: r.FormValue("data_path"),
 		TitleRU:  r.FormValue("title_ru"),
 		Options:  r.FormValue("options"),
+		Columns:  r.FormValue("columns"),
 	}
 	res, err := applyEditOp([]byte(r.FormValue("yaml")), req)
 	if err != nil {

--- a/internal/launcher/forms_handlers.go
+++ b/internal/launcher/forms_handlers.go
@@ -743,6 +743,21 @@ func (h *handler) configuratorFormsPreview(w http.ResponseWriter, r *http.Reques
 		entity = "Объект"
 	}
 
+	// Состав табличных частей — чтобы ТЧ без явных колонок предпросмотр рисовал
+	// так же, как её покажет рантайм: всеми реквизитами (#1123). Метаданные
+	// необязательны: не открылась база — предпросмотр деградирует до подсказки,
+	// но не до ошибки, поэтому ошибку загрузки здесь глотаем намеренно.
+	var tps previewTableParts
+	if b, err := h.store.Get(chi.URLParam(r, "id")); err == nil {
+		if proj, perr := h.loadProjectFor(r.Context(), b); perr == nil {
+			tps = make(previewTableParts)
+			for _, tp := range objectScaffoldTableParts(proj, entity) {
+				tps[tp.Name] = tp.Columns
+			}
+			proj.Close()
+		}
+	}
+
 	tmpPath, cleanup, err := writeTempFile("obpreview-*.form.yaml", yamlBody)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
@@ -758,7 +773,7 @@ func (h *handler) configuratorFormsPreview(w http.ResponseWriter, r *http.Reques
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	writeBody(w, []byte(renderManagedFormPreview(fm)))
+	writeBody(w, []byte(renderManagedFormPreview(fm, tps)))
 }
 
 // configuratorFormsImport1C — multipart-загрузка ZIP с Form.xml + Module.bsl

--- a/internal/launcher/forms_handlers_test.go
+++ b/internal/launcher/forms_handlers_test.go
@@ -307,7 +307,7 @@ func TestRenderManagedFormPreview(t *testing.T) {
 			},
 		},
 	}
-	html := renderManagedFormPreview(fm)
+	html := renderManagedFormPreview(fm, nil)
 	must := []string{
 		"Карточка контрагента",
 		"◇ managed",
@@ -346,7 +346,7 @@ func TestRenderManagedFormPreview_StandalonePage(t *testing.T) {
 			},
 		},
 	}
-	html := renderManagedFormPreview(fm)
+	html := renderManagedFormPreview(fm, nil)
 	if strings.Contains(html, "предпросмотр не реализован") {
 		t.Errorf("отдельная страница даёт «предпросмотр не реализован»:\n%s", html)
 	}
@@ -376,7 +376,7 @@ func TestRenderManagedFormPreview_TablePartColumns(t *testing.T) {
 			},
 		},
 	}
-	html := renderManagedFormPreview(fm)
+	html := renderManagedFormPreview(fm, nil)
 	if strings.Contains(html, "Предпросмотр упрощённый") {
 		t.Errorf("табличная часть осталась строкой-заглушкой:\n%s", html)
 	}
@@ -387,18 +387,71 @@ func TestRenderManagedFormPreview_TablePartColumns(t *testing.T) {
 	}
 }
 
-// Табличная часть без выбранных колонок — подсказка, не таблица и не заглушка.
-func TestRenderManagedFormPreview_TablePartNoColumns(t *testing.T) {
-	fm := &metadata.FormModule{
+// tpOnlyForm — форма из одной табличной части без явных колонок: так ТЧ
+// объявлены во всех примерах конфигураций (trade, tasks, crm, finance).
+func tpOnlyForm() *metadata.FormModule {
+	return &metadata.FormModule{
 		EntityName: "Заказ",
 		Elements: []*metadata.FormElement{
 			{Kind: metadata.FormElementTablePart, Name: "ТабТовары",
 				TitleMap: map[string]string{"ru": "Товары"}, DataPath: "Объект.Товары"},
 		},
 	}
-	html := renderManagedFormPreview(fm)
-	if !strings.Contains(html, "Колонки не выбраны") {
-		t.Errorf("нет подсказки про невыбранные колонки:\n%s", html)
+}
+
+// Табличная часть без явных колонок: рантайм показывает ВСЕ реквизиты
+// (managedTPColumnPlan), поэтому предпросмотр обязан рисовать их таблицей, а не
+// изображать пустоту. Раньше здесь была подсказка «Колонки не выбраны», и
+// пользователь видел в конструкторе пустую ТЧ при полной таблице в рантайме —
+// а «исправление» галочкой убирало все колонки, кроме отмеченной (#1123).
+func TestRenderManagedFormPreview_ТЧБезКолонокРисуетВсеРеквизиты(t *testing.T) {
+	html := renderManagedFormPreview(tpOnlyForm(), previewTableParts{
+		"Товары": {{Name: "Номенклатура"}, {Name: "Количество"}, {Name: "Цена", Title: "Цена, руб"}},
+	})
+	for _, s := range []string{"tp-prev-tbl", "<th>Номенклатура</th>", "<th>Количество</th>", "<th>Цена, руб</th>"} {
+		if !strings.Contains(html, s) {
+			t.Errorf("в предпросмотре ТЧ без явных колонок нет %q:\n%s", s, html)
+		}
+	}
+	if strings.Contains(html, "Колонки не выбраны") {
+		t.Errorf("предпросмотр всё ещё называет ТЧ пустой:\n%s", html)
+	}
+	if !strings.Contains(html, "Состав не задан") {
+		t.Errorf("предпросмотр не сообщает, что состав не задан явно:\n%s", html)
+	}
+}
+
+// Метаданные ТЧ недоступны (предпросмотр без открытой базы) — перечислить
+// нечего, но соглашение «пусто = показываются все» назвать обязаны.
+func TestRenderManagedFormPreview_ТЧБезМетаданныхНазываетСоглашение(t *testing.T) {
+	html := renderManagedFormPreview(tpOnlyForm(), nil)
+	if !strings.Contains(html, "показываются все реквизиты табличной части") {
+		t.Errorf("нет подсказки про показ всех реквизитов:\n%s", html)
+	}
+	// Именно тег таблицы, а не класс: класс .tp-prev-tbl есть и в блоке стилей.
+	if strings.Contains(html, `<table class="tp-prev-tbl">`) {
+		t.Errorf("без метаданных таблицу рисовать нечем, но она нарисована:\n%s", html)
+	}
+}
+
+// Явный состав колонок метаданные не перекрывают: выбрана одна — показана одна.
+func TestRenderManagedFormPreview_ЯвныйСоставСильнееМетаданных(t *testing.T) {
+	fm := tpOnlyForm()
+	fm.Elements[0].Children = []*metadata.FormElement{
+		{Kind: metadata.FormElementColumn, Name: "КолЦена",
+			TitleMap: map[string]string{"ru": "Цена"}, DataPath: "Объект.Товары.Цена"},
+	}
+	html := renderManagedFormPreview(fm, previewTableParts{
+		"Товары": {{Name: "Номенклатура"}, {Name: "Количество"}, {Name: "Цена"}},
+	})
+	if !strings.Contains(html, "<th>Цена</th>") {
+		t.Errorf("выбранной колонки нет в предпросмотре:\n%s", html)
+	}
+	if strings.Contains(html, "<th>Номенклатура</th>") {
+		t.Errorf("предпросмотр дорисовал колонку, которую состав не выбирал:\n%s", html)
+	}
+	if strings.Contains(html, "Состав не задан") {
+		t.Errorf("явный состав назван незаданным:\n%s", html)
 	}
 }
 

--- a/internal/launcher/forms_tmpl.go
+++ b/internal/launcher/forms_tmpl.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"html/template"
 	"net/http"
+	"strings"
 
 	"github.com/ivantit66/onebase/internal/metadata"
 )
@@ -1341,48 +1342,100 @@ function tablePartName() {
   var i = dp.lastIndexOf('.');
   return i >= 0 ? dp.slice(i + 1) : dp;
 }
-// Уже добавленные колонки ТЧ tpNodeId: поле (последний сегмент data_path) → node-id.
-function presentColumns(tpNodeId) {
-  var map = {}, prefix = tpNodeId + '.children.';
+// colKey — ключ сопоставления колонки реквизиту. Регистронезависимый, потому что
+// таков рантайм (managedTPFieldIndexForColumn сравнивает через strings.EqualFold).
+function colKey(s) { return (s || '').trim().toLowerCase(); }
+
+// columnChildren — прямые дети kind:Колонка табличной части, в порядке YAML.
+// Порядок восстанавливаем по числовому индексу в node-id, а не по обходу
+// Object.keys(_model): модель приходит из Go-map, порядок ключей в JSON случаен.
+function columnChildren(tpNodeId) {
+  var prefix = tpNodeId + '.children.', out = [];
   Object.keys(_model).forEach(function (id) {
     if (id.indexOf(prefix) !== 0) return;
-    var inf = _model[id];
-    if ((inf.kind || '') !== 'Колонка') return;
-    var dp = inf.dataPath || '', j = dp.lastIndexOf('.');
-    var seg = j >= 0 ? dp.slice(j + 1) : dp;
-    if (seg) map[seg] = id;
+    var rest = id.slice(prefix.length);
+    if (!/^[0-9]+$/.test(rest)) return;   // только прямые дети, не внуки
+    if ((_model[id].kind || '') !== 'Колонка') return;
+    out.push({ id: id, idx: parseInt(rest, 10), info: _model[id] });
   });
-  return map;
+  out.sort(function (a, b) { return a.idx - b.idx; });
+  return out;
+}
+
+// Уже объявленные колонки ТЧ: {map: реквизит → node-id, order: [реквизит]}.
+// Сопоставление повторяет managedTPFieldIndexForColumn — data_path, затем field,
+// затем имя элемента, первое совпадение с реальным реквизитом ТЧ. Раньше
+// смотрели только data_path, поэтому колонка, объявленная ключом field, в
+// рантайме была видна, а в панели стояла без галочки (#1123).
+function presentColumns(tpNodeId, cols) {
+  var known = {};
+  (cols || []).forEach(function (c) { known[colKey(c.name)] = c.name; });
+  var map = {}, order = [];
+  columnChildren(tpNodeId).forEach(function (ch) {
+    var dp = ch.info.dataPath || '', j = dp.lastIndexOf('.');
+    var cands = [j >= 0 ? dp.slice(j + 1) : dp, ch.info.field, ch.info.name];
+    for (var k = 0; k < cands.length; k++) {
+      var name = known[colKey(cands[k])];
+      if (!name) continue;
+      if (!map[name]) { map[name] = ch.id; order.push(name); }
+      return;
+    }
+  });
+  return { map: map, order: order };
 }
 function addColumnsEditor(panel) {
   var tp = tablePartName();
   var cols = _tableParts[tp] || [];
-  var present = presentColumns(_selected);
   var hd = document.createElement('div'); hd.className = 'prop-row';
   var l = document.createElement('label'); l.textContent = 'Колонки (показывать):';
   hd.appendChild(l); panel.appendChild(hd);
   if (!cols.length) {
-    var note = document.createElement('div'); note.className = 'prop-empty';
-    note.textContent = 'Состав колонок неизвестен (метаданные ТЧ не загружены).';
-    panel.appendChild(note); return;
+    var unknown = document.createElement('div'); unknown.className = 'prop-empty';
+    unknown.textContent = 'Состав колонок неизвестен (метаданные ТЧ не загружены).';
+    panel.appendChild(unknown); return;
   }
+  var st = presentColumns(_selected, cols);
+  // Явного состава нет — рантайм показывает ВСЕ реквизиты (managedTPColumnPlan:
+  // «ничего не выбрано» = «показать всё»). Галочки в этом состоянии обязаны
+  // стоять: снятые читались как «не показывается ничего», хотя пользователь
+  // видит полную таблицу, — и подталкивали поставить одну, что на самом деле
+  // убирает все остальные колонки (#1123).
+  var explicit = st.order.length > 0;
+  var note = document.createElement('div'); note.className = 'prop-empty';
+  note.textContent = explicit
+    ? 'Состав задан явно. Снимете все галочки — вернётся показ всех колонок.'
+    : 'Состав не задан — показываются все колонки. Снимите галочку, чтобы задать состав явно.';
+  panel.appendChild(note);
   cols.forEach(function (c) {
     var row = document.createElement('div'); row.className = 'prop-row prop-check';
-    var cb = document.createElement('input'); cb.type = 'checkbox'; cb.checked = !!present[c.name];
-    cb.addEventListener('change', function () { toggleColumn(tp, c, cb.checked, present[c.name]); });
+    var cb = document.createElement('input'); cb.type = 'checkbox';
+    cb.checked = explicit ? !!st.map[c.name] : true;
+    cb.addEventListener('change', function () { toggleColumn(tp, cols, c, cb.checked, st, explicit); });
     var lab = document.createElement('label'); lab.textContent = c.title || c.name;
     row.appendChild(cb); row.appendChild(lab); panel.appendChild(row);
   });
 }
 // Включение колонки → insert kind:Колонка в конец ТЧ; выключение → delete её узла.
 // Выделение удерживаем на ТЧ, чтобы можно было щёлкать чекбоксы подряд.
-function toggleColumn(tp, col, on, existingId) {
+//
+// Особый случай — снятие галочки, когда явного состава ещё нет: удалять нечего,
+// а один insert оставил бы ровно одну колонку вместо «всех минус снятая».
+// Поэтому здесь материализуем весь состав без снятой колонки, и одной командой
+// insertColumns: серия запросов при обрыве на середине тихо спрятала бы
+// колонки, которых никто не снимал (#1123).
+function toggleColumn(tp, cols, col, on, st, explicit) {
   var tpId = _selected, p;
-  if (on) {
+  if (!explicit && !on) {
+    var rest = cols.filter(function (c) { return c.name !== col.name; });
+    if (!rest.length) return;   // единственная колонка: «спрятать всё» состава не имеет
+    p = editOp({ op: 'insertColumns', parent: tpId, columns: JSON.stringify(rest.map(function (c) {
+      return { name: 'Кол' + c.name, title: c.title || '', data_path: 'Объект.' + tp + '.' + c.name };
+    })) }, true);
+  } else if (on) {
     p = editOp({ op: 'insert', parent: tpId, index: 9999, kind: 'Колонка',
       name: 'Кол' + col.name, data_path: 'Объект.' + tp + '.' + col.name, title_ru: col.title || '' }, true);
-  } else if (existingId) {
-    p = editOp({ op: 'delete', node: existingId }, true);
+  } else if (st.map[col.name]) {
+    p = editOp({ op: 'delete', node: st.map[col.name] }, true);
   } else { return; }
   p.then(function (resp) { if (resp && resp.ok) selectNode(tpId); });
 }
@@ -1466,14 +1519,21 @@ func previewErrorHTML(msg string) string {
 		html.EscapeString(msg))
 }
 
+// previewTableParts — состав табличных частей объекта (имя ТЧ → реквизиты) для
+// предпросмотра. Нужен ровно там, где колонки в форме явно не объявлены: рантайм
+// в этом случае показывает все реквизиты, и предпросмотр обязан показывать то же
+// (#1123). nil — метаданные недоступны, предпросмотр честно говорит об этом.
+type previewTableParts map[string][]formScaffoldAttr
+
 // renderManagedFormPreview генерирует упрощённый HTML-предпросмотр
-// дерева элементов формы. Не использует metadata.Entity — отрисовывает
-// абстрактные input/checkbox/group на основе FormModule.Elements.
+// дерева элементов формы. Отрисовывает абстрактные input/checkbox/group на
+// основе FormModule.Elements; из metadata.Entity берёт только состав табличных
+// частей (tps) — чтобы ТЧ без явных колонок выглядела как в рантайме.
 //
 // Этого достаточно для UI-редактора чтобы оценить структуру формы;
 // полноценный рендер с реальными данными доступен после сохранения
 // через рантайм-handler /ui/.../form (этап 3).
-func renderManagedFormPreview(fm *metadata.FormModule) string {
+func renderManagedFormPreview(fm *metadata.FormModule, tps previewTableParts) string {
 	var buf bytes.Buffer
 	buf.WriteString(`<!doctype html><html><head><meta charset="utf-8"><style>
 body{margin:0;padding:18px;font-family:-apple-system,sans-serif;background:#fff;color:#334;font-size:13px}
@@ -1516,7 +1576,7 @@ legend{font-weight:600;color:#475569;padding:0 6px;font-size:12px}
 
 	tabsCounter := 0
 	for _, el := range fm.Elements {
-		renderPreviewElement(&buf, el, &tabsCounter)
+		renderPreviewElement(&buf, el, &tabsCounter, tps)
 	}
 
 	// Inline-JS для переключения вкладок. Работает в iframe sandbox
@@ -1541,7 +1601,7 @@ legend{font-weight:600;color:#475569;padding:0 6px;font-size:12px}
 	return buf.String()
 }
 
-func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCounter *int) {
+func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCounter *int, tps previewTableParts) {
 	if el == nil {
 		return
 	}
@@ -1559,7 +1619,7 @@ func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCount
 		}
 		fmt.Fprintf(buf, `<fieldset%s><legend>%s</legend><div class="group-body">`, cls, html.EscapeString(title))
 		for _, c := range el.Children {
-			renderPreviewElement(buf, c, tabsCounter)
+			renderPreviewElement(buf, c, tabsCounter, tps)
 		}
 		buf.WriteString(`</div></fieldset>`)
 	case metadata.FormElementPages:
@@ -1600,7 +1660,7 @@ func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCount
 			}
 			fmt.Fprintf(buf, `<div class="%s">`, cls)
 			for _, c := range p.Children {
-				renderPreviewElement(buf, c, tabsCounter)
+				renderPreviewElement(buf, c, tabsCounter, tps)
 			}
 			buf.WriteString(`</div>`)
 			pageIdx++
@@ -1611,7 +1671,7 @@ func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCount
 		// рисуем именованным блоком с детьми, а не «предпросмотр не реализован».
 		fmt.Fprintf(buf, `<fieldset><legend>%s</legend>`, html.EscapeString(title))
 		for _, c := range el.Children {
-			renderPreviewElement(buf, c, tabsCounter)
+			renderPreviewElement(buf, c, tabsCounter, tps)
 		}
 		buf.WriteString(`</fieldset>`)
 	case metadata.FormElementField:
@@ -1649,26 +1709,52 @@ func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCount
 		fmt.Fprintf(buf, `<div class="hint">[Картинка: %s]</div>`, html.EscapeString(el.Name))
 	case metadata.FormElementTable, metadata.FormElementTablePart:
 		// Колонки, выбранные в конструкторе (дочерние kind:Колонка), рисуем
-		// реальной таблицей-каркасом с парой пустых строк. Без явных колонок —
-		// подсказка (в рантайме они подставятся из метаданных автоматически).
+		// реальной таблицей-каркасом с парой пустых строк.
 		var cols []*metadata.FormElement
 		for _, c := range el.Children {
 			if c != nil && c.Kind == metadata.FormElementColumn {
 				cols = append(cols, c)
 			}
 		}
-		fmt.Fprintf(buf, `<div class="tp-prev"><div class="tp-prev-hd">▦ %s</div>`, html.EscapeString(title))
-		if len(cols) == 0 {
-			buf.WriteString(`<div class="hint">Колонки не выбраны — отметьте состав в свойствах табличной части (в рантайме иначе показываются все поля).</div>`)
-		} else {
-			buf.WriteString(`<table class="tp-prev-tbl"><thead><tr>`)
+		// Без явных колонок рантайм показывает ВСЕ реквизиты табличной части
+		// (managedTPColumnPlan). Раньше предпросмотр в этом месте рисовал
+		// подсказку вместо таблицы — то есть показывал пустоту там, где
+		// пользователь увидит полный набор колонок, и подталкивал «исправить»
+		// это галочкой, которая на самом деле убирает все колонки, кроме
+		// отмеченной (#1123). Заголовки берём из метаданных ТЧ.
+		headers := make([]string, 0, len(cols))
+		fallback := ""
+		if len(cols) > 0 {
 			for _, c := range cols {
-				fmt.Fprintf(buf, `<th>%s</th>`, html.EscapeString(columnLabel(c)))
+				headers = append(headers, columnLabel(c))
+			}
+		} else if attrs := tps[previewTablePartName(el)]; len(attrs) > 0 {
+			for _, a := range attrs {
+				name := a.Title
+				if strings.TrimSpace(name) == "" {
+					name = a.Name
+				}
+				headers = append(headers, name)
+			}
+			fallback = "Состав не задан — показываются все реквизиты табличной части."
+		}
+		fmt.Fprintf(buf, `<div class="tp-prev"><div class="tp-prev-hd">▦ %s</div>`, html.EscapeString(title))
+		if len(headers) == 0 {
+			// Метаданные ТЧ недоступны (предпросмотр без базы или ТЧ не найдена):
+			// перечислить нечего, но соглашение назвать обязаны.
+			buf.WriteString(`<div class="hint">Состав не задан — в рантайме показываются все реквизиты табличной части.</div>`)
+		} else {
+			if fallback != "" {
+				fmt.Fprintf(buf, `<div class="hint">%s</div>`, html.EscapeString(fallback))
+			}
+			buf.WriteString(`<table class="tp-prev-tbl"><thead><tr>`)
+			for _, h := range headers {
+				fmt.Fprintf(buf, `<th>%s</th>`, html.EscapeString(h))
 			}
 			buf.WriteString(`</tr></thead><tbody>`)
 			for r := 0; r < 2; r++ {
 				buf.WriteString(`<tr>`)
-				for range cols {
+				for range headers {
 					buf.WriteString(`<td></td>`)
 				}
 				buf.WriteString(`</tr>`)
@@ -1680,12 +1766,22 @@ func renderPreviewElement(buf *bytes.Buffer, el *metadata.FormElement, tabsCount
 		// командная панель — обычно рендерится в toolbar над формой;
 		// в preview просто рисуем кнопки в ряд.
 		for _, c := range el.Children {
-			renderPreviewElement(buf, c, tabsCounter)
+			renderPreviewElement(buf, c, tabsCounter, tps)
 		}
 	default:
 		fmt.Fprintf(buf, `<div class="unknown">Элемент «%s» типа «%s»: предпросмотр не реализован.</div>`,
 			html.EscapeString(el.Name), html.EscapeString(string(el.Kind)))
 	}
+}
+
+// previewTablePartName — имя табличной части элемента формы: последний сегмент
+// data_path ("Объект.Товары" → "Товары"), иначе имя элемента. Тот же вывод, что
+// у tablePartName() в клиенте конструктора, — ключ для previewTableParts.
+func previewTablePartName(el *metadata.FormElement) string {
+	if dp := strings.TrimSpace(el.DataPath); dp != "" {
+		return lastSegment(dp)
+	}
+	return strings.TrimSpace(el.Name)
 }
 
 // lastSegment — последний компонент пути "Объект.Контрагент" → "Контрагент".

--- a/internal/launcher/forms_tp_default_columns_test.go
+++ b/internal/launcher/forms_tp_default_columns_test.go
@@ -1,0 +1,191 @@
+package launcher
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/dsl/loader"
+	"github.com/ivantit66/onebase/internal/formdoc"
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Расхождение #1123: рантайм (managedTPColumnPlan) трактует «ни одного ребёнка
+// kind: Колонка» как «показать ВСЕ реквизиты», а конструктор изображал пустоту —
+// холст писал «колонки не выбраны», галочки в панели стояли снятыми. Пользователь
+// видел в работающей форме полную таблицу, а в конструкторе пустую ТЧ, и
+// «исправлял» это галочкой, которая на самом деле убирает все колонки, кроме
+// отмеченной. Так объявлены ТЧ во всех примерах конфигураций.
+
+// tpFormYAML — форма из одной табличной части без явных колонок.
+const tpFormYAML = `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  title:
+    ru: "Поступление"
+elements:
+  - kind: ТабличнаяЧасть
+    name: ТабТовары
+    title:
+      ru: "Товары"
+    data_path: Объект.Товары
+`
+
+func TestХолст_ТЧБезКолонокНеНазываетсяПустой(t *testing.T) {
+	doc, err := formdoc.Load([]byte(tpFormYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	html, err := renderFormCanvas(doc, "")
+	if err != nil {
+		t.Fatalf("renderFormCanvas: %v", err)
+	}
+	if strings.Contains(html, "колонки не выбраны") {
+		t.Errorf("холст называет пустой ТЧ, у которой рантайм покажет все колонки:\n%s", html)
+	}
+	if !strings.Contains(html, "все колонки (по умолчанию)") {
+		t.Errorf("холст не называет состояние «показываются все колонки»:\n%s", html)
+	}
+}
+
+// Явный состав холст обязан показывать как есть — иначе подпись «по умолчанию»
+// появлялась бы там, где состав как раз задан руками.
+func TestХолст_ТЧСКолонкамиПоказываетИх(t *testing.T) {
+	src := strings.Replace(tpFormYAML, "    data_path: Объект.Товары\n",
+		`    data_path: Объект.Товары
+    children:
+      - kind: Колонка
+        name: КолЦена
+        data_path: Объект.Товары.Цена
+`, 1)
+	doc, err := formdoc.Load([]byte(src))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	html, err := renderFormCanvas(doc, "")
+	if err != nil {
+		t.Fatalf("renderFormCanvas: %v", err)
+	}
+	if strings.Contains(html, "все колонки (по умолчанию)") {
+		t.Errorf("холст назвал явный состав умолчанием:\n%s", html)
+	}
+	if !strings.Contains(html, "Цена") {
+		t.Errorf("холст не показал объявленную колонку:\n%s", html)
+	}
+}
+
+// Ребёнок не-Колонка не должен считаться заданным составом: рантайм переходит в
+// режим «показать выбранное» только по детям kind: Колонка.
+func TestХолст_ПостороннийРебёнокНеСчитаетсяСоставом(t *testing.T) {
+	src := strings.Replace(tpFormYAML, "    data_path: Объект.Товары\n",
+		`    data_path: Объект.Товары
+    children:
+      - kind: Кнопка
+        name: КнопкаЗаполнить
+`, 1)
+	doc, err := formdoc.Load([]byte(src))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	html, err := renderFormCanvas(doc, "")
+	if err != nil {
+		t.Fatalf("renderFormCanvas: %v", err)
+	}
+	if !strings.Contains(html, "все колонки (по умолчанию)") {
+		t.Errorf("кнопка внутри ТЧ засчитана за состав колонок:\n%s", html)
+	}
+}
+
+// Рантайм сопоставляет колонку реквизиту по data_path, field ИЛИ имени
+// (managedTPFieldIndexForColumn), а в модель холста ключ field не попадал вовсе —
+// поэтому панель свойств не могла поставить галочку такой колонке.
+func TestМодельХолста_КолонкаЧерезFieldПопадаетВМодель(t *testing.T) {
+	src := strings.Replace(tpFormYAML, "    data_path: Объект.Товары\n",
+		`    data_path: Объект.Товары
+    children:
+      - kind: Колонка
+        name: КолЦена
+        field: Цена
+`, 1)
+	doc, err := formdoc.Load([]byte(src))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	model, err := canvasModel(doc)
+	if err != nil {
+		t.Fatalf("canvasModel: %v", err)
+	}
+	info, ok := model["elements.0.children.0"]
+	if !ok {
+		t.Fatalf("колонки нет в модели: %+v", model)
+	}
+	if info.Field != "Цена" {
+		t.Errorf("ключ field не попал в модель холста: %+v", info)
+	}
+}
+
+// insertColumns — материализация состава одной командой. Серия из N запросов с
+// клиента при обрыве на середине оставила бы ТЧ с ЯВНЫМ составом, урезанным до
+// места обрыва, то есть тихо спрятала бы колонки, которых никто не снимал.
+func TestEditOp_InsertColumnsМатериализуетСоставЦеликом(t *testing.T) {
+	res, err := applyEditOp([]byte(tpFormYAML), editOpRequest{
+		Op:     "insertColumns",
+		Parent: "elements.0",
+		Columns: `[{"name":"КолНоменклатура","title":"Номенклатура","data_path":"Объект.Товары.Номенклатура"},
+		           {"name":"КолКоличество","title":"Количество","data_path":"Объект.Товары.Количество"},
+		           {"name":"КолСумма","title":"Сумма","data_path":"Объект.Товары.Сумма"}]`,
+	})
+	if err != nil {
+		t.Fatalf("applyEditOp: %v", err)
+	}
+	if res.SelectedID != "elements.0" {
+		t.Errorf("выделение ушло с табличной части: %q", res.SelectedID)
+	}
+
+	// Проверяем не текст YAML, а то, что из него прочитает рантайм: колонки
+	// должны стать детьми ТЧ в присланном порядке.
+	fm := loadFormModule(t, res.YAML)
+	if len(fm.Elements) != 1 {
+		t.Fatalf("ожидался один элемент формы, получено %d", len(fm.Elements))
+	}
+	var got []string
+	for _, c := range fm.Elements[0].Children {
+		if c.Kind != metadata.FormElementColumn {
+			t.Errorf("среди детей ТЧ появился %q", c.Kind)
+			continue
+		}
+		got = append(got, c.DataPath)
+	}
+	want := []string{"Объект.Товары.Номенклатура", "Объект.Товары.Количество", "Объект.Товары.Сумма"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("состав колонок не тот:\nбыло  %v\nнадо  %v\nYAML:\n%s", got, want, res.YAML)
+	}
+}
+
+func TestEditOp_InsertColumnsОтвергаетПустоеИНеразборное(t *testing.T) {
+	for name, req := range map[string]editOpRequest{
+		"без parent":       {Op: "insertColumns", Columns: `[{"name":"К"}]`},
+		"пустой список":    {Op: "insertColumns", Parent: "elements.0", Columns: `[]`},
+		"неразборный JSON": {Op: "insertColumns", Parent: "elements.0", Columns: `{`},
+	} {
+		if _, err := applyEditOp([]byte(tpFormYAML), req); err == nil {
+			t.Errorf("%s: команда принята, хотя состав задать нечем", name)
+		}
+	}
+}
+
+// loadFormModule прогоняет YAML через тот же загрузчик, которым форму читает
+// рантайм: тест обязан идти путём пользователя, а не разбирать YAML по-своему.
+func loadFormModule(t *testing.T, yamlSrc string) *metadata.FormModule {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "объекта.form.yaml")
+	if err := os.WriteFile(path, []byte(yamlSrc), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	fm, err := loader.NewManagedFormLoader().LoadFormFile(path, "Поступление")
+	if err != nil {
+		t.Fatalf("LoadFormFile: %v\nYAML:\n%s", err, yamlSrc)
+	}
+	return fm
+}

--- a/internal/launcher/forms_tp_panel_test.go
+++ b/internal/launcher/forms_tp_panel_test.go
@@ -106,3 +106,55 @@ elements:
 		t.Fatalf("после перечитывания auto_sum не взведён: %+v", els[0].El)
 	}
 }
+
+// Панель свойств ТЧ рисовала все галочки состава снятыми, когда колонки не
+// объявлены, — хотя рантайм в этом случае показывает ВСЕ реквизиты. Подпись
+// «Колонки (показывать):» при снятых галочках читается как «не показывается
+// ничего», и пользователь ставил галочку, чтобы «вернуть» колонку; на деле
+// первая же галочка убирает все остальные (#1123).
+func TestПанельСвойствТЧ_БезСоставаГалочкиСтоят(t *testing.T) {
+	script := formsEditorScript(t)
+	if !strings.Contains(script, "cb.checked = explicit ? !!st.map[c.name] : true") {
+		t.Errorf("галочки состава не взводятся при незаданном составе:\n%s",
+			extractContext(script, "addColumnsEditor", 900))
+	}
+	for _, s := range []string{
+		"Состав не задан — показываются все колонки.",
+		"Состав задан явно.",
+	} {
+		if !strings.Contains(script, s) {
+			t.Errorf("панель не поясняет состояние состава колонок, нет %q", s)
+		}
+	}
+}
+
+// Снятие первой галочки — это не «убрать одну колонку», а «объявить все
+// остальные». Одной командой: серия запросов при обрыве на середине оставила бы
+// явный состав, урезанный до места обрыва.
+func TestПанельСвойствТЧ_СнятиеПервойГалочкиМатериализуетСостав(t *testing.T) {
+	script := formsEditorScript(t)
+	if !strings.Contains(script, "op: 'insertColumns'") {
+		t.Errorf("материализация состава идёт не одной командой:\n%s",
+			extractContext(script, "function toggleColumn", 900))
+	}
+	if !strings.Contains(script, "if (!explicit && !on)") {
+		t.Errorf("снятие галочки при незаданном составе не выделено в отдельный случай:\n%s",
+			extractContext(script, "function toggleColumn", 900))
+	}
+}
+
+// Сопоставление колонки реквизиту должно повторять рантайм
+// (managedTPFieldIndexForColumn): data_path → field → имя элемента.
+func TestПанельСвойствТЧ_КолонкаСопоставляетсяПоFieldИИмени(t *testing.T) {
+	script := formsEditorScript(t)
+	if !strings.Contains(script, "ch.info.field") {
+		t.Errorf("панель не смотрит ключ field при сопоставлении колонки:\n%s",
+			extractContext(script, "function presentColumns", 800))
+	}
+	// Порядок объявленных колонок берётся из node-id: модель приходит из
+	// Go-map, и порядок ключей в JSON случаен.
+	if !strings.Contains(script, "return a.idx - b.idx") {
+		t.Errorf("порядок колонок берётся из порядка ключей модели, а он случаен:\n%s",
+			extractContext(script, "function columnChildren", 800))
+	}
+}

--- a/internal/ui/tp_column_composition_test.go
+++ b/internal/ui/tp_column_composition_test.go
@@ -334,6 +334,33 @@ func TestTPКолонки_БезОбработчикаКартаНеРендер
 	}
 }
 
+// Колонку можно объявить ключом field, без data_path: managedTPFieldIndexForColumn
+// перебирает data_path → field → имя элемента. Форма её показывает — а панель
+// свойств конструктора такую колонку не признавала и рисовала галочку снятой,
+// потому что сопоставляла только по data_path (#1123). Раз конструктор теперь
+// повторяет ту же цепочку, рантайм обязан её поддерживать и дальше.
+func TestTPКолонки_ВыборПоКлючуField(t *testing.T) {
+	s, order, id := tpColumnsFixture(t, &metadata.FormElement{
+		Kind: metadata.FormElementTablePart, Name: "ТабСтроки", DataPath: "Объект.Строки",
+		Children: []*metadata.FormElement{
+			{Kind: metadata.FormElementColumn, Name: "КолЦена", FieldName: "Цена"},
+		},
+	})
+	cols := parseManagedTPColumns(t, tpColumnsFormHTML(t, s, order, id))
+
+	if len(cols) == 0 {
+		t.Fatalf("колонок нет вовсе: %+v", cols)
+	}
+	if cols[0].ID != "Цена" || cols[0].Hidden {
+		t.Errorf("колонка по ключу field не выбрана: %+v", cols[0])
+	}
+	for _, col := range cols[1:] {
+		if !col.Hidden {
+			t.Errorf("колонка %q показана, хотя состав выбрал только Цену", col.ID)
+		}
+	}
+}
+
 // tpTableFragment вырезает кусок разметки вокруг грида — чтобы падение теста
 // показывало разметку табличной части, а не всю страницу.
 func tpTableFragment(rendered string) string {


### PR DESCRIPTION
Конструктор и рантайм по-разному понимали «колонки ТЧ не объявлены».

**Рантайм** (`managedTPColumnPlan`): нет ни одного ребёнка `kind: Колонка` →
показываются **все** реквизиты. **Конструктор** ту же пустоту изображал
пустотой: холст писал «колонки не выбраны», галочки состава стояли снятыми,
предпросмотр рисовал подсказку вместо таблицы. Так объявлены ТЧ во всех
примерах конфигураций (trade, tasks, crm, finance) — штатное состояние
выглядело сломанным.

Опаснее самой путаницы то, к чему она подталкивала. Галочка в этом состоянии
не «добавляет колонку», а переключает смысл с «все» на «только отмеченные»:

```
без детей            → видно:[Номенклатура Количество Цена Сумма]  скрыто:[]
после одной галочки  → видно:[Номенклатура]  скрыто:[Количество Цена Сумма]
```

То есть попытка вернуть колонку убирала три остальных.

## Что сделано

- **Панель свойств**: при незаданном составе галочки стоят, а текст называет
  состояние («Состав не задан — показываются все колонки»). Снятие первой
  галочки материализует весь состав без снятой, а не оставляет одну колонку.
- **Материализация — одной командой** `insertColumns`, а не серией из N
  запросов с клиента: обрыв на середине оставил бы ТЧ с ЯВНЫМ составом,
  урезанным до случайного места обрыва, — то есть тихо спрятал бы колонки,
  которых никто не снимал.
- **Холст**: «все колонки (по умолчанию)» вместо «колонки не выбраны».
  Признак — наличие детей именно `kind: Колонка`, как и в рантайме, а не
  любых детей.
- **Предпросмотр**: рисует таблицу по реквизитам ТЧ, когда состав не задан.
  Метаданные необязательны — без открытой базы предпросмотр деградирует до
  подсказки, называющей соглашение, но не до ошибки.
- **Сопоставление колонки реквизиту** в панели повторяет рантайм
  (`data_path` → `field` → имя): колонка, объявленная ключом `field`, в
  рантайме была видна, а в панели стояла без галочки. Ключ `field` добавлен
  в модель холста, где его не было вовсе.

Побочно: порядок объявленных колонок берётся из индекса в node-id. Раньше он
брался из порядка ключей `_model`, а модель приходит из Go-map — порядок
ключей в JSON случаен.

Явный состав нигде не трогается: включение и выключение колонки при заданном
составе работают как раньше (один `insert` / один `delete`), поэтому имена,
заголовки и обработчики соседних колонок остаются на месте.

## Проверено

Go-тесты: холст (пустой состав / явный состав / посторонний ребёнок), модель
холста с `field`, `insertColumns` (материализация целиком + отказ на пустом и
неразборном входе), предпросмотр (все реквизиты / без метаданных / явный
состав сильнее метаданных), панель свойств. Результат `insertColumns`
проверяется не текстом YAML, а прогоном через тот же загрузчик, которым форму
читает рантайм.

В `internal/ui` добавлен случай, которого не хватало: колонка через `field:`
выбирает состав — проверено через публичный путь (GET карточки документа),
как и остальные тесты состава колонок.

Логика панели дополнительно прогнана в node на извлечённом inline-скрипте:
галочки при незаданном составе, материализация одной командой без снятой
колонки, `delete` при заданном составе, признание колонки через `field`,
порядок по node-id. Прогон разовый, в репозиторий не добавлялся —
инфраструктуры для исполнения шаблонного JS в `go test` здесь нет.

`go test ./...` зелёный, `go vet ./...` чист, gate inline-JS (`jsextract` +
`node --check`, 67 блоков) и `i18ncheck` проходят.

Fixes #1123
