### PR TITLE
fix(pipeline): allow explicit recovery of malformed carry

### DIFF
--- a/.claude/skills/merge-shepherd/SKILL.md
+++ b/.claude/skills/merge-shepherd/SKILL.md
@@ -157,7 +157,7 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
    ids комментариев и label events: они принадлежат разным таблицам и не задают
    общий порядок.
 
-   Разрешены ровно три способа связать этот ship-transition с текущим proof:
+   Разрешены ровно четыре способа связать этот ship-transition с текущим proof:
 
    - **обычный:** edge `ship` расположен после edges review-комментария, claim и
      completion текущего SHA;
@@ -169,6 +169,10 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
      до intent/done-протокола, а человек заново поставил `ship` после anchor
      этого HEAD и интеграционное REVIEW уже создало для него каноничный proof с
      outcome `reviewed`.
+   - **protocol-recovery reauthorized:** текущий HEAD — точный `to` trusted
+     intent/done handoff, исходный carry которого невалиден; человек заново
+     поставил `ship` после edge самого done, а интеграционное REVIEW уже создало
+     каноничный proof текущего HEAD с outcome `reviewed`.
 
    Legacy reauthorization валидна только если текущий HEAD `to` — merge-коммит
    ровно с двумя parents `[from, base]`; `from` имеет каноничный proof `reviewed`
@@ -179,6 +183,15 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
    label допустимо. Докажи условия двумя стабильными полными GraphQL snapshot и
    REST parents; похожий merge message доказательством не считается. Новый push
    после re-ship отменяет разрешение.
+
+   Protocol-recovery reauthorization требует trusted не редактированные
+   intent/done, exact parents `[from, base]`, каноничный source proof `from`,
+   ровно один `PullRequestCommit` между intent и done, `base` как предка
+   текущего `main` и последний trusted `ship` от `ivanarama` после edge done.
+   После done не допускаются HEAD/base lifecycle events. Исходный stale
+   `ship-event` не оживает: новый label разрешает только точный текущий HEAD и
+   отменяется следующим push. Условия доказываются двумя стабильными GraphQL
+   snapshot и REST parents.
 
    Base-sync carry состоит из точных отдельных строк:
 
@@ -204,12 +217,13 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
    оставаться исходным trusted `LabeledEvent`: снятие/повторная постановка,
    edit/delete marker, чужой head event или разрыв `previous` отменяют carry.
 
-   Если текущий HEAD равен `to` валидного последнего done либо является точным
-   legacy base-sync с re-ship после его anchor, но каноничного proof текущего
+   Если текущий HEAD равен `to` валидного последнего done, является точным
+   legacy base-sync с re-ship после его anchor либо имеет доказанный
+   protocol-recovery re-ship после своего done, но каноничного proof текущего
    HEAD ещё нет, это **не stale ship**: ничего не меняй, зафиксируй
    «ожидает интеграционное REVIEW» и переходи к следующему PR. Во всех остальных
    случаях отсутствие актуальной завершённой пары, более поздний override либо
-   отсутствие обычного/carried/legacy-reauthorized разрешения — stale `ship`. Выполни атомарную
+   отсутствие обычного/carried/legacy/protocol-recovery разрешения — stale `ship`. Выполни атомарную
    передачу в REVIEW: сними `ship` через REST → сверь удаление → оставь
    комментарий «ship снят: текущий HEAD ещё не прошёл ревью» → прекрати обработку
    PR. После снятия `ship` комментарий является разрешённым завершающим шагом
@@ -224,9 +238,11 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
 
 3. По состоянию:
    - **BEHIND** → после полного label+SHA+authorization-гейта (включая допустимое
-     legacy reauthorization) сохрани проверенный
+     legacy либо protocol-recovery reauthorization) сохрани проверенный
      SHA, текущий `baseRefOid`, ids proof, node id исходного ship-transition и id
-     предыдущего done (`none` для первого sync). Сначала опубликуй exact intent:
+     предыдущего done (`none` для первого sync). Для protocol-recovery всегда
+     начни новую исправленную цепочку с `previous=none`; malformed historical
+     done остаётся только доказанным anchor reauthorization. Сначала опубликуй exact intent:
 
      ```
      <!-- pp:base-sync-intent from=<SHA> base=<baseRefOid> review-comment=<id> claim=<id> completion=<id> ship-event=<node id> previous=<done id|none> -->

--- a/.claude/skills/review-queue/SKILL.md
+++ b/.claude/skills/review-queue/SKILL.md
@@ -371,6 +371,24 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
    GraphQL snapshot и REST parents; похожий merge message доказательством не
    считается.
 
+   Protocol-recovery re-ship — отдельный узкий путь для исторического handoff,
+   у которого уже есть trusted не редактированные `pp:base-sync-intent` и
+   `pp:base-sync-done`, но исходный carry оказался невалиден (например,
+   адресованный `ship-event` расположен до completion). Он валиден, только если
+   текущий HEAD в точности равен `to` этого done; commit имеет parents
+   `[from, base]`; адресованный source proof `from` каноничен; между intent и
+   done был ровно один `PullRequestCommit`; `base` — предок текущего `main`; а
+   **последний** ship-transition — новый trusted `LabeledEvent` от `ivanarama`
+   уже после edge самого done. После done и до нового label/current snapshot не
+   должно быть HEAD/base lifecycle events. Снятие старой метки непосредственно
+   перед новым trusted label допустимо. Докажи это двумя стабильными полными
+   GraphQL snapshot и REST parents. Новый label явно разрешает проверить точный
+   текущий `to`, но не делает старый carry валидным и не наследуется следующим
+   push. После успешного интеграционного REVIEW MERGE принимает это разрешение
+   без ещё одного клика; если нужен следующий base-sync, он начинает новую
+   carry-цепочку с `previous=none`, используя этот recovery re-ship как
+   authorization исходного `from`.
+
    Контрольная таблица — применяй её буквально:
 
    | Состояние | Действие |
@@ -379,6 +397,7 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
    | есть `ship`, но нет валидного незавершённого `pp:base-sync-done` и нет legacy re-ship для текущего HEAD | пропустить |
    | есть `ship`, текущий HEAD равен `to` валидной carry-цепочки и ещё не имеет committed-пары | единственное интеграционное REVIEW запуска; после committed-пары закончить весь этап |
    | есть `ship`, текущий HEAD ещё без committed-пары и валиден legacy re-ship после его anchor | единственное интеграционное REVIEW запуска; после committed-пары закончить весь этап |
+   | есть `ship`, текущий HEAD ещё без committed-пары и валиден protocol-recovery re-ship после его `pp:base-sync-done` | единственное интеграционное REVIEW запуска; после committed-пары закончить весь этап |
    | есть каноничный committed-маркер и `changes-requested` / `needs-decision`, более позднего override нет | пропустить: мяч у FIX / человека |
    | после committed-пары есть непоглощённый override при `changes-requested` / `needs-decision` | REVIEW продолжает; старая маршрутная метка не является стопом |
    | есть валидный `PP-Fix-Transition` нового HEAD и незавершённая post-push фаза | пропустить: мяч у финализации FIX |

--- a/docs/maintenance-pipeline.md
+++ b/docs/maintenance-pipeline.md
@@ -515,6 +515,13 @@ HEAD — ровно двухродительский merge `[ранее пров
 REVIEW сначала доказывает эту lineage полным GraphQL timeline и REST parents;
 любой новый push отменяет re-ship. После успешного интеграционного REVIEW второй
 клик не требуется, а следующий base-sync уже записывается новым протоколом.
+Если старый воркер уже записал intent/done, но связал carry с `ship-event` до
+source completion, этот malformed handoff не чинится притворным продолжением
+цепочки. Человек повторно ставит `ship` после edge done; REVIEW доказывает exact
+`to`, parents `[from, base]`, source proof, единственный commit event и отсутствие
+последующих HEAD/base events. Это protocol-recovery reauthorization точного
+текущего HEAD. Следующий push его отменяет, а следующий base-sync начинает новую
+цепочку с `previous=none`.
 Одновременно активен только один такой handoff. MERGE обновляет первый PR и
 останавливает весь запуск; REVIEW делает единственный интеграционный аудит этого
 PR и тоже останавливается; следующий MERGE сначала доводит владельца барьера до

--- a/internal/pipelinecontract/skills_test.go
+++ b/internal/pipelinecontract/skills_test.go
@@ -673,7 +673,7 @@ func TestLegacyBaseSyncCanBeExplicitlyReauthorizedWithoutPingPong(t *testing.T) 
 		"Новый label является явным разрешением проверить и затем влить точный уже существующий `to`, но не наследуется следующим push",
 	)
 	requireAllCompact(t, merge,
-		"Разрешены ровно три способа связать этот ship-transition с текущим proof",
+		"Разрешены ровно четыре способа связать этот ship-transition с текущим proof",
 		"legacy reauthorized",
 		"текущий HEAD `to` — merge-коммит ровно с двумя parents `[from, base]`",
 		"последний ship-transition — новый trusted `LabeledEvent` от `ivanarama` после anchor `to`",
@@ -689,6 +689,30 @@ func TestLegacyBaseSyncCanBeExplicitlyReauthorizedWithoutPingPong(t *testing.T) 
 		"следующий base-sync уже записывается новым протоколом",
 		"Одновременно активен только один такой handoff",
 		"следующий MERGE сначала доводит владельца барьера до слияния",
+	)
+}
+
+func TestMalformedProtocolCarryCanBeExplicitlyReauthorized(t *testing.T) {
+	review := skill(t, "review-queue")
+	merge := skill(t, "merge-shepherd")
+	docs := repositoryFile(t, "docs", "maintenance-pipeline.md")
+	requireAllCompact(t, review,
+		"Protocol-recovery re-ship — отдельный узкий путь",
+		"исходный carry оказался невалиден",
+		"после edge самого done",
+		"не делает старый carry валидным",
+		"начинает новую carry-цепочку с `previous=none`",
+	)
+	requireAllCompact(t, merge,
+		"Разрешены ровно четыре способа",
+		"**protocol-recovery reauthorized:**",
+		"последний trusted `ship` от `ivanarama` после edge done",
+		"Для protocol-recovery всегда начни новую исправленную цепочку с `previous=none`",
+	)
+	requireAllCompact(t, docs,
+		"malformed handoff не чинится притворным продолжением цепочки",
+		"protocol-recovery reauthorization точного текущего HEAD",
+		"следующий base-sync начинает новую цепочку с `previous=none`",
 	)
 }
 


### PR DESCRIPTION
## Проблема

Быстрый health допускал exact base-sync owner, но полный GraphQL gate не имел пути восстановления, если исторический intent/done ссылался на ship до source completion. Новый человеческий ship после done всё равно отвергался.

## Исправление

- отдельный protocol-recovery reauthorization точного текущего HEAD
- обязательные exact parents/source proof/single event/stable GraphQL snapshots
- новый push отменяет разрешение
- следующий base-sync начинает чистую previous=none цепочку

## Проверка

- go test ./internal/pipelinecontract ./tools/pipelinehealth