### PR TITLE
fix(pipeline): read authoritative base tip

### DIFF
--- a/.claude/skills/merge-shepherd/SKILL.md
+++ b/.claude/skills/merge-shepherd/SKILL.md
@@ -239,18 +239,22 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
 3. По состоянию:
    - **BEHIND** → после полного label+SHA+authorization-гейта (включая допустимое
      legacy либо protocol-recovery reauthorization) сохрани проверенный
-     SHA, текущий `baseRefOid`, ids proof, node id исходного ship-transition и id
+     SHA, ids proof, node id исходного ship-transition и id
      предыдущего done (`none` для первого sync). Для protocol-recovery всегда
      начни новую исправленную цепочку с `previous=none`; malformed historical
-     done остаётся только доказанным anchor reauthorization. Сначала опубликуй exact intent:
+     done остаётся только доказанным anchor reauthorization. Authoritative tip
+     целевой ветки получи только прямым REST-чтением
+     `gh api repos/ivanarama/onebase/git/ref/heads/main --jq .object.sha`;
+     `PullRequest.baseRefOid` не используй как tip `main`. Сначала опубликуй exact intent:
 
      ```
-     <!-- pp:base-sync-intent from=<SHA> base=<baseRefOid> review-comment=<id> claim=<id> completion=<id> ship-event=<node id> previous=<done id|none> -->
+     <!-- pp:base-sync-intent from=<SHA> base=<authoritative main ref SHA> review-comment=<id> claim=<id> completion=<id> ship-event=<node id> previous=<done id|none> -->
      ```
 
      Перечитай полный timeline. Продолжает только самый ранний валидный intent
      для этой пары `from` + authorization; параллельный worker, создавший более
-     поздний intent, останавливается. Затем ещё раз выполни полный гейт и вызови
+     поздний intent, останавливается. Непосредственно перед update ещё раз
+     прочитай `refs/heads/main`; затем ещё раз выполни полный гейт и вызови
      compare-and-update:
 
      ```
@@ -267,7 +271,12 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
      stale-ship передача.
 
      После успешного update или доказанного recovery прочитай новый HEAD и его
-     parents, повтори стабильный timeline gate и опубликуй exact done:
+     parents. `done.base` всегда равен фактическому второму parent, а не слепой
+     копии `intent.base`. Если `main` сдвинулся между intent и update, расхождение
+     допустимо только когда `intent.base` — предок фактического parent,
+     фактический parent — предок текущего `main`, а остальные timeline/HEAD
+     условия сохранились; диагностика обязана показать
+     `base_sync_base_advanced`. Повтори стабильный timeline gate и опубликуй exact done:
 
      ```
      <!-- pp:base-sync-done intent=<id> from=<SHA> to=<новый SHA> base=<второй parent> previous=<done id|none> ship-event=<node id> -->

--- a/.claude/skills/review-queue/SKILL.md
+++ b/.claude/skills/review-queue/SKILL.md
@@ -358,6 +358,14 @@ Windows-1251 и превратить `Триаж` в `РўСЂРёР°Р¶`. П�
    marker или сам merge-коммит: нужна вся непрерывная цепочка. Intent без done —
    незавершённая транзакция MERGE, её REVIEW не захватывает.
 
+   `intent.base` — наблюдавшийся tip `refs/heads/main` перед update, а
+   `done.base` — фактический второй parent созданного merge-коммита. Обычно они
+   равны. Если base успел сдвинуться между intent и update, принимай различие
+   только когда `intent.base` является предком `done.base`, `done.base` равен
+   второму parent и является предком текущего `main`; все остальные
+   timeline/HEAD fences остаются обязательными. Такой случай должен быть виден
+   в health как `base_sync_base_advanced`.
+
    Legacy re-ship нужен только для веток, которые MERGE обновил до внедрения
    intent/done. Он валиден, когда текущий HEAD `to` — merge-коммит ровно с двумя
    parents `[from, base]`; `from` имеет каноничный proof `reviewed` и trusted

--- a/docs/maintenance-pipeline.md
+++ b/docs/maintenance-pipeline.md
@@ -576,6 +576,11 @@ ship-event. Следующие звенья ссылаются через `previ
 новый proof его `to`. Intent выбирается по правилу earliest-wins, поэтому два
 параллельных пастуха не обновляют ветку дважды. Crash до update безопасно
 повторяет CAS, crash после update проверяет parents/timeline и дописывает done.
+Tip `main` для intent читается напрямую из `git/ref/heads/main`, а не из
+`PullRequest.baseRefOid`. Поле `done.base` берётся из фактического второго
+parent. Если base сдвинулся между intent и update, различие допустимо только при
+доказанной ancestry `intent.base → done.base → current main` и показывается
+диагностикой `base_sync_base_advanced`.
 Edit/delete, разрыв цепочки, снятие `ship` или любой недоказанный push закрывают
 carry и требуют нового решения человека.
 

--- a/internal/pipelinecontract/skills_test.go
+++ b/internal/pipelinecontract/skills_test.go
@@ -716,6 +716,27 @@ func TestMalformedProtocolCarryCanBeExplicitlyReauthorized(t *testing.T) {
 	)
 }
 
+func TestBaseTipComesFromAuthoritativeRefAndDriftIsVisible(t *testing.T) {
+	review := skill(t, "review-queue")
+	merge := skill(t, "merge-shepherd")
+	docs := repositoryFile(t, "docs", "maintenance-pipeline.md")
+	requireAllCompact(t, merge,
+		"gh api repos/ivanarama/onebase/git/ref/heads/main --jq .object.sha",
+		"`PullRequest.baseRefOid` не используй как tip `main`",
+		"`done.base` всегда равен фактическому второму parent",
+		"`base_sync_base_advanced`",
+	)
+	requireAllCompact(t, review,
+		"`intent.base` — наблюдавшийся tip `refs/heads/main` перед update",
+		"`done.base` — фактический второй parent",
+		"`intent.base` является предком `done.base`",
+	)
+	requireAllCompact(t, docs,
+		"Tip `main` для intent читается напрямую из `git/ref/heads/main`",
+		"ancestry `intent.base → done.base → current main`",
+	)
+}
+
 func TestFixAndMergeCheckoutExactlyReviewedHead(t *testing.T) {
 	fixer := skill(t, "fix-approved")
 	merge := skill(t, "merge-shepherd")

--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -322,7 +322,11 @@ func analyze(prs []apiPull, owner string) report {
 		depth := reviewDepth(pr.Comments, owner)
 		item := candidate{Number: pr.Number, Title: pr.Title, URL: pr.HTMLURL, Head: pr.Head.SHA, Depth: depth, Stage: "review"}
 		currentCompletions, latestCompletion, latestOverride := currentProtocolState(pr.Comments, owner, pr.Head.SHA)
-		carryDone, carryIntentOpen := baseSyncRESTState(pr.Comments, owner, pr.Head.SHA)
+		carryDone, carryIntentOpen, baseAdvanced := baseSyncRESTState(pr.Comments, owner, pr.Head.SHA)
+		if baseAdvanced {
+			result.add("yellow", "base_sync_base_advanced", pr.Number,
+				"base сдвинулся между intent и done; GraphQL gate должен проверить actual parent и ancestry")
+		}
 
 		if labels["changes-requested"] && labels["needs-decision"] {
 			result.add("yellow", "route_transition_open", pr.Number,
@@ -613,13 +617,13 @@ func currentClaimCount(comments []apiComment, owner, head string) int {
 }
 
 type baseSyncIntentShape struct {
-	from, previous, shipEvent string
+	from, base, previous, shipEvent string
 }
 
 // baseSyncRESTState is deliberately only an operational hint. The mutation
 // contracts still prove comment nodes, timeline edges and commit parents with
 // two stable GraphQL snapshots before changing GitHub state.
-func baseSyncRESTState(comments []apiComment, owner, head string) (doneCurrent, intentOpen bool) {
+func baseSyncRESTState(comments []apiComment, owner, head string) (doneCurrent, intentOpen, baseAdvanced bool) {
 	intents := map[int64]baseSyncIntentShape{}
 	doneIntents := map[int64]bool{}
 	for _, comment := range comments {
@@ -627,7 +631,7 @@ func baseSyncRESTState(comments []apiComment, owner, head string) (doneCurrent, 
 			continue
 		}
 		if match := baseSyncIntent.FindStringSubmatch(comment.Body); match != nil {
-			intents[comment.ID] = baseSyncIntentShape{from: match[1], previous: match[7], shipEvent: match[6]}
+			intents[comment.ID] = baseSyncIntentShape{from: match[1], base: match[2], previous: match[7], shipEvent: match[6]}
 		}
 		if match := baseSyncDone.FindStringSubmatch(comment.Body); match != nil {
 			intentID, err := strconv.ParseInt(match[1], 10, 64)
@@ -639,6 +643,7 @@ func baseSyncRESTState(comments []apiComment, owner, head string) (doneCurrent, 
 			doneIntents[intentID] = true
 			if match[3] == head {
 				doneCurrent = true
+				baseAdvanced = intent.base != match[4]
 			}
 		}
 	}
@@ -648,7 +653,7 @@ func baseSyncRESTState(comments []apiComment, owner, head string) (doneCurrent, 
 			break
 		}
 	}
-	return doneCurrent, intentOpen
+	return doneCurrent, intentOpen, baseAdvanced
 }
 
 func duplicateCompletionEpoch(comments []apiComment, owner, head string) bool {

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -165,6 +165,17 @@ func TestLegacyReShipIsVisibleAsPriorityValidationCandidate(t *testing.T) {
 	}
 }
 
+func TestBaseAdvanceBetweenIntentAndDoneIsVisible(t *testing.T) {
+	item := addComment(testPR(77, headB, "ship"), 30,
+		fmt.Sprintf("<!-- pp:base-sync-intent from=%s base=%s review-comment=20 claim=25 completion=29 ship-event=LE_test previous=none -->", headA, headA))
+	item = addComment(item, 31,
+		fmt.Sprintf("<!-- pp:base-sync-done intent=30 from=%s to=%s base=%s previous=none ship-event=LE_test -->", headA, headB, headB))
+	got := analyze([]apiPull{item}, "ivanarama")
+	if !hasFinding(got, "base_sync_base_advanced") {
+		t.Fatalf("base advance between intent and done is invisible: %+v", got)
+	}
+}
+
 func TestSingleFlightExposesOnlyFirstIntegrationReview(t *testing.T) {
 	first := addComment(testPR(20, headB, "ship"), 30, completion(headA, 20, 25))
 	second := addComment(testPR(30, headB, "ship"), 31, completion(headA, 21, 26))


### PR DESCRIPTION
## Проблема

MERGE использовал PullRequest.baseRefOid как tip main. На #1222 он вернул 2ff580e, хотя actual main и второй parent были e0fd7b0.

## Исправление

- authoritative base читается из git/ref/heads/main
- done.base берётся из фактического второго parent
- допустимый сдвиг base требует ancestry gate
- health показывает base_sync_base_advanced

## Проверка

- go test ./internal/pipelinecontract ./tools/pipelinehealth
- live health: только #1222, finding base_sync_base_advanced