### PR TITLE
fix(pipeline): expose executable MERGE queue

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -53,6 +53,7 @@ type apiPull struct {
 	Title     string `json:"title"`
 	HTMLURL   string `json:"html_url"`
 	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 	State     string `json:"state"`
 	Draft     bool   `json:"draft"`
 	Head      struct {
@@ -84,6 +85,7 @@ type candidate struct {
 	Stage          string `json:"stage"`
 	Priority       int    `json:"priority"`
 	PrioritySource string `json:"priority_source"`
+	UpdatedAt      string `json:"updated_at"`
 }
 
 type finding struct {
@@ -107,6 +109,7 @@ type report struct {
 	ReviewedWaitingShip     []candidate `json:"reviewed_waiting_ship"`
 	IntegrationOwner        *candidate  `json:"integration_owner,omitempty"`
 	MergeCandidates         []candidate `json:"merge_candidates"`
+	MergeExecutable         []candidate `json:"merge_executable"`
 	FixCandidates           []candidate `json:"fix_candidates"`
 	HumanWaiting            []candidate `json:"human_waiting"`
 	Findings                []finding   `json:"findings"`
@@ -315,7 +318,7 @@ func analyze(prs []apiPull, owner string) report {
 		State: "green", Scope: "fast REST snapshot; mutation gates remain GraphQL",
 		Scheduler: "two-lane-safety-priority-aging-depth-number", Checked: len(prs),
 		ReviewCandidates: []candidate{}, ContentReviewCandidates: []candidate{},
-		ReviewBacklog: []candidate{}, ReviewedWaitingShip: []candidate{}, MergeCandidates: []candidate{}, FixCandidates: []candidate{},
+		ReviewBacklog: []candidate{}, ReviewedWaitingShip: []candidate{}, MergeCandidates: []candidate{}, MergeExecutable: []candidate{}, FixCandidates: []candidate{},
 		HumanWaiting: []candidate{}, Findings: []finding{},
 	}
 	now := time.Now().UTC()
@@ -332,7 +335,7 @@ func analyze(prs []apiPull, owner string) report {
 		labels := labelSet(pr.Labels)
 		depth := reviewDepth(pr.Comments, owner)
 		priority, prioritySource := queuePriority(labels, pr.CreatedAt, now)
-		item := candidate{Number: pr.Number, Title: pr.Title, URL: pr.HTMLURL, Head: pr.Head.SHA, Depth: depth, Stage: "review", Priority: priority, PrioritySource: prioritySource}
+		item := candidate{Number: pr.Number, Title: pr.Title, URL: pr.HTMLURL, Head: pr.Head.SHA, Depth: depth, Stage: "review", Priority: priority, PrioritySource: prioritySource, UpdatedAt: pr.UpdatedAt}
 		currentCompletions, latestCompletion, latestOverride := currentProtocolState(pr.Comments, owner, pr.Head.SHA)
 		carryDone, carryIntentOpen, baseAdvanced := baseSyncRESTState(pr.Comments, owner, pr.Head.SHA)
 		if baseAdvanced {
@@ -420,6 +423,7 @@ func analyze(prs []apiPull, owner string) report {
 	sortCandidates(result.ContentReviewCandidates)
 	sortCandidates(result.ReviewCandidates)
 	applySingleFlight(&result)
+	setMergeExecutable(&result)
 	result.ReviewBacklog = append(result.ReviewBacklog, result.ContentReviewCandidates...)
 	if result.IntegrationOwner != nil && candidatePriority(result.IntegrationOwner.Stage) == 1 {
 		result.ReviewBacklog = append(result.ReviewBacklog, *result.IntegrationOwner)
@@ -427,6 +431,7 @@ func analyze(prs []apiPull, owner string) report {
 	sortCandidates(result.ReviewBacklog)
 	sortCandidates(result.ReviewedWaitingShip)
 	sortCandidates(result.MergeCandidates)
+	sortCandidates(result.MergeExecutable)
 	sortCandidates(result.FixCandidates)
 	sortCandidates(result.HumanWaiting)
 	return result
@@ -593,9 +598,9 @@ func (result *report) finish() {
 		owner = fmt.Sprintf("#%d(%s)", result.IntegrationOwner.Number, result.IntegrationOwner.Stage)
 	}
 	result.Summary = fmt.Sprintf(
-		"PR: %d; issues: %d; REVIEW исполняемо: %d (следующие %s); всего ждут REVIEW: %d; содержательное: %d; интеграционный владелец: %s; ждут ship: %d; MERGE: %d; FIX: %d; человек: %d; сигналов: %d",
+		"PR: %d; issues: %d; REVIEW исполняемо: %d (следующие %s); всего ждут REVIEW: %d; содержательное: %d; интеграционный владелец: %s; ждут ship: %d; MERGE исполняемо: %d; всего MERGE: %d; FIX: %d; человек: %d; сигналов: %d",
 		result.Checked, result.IssuesChecked, len(result.ReviewCandidates), next,
-		len(result.ReviewBacklog), len(result.ContentReviewCandidates), owner, len(result.ReviewedWaitingShip), len(result.MergeCandidates), len(result.FixCandidates),
+		len(result.ReviewBacklog), len(result.ContentReviewCandidates), owner, len(result.ReviewedWaitingShip), len(result.MergeExecutable), len(result.MergeCandidates), len(result.FixCandidates),
 		len(result.HumanWaiting), len(result.Findings))
 }
 
@@ -824,6 +829,22 @@ func applySingleFlight(result *report) {
 	result.ReviewCandidates = []candidate{owner}
 	result.add("yellow", "single_flight_barrier", owner.Number,
 		fmt.Sprintf("владелец интеграционной полосы; REVIEW проверяет только интеграционную дельту этого PR, содержательных кандидатов отложено: %d, следующих интеграционных: %d", len(result.ContentReviewCandidates), deferredIntegration))
+}
+
+func setMergeExecutable(result *report) {
+	if result.IntegrationOwner == nil {
+		result.MergeExecutable = append([]candidate{}, result.MergeCandidates...)
+		return
+	}
+	if candidatePriority(result.IntegrationOwner.Stage) != 0 {
+		return
+	}
+	for _, item := range result.MergeCandidates {
+		if item.Number == result.IntegrationOwner.Number {
+			result.MergeExecutable = []candidate{item}
+			return
+		}
+	}
 }
 
 func printReport(writer io.Writer, result report) {

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 func testPR(number int, head string, labels ...string) apiPull {
-	item := apiPull{Number: number, Title: "PR", HTMLURL: "https://example.test/pr", State: "open"}
+	item := apiPull{Number: number, Title: "PR", HTMLURL: "https://example.test/pr", UpdatedAt: "2026-09-01T00:00:00Z", State: "open"}
 	item.Head.SHA = head
 	item.Base.Ref = "main"
 	for _, name := range labels {
@@ -152,6 +152,7 @@ func TestCompletedIntegrationReviewKeepsBarrierUntilMerge(t *testing.T) {
 	got := analyze([]apiPull{wouldBeNext, ordinary, owner}, "ivanarama")
 	if len(got.ReviewCandidates) != 1 || got.ReviewCandidates[0].Number != 40 ||
 		got.IntegrationOwner == nil || got.IntegrationOwner.Number != 20 ||
+		len(got.MergeExecutable) != 1 || got.MergeExecutable[0].Number != 20 ||
 		!hasFinding(got, "base_sync_waiting_merge") ||
 		!hasFinding(got, "single_flight_barrier") {
 		t.Fatalf("merge-ready owner incorrectly blocked content review: %+v", got)
@@ -224,8 +225,23 @@ func TestTrustedShipWithCurrentProofIsVisibleToMerge(t *testing.T) {
 	item := addComment(testPR(10, headA, "reviewed", "ship"), 30, completion(headA, 20, 25))
 	got := analyze([]apiPull{item}, "ivanarama")
 	if len(got.MergeCandidates) != 1 || got.MergeCandidates[0].Number != 10 ||
-		got.MergeCandidates[0].Stage != "merge" {
+		got.MergeCandidates[0].Stage != "merge" ||
+		len(got.MergeExecutable) != 1 || got.MergeExecutable[0].Number != 10 ||
+		got.MergeExecutable[0].UpdatedAt != "2026-09-01T00:00:00Z" {
 		t.Fatalf("ordinary merge candidate was hidden: %+v", got)
+	}
+}
+
+func TestIntegrationReviewBlocksUnrelatedMergeWake(t *testing.T) {
+	owner := addComment(testPR(20, headB, "ship", "reviewed"), 30, syncIntent(headA, 10, 20, 25))
+	owner = addComment(owner, 31, syncDone(30, headA, headB))
+	ordinary := addComment(testPR(40, headA, "reviewed", "ship"), 50, completion(headA, 45, 46))
+
+	got := analyze([]apiPull{ordinary, owner}, "ivanarama")
+	if got.IntegrationOwner == nil || got.IntegrationOwner.Number != 20 ||
+		len(got.MergeCandidates) != 1 || got.MergeCandidates[0].Number != 40 ||
+		len(got.MergeExecutable) != 0 {
+		t.Fatalf("MERGE wake ignored the integration-review barrier: %+v", got)
 	}
 }
 


### PR DESCRIPTION
Separates the full MERGE backlog from work that single-flight permits right now, and includes candidate update identity for PromptPilot wake latching.`n`nTests: go test ./tools/pipelinehealth ./internal/pipelinecontract.