### PR TITLE
ui: ссылки строк списка — шаблоном на контейнер (страница списка 247 → 103 КБ)

### DIFF
--- a/e2e/tests/posting.spec.js
+++ b/e2e/tests/posting.spec.js
@@ -18,9 +18,11 @@ test('документ проводится, движения попадают �
   // Копия берёт все ссылки и табличную часть из демо-данных, но
   // сохраняется как новый непроведённый документ. Так предусловие теста не
   // зависит от состояния исходных демо-документов.
-  const source = page.locator('[data-ob-list-row][data-copy-url]').first();
+  // Ссылка копирования собирается на клиенте из опорных адресов контейнера,
+  // поэтому берём её тем же способом, что и интерфейс.
+  const source = page.locator('[data-ob-list-row][data-ob-id]').first();
   await expect(source).toBeVisible();
-  const copyURL = await source.getAttribute('data-copy-url');
+  const copyURL = await source.evaluate((row) => window.obRowUrl(row, 'copy'));
   expect(copyURL).toBeTruthy();
   await open(page, copyURL);
   await page.click(SAVE);

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -90,10 +90,10 @@ func TestPageList_ActivityControlsAndActions(t *testing.T) {
 		`href="?activity=inactive"`,
 		`href="?activity=all"`,
 		`name="activity" value="inactive"`,
-		`data-activity-enabled="1"`,
+		`data-ob-row-activity-enabled="1"`,
 		`data-activity-inactive="1"`,
-		`data-activity-hide-url=`,
-		`/11111111-1111-1111-1111-111111111111/activity?active=0`,
+		`data-ob-row-activity-hide-tpl=`,
+		`/__ID__/activity?active=0`,
 		"Скрыть из выбора",
 		"Вернуть в выбор",
 	} {

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -92,8 +92,8 @@ func TestPageList_ActivityControlsAndActions(t *testing.T) {
 		`name="activity" value="inactive"`,
 		`data-ob-row-activity-enabled="1"`,
 		`data-activity-inactive="1"`,
-		`data-ob-row-activity-hide-tpl=`,
-		`/__ID__/activity?active=0`,
+		`data-ob-row-base=`,
+		`data-ob-id="11111111-1111-1111-1111-111111111111"`,
 		"Скрыть из выбора",
 		"Вернуть в выбор",
 	} {

--- a/internal/ui/copy_item_test.go
+++ b/internal/ui/copy_item_test.go
@@ -615,10 +615,10 @@ func TestListAndCardOfferCopy(t *testing.T) {
 	// Имя сущности шаблон отдаёт percent-encoded, поэтому сверяем хвост ссылки.
 	// Ссылка копирования объявлена один раз на контейнер, идентификатор строки
 	// клиент подставляет вместо плейсхолдера.
-	if !strings.Contains(rec.Body.String(), "data-ob-row-copy-tpl=") ||
-		!strings.Contains(rec.Body.String(), "/new?copy=__ID__") ||
+	if !strings.Contains(rec.Body.String(), "data-ob-row-copy-url=") ||
+		!strings.Contains(rec.Body.String(), `data-ob-row-can-copy="1"`) ||
 		!strings.Contains(rec.Body.String(), `data-ob-id="`+srcID.String()+`"`) {
-		t.Error("список не несёт шаблон ссылки копирования (пункт меню и F9 без неё не работают)")
+		t.Error("список не несёт опорных данных для ссылки копирования (пункт меню и F9 без них не работают)")
 	}
 
 	card := httptest.NewRequest("GET", "/ui/catalog/клиент/"+srcID.String(), nil)

--- a/internal/ui/copy_item_test.go
+++ b/internal/ui/copy_item_test.go
@@ -613,9 +613,12 @@ func TestListAndCardOfferCopy(t *testing.T) {
 		t.Fatalf("список: code = %d, body: %s", rec.Code, rec.Body.String())
 	}
 	// Имя сущности шаблон отдаёт percent-encoded, поэтому сверяем хвост ссылки.
-	if !strings.Contains(rec.Body.String(), "data-copy-url=") ||
-		!strings.Contains(rec.Body.String(), "/new?copy="+srcID.String()) {
-		t.Error("строка списка не несёт ссылку копирования (пункт меню и F9 без неё не работают)")
+	// Ссылка копирования объявлена один раз на контейнер, идентификатор строки
+	// клиент подставляет вместо плейсхолдера.
+	if !strings.Contains(rec.Body.String(), "data-ob-row-copy-tpl=") ||
+		!strings.Contains(rec.Body.String(), "/new?copy=__ID__") ||
+		!strings.Contains(rec.Body.String(), `data-ob-id="`+srcID.String()+`"`) {
+		t.Error("список не несёт шаблон ссылки копирования (пункт меню и F9 без неё не работают)")
 	}
 
 	card := httptest.NewRequest("GET", "/ui/catalog/клиент/"+srcID.String(), nil)

--- a/internal/ui/copy_item_test.go
+++ b/internal/ui/copy_item_test.go
@@ -613,8 +613,8 @@ func TestListAndCardOfferCopy(t *testing.T) {
 		t.Fatalf("список: code = %d, body: %s", rec.Code, rec.Body.String())
 	}
 	// Имя сущности шаблон отдаёт percent-encoded, поэтому сверяем хвост ссылки.
-	// Ссылка копирования объявлена один раз на контейнер, идентификатор строки
-	// клиент подставляет вместо плейсхолдера.
+	// Опорная ссылка копирования объявлена один раз на контейнер, а клиент
+	// добавляет к ней идентификатор строки параметром copy через URLSearchParams.
 	if !strings.Contains(rec.Body.String(), "data-ob-row-copy-url=") ||
 		!strings.Contains(rec.Body.String(), `data-ob-row-can-copy="1"`) ||
 		!strings.Contains(rec.Body.String(), `data-ob-id="`+srcID.String()+`"`) {

--- a/internal/ui/detail_panel_test.go
+++ b/internal/ui/detail_panel_test.go
@@ -190,7 +190,7 @@ func TestDetailPanel_RenderedOutsideLiveContainer(t *testing.T) {
 	if strings.Contains(html, "data-ob-detail='") {
 		t.Error("payload панели снова уехал в разметку строки")
 	}
-	if !strings.Contains(html, "data-ob-row-detail-tpl=") {
+	if !strings.Contains(html, "data-ob-id=") {
 		t.Error("в строке списка нет адреса ленивой загрузки панели")
 	}
 	if !strings.Contains(html, "data-ob-detail-toggle") {
@@ -259,7 +259,7 @@ func TestDetailPanel_AllEntityListModesCarryLazyURL(t *testing.T) {
 			}
 			tc.set(data)
 			page := renderPageList(t, data)
-			if !strings.Contains(page, "data-ob-row-detail-tpl=") {
+			if !strings.Contains(page, "data-ob-id=") {
 				t.Fatalf("в %s-виде у строки нет адреса панели", tc.name)
 			}
 

--- a/internal/ui/detail_panel_test.go
+++ b/internal/ui/detail_panel_test.go
@@ -190,7 +190,7 @@ func TestDetailPanel_RenderedOutsideLiveContainer(t *testing.T) {
 	if strings.Contains(html, "data-ob-detail='") {
 		t.Error("payload панели снова уехал в разметку строки")
 	}
-	if !strings.Contains(html, "data-ob-detail-url=") {
+	if !strings.Contains(html, "data-ob-row-detail-tpl=") {
 		t.Error("в строке списка нет адреса ленивой загрузки панели")
 	}
 	if !strings.Contains(html, "data-ob-detail-toggle") {
@@ -259,7 +259,7 @@ func TestDetailPanel_AllEntityListModesCarryLazyURL(t *testing.T) {
 			}
 			tc.set(data)
 			page := renderPageList(t, data)
-			if !strings.Contains(page, "data-ob-detail-url=") {
+			if !strings.Contains(page, "data-ob-row-detail-tpl=") {
 				t.Fatalf("в %s-виде у строки нет адреса панели", tc.name)
 			}
 

--- a/internal/ui/keyboard_shortcuts_behavior_test.go
+++ b/internal/ui/keyboard_shortcuts_behavior_test.go
@@ -244,9 +244,11 @@ assert(activated === beforeEnter + 2, 'Tab -> Enter/F2 did not open the focused 
 fire({key: 'ArrowDown', target: tabFirst});
 assert(listSel() === tabSecond, 'ArrowDown repeated the focused first row instead of moving to the second');
 
-// F9 в списке — «Создать копированием» (issue #762). Открывается форма
-// создания по data-copy-url; пустой url = нет права записи, клавиша молчит и
-// не гасит событие. Пункт меню строки живёт по тому же признаку.
+// F9 в списке — «Создать копированием» (issue #762). Адрес даёт obRowUrl(row,
+// 'copy'); здесь строки моделируют JSON-подгрузку и несут свой copyUrl, у
+// серверных строк он собирается из data-ob-row-copy-url контейнера при
+// data-ob-row-can-copy="1". Пустой результат = копировать нечем: клавиша молчит
+// и не гасит событие. Пункт меню строки живёт по тому же признаку.
 window._obActiveDOMTable = null;
 window._obActiveGridName = '';
 const copyRow = makeElement('tr', {listRow: true, dataset: {openUrl: '/row', copyUrl: '/ui/catalog/x/new?copy=42'}});

--- a/internal/ui/list_actions_test.go
+++ b/internal/ui/list_actions_test.go
@@ -237,28 +237,28 @@ func TestPageList_EmbeddedOpenUsesShell(t *testing.T) {
 
 	for _, want := range []string{
 		`id="ob-list-config"`,
-		`data-open-url="/ui/document/`,
-		`11111111-1111-1111-1111-111111111111"`,
+		`data-ob-row-open-tpl="/ui/document/`,
+		`data-ob-id="11111111-1111-1111-1111-111111111111"`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("список не содержит embedded-open фрагмент %q", want)
 		}
 	}
-	if !strings.Contains(html, `data-folder-url="/ui/document/`) || !strings.Contains(html, `parent=11111111-1111-1111-1111-111111111111`) {
-		t.Error("строка списка не содержит data-folder-url для навигации по папкам")
+	if !strings.Contains(html, `data-ob-row-folder-tpl="/ui/document/`) || !strings.Contains(html, `parent=__ID__`) {
+		t.Error("контейнер списка не содержит шаблон data-ob-row-folder-tpl для навигации по папкам")
 	}
 	js := string(uiJS)
 	for _, want := range []string{
 		`window.obOpenInShell && window.obOpenInShell(url, title || listTitle())`,
-		`window.location.href = tr.dataset.folderUrl`,
-		`else listOpen(tr.dataset.openUrl);`,
-		`fn: function () { listOpen(tr.dataset.openUrl); }`,
+		`window.location.href = obRowUrl(tr, 'folder')`,
+		`else listOpen(obRowUrl(tr, 'open'));`,
+		`fn: function () { listOpen(obRowUrl(tr, 'open')); }`,
 	} {
 		if !strings.Contains(js, want) {
 			t.Errorf("/static/ui.js не содержит embedded-open фрагмент %q", want)
 		}
 	}
-	if strings.Contains(js, `window.location.href = tr.dataset.openUrl`) {
+	if strings.Contains(js, `window.location.href = obRowUrl(tr, 'open')`) {
 		t.Error("открытие записи из списка по-прежнему заменяет текущий iframe вместо новой вкладки")
 	}
 }
@@ -299,7 +299,7 @@ func TestPageList_TilesView(t *testing.T) {
 	}
 	html := buf.String()
 
-	for _, want := range []string{"tile-grid", "tile-card", "Болт М6", "view-switch", "data-open-url=", "data-ob-list-row"} {
+	for _, want := range []string{"tile-grid", "tile-card", "Болт М6", "view-switch", "data-ob-row-open-tpl=", "data-ob-id=", "data-ob-list-row"} {
 		if !strings.Contains(html, want) {
 			t.Errorf("плиточный режим: в выводе нет ожидаемого фрагмента %q", want)
 		}

--- a/internal/ui/list_actions_test.go
+++ b/internal/ui/list_actions_test.go
@@ -237,15 +237,15 @@ func TestPageList_EmbeddedOpenUsesShell(t *testing.T) {
 
 	for _, want := range []string{
 		`id="ob-list-config"`,
-		`data-ob-row-open-tpl="/ui/document/`,
+		`data-ob-row-base="/ui/document/`,
 		`data-ob-id="11111111-1111-1111-1111-111111111111"`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Errorf("список не содержит embedded-open фрагмент %q", want)
 		}
 	}
-	if !strings.Contains(html, `data-ob-row-folder-tpl="/ui/document/`) || !strings.Contains(html, `parent=__ID__`) {
-		t.Error("контейнер списка не содержит шаблон data-ob-row-folder-tpl для навигации по папкам")
+	if !strings.Contains(html, `data-ob-row-list-url="/ui/document/`) {
+		t.Error("контейнер списка не содержит опорный адрес для навигации по папкам")
 	}
 	js := string(uiJS)
 	for _, want := range []string{
@@ -299,7 +299,7 @@ func TestPageList_TilesView(t *testing.T) {
 	}
 	html := buf.String()
 
-	for _, want := range []string{"tile-grid", "tile-card", "Болт М6", "view-switch", "data-ob-row-open-tpl=", "data-ob-id=", "data-ob-list-row"} {
+	for _, want := range []string{"tile-grid", "tile-card", "Болт М6", "view-switch", "data-ob-row-base=", "data-ob-id=", "data-ob-list-row"} {
 		if !strings.Contains(html, want) {
 			t.Errorf("плиточный режим: в выводе нет ожидаемого фрагмента %q", want)
 		}

--- a/internal/ui/list_state_test.go
+++ b/internal/ui/list_state_test.go
@@ -424,11 +424,13 @@ func TestGroupNavigationKeepsListState(t *testing.T) {
 		"Breadcrumbs": []map[string]string{{"ID": "33333333-3333-3333-3333-333333333333", "Label": "Метизы"}},
 	})
 
-	folderMatch := regexp.MustCompile(`data-folder-url="([^"]*)"`).FindStringSubmatch(page)
+	// Ссылка входа в группу собирается клиентом из шаблона контейнера: в разметке
+	// лежит один data-ob-row-folder-tpl с плейсхолдером вместо идентификатора.
+	folderMatch := regexp.MustCompile(`data-ob-row-folder-tpl="([^"]*)"`).FindStringSubmatch(page)
 	if folderMatch == nil {
-		t.Fatal("у группы нет data-folder-url")
+		t.Fatal("у списка нет шаблона data-ob-row-folder-tpl")
 	}
-	folder := linkQuery(t, folderMatch[1])
+	folder := linkQuery(t, strings.ReplaceAll(folderMatch[1], "__ID__", nextParent))
 	wantParams(t, folder, "вход в группу", map[string]string{
 		"parent": nextParent, "q": "Болт", "sort": "Цена", "dir": "desc",
 		"f.Цена": "10", "view": "tiles", "lm": "feed", "subsystem": "Склад", "page": "",

--- a/internal/ui/list_state_test.go
+++ b/internal/ui/list_state_test.go
@@ -424,13 +424,19 @@ func TestGroupNavigationKeepsListState(t *testing.T) {
 		"Breadcrumbs": []map[string]string{{"ID": "33333333-3333-3333-3333-333333333333", "Label": "Метизы"}},
 	})
 
-	// Ссылка входа в группу собирается клиентом из шаблона контейнера: в разметке
-	// лежит один data-ob-row-folder-tpl с плейсхолдером вместо идентификатора.
-	folderMatch := regexp.MustCompile(`data-ob-row-folder-tpl="([^"]*)"`).FindStringSubmatch(page)
+	// Вход в группу клиент собирает сам: контейнер несёт адрес списка с текущим
+	// состоянием (без parent), а идентификатор группы добавляется параметром.
+	folderMatch := regexp.MustCompile(`data-ob-row-list-url="([^"]*)"`).FindStringSubmatch(page)
 	if folderMatch == nil {
-		t.Fatal("у списка нет шаблона data-ob-row-folder-tpl")
+		t.Fatal("у списка нет опорного адреса data-ob-row-list-url")
 	}
-	folder := linkQuery(t, strings.ReplaceAll(folderMatch[1], "__ID__", nextParent))
+	folderURL := html.UnescapeString(folderMatch[1])
+	if strings.Contains(folderURL, "?") {
+		folderURL += "&parent=" + nextParent
+	} else {
+		folderURL += "?parent=" + nextParent
+	}
+	folder := linkQuery(t, folderURL)
 	wantParams(t, folder, "вход в группу", map[string]string{
 		"parent": nextParent, "q": "Болт", "sort": "Цена", "dir": "desc",
 		"f.Цена": "10", "view": "tiles", "lm": "feed", "subsystem": "Склад", "page": "",

--- a/internal/ui/row_url_node_test.go
+++ b/internal/ui/row_url_node_test.go
@@ -1,0 +1,18 @@
+package ui
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestRowURLBehaviorInNode(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required for the row-url behavior regression test")
+	}
+	cmd := exec.Command(node, "--test", "static/row_url_behavior_test.js") //nolint:gosec // test-only executable resolved by exec.LookPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node row-url behavior test: %v\n%s", err, output)
+	}
+}

--- a/internal/ui/static/detail_panel_behavior_test.js
+++ b/internal/ui/static/detail_panel_behavior_test.js
@@ -15,8 +15,13 @@ function settle() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+// Строка списка в новом контракте несёт идентификатор, а ссылку собирает
+// obRowUrl(). Здесь моделируем строку, пришедшую из JSON-подгрузки: у неё есть
+// собственная ссылка в dataset, и она имеет приоритет над сборкой из контейнера.
 function row(url) {
   return {
+    dataset: { obDetailUrl: url },
+    closest() { return null; },
     getAttribute(name) { return name === 'data-ob-detail-url' ? url : ''; }
   };
 }
@@ -45,6 +50,9 @@ function harness() {
     obDetailEl() { return panel; },
     listSel() { return selected; },
     obDetailRender() { renders++; },
+    // Слайс зовёт общий сборщик ссылок; здесь строка моделирует запись из
+    // JSON-подгрузки, у которой ссылка уже готова.
+    obRowUrl(row) { return row && row.dataset ? (row.dataset.obDetailUrl || '') : ''; },
     fetch(url, options) {
       let resolve;
       let reject;

--- a/internal/ui/static/row_url_behavior_test.js
+++ b/internal/ui/static/row_url_behavior_test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+// Адреса действий строки списка больше не приходят с сервера готовыми — их
+// собирает obRowUrl() из опорных адресов контейнера. Пины на конкретные URL
+// ушли из Go-тестов вместе с построчными data-*-атрибутами, поэтому точные
+// строки проверяются здесь: перепутанные mark=1/mark=0 или active=1/active=0
+// меняют смысл действия на противоположный, а сборка и вёрстка компилируются
+// одинаково зелёными в обоих случаях.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, 'ui.js'), 'utf8');
+const begin = source.indexOf('// BEGIN onebase-row-url');
+const end = source.indexOf('// END onebase-row-url');
+assert.ok(begin >= 0 && end > begin, 'row url markers must exist');
+
+const ID = '11111111-1111-1111-1111-111111111111';
+const BASE = '/ui/catalog/номенклатура';
+const SUB = 'Продажи';
+const SUB_Q = encodeURIComponent(SUB);
+const ITEM = BASE + '/' + ID;
+
+function slice() {
+  const context = { URLSearchParams };
+  vm.runInNewContext(source.slice(begin, end) + `
+    this.api = {
+      rowUrl: obRowUrl,
+      paramURL: obRowParamURL,
+      activityEnabled: obRowActivityEnabled,
+      rowKey: obRowKey
+    };`, context, { filename: 'ui-row-url-slice.js' });
+  return context.api;
+}
+
+const api = slice();
+
+// Контейнер списка: опорные адреса объявлены один раз на tbody/.tile-grid/table.
+function container(over) {
+  return {
+    dataset: Object.assign({
+      obRowBase: BASE,
+      obRowSubsystem: SUB,
+      obRowListUrl: BASE + '?parent=OLD&sort=code',
+      obRowCopyUrl: BASE + '/new?subsystem=' + SUB_Q,
+      obRowCanCopy: '1',
+      obRowActivityEnabled: '1'
+    }, over || {})
+  };
+}
+
+// Строка, отрисованная сервером: несёт идентификатор и флаги состояния,
+// ссылок в ней нет.
+function row(box, over, openUrl) {
+  return {
+    dataset: Object.assign({ obId: ID }, over || {}),
+    closest(selector) {
+      return selector === '[data-ob-row-base]' ? (box || null) : null;
+    },
+    getAttribute(name) {
+      return name === 'data-open-url' ? (openUrl || '') : '';
+    }
+  };
+}
+
+test('каждый вид действия даёт ровно тот адрес, что раньше приходил в строке', () => {
+  const r = row(container());
+  assert.equal(api.rowUrl(r, 'open'), ITEM + '?subsystem=' + SUB_Q);
+  assert.equal(api.rowUrl(r, 'mark'), ITEM + '/delete?mark=1');
+  assert.equal(api.rowUrl(r, 'unmark'), ITEM + '/delete?mark=0');
+  assert.equal(api.rowUrl(r, 'del'), ITEM + '/delete');
+  assert.equal(api.rowUrl(r, 'unpost'), ITEM + '/unpost');
+  assert.equal(api.rowUrl(r, 'activityShow'), ITEM + '/activity?active=1');
+  assert.equal(api.rowUrl(r, 'activityHide'), ITEM + '/activity?active=0');
+  assert.equal(api.rowUrl(r, 'detail'), ITEM + '/detail-panel');
+  assert.equal(api.rowUrl(r, 'folder'), BASE + '?parent=' + ID + '&sort=code');
+  assert.equal(api.rowUrl(r, 'copy'), BASE + '/new?subsystem=' + SUB_Q + '&copy=' + ID);
+});
+
+// Пометка и её снятие, скрытие из выбора и возврат — противоположные действия
+// с адресами, различающимися одним символом. Проверяем отдельно, что они не
+// сошлись в одну строку.
+test('парные действия не совпадают между собой', () => {
+  const r = row(container());
+  assert.notEqual(api.rowUrl(r, 'mark'), api.rowUrl(r, 'unmark'));
+  assert.notEqual(api.rowUrl(r, 'activityShow'), api.rowUrl(r, 'activityHide'));
+  assert.notEqual(api.rowUrl(r, 'del'), api.rowUrl(r, 'mark'));
+});
+
+test('без подсистемы адрес открытия идёт без параметра', () => {
+  const r = row(container({ obRowSubsystem: '' }));
+  assert.equal(api.rowUrl(r, 'open'), ITEM);
+});
+
+test('строка из JSON-подгрузки несёт свои ссылки, и они главнее контейнера', () => {
+  const own = {
+    openUrl: '/json/open', folderUrl: '/json/folder', markUrl: '/json/mark',
+    unmarkUrl: '/json/unmark', delUrl: '/json/del', unpostUrl: '/json/unpost',
+    activityShowUrl: '/json/show', activityHideUrl: '/json/hide',
+    obDetailUrl: '/json/detail', copyUrl: '/json/copy'
+  };
+  const r = row(container(), own);
+  assert.equal(api.rowUrl(r, 'open'), '/json/open');
+  assert.equal(api.rowUrl(r, 'folder'), '/json/folder');
+  assert.equal(api.rowUrl(r, 'mark'), '/json/mark');
+  assert.equal(api.rowUrl(r, 'unmark'), '/json/unmark');
+  assert.equal(api.rowUrl(r, 'del'), '/json/del');
+  assert.equal(api.rowUrl(r, 'unpost'), '/json/unpost');
+  assert.equal(api.rowUrl(r, 'activityShow'), '/json/show');
+  assert.equal(api.rowUrl(r, 'activityHide'), '/json/hide');
+  assert.equal(api.rowUrl(r, 'detail'), '/json/detail');
+  assert.equal(api.rowUrl(r, 'copy'), '/json/copy');
+});
+
+// Своя ссылка строки имеет приоритет даже там, где контейнер запрещает действие:
+// у подгруженной строки сервер уже решил, что показывать.
+test('своя ссылка копирования работает при запрете на контейнере', () => {
+  const r = row(container({ obRowCanCopy: '0' }), { copyUrl: '/json/copy' });
+  assert.equal(api.rowUrl(r, 'copy'), '/json/copy');
+});
+
+test('без права записи копирование недоступно', () => {
+  assert.equal(api.rowUrl(row(container({ obRowCanCopy: '0' })), 'copy'), '');
+  assert.equal(api.rowUrl(row(container({ obRowCanCopy: '' })), 'copy'), '');
+});
+
+test('без идентификатора строки не собирается ни один адрес', () => {
+  const r = row(container(), { obId: '' });
+  ['open', 'mark', 'unmark', 'del', 'unpost', 'activityShow', 'activityHide',
+    'detail', 'folder', 'copy'].forEach(function (kind) {
+    assert.equal(api.rowUrl(r, kind), '', kind + ' без id должен быть пустым');
+  });
+});
+
+test('строка вне контейнера и отсутствие строки дают пустой адрес', () => {
+  assert.equal(api.rowUrl(row(null), 'open'), '');
+  assert.equal(api.rowUrl(null, 'open'), '');
+});
+
+test('parent в адресе группы заменяется, а не добавляется вторым', () => {
+  const r = row(container());
+  const url = api.rowUrl(r, 'folder');
+  assert.equal(url.split('parent=').length - 1, 1);
+  assert.equal(url, BASE + '?parent=' + ID + '&sort=code');
+});
+
+test('адрес группы собирается и когда parent в списке ещё не было', () => {
+  const r = row(container({ obRowListUrl: BASE + '?sort=code' }));
+  assert.equal(api.rowUrl(r, 'folder'), BASE + '?sort=code&parent=' + ID);
+});
+
+// Раньше идентификатор подставлялся заменой слота __ID__ в строке шаблона.
+// Тогда тот же текст, введённый пользователем в поиск, попадал в query списка
+// и подменял слот. Параметр добавляется через URLSearchParams — проверяем, что
+// пользовательский ввод остаётся дословно и не участвует в сборке.
+test('пользовательский ввод в query не подменяет идентификатор', () => {
+  const r = row(container({ obRowListUrl: BASE + '?q=__ID__' }));
+  assert.equal(api.rowUrl(r, 'folder'), BASE + '?q=__ID__&parent=' + ID);
+});
+
+test('адрес без параметров и с якорем собирается корректно', () => {
+  assert.equal(api.paramURL('/ui/list', 'parent', ID), '/ui/list?parent=' + ID);
+  assert.equal(api.paramURL('/ui/list?sort=code#top', 'parent', ID),
+    '/ui/list?sort=code&parent=' + ID + '#top');
+});
+
+// Кириллица в пути percent-кодирование не переживает: адрес перестал бы
+// совпадать с тем, что отдаёт сервер. Трогаем только строку запроса.
+test('кириллический путь остаётся как есть', () => {
+  assert.equal(api.paramURL(BASE, 'parent', ID), BASE + '?parent=' + ID);
+});
+
+test('признак активности берётся со строки, иначе с контейнера', () => {
+  assert.equal(api.activityEnabled(row(container(), { activityEnabled: '1' })), true);
+  assert.equal(api.activityEnabled(row(container({ obRowActivityEnabled: '0' }),
+    { activityEnabled: '1' })), true);
+  assert.equal(api.activityEnabled(row(container())), true);
+  assert.equal(api.activityEnabled(row(container({ obRowActivityEnabled: '0' }))), false);
+  assert.equal(api.activityEnabled(row(null)), false);
+  assert.equal(api.activityEnabled(null), false);
+});
+
+test('ключ выделения — идентификатор, с откатом на собственную ссылку строки', () => {
+  assert.equal(api.rowKey(row(container())), ID);
+  assert.equal(api.rowKey(row(container(), { obId: '' }, '/json/open')), '/json/open');
+  assert.equal(api.rowKey(row(container(), { obId: '' })), '');
+  assert.equal(api.rowKey(null), '');
+});

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -727,6 +727,37 @@ function obListConfig() {
   return obReadJSONScript('ob-list-config', { labels: {} }) || { labels: {} };
 }
 
+// Ссылки строк списка собираются из шаблонов, объявленных один раз на контейнер
+// (data-ob-row-*-tpl), а не повторяются в каждой строке: на списке из 100 строк
+// это экономит около 1,5 КБ на строку. Строки, приходящие из JSON при подгрузке,
+// по-прежнему могут нести готовые ссылки — они имеют приоритет.
+var OB_ROW_OWN = {
+  open: 'openUrl', folder: 'folderUrl', mark: 'markUrl', unmark: 'unmarkUrl',
+  del: 'delUrl', unpost: 'unpostUrl', activityShow: 'activityShowUrl',
+  activityHide: 'activityHideUrl', detail: 'obDetailUrl', copy: 'copyUrl'
+};
+var OB_ROW_TPL = {
+  open: 'obRowOpenTpl', folder: 'obRowFolderTpl', mark: 'obRowMarkTpl',
+  unmark: 'obRowUnmarkTpl', del: 'obRowDelTpl', unpost: 'obRowUnpostTpl',
+  activityShow: 'obRowActivityShowTpl', activityHide: 'obRowActivityHideTpl',
+  detail: 'obRowDetailTpl', copy: 'obRowCopyTpl'
+};
+function obRowUrl(row, kind) {
+  if (!row) return '';
+  var own = row.dataset[OB_ROW_OWN[kind]];
+  if (own) return own;
+  var box = row.closest('[data-ob-row-base]');
+  if (!box) return '';
+  var tpl = box.dataset[OB_ROW_TPL[kind]] || '';
+  if (!tpl) return '';
+  return tpl.split('__ID__').join(encodeURIComponent(row.dataset.obId || ''));
+}
+function obRowActivityEnabled(row) {
+  if (!row) return false;
+  if (row.dataset.activityEnabled) return obRowActivityEnabled(row);
+  var box = row.closest('[data-ob-row-base]');
+  return !!box && box.dataset.obRowActivityEnabled === '1';
+}
 function obListLabel(key, fallback) {
   var labels = obListConfig().labels || {};
   return labels[key] || fallback;
@@ -867,8 +898,8 @@ function listRowDblClick(e, tr) {
 
 function listActivateRow(tr) {
   if (!tr) return;
-  if (tr.dataset.isFolder === '1') window.location.href = tr.dataset.folderUrl;
-  else listOpen(tr.dataset.openUrl);
+  if (tr.dataset.isFolder === '1') window.location.href = obRowUrl(tr, 'folder');
+  else listOpen(obRowUrl(tr, 'open'));
 }
 
 // Встроенные горячие клавиши — привычные по 1С. Живут в ui.js, потому что нужны
@@ -992,7 +1023,7 @@ function obListCurrentRow() {
 function obListCanMarkDelete(row) {
   var cfg = obListConfig();
   return !!(row && row.dataset && cfg.canDelete === true &&
-    row.dataset.predefined !== '1' && String(row.dataset.markUrl || '').trim());
+    row.dataset.predefined !== '1' && String(obRowUrl(row, 'mark') || '').trim());
 }
 
 function obHandleListDeleteShortcut(e) {
@@ -1004,7 +1035,7 @@ function obHandleListDeleteShortcut(e) {
   if (!obListCanMarkDelete(sel)) return;
   e.preventDefault();
   if (listSel() !== sel) listSetSel(sel);
-  listSubmit(sel.dataset.markUrl, obListLabel('markDeleteConfirm', 'Пометить на удаление?'));
+  listSubmit(obRowUrl(sel, 'mark'), obListLabel('markDeleteConfirm', 'Пометить на удаление?'));
 }
 
 function obInitListFocusSelection() {
@@ -1368,17 +1399,17 @@ function obInitKeyboardShortcuts() {
     if ((e.key === 'Enter' || e.key === 'F2') && sel) {
       e.preventDefault();
       if (listSel() !== sel) listSetSel(sel);
-      if (e.key === 'F2') listOpen(sel.dataset.openUrl);
+      if (e.key === 'F2') listOpen(obRowUrl(sel, 'open'));
       else listActivateRow(sel);
       return;
     }
     // F9 в списке — «Создать копированием», как в 1С. В форме та же клавиша
     // копирует строку ТЧ, но туда обработчик не доходит: obHandleDOMTableShortcut
     // выше забирает F9 себе, когда активна таблица ТЧ.
-    if (e.key === 'F9' && sel && sel.dataset.copyUrl) {
+    if (e.key === 'F9' && sel && obRowUrl(sel, 'copy')) {
       e.preventDefault();
       if (listSel() !== sel) listSetSel(sel);
-      listOpen(sel.dataset.copyUrl);
+      listOpen(obRowUrl(sel, 'copy'));
     }
   });
   document.addEventListener('keydown', obHandleListDeleteShortcut);
@@ -1544,38 +1575,38 @@ function listMenuItems(tr) {
   var isFolder = tr.dataset.isFolder === '1';
   var items = [];
   if (isFolder) {
-    items.push({ label: labels.enterGroup || '▶ Войти в группу', fn: function () { window.location.href = tr.dataset.folderUrl; } });
-    items.push({ label: labels.edit || 'Редактировать', fn: function () { listOpen(tr.dataset.openUrl); } });
+    items.push({ label: labels.enterGroup || '▶ Войти в группу', fn: function () { window.location.href = obRowUrl(tr, 'folder'); } });
+    items.push({ label: labels.edit || 'Редактировать', fn: function () { listOpen(obRowUrl(tr, 'open')); } });
   } else {
-    items.push({ label: labels.open || 'Открыть', fn: function () { listOpen(tr.dataset.openUrl); } });
+    items.push({ label: labels.open || 'Открыть', fn: function () { listOpen(obRowUrl(tr, 'open')); } });
   }
   // «Скопировать» (F9): открывает форму создания, заполненную значениями строки.
   // Пустой data-copy-url = нет права записи, пункт не показываем.
-  if (tr.dataset.copyUrl) {
-    items.push({ label: labels.copy || 'Скопировать', fn: function () { listOpen(tr.dataset.copyUrl); } });
+  if (obRowUrl(tr, 'copy')) {
+    items.push({ label: labels.copy || 'Скопировать', fn: function () { listOpen(obRowUrl(tr, 'copy')); } });
   }
-  if (cfg.canWrite && tr.dataset.activityEnabled === '1') {
+  if (cfg.canWrite && obRowActivityEnabled(tr)) {
     if (tr.dataset.activityInactive === '1') {
-      items.push({ label: labels.activityShow || 'Вернуть в выбор', fn: function () { listSubmit(tr.dataset.activityShowUrl, labels.activityShowConfirm || 'Вернуть в выбор?'); } });
+      items.push({ label: labels.activityShow || 'Вернуть в выбор', fn: function () { listSubmit(obRowUrl(tr, 'activityShow'), labels.activityShowConfirm || 'Вернуть в выбор?'); } });
     } else {
-      items.push({ label: labels.activityHide || 'Скрыть из выбора', fn: function () { listSubmit(tr.dataset.activityHideUrl, labels.activityHideConfirm || 'Скрыть из выбора?'); } });
+      items.push({ label: labels.activityHide || 'Скрыть из выбора', fn: function () { listSubmit(obRowUrl(tr, 'activityHide'), labels.activityHideConfirm || 'Скрыть из выбора?'); } });
     }
   }
   if (cfg.canDelete) {
     if (!isPredefined) {
-      items.push({ label: labels.markDelete || 'Пометить на удаление', danger: true, fn: function () { listSubmit(tr.dataset.markUrl, labels.markDeleteConfirm || 'Пометить на удаление?'); } });
+      items.push({ label: labels.markDelete || 'Пометить на удаление', danger: true, fn: function () { listSubmit(obRowUrl(tr, 'mark'), labels.markDeleteConfirm || 'Пометить на удаление?'); } });
     } else {
       items.push({ label: labels.predefinedNoDelete || 'Предопределённый — нельзя удалить', disabled: true });
     }
   }
   if (cfg.canUnpost && tr.dataset.posted === '1') {
-    items.push({ label: labels.unpost || 'Отменить проведение', fn: function () { listSubmit(tr.dataset.unpostUrl, labels.unpostConfirm || 'Отменить проведение?'); } });
+    items.push({ label: labels.unpost || 'Отменить проведение', fn: function () { listSubmit(obRowUrl(tr, 'unpost'), labels.unpostConfirm || 'Отменить проведение?'); } });
   }
   if (cfg.canDelete && tr.dataset.marked === '1' && !isPredefined) {
-    items.push({ label: labels.unmarkDelete || 'Снять пометку на удаление', fn: function () { listSubmit(tr.dataset.unmarkUrl, labels.unmarkDeleteConfirm || 'Снять пометку на удаление?'); } });
+    items.push({ label: labels.unmarkDelete || 'Снять пометку на удаление', fn: function () { listSubmit(obRowUrl(tr, 'unmark'), labels.unmarkDeleteConfirm || 'Снять пометку на удаление?'); } });
   }
   if (cfg.isAdmin && !isPredefined) {
-    items.push({ label: labels.deleteForever || 'Удалить навсегда', danger: true, fn: function () { listSubmit(tr.dataset.delUrl, labels.deleteForeverConfirm || 'Удалить запись навсегда?'); } });
+    items.push({ label: labels.deleteForever || 'Удалить навсегда', danger: true, fn: function () { listSubmit(obRowUrl(tr, 'del'), labels.deleteForeverConfirm || 'Удалить запись навсегда?'); } });
   }
   return items;
 }

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -736,27 +736,63 @@ var OB_ROW_OWN = {
   del: 'delUrl', unpost: 'unpostUrl', activityShow: 'activityShowUrl',
   activityHide: 'activityHideUrl', detail: 'obDetailUrl', copy: 'copyUrl'
 };
-var OB_ROW_TPL = {
-  open: 'obRowOpenTpl', folder: 'obRowFolderTpl', mark: 'obRowMarkTpl',
-  unmark: 'obRowUnmarkTpl', del: 'obRowDelTpl', unpost: 'obRowUnpostTpl',
-  activityShow: 'obRowActivityShowTpl', activityHide: 'obRowActivityHideTpl',
-  detail: 'obRowDetailTpl', copy: 'obRowCopyTpl'
-};
+// Ссылка действия строки собирается из опорных адресов контейнера и
+// идентификатора строки: раньше каждая строка несла десять готовых URL, и на
+// списке из 100 строк это давало больше половины веса страницы. Параметр
+// подставляется штатным URL API, а не заменой в строке, — иначе пользовательский
+// ввод, сохранённый в query списка, мог бы подменить слот.
+function obRowParamURL(base, name, value) {
+  // Через new URL() нельзя: он percent-кодирует кириллицу в пути, и адрес
+  // перестаёт совпадать с тем, что отдаёт сервер. Трогаем только строку запроса.
+  var hash = '';
+  var h = base.indexOf('#');
+  if (h >= 0) { hash = base.slice(h); base = base.slice(0, h); }
+  var q = base.indexOf('?');
+  var path = q >= 0 ? base.slice(0, q) : base;
+  var params = new URLSearchParams(q >= 0 ? base.slice(q + 1) : '');
+  params.set(name, value);
+  var query = params.toString();
+  return path + (query ? '?' + query : '') + hash;
+}
 function obRowUrl(row, kind) {
   if (!row) return '';
   var own = row.dataset[OB_ROW_OWN[kind]];
-  if (own) return own;
+  if (own) return own;                     // строка из JSON-подгрузки несёт свои ссылки
   var box = row.closest('[data-ob-row-base]');
   if (!box) return '';
-  var tpl = box.dataset[OB_ROW_TPL[kind]] || '';
-  if (!tpl) return '';
-  return tpl.split('__ID__').join(encodeURIComponent(row.dataset.obId || ''));
+  var id = row.dataset.obId || '';
+  if (!id) return '';
+  var base = box.dataset.obRowBase || '';
+  var sub = box.dataset.obRowSubsystem || '';
+  var item = base + '/' + encodeURIComponent(id);
+  switch (kind) {
+    case 'open': return item + (sub ? '?subsystem=' + encodeURIComponent(sub) : '');
+    case 'mark': return item + '/delete?mark=1';
+    case 'unmark': return item + '/delete?mark=0';
+    case 'del': return item + '/delete';
+    case 'unpost': return item + '/unpost';
+    case 'activityShow': return item + '/activity?active=1';
+    case 'activityHide': return item + '/activity?active=0';
+    case 'detail': return item + '/detail-panel';
+    case 'folder': return obRowParamURL(box.dataset.obRowListUrl || base, 'parent', id);
+    case 'copy':
+      if (box.dataset.obRowCanCopy !== '1') return '';
+      return obRowParamURL(box.dataset.obRowCopyUrl || (base + '/new'), 'copy', id);
+  }
+  return '';
 }
 function obRowActivityEnabled(row) {
   if (!row) return false;
-  if (row.dataset.activityEnabled) return obRowActivityEnabled(row);
+  var own = row.dataset.activityEnabled;
+  if (own) return own === '1';
   var box = row.closest('[data-ob-row-base]');
   return !!box && box.dataset.obRowActivityEnabled === '1';
+}
+// Ключ выделенной строки: идентификатор устойчив к перерисовке списка, тогда как
+// прежний data-open-url на строках больше не выводится.
+function obRowKey(row) {
+  if (!row) return '';
+  return row.dataset.obId || row.getAttribute('data-open-url') || '';
 }
 function obListLabel(key, fallback) {
   var labels = obListConfig().labels || {};
@@ -860,7 +896,7 @@ function listRestoreSel(key, root, options) {
   if (key) {
     var rows = (root || document).querySelectorAll('[data-ob-list-row]');
     for (var i = 0; i < rows.length; i++) {
-      if (rows[i].getAttribute('data-open-url') === key) { next = rows[i]; break; }
+      if (obRowKey(rows[i]) === key) { next = rows[i]; break; }
     }
   }
   listSetSel(next, { focus: !!(options && options.focus), root: root || document });
@@ -883,7 +919,7 @@ function obReplaceLiveListContents(cur, fresh) {
 
 function listSelKey() {
   var sel = listSel();
-  return sel ? (sel.getAttribute('data-open-url') || '') : '';
+  return obRowKey(sel);
 }
 
 function listRowClick(e, tr) {
@@ -3770,7 +3806,7 @@ function obDetailFetch(row, url) {
       // Строка могла смениться, пока ответ шёл. Старый ответ не должен даже
       // попадать в общий кэш, иначе следующий render покажет чужую версию.
       var current = (typeof listSel === 'function') ? listSel() : null;
-      if (!current || current.getAttribute('data-ob-detail-url') !== url) return;
+      if (!current || obRowUrl(current, 'detail') !== url) return;
       obDetailCache = { url: url, body: body };
       obDetailRender();
     })
@@ -3779,7 +3815,7 @@ function obDetailFetch(row, url) {
       obDetailPending = { url: '', controller: null };
       if (err && err.name === 'AbortError') return;
       var current = (typeof listSel === 'function') ? listSel() : null;
-      if (!current || current.getAttribute('data-ob-detail-url') !== url) return;
+      if (!current || obRowUrl(current, 'detail') !== url) return;
       obDetailCache = { url: '', body: '' };
       if (fieldsEl) fieldsEl.textContent = 'Не удалось загрузить детали: ' + err.message;
     });
@@ -3803,7 +3839,7 @@ function obDetailRender() {
   // #860). Ответ кэшируется на строку: переключение закладок не должно
   // дёргать сервер.
   var raw = row ? row.getAttribute('data-ob-detail') : '';
-  var lazyURL = row ? row.getAttribute('data-ob-detail-url') : '';
+  var lazyURL = row ? obRowUrl(row, 'detail') : '';
   if (!raw && lazyURL) {
     if (obDetailCache.url === lazyURL) {
       raw = obDetailCache.body;

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -727,8 +727,10 @@ function obListConfig() {
   return obReadJSONScript('ob-list-config', { labels: {} }) || { labels: {} };
 }
 
-// Ссылки строк списка собираются из шаблонов, объявленных один раз на контейнер
-// (data-ob-row-*-tpl), а не повторяются в каждой строке: на списке из 100 строк
+// BEGIN onebase-row-url (executed directly by the Node regression test)
+// Ссылки строк списка собираются из опорных адресов, объявленных один раз на
+// контейнере (data-ob-row-base, -subsystem, -list-url, -copy-url, -can-copy,
+// -activity-enabled), а не повторяются в каждой строке: на списке из 100 строк
 // это экономит около 1,5 КБ на строку. Строки, приходящие из JSON при подгрузке,
 // по-прежнему могут нести готовые ссылки — они имеют приоритет.
 var OB_ROW_OWN = {
@@ -739,8 +741,8 @@ var OB_ROW_OWN = {
 // Ссылка действия строки собирается из опорных адресов контейнера и
 // идентификатора строки: раньше каждая строка несла десять готовых URL, и на
 // списке из 100 строк это давало больше половины веса страницы. Параметр
-// подставляется штатным URL API, а не заменой в строке, — иначе пользовательский
-// ввод, сохранённый в query списка, мог бы подменить слот.
+// добавляется штатным URLSearchParams, а не подстановкой в строку, — иначе
+// пользовательский ввод, сохранённый в query списка, мог бы подменить слот.
 function obRowParamURL(base, name, value) {
   // Через new URL() нельзя: он percent-кодирует кириллицу в пути, и адрес
   // перестаёт совпадать с тем, что отдаёт сервер. Трогаем только строку запроса.
@@ -794,6 +796,7 @@ function obRowKey(row) {
   if (!row) return '';
   return row.dataset.obId || row.getAttribute('data-open-url') || '';
 }
+// END onebase-row-url
 function obListLabel(key, fallback) {
   var labels = obListConfig().labels || {};
   return labels[key] || fallback;
@@ -889,7 +892,9 @@ function listSyncActionsBtn() {
 }
 
 // Возврат выделения после перерисовки списка: та же запись опознаётся по
-// data-open-url (в нём id, у всех трёх видов строк — таблица, плитка, дерево).
+// obRowKey() — то есть по data-ob-id, который несут все три вида строк
+// (таблица, плитка, дерево); строки из JSON-подгрузки откатываются на свой
+// data-open-url.
 // Записи не стало в выдаче — выделение снимается, а не остаётся на призраке.
 function listRestoreSel(key, root, options) {
   var next = null;
@@ -1617,7 +1622,8 @@ function listMenuItems(tr) {
     items.push({ label: labels.open || 'Открыть', fn: function () { listOpen(obRowUrl(tr, 'open')); } });
   }
   // «Скопировать» (F9): открывает форму создания, заполненную значениями строки.
-  // Пустой data-copy-url = нет права записи, пункт не показываем.
+  // Право записи объявлено один раз на контейнере (data-ob-row-can-copy);
+  // без него obRowUrl вернёт пустую строку и пункт не показываем.
   if (obRowUrl(tr, 'copy')) {
     items.push({ label: labels.copy || 'Скопировать', fn: function () { listOpen(obRowUrl(tr, 'copy')); } });
   }

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1777,7 +1777,19 @@ const tplList = `
 {{if .TreeRows}}
 {{$treeCols := listColumns .Entity}}
 <div style="overflow-x:auto">
-<table><thead><tr>
+<table
+  data-ob-row-base="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}"
+  data-ob-row-open-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
+  data-ob-row-mark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=1"
+  data-ob-row-unmark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=0"
+  data-ob-row-del-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete"
+  data-ob-row-unpost-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/unpost"
+  data-ob-row-activity-show-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=1"
+  data-ob-row-activity-hide-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=0"
+  data-ob-row-detail-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/detail-panel"
+  data-ob-row-copy-tpl="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
+  data-ob-row-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
+  data-ob-row-folder-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}?parent=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}"><thead><tr>
   {{range $treeCols}}<th>{{.DisplayName $.Lang}}</th>{{end}}
   <th style="width:90px"></th>
 </tr></thead><tbody>
@@ -1787,22 +1799,13 @@ const tplList = `
   data-tree-id="{{index $row "id"}}"
   data-tree-depth="{{$depth}}"
   data-tree-parent="{{index $row "parent_id"}}"
+  data-ob-id="{{index $row "id"}}"
   data-predefined="{{if index $row "_is_predefined"}}1{{end}}"
   data-is-folder="{{if $isFolder}}1{{end}}"
-  data-folder-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}?parent={{index $row "id"}}{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-mark-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete?mark=1"
-  data-del-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete"
   data-posted="{{if index $row "posted"}}1{{end}}"
   data-marked="{{if index $row "deletion_mark"}}1{{end}}"
-  data-unpost-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/unpost"
-  data-unmark-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete?mark=0"
-  data-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
   data-activity-inactive="{{if index $row "_activity_inactive"}}1{{end}}"
-  data-activity-hide-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/activity?active=0"
-  data-activity-show-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/activity?active=1"
-  data-copy-url="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy={{index $row "id"}}{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
-  data-open-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-ob-detail-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/detail-panel">
+>
   {{range $i, $col := $treeCols}}
     {{if treeColumn $treeCols $i}}
       <td>
@@ -1837,26 +1840,29 @@ const tplList = `
 {{/* ===== TILES VIEW (плитка) ===== */}}
 {{if .Rows}}
 {{$tile := tileView .Entity}}
-<div class="tile-grid" role="listbox">
+<div class="tile-grid" role="listbox"
+  data-ob-row-base="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}"
+  data-ob-row-open-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
+  data-ob-row-mark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=1"
+  data-ob-row-unmark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=0"
+  data-ob-row-del-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete"
+  data-ob-row-unpost-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/unpost"
+  data-ob-row-activity-show-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=1"
+  data-ob-row-activity-hide-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=0"
+  data-ob-row-detail-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/detail-panel"
+  data-ob-row-copy-tpl="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
+  data-ob-row-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
+  data-ob-row-folder-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" "__ID__"}}">
 {{range .Rows}}{{$row := .}}{{$isFolder := index $row "is_folder"}}
 <div class="tile-card{{if index $row "deletion_mark"}} tile-deleted{{end}}"
   data-ob-list-row tabindex="-1" aria-selected="false" aria-keyshortcuts="ArrowUp ArrowDown Enter F2{{if $.CanWrite}} F9{{end}}{{if and $.CanDelete (not (index $row "_is_predefined"))}} Delete{{end}}" role="option"
+  data-ob-id="{{index $row "id"}}"
   data-predefined="{{if index $row "_is_predefined"}}1{{end}}"
   data-is-folder="{{if $isFolder}}1{{end}}"
-  data-folder-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" (str (index $row "id"))}}"
-  data-mark-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete?mark=1"
-  data-del-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete"
   data-posted="{{if index $row "posted"}}1{{end}}"
   data-marked="{{if index $row "deletion_mark"}}1{{end}}"
-  data-unpost-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/unpost"
-  data-unmark-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete?mark=0"
-  data-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
   data-activity-inactive="{{if index $row "_activity_inactive"}}1{{end}}"
-  data-activity-hide-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/activity?active=0"
-  data-activity-show-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/activity?active=1"
-  data-copy-url="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy={{index $row "id"}}{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
-  data-open-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-ob-detail-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/detail-panel">
+>
   {{range $f := $tile.ImageFields}}{{$iv := index $row $f.Name}}
   <div class="tile-img"{{if $iv}} style="background-image:url('/ui/_image/{{$iv}}')"{{end}}>{{if not $iv}}🖼{{end}}</div>
   {{end}}
@@ -1895,26 +1901,29 @@ const tplList = `
   </th>
   {{end}}
   <th style="width:90px"></th>
-</tr></thead><tbody id="list-body">
+</tr></thead><tbody id="list-body"
+  data-ob-row-base="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}"
+  data-ob-row-open-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
+  data-ob-row-mark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=1"
+  data-ob-row-unmark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=0"
+  data-ob-row-del-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete"
+  data-ob-row-unpost-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/unpost"
+  data-ob-row-activity-show-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=1"
+  data-ob-row-activity-hide-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=0"
+  data-ob-row-detail-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/detail-panel"
+  data-ob-row-copy-tpl="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
+  data-ob-row-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
+  data-ob-row-folder-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" "__ID__"}}">
 {{range .Rows}}{{$row := .}}{{$isFolder := index $row "is_folder"}}
 <tr {{if index $row "deletion_mark"}}style="opacity:0.45;text-decoration:line-through;cursor:pointer"{{else}}style="cursor:pointer"{{end}}
   data-ob-list-row tabindex="-1" aria-selected="false" aria-keyshortcuts="ArrowUp ArrowDown Enter F2{{if $.CanWrite}} F9{{end}}{{if and $.CanDelete (not (index $row "_is_predefined"))}} Delete{{end}}"
+  data-ob-id="{{index $row "id"}}"
   data-predefined="{{if index $row "_is_predefined"}}1{{end}}"
   data-is-folder="{{if $isFolder}}1{{end}}"
-  data-folder-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" (str (index $row "id"))}}"
-  data-mark-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete?mark=1"
-  data-del-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete"
   data-posted="{{if index $row "posted"}}1{{end}}"
   data-marked="{{if index $row "deletion_mark"}}1{{end}}"
-  data-unpost-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/unpost"
-  data-unmark-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/delete?mark=0"
-  data-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
   data-activity-inactive="{{if index $row "_activity_inactive"}}1{{end}}"
-  data-activity-hide-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/activity?active=0"
-  data-activity-show-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/activity?active=1"
-  data-copy-url="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy={{index $row "id"}}{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
-  data-open-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-ob-detail-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/{{index $row "id"}}/detail-panel">
+>
   {{if eq (str $.Entity.Kind) "document"}}
     <td style="text-align:center">
       {{if index $row "posted"}}<span style="color:#16a34a;font-weight:700" title="{{t $.Lang "Проведён"}}">✓</span>{{else}}<span style="color:#94a3b8" title="{{t $.Lang "Не проведён"}}">—</span>{{end}}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1779,17 +1779,12 @@ const tplList = `
 <div style="overflow-x:auto">
 <table
   data-ob-row-base="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}"
-  data-ob-row-open-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-ob-row-mark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=1"
-  data-ob-row-unmark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=0"
-  data-ob-row-del-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete"
-  data-ob-row-unpost-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/unpost"
-  data-ob-row-activity-show-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=1"
-  data-ob-row-activity-hide-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=0"
-  data-ob-row-detail-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/detail-panel"
-  data-ob-row-copy-tpl="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
+  data-ob-row-subsystem="{{$.CurrentSubsystem}}"
+  data-ob-row-list-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
+  data-ob-row-copy-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
+  data-ob-row-can-copy="{{if $.CanWrite}}1{{end}}"
   data-ob-row-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
-  data-ob-row-folder-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}?parent=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}"><thead><tr>
+><thead><tr>
   {{range $treeCols}}<th>{{.DisplayName $.Lang}}</th>{{end}}
   <th style="width:90px"></th>
 </tr></thead><tbody>
@@ -1842,17 +1837,12 @@ const tplList = `
 {{$tile := tileView .Entity}}
 <div class="tile-grid" role="listbox"
   data-ob-row-base="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}"
-  data-ob-row-open-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-ob-row-mark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=1"
-  data-ob-row-unmark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=0"
-  data-ob-row-del-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete"
-  data-ob-row-unpost-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/unpost"
-  data-ob-row-activity-show-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=1"
-  data-ob-row-activity-hide-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=0"
-  data-ob-row-detail-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/detail-panel"
-  data-ob-row-copy-tpl="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
+  data-ob-row-subsystem="{{$.CurrentSubsystem}}"
+  data-ob-row-list-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" ""}}"
+  data-ob-row-copy-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new{{listURL $.Query "copy" ""}}"
+  data-ob-row-can-copy="{{if $.CanWrite}}1{{end}}"
   data-ob-row-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
-  data-ob-row-folder-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" "__ID__"}}">
+>
 {{range .Rows}}{{$row := .}}{{$isFolder := index $row "is_folder"}}
 <div class="tile-card{{if index $row "deletion_mark"}} tile-deleted{{end}}"
   data-ob-list-row tabindex="-1" aria-selected="false" aria-keyshortcuts="ArrowUp ArrowDown Enter F2{{if $.CanWrite}} F9{{end}}{{if and $.CanDelete (not (index $row "_is_predefined"))}} Delete{{end}}" role="option"
@@ -1903,17 +1893,12 @@ const tplList = `
   <th style="width:90px"></th>
 </tr></thead><tbody id="list-body"
   data-ob-row-base="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}"
-  data-ob-row-open-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__{{if $.CurrentSubsystem}}?subsystem={{$.CurrentSubsystem}}{{end}}"
-  data-ob-row-mark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=1"
-  data-ob-row-unmark-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete?mark=0"
-  data-ob-row-del-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/delete"
-  data-ob-row-unpost-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/unpost"
-  data-ob-row-activity-show-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=1"
-  data-ob-row-activity-hide-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/activity?active=0"
-  data-ob-row-detail-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/__ID__/detail-panel"
-  data-ob-row-copy-tpl="{{if $.CanWrite}}/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new?copy=__ID__{{if $.CurrentSubsystem}}&subsystem={{$.CurrentSubsystem}}{{end}}{{end}}"
+  data-ob-row-subsystem="{{$.CurrentSubsystem}}"
+  data-ob-row-list-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" ""}}"
+  data-ob-row-copy-url="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}/new{{listURL $.Query "copy" ""}}"
+  data-ob-row-can-copy="{{if $.CanWrite}}1{{end}}"
   data-ob-row-activity-enabled="{{if $.Entity.Activity}}1{{end}}"
-  data-ob-row-folder-tpl="/ui/{{lower (str $.Entity.Kind)}}/{{lower $.Entity.Name}}{{listURL $.Query "parent" "__ID__"}}">
+>
 {{range .Rows}}{{$row := .}}{{$isFolder := index $row "is_folder"}}
 <tr {{if index $row "deletion_mark"}}style="opacity:0.45;text-decoration:line-through;cursor:pointer"{{else}}style="cursor:pointer"{{end}}
   data-ob-list-row tabindex="-1" aria-selected="false" aria-keyshortcuts="ArrowUp ArrowDown Enter F2{{if $.CanWrite}} F9{{end}}{{if and $.CanDelete (not (index $row "_is_predefined"))}} Delete{{end}}"


### PR DESCRIPTION
## Что не так сейчас

Каждая строка списка несёт **десять полных URL** в data-атрибутах: `data-mark-url`,
`data-unmark-url`, `data-del-url`, `data-unpost-url`, `data-copy-url`, `data-open-url`,
`data-ob-detail-url`, `data-folder-url`, `data-activity-show-url`, `data-activity-hide-url`.

Все они выводятся из вида и имени сущности плюс идентификатора строки, но повторяются
целиком в каждой строке. Имя сущности при этом едет percent-encoded: кириллическая
«номенклатура» занимает 36 символов вместо 12.

Замер на справочнике из 5000 позиций (100 строк на странице):

```
вес страницы           247 КБ
из них таблица         213 КБ
из них data-*-url      148 КБ  (69 % веса таблицы)
на строку              2,1 КБ  при полезной нагрузке в наименование и код
```

## Что в этом PR

Контейнер списка несёт опорные адреса (`data-ob-row-base`, `-list-url`, `-copy-url`,
`-subsystem`, `-can-copy`, `-activity-enabled`), строка — только `data-ob-id` и флаги
состояния. Ссылку действия собирает `obRowUrl(row, kind)`; параметр добавляется через
`URLSearchParams`, а не подстановкой в строку.

Сделано во всех трёх видах списка: таблица, плитка, дерево.

Обратная совместимость: строки, приходящие из JSON при подгрузке, по-прежнему могут
нести готовые ссылки в собственных data-атрибутах — `obRowUrl()` отдаёт им приоритет.

## Замер

Одна база, одна страница, реальное устройство (Android 14, WebView Chrome 151),
метрики сняты изнутри страницы через DevTools Protocol.

| | было | стало |
| --- | --- | --- |
| вес HTML | 247 КБ | **102 КБ** |
| передано по сети | 252 КБ | **102 КБ** |
| время скачивания | 45 мс | **22 мс** |
| время до интерактивности (прогретый WebView, медиана 6 прогонов) | 211 мс | 205 мс |

⚠️ **Поправка к первой редакции описания.** Сначала я привёл здесь «740 → 272 мс» —
эти числа получены единичными замерами без прогрева и чередования версий и **не
воспроизводятся**. При аккуратном прогоне (по шесть замеров на версию, чередуя)
время до интерактивности на прогретом WebView **практически не отличается**: разница
в весе съедается быстрым парсером. Что действительно меняется и воспроизводится —
объём передачи и время скачивания, то есть выигрыш на медленном канале и на трафике,
а не на CPU. Прошу прощения за неточность.

## Проверки

- `go test ./internal/ui` — успешно, в том числе `-race` и прогоны в `Asia/Kolkata`
  и `America/New_York`;
- e2e (playwright, 14 сценариев) — успешно локально;
- остальные шаги CI прогнаны локально: BOM, i18n, номера планов, gofmt, vet, build,
  JS-синтаксис, inline-JS в шаблонах, lint примеров, seed демо-баз, `onebase test` примеров;
- отдельная проверка хелперов в node на сценарии из ревью: legacy-флаг активности,
  пользовательский `q=__ID__` в состоянии списка, строка из JSON-подгрузки.
