### PR TITLE
fix(pipelinehealth): определять владельца интеграционной полосы по родителям HEAD

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -69,6 +69,11 @@ type apiPull struct {
 	} `json:"base"`
 	Labels   []apiLabel   `json:"labels"`
 	Comments []apiComment `json:"-"`
+	// HeadParents holds the parent SHAs of the head commit. An automatic
+	// base-sync always leaves a merge commit; an ordinary FIX push leaves a
+	// single-parent commit. Without this the integration lane cannot be told
+	// apart from a normal review round.
+	HeadParents []string `json:"head_parents,omitempty"`
 }
 
 type apiIssue struct {
@@ -206,6 +211,21 @@ func loadPulls(repo, fixture string) ([]apiPull, error) {
 				path := fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", repo, prs[index].Number)
 				if err := ghJSONLines(gh, &prs[index].Comments, "api", "--paginate", path, "--jq", ".[]"); err != nil {
 					errs <- fmt.Errorf("comments for PR #%d: %w", prs[index].Number, err)
+					continue
+				}
+				if !needsHeadParents(prs[index]) {
+					continue
+				}
+				var parents []struct {
+					SHA string `json:"sha"`
+				}
+				commit := fmt.Sprintf("repos/%s/commits/%s", repo, prs[index].Head.SHA)
+				if err := ghJSONLines(gh, &parents, "api", commit, "--jq", ".parents[]"); err != nil {
+					errs <- fmt.Errorf("head parents for PR #%d: %w", prs[index].Number, err)
+					continue
+				}
+				for _, parent := range parents {
+					prs[index].HeadParents = append(prs[index].HeadParents, parent.SHA)
 				}
 			}
 		}()
@@ -388,7 +408,7 @@ func analyze(prs []apiPull, owner string) report {
 				result.MergeCandidates = append(result.MergeCandidates, item)
 				result.add("yellow", "base_sync_waiting_merge", pr.Number,
 					"интеграционное REVIEW готово; барьер остаётся у PR до фактического merge")
-			case currentCompletions > 0 && depth > currentCompletions:
+			case currentCompletions > 0 && depth > currentCompletions && headIsBaseSyncMerge(pr):
 				item.Stage = "legacy-integration-merge-ready"
 				result.ReviewCandidates = append(result.ReviewCandidates, item)
 				result.MergeCandidates = append(result.MergeCandidates, item)
@@ -399,9 +419,10 @@ func analyze(prs []apiPull, owner string) report {
 				result.ReviewCandidates = append(result.ReviewCandidates, item)
 				result.add("yellow", "base_sync_waiting_review", pr.Number,
 					"ship сохранён; текущий HEAD ожидает интеграционное REVIEW")
-			case currentCompletions == 0 && depth > 0:
-				// REST cannot prove legacy merge parents or timeline edge order. Expose
-				// this as a priority candidate; REVIEW still performs the full GraphQL gate.
+			case currentCompletions == 0 && depth > 0 && headIsBaseSyncMerge(pr):
+				// REST cannot prove legacy timeline edge order, but the merge shape of
+				// the head commit is a fact. Expose this as a priority candidate;
+				// REVIEW still performs the full GraphQL gate.
 				item.Stage = "legacy-integration-review"
 				result.ReviewCandidates = append(result.ReviewCandidates, item)
 				result.add("yellow", "legacy_ship_waiting_review_validation", pr.Number,
@@ -412,6 +433,12 @@ func analyze(prs []apiPull, owner string) report {
 				result.ContentReviewCandidates = append(result.ContentReviewCandidates, item)
 				result.add("yellow", "ship_waiting_initial_review", pr.Number,
 					"ship сохранён как разрешение слить этот HEAD после успешного REVIEW")
+			case currentCompletions == 0 && !protocolHistory:
+				// Ordinary next FIX round: earlier HEADs were reviewed, this one is a
+				// plain push. It belongs to the content lane, not the integration lane.
+				result.ContentReviewCandidates = append(result.ContentReviewCandidates, item)
+				result.add("yellow", "ship_waiting_next_round_review", pr.Number,
+					"ship сохранён; новый HEAD после доработки ожидает обычное REVIEW")
 			case currentCompletions > 0:
 				item.Stage = "merge"
 				result.MergeCandidates = append(result.MergeCandidates, item)
@@ -736,6 +763,26 @@ func (result *report) add(severity, code string, pr int, message string) {
 
 func (result *report) addIssue(severity, code string, issue int, message string) {
 	result.Findings = append(result.Findings, finding{Severity: severity, Code: code, Issue: issue, Message: message})
+}
+
+// needsHeadParents limits the extra commit read to pull requests whose stage
+// can depend on it: an open ship candidate targeting main.
+func needsHeadParents(pr apiPull) bool {
+	if pr.State != "open" || pr.Base.Ref != "main" || pr.Draft || pr.Head.SHA == "" {
+		return false
+	}
+	return labelSet(pr.Labels)["ship"]
+}
+
+// headIsBaseSyncMerge reports whether the head commit has the shape every
+// base-sync leaves behind: a merge of the reviewed head with the base branch.
+// Review history alone never proves this, and an ordinary FIX round —
+// changes-requested, push, green review — produces exactly the same comment
+// trail as a legacy base-sync. Unknown parents count as "not a merge": a false
+// integration owner hides the real one from REVIEW and deadlocks the lane,
+// while a missed one only falls back to the full GraphQL gate in MERGE.
+func headIsBaseSyncMerge(pr apiPull) bool {
+	return len(pr.HeadParents) == 2
 }
 
 func labelSet(labels []apiLabel) map[string]bool {

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -46,6 +46,13 @@ func syncDone(intentID int64, from, to string) string {
 		intentID, from, to, headB)
 }
 
+// withMergeHead gives the pull request the two-parent head commit every
+// base-sync leaves behind. Comment history alone never proves that shape.
+func withMergeHead(item apiPull) apiPull {
+	item.HeadParents = []string{headA, headB}
+	return item
+}
+
 func hasFinding(result report, code string) bool {
 	for _, item := range result.Findings {
 		if item.Code == code {
@@ -146,7 +153,7 @@ func TestCompletedIntegrationReviewKeepsBarrierUntilMerge(t *testing.T) {
 	owner := addComment(testPR(20, headB, "ship", "reviewed"), 30, syncIntent(headA, 10, 20, 25))
 	owner = addComment(owner, 31, syncDone(30, headA, headB))
 	owner = addComment(owner, 40, completion(headB, 35, 36))
-	wouldBeNext := addComment(testPR(30, headB, "ship"), 41, completion(headA, 37, 38))
+	wouldBeNext := withMergeHead(addComment(testPR(30, headB, "ship"), 41, completion(headA, 37, 38)))
 	ordinary := testPR(40, headA)
 
 	got := analyze([]apiPull{wouldBeNext, ordinary, owner}, "ivanarama")
@@ -161,7 +168,7 @@ func TestCompletedIntegrationReviewKeepsBarrierUntilMerge(t *testing.T) {
 
 func TestLegacyReShipIsVisibleAsPriorityValidationCandidate(t *testing.T) {
 	ordinary := testPR(1, headA)
-	legacy := addComment(testPR(99, headB, "ship"), 30, completion(headA, 20, 25))
+	legacy := withMergeHead(addComment(testPR(99, headB, "ship"), 30, completion(headA, 20, 25)))
 
 	got := analyze([]apiPull{ordinary, legacy}, "ivanarama")
 	if len(got.ReviewCandidates) != 1 || got.ReviewCandidates[0].Number != 99 ||
@@ -170,6 +177,83 @@ func TestLegacyReShipIsVisibleAsPriorityValidationCandidate(t *testing.T) {
 	}
 	if !hasFinding(got, "legacy_ship_waiting_review_validation") {
 		t.Fatalf("legacy re-ship is invisible: %+v", got)
+	}
+}
+
+func TestOrdinaryFixRoundIsNotAnIntegrationOwner(t *testing.T) {
+	// changes-requested, push, no review of the new head yet. The comment trail
+	// is identical to a legacy re-ship; only the single-parent head tells them
+	// apart, and this PR must not seize the integration lane.
+	fixRound := addComment(testPR(99, headB, "ship"), 30, completion(headA, 20, 25))
+
+	got := analyze([]apiPull{fixRound}, "ivanarama")
+	if got.IntegrationOwner != nil {
+		t.Fatalf("ordinary fix round became a false integration owner: %+v", got.IntegrationOwner)
+	}
+	if len(got.ContentReviewCandidates) != 1 || got.ContentReviewCandidates[0].Number != 99 ||
+		got.ContentReviewCandidates[0].Stage != "review" {
+		t.Fatalf("new head after a fix round left the content lane: %+v", got.ContentReviewCandidates)
+	}
+	if hasFinding(got, "legacy_ship_waiting_review_validation") ||
+		!hasFinding(got, "ship_waiting_next_round_review") {
+		t.Fatalf("fix round was reported as legacy lineage: %+v", got.Findings)
+	}
+}
+
+func TestReviewedFixRoundStaysOrdinaryMergeCandidate(t *testing.T) {
+	// Two review rounds, the current head green: depth exceeds the completions
+	// of this head, which used to be read as a legacy base-sync.
+	item := addComment(testPR(99, headB, "ship", "reviewed"), 30, completion(headA, 20, 25))
+	item = addComment(item, 31, completion(headB, 40, 45))
+
+	got := analyze([]apiPull{item}, "ivanarama")
+	if got.IntegrationOwner != nil {
+		t.Fatalf("reviewed fix round became a false integration owner: %+v", got.IntegrationOwner)
+	}
+	if len(got.MergeCandidates) != 1 || got.MergeCandidates[0].Stage != "merge" ||
+		len(got.MergeExecutable) != 1 || got.MergeExecutable[0].Number != 99 {
+		t.Fatalf("ordinary merge candidate was routed into the integration lane: %+v", got)
+	}
+	if hasFinding(got, "legacy_ship_waiting_merge") {
+		t.Fatalf("review depth alone was accepted as legacy proof: %+v", got.Findings)
+	}
+}
+
+func TestLegacyMergeHeadWithCurrentProofOwnsTheLane(t *testing.T) {
+	item := withMergeHead(addComment(testPR(99, headB, "ship", "reviewed"), 30, completion(headA, 20, 25)))
+	item = addComment(item, 31, completion(headB, 40, 45))
+
+	got := analyze([]apiPull{item}, "ivanarama")
+	if got.IntegrationOwner == nil || got.IntegrationOwner.Number != 99 ||
+		got.IntegrationOwner.Stage != "legacy-integration-merge-ready" ||
+		len(got.MergeExecutable) != 1 || got.MergeExecutable[0].Number != 99 ||
+		!hasFinding(got, "legacy_ship_waiting_merge") {
+		t.Fatalf("genuine legacy base-sync lost the lane: %+v", got)
+	}
+}
+
+func TestBaseSyncOwnerSurvivesLowerNumberedFixRounds(t *testing.T) {
+	// The deadlock this guards: ordinary fix rounds with smaller numbers used to
+	// win the lane, which hid the real base-sync owner from REVIEW while MERGE
+	// refused the impostor — so neither stage could move.
+	impostor := addComment(testPR(20, headB, "ship", "reviewed"), 30, completion(headA, 20, 25))
+	impostor = addComment(impostor, 31, completion(headB, 40, 45))
+	owner := withMergeHead(addComment(testPR(90, headB, "ship", "reviewed"), 32, syncIntent(headA, 10, 21, 26)))
+	owner = addComment(owner, 33, syncDone(32, headA, headB))
+
+	got := analyze([]apiPull{impostor, owner}, "ivanarama")
+	if got.IntegrationOwner == nil || got.IntegrationOwner.Number != 90 ||
+		got.IntegrationOwner.Stage != "integration-review" {
+		t.Fatalf("base-sync owner lost the lane to a fix round: %+v", got.IntegrationOwner)
+	}
+	if len(got.ReviewCandidates) != 1 || got.ReviewCandidates[0].Number != 90 {
+		t.Fatalf("REVIEW cannot reach the base-sync owner: %+v", got.ReviewCandidates)
+	}
+	if len(got.MergeExecutable) != 0 {
+		t.Fatalf("MERGE was offered a PR while the owner waits for REVIEW: %+v", got.MergeExecutable)
+	}
+	if len(got.MergeCandidates) != 1 || got.MergeCandidates[0].Number != 20 {
+		t.Fatalf("ordinary candidate left the merge queue: %+v", got.MergeCandidates)
 	}
 }
 
@@ -185,8 +269,8 @@ func TestBaseAdvanceBetweenIntentAndDoneIsVisible(t *testing.T) {
 }
 
 func TestSingleFlightExposesOnlyFirstIntegrationReview(t *testing.T) {
-	first := addComment(testPR(20, headB, "ship"), 30, completion(headA, 20, 25))
-	second := addComment(testPR(30, headB, "ship"), 31, completion(headA, 21, 26))
+	first := withMergeHead(addComment(testPR(20, headB, "ship"), 30, completion(headA, 20, 25)))
+	second := withMergeHead(addComment(testPR(30, headB, "ship"), 31, completion(headA, 21, 26)))
 	ordinary := testPR(1, headA)
 
 	got := analyze([]apiPull{second, ordinary, first}, "ivanarama")


### PR DESCRIPTION
## Что было

`pipelinehealth` определял стадии `legacy-integration-merge-ready` и
`legacy-integration-review` по условию `depth > currentCompletions` — то есть
«у PR был завершённый круг ревью на прежнем SHA». Это признак **обычной жизни
любого PR**: `changes-requested` → правка → `reviewed` даёт `depth=2` при одном
завершении текущего HEAD. Родители коммита не проверялись нигде, хотя именно они
отличают base-sync (коммит слияния, два родителя) от обычной правки (один).

## Чем это кончилось

Взаимоблокировкой конвейера, которую поймал ручной прогон MERGE 04.09.2026:

1. Ложными владельцами полосы стали шесть PR — #1221, #1232, #1269, #1270,
   #1286, #1329. Первый по номеру (#1221) объявлялся `merge_executable`.
2. Так как стадия владельца имеет приоритет 0, `applySingleFlight` заменял
   очередь REVIEW содержательной — и настоящие владельцы полосы #1293, #1295,
   #1310 исчезали **из всех списков** отчёта, оставаясь только в `findings`.
3. MERGE по полному GraphQL-протоколу #1221 отвергал: у него один родитель, он
   отстаёт от `main`, а подтянуть его — значит занять полосу, которую держит
   #1293.

Итог: дашборд ждал мержа того, кого влить нельзя, и прятал того, кого надо
отревьюить. Ни один этап не мог сдвинуться.

Отдельно важно: чинить только первую ветку было нельзя — вторая содержит ту же
ошибку, и владельцем стал бы #1225 (тоже один родитель, номер меньше 1293).
Блокировка просто переехала бы на один PR.

## Что сделано

- Обе `legacy-*` ветки требуют HEAD с ровно двумя родителями. Родители читаются
  одним REST-запросом на PR с меткой `ship` (~18 на прогон), в том же пуле, что
  и комментарии.
- Неизвестные родители считаются «не слияние». Направление выбрано осознанно:
  ложный владелец останавливает весь конвейер, пропущенный — лишь откатывается к
  полному GraphQL-гейту в MERGE.
- PR с новым HEAD после доработки уходит в содержательную полосу с новым
  сигналом `ship_waiting_next_round_review`, а не пропадает из очередей.

## Проверка

На живой очереди после правки: владелец — **#1293** (`integration-review`),
`review_candidates` = `[#1293]`, `merge_executable` пуст, шесть ложных владельцев
вернулись в обычную merge-очередь, сигналов 6 вместо 12. Это совпадает с
выводом полного протокола MERGE, сделанным вручную.

Тестов у обеих веток не было ни одного — поэтому дефект и доехал. Добавлены
четыре: обычный круг FIX не становится владельцем (`#1225`), отревьюенный круг
остаётся обычным merge-кандидатом (`#1221`), настоящий legacy с двумя родителями
полосу сохраняет, и сквозной — владелец base-sync не вытесняется PR с меньшим
номером. Три из четырёх падают на старом коде; четвёртый — покрытие ветки,
которого не было. Три существующих теста опирались на сломанный признак и
получили честный двухродительский HEAD.

Заявки нет: дефект найден при ручном прогоне MERGE, правка сделана в обход
конвейера по прямому указанию, потому что конвейер этим дефектом и остановлен.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wq36TDUKWFass62831kmM
