### PR TITLE
fix(dsl): типизировать пустые поля объектов

### DIFF
--- a/internal/dsl/interpreter/catalogs_proxy.go
+++ b/internal/dsl/interpreter/catalogs_proxy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/i18n/i18nerr"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/typedempty"
 )
 
 // Статусы safe-match API (ПроверитьСовпадениеПоРеквизиту): кладутся в поле
@@ -252,7 +253,7 @@ func (r *CatalogsRoot) Get(entityName string) any {
 	}
 	return &CatalogProxy{entity: entity, db: r.db, ctxSrc: r.ctxSrc, caller: r.caller,
 		access: r.access, fieldSearch: r.fieldSearch, registrar: r.registrar, objFactory: r.objFactory,
-		deleter: r.deleter}
+		deleter: r.deleter, lookup: r.lookup}
 }
 
 func (r *CatalogsRoot) Set(_ string, _ any) {}
@@ -272,6 +273,7 @@ type CatalogProxy struct {
 	registrar   ExchangeRegistrar
 	objFactory  CatalogObjectFactory
 	deleter     CatalogDeleter
+	lookup      EntityLookup
 }
 
 // NewCatalogProxy создаёт менеджера справочника для привязки к ссылкам,
@@ -314,6 +316,13 @@ func (p *CatalogProxy) WithExchangeRegistrar(reg ExchangeRegistrar) *CatalogProx
 // (менеджеру ссылки). Для цепочки.
 func (p *CatalogProxy) WithObjectFactory(f CatalogObjectFactory) *CatalogProxy {
 	p.objFactory = f
+	return p
+}
+
+// WithEntityLookup supplies metadata for typed empty reference values returned
+// by the legacy writer used outside the UI object factory.
+func (p *CatalogProxy) WithEntityLookup(lookup EntityLookup) *CatalogProxy {
+	p.lookup = lookup
 	return p
 }
 
@@ -399,6 +408,7 @@ func (p *CatalogProxy) CallMethod(method string, args []any) any {
 			access:    p.access,
 			registrar: p.registrar,
 			deleter:   p.deleter,
+			lookup:    p.lookup,
 			fields:    map[string]any{},
 		}
 	case "удалить", "delete":
@@ -481,6 +491,7 @@ func (p *CatalogProxy) LoadObject(uuidStr string) (any, error) {
 		access:    p.access,
 		registrar: p.registrar,
 		deleter:   p.deleter,
+		lookup:    p.lookup,
 		idStr:     uuidStr,
 		fields:    fields,
 	}, nil
@@ -661,6 +672,7 @@ type CatalogRecordWriter struct {
 	access    RowAccessChecker
 	registrar ExchangeRegistrar
 	deleter   CatalogDeleter // проносится в Manager возвращаемой ссылки
+	lookup    EntityLookup
 	idStr     string
 	fields    map[string]any
 }
@@ -686,10 +698,61 @@ func (w *CatalogRecordWriter) Get(name string) any {
 	low := strings.ToLower(name)
 	for k, v := range w.fields {
 		if strings.ToLower(k) == low {
-			return v
+			return w.declaredValue(name, v)
 		}
 	}
-	return nil
+	return w.declaredValue(name, nil)
+}
+
+func (w *CatalogRecordWriter) declaredValue(name string, raw any) any {
+	if w == nil || w.entity == nil {
+		return raw
+	}
+	for i := range w.entity.Fields {
+		field := &w.entity.Fields[i]
+		if !strings.EqualFold(field.Name, name) {
+			continue
+		}
+		desc, _ := typedempty.FromField(field)
+		if field.RefEntity == "" {
+			return typedempty.Normalize(desc, raw, nil)
+		}
+		var target *metadata.Entity
+		if w.lookup != nil {
+			target = w.lookup.GetEntity(field.RefEntity)
+		}
+		manager := RefManager(nil)
+		if target != nil && target.Kind == metadata.KindCatalog {
+			manager = &CatalogProxy{entity: target, db: w.db, ctxSrc: w.ctxSrc, access: w.access, registrar: w.registrar, deleter: w.deleter, lookup: w.lookup}
+		}
+		ref := &Ref{Type: field.RefEntity, Kind: refKindFromEntity(target), Manager: manager}
+		if raw != nil {
+			if existing, ok := raw.(*Ref); ok {
+				copy := *existing
+				if copy.Type == "" {
+					copy.Type = field.RefEntity
+				}
+				if copy.Kind == "" {
+					copy.Kind = ref.Kind
+				}
+				if copy.Manager == nil {
+					copy.Manager = manager
+				}
+				return &copy
+			}
+			ref.UUID = strings.TrimSpace(fmt.Sprint(raw))
+			ref.Name = ref.UUID
+		}
+		return ref
+	}
+	return raw
+}
+
+func refKindFromEntity(entity *metadata.Entity) metadata.Kind {
+	if entity == nil {
+		return ""
+	}
+	return entity.Kind
 }
 
 // Set — установка значения поля (Зап.Поле = значение).
@@ -770,7 +833,7 @@ func (w *CatalogRecordWriter) CallMethod(method string, args []any) any {
 		return &Ref{
 			UUID: id, Name: name, Type: w.entity.Name, Kind: w.entity.Kind,
 			Manager: &CatalogProxy{entity: w.entity, db: w.db, ctxSrc: w.ctxSrc, access: w.access,
-				registrar: w.registrar, deleter: w.deleter},
+				registrar: w.registrar, deleter: w.deleter, lookup: w.lookup},
 		}
 	case "установитьзначение", "setvalue":
 		if len(args) >= 2 {

--- a/internal/dsl/interpreter/catalogs_proxy_test.go
+++ b/internal/dsl/interpreter/catalogs_proxy_test.go
@@ -4,11 +4,45 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/i18n/i18nerr"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/shopspring/decimal"
 )
+
+func TestCatalogRecordWriter_DeclaredEmptyValuesAreTyped(t *testing.T) {
+	target := &metadata.Entity{Name: "Владельцы", Kind: metadata.KindCatalog}
+	entity := &metadata.Entity{Name: "Карточки", Kind: metadata.KindCatalog, Fields: []metadata.Field{
+		{Name: "Сумма", Type: metadata.FieldTypeNumber},
+		{Name: "Флаг", Type: metadata.FieldTypeBool},
+		{Name: "Текст", Type: metadata.FieldTypeString},
+		{Name: "Дата", Type: metadata.FieldTypeDate},
+		{Name: "Владелец", Type: "reference:Владельцы", RefEntity: "Владельцы"},
+	}}
+	lookup := &fakeEntityLookup{m: map[string]*metadata.Entity{entity.Name: entity, target.Name: target}}
+	w := &CatalogRecordWriter{entity: entity, lookup: lookup, fields: map[string]any{}}
+	if got, ok := w.Get("Сумма").(decimal.Decimal); !ok || !got.IsZero() {
+		t.Fatalf("Сумма = %T(%v)", w.Get("Сумма"), w.Get("Сумма"))
+	}
+	if got := w.Get("Флаг"); got != false {
+		t.Fatalf("Флаг = %T(%v)", got, got)
+	}
+	if got := w.Get("Текст"); got != "" {
+		t.Fatalf("Текст = %T(%v)", got, got)
+	}
+	if got, ok := w.Get("Дата").(time.Time); !ok || !got.IsZero() {
+		t.Fatalf("Дата = %T(%v)", w.Get("Дата"), w.Get("Дата"))
+	}
+	ref, ok := w.Get("Владелец").(*Ref)
+	if !ok || ref.UUID != "" || ref.Type != target.Name || ref.Kind != metadata.KindCatalog {
+		t.Fatalf("Владелец = %#v (%T)", ref, w.Get("Владелец"))
+	}
+	if len(w.fields) != 0 {
+		t.Fatalf("чтение изменило writer: %#v", w.fields)
+	}
+}
 
 // fakeCatalogsDB stubs storage for catalog/predefined lookups in tests.
 type fakeCatalogsDB struct {

--- a/internal/dsl/interpreter/env.go
+++ b/internal/dsl/interpreter/env.go
@@ -45,9 +45,20 @@ type MethodLister interface {
 }
 
 // MapThis wraps map[string]any as a This (used for tablepart rows and register movement records).
-type MapThis struct{ M map[string]any }
+// Read/Write are optional metadata-aware hooks; retaining the concrete wrapper
+// keeps compatibility for callers that inspect M directly.
+type MapThis struct {
+	M     map[string]any
+	Read  func(name string) (value any, handled bool)
+	Write func(name string, value any) bool
+}
 
 func (m *MapThis) Get(name string) any {
+	if m.Read != nil {
+		if value, handled := m.Read(name); handled {
+			return value
+		}
+	}
 	low := strings.ToLower(name)
 	for k, v := range m.M {
 		if strings.ToLower(k) == low {
@@ -58,6 +69,9 @@ func (m *MapThis) Get(name string) any {
 }
 
 func (m *MapThis) Set(name string, v any) {
+	if m.Write != nil && m.Write(name, v) {
+		return
+	}
 	low := strings.ToLower(name)
 	for k := range m.M {
 		if strings.ToLower(k) == low {

--- a/internal/entityservice/defaults.go
+++ b/internal/entityservice/defaults.go
@@ -436,13 +436,14 @@ func (s *Service) NewObject(ctx context.Context, req NewObjectRequest) (NewObjec
 		vars = make(map[string]any)
 	}
 	defer interpreter.RollbackTxExecution(txState)
-	// Имя параметра выбирает пользователь (Объект, ЭтотОбъект, Док…).
-	if len(proc.Params) > 0 {
-		vars[proc.Params[0].Literal] = obj
-	}
 	var thisVal interpreter.This = obj
 	if s.MakeThis != nil {
 		thisVal = s.MakeThis(hookCtx, txState, obj, entity)
+	}
+	// Имя параметра выбирает пользователь (Объект, ЭтотОбъект, Док…). Оно
+	// должно видеть ту же metadata-aware обёртку, что и неявный this.
+	if len(proc.Params) > 0 {
+		vars[proc.Params[0].Literal] = thisVal
 	}
 	runErr := s.runHook(hookCtx, proc, thisVal, vars)
 	if runErr = interpreter.FinishTxExecution(txState, runErr); runErr != nil {

--- a/internal/storage/register.go
+++ b/internal/storage/register.go
@@ -26,16 +26,19 @@ func resolveRefArg(d Dialect, v any) any {
 		}
 		return nil
 	case string:
-		if val != "" {
-			if id, err := uuid.Parse(val); err == nil {
-				return idArg(d, id)
-			}
+		if val == "" {
+			return nil
+		}
+		if id, err := uuid.Parse(val); err == nil {
+			return idArg(d, id)
 		}
 	case refUUIDGetter:
-		if uuidStr := val.GetRefUUID(); uuidStr != "" {
-			if id, err := uuid.Parse(uuidStr); err == nil {
-				return idArg(d, id)
-			}
+		uuidStr := val.GetRefUUID()
+		if uuidStr == "" {
+			return nil
+		}
+		if id, err := uuid.Parse(uuidStr); err == nil {
+			return idArg(d, id)
 		}
 	}
 	return v

--- a/internal/storage/register_test.go
+++ b/internal/storage/register_test.go
@@ -72,6 +72,16 @@ func TestNormalizeRegArg_Nil(t *testing.T) {
 	}
 }
 
+func TestNormalizeRegArg_EmptyReferenceIsNull(t *testing.T) {
+	d := SQLiteDialect{}
+	if got := normalizeRegArg(d, &fakeRef{}, true); got != nil {
+		t.Errorf("пустой Ref → %T(%v), ожидался nil", got, got)
+	}
+	if got := normalizeRegArg(d, "", true); got != nil {
+		t.Errorf("пустая строка ссылки → %T(%v), ожидался nil", got, got)
+	}
+}
+
 // UUID-строка в reference-поле должна пройти через idArg.
 func TestNormalizeRegArg_UUIDString_AsRef(t *testing.T) {
 	d := SQLiteDialect{}

--- a/internal/typedempty/typedempty.go
+++ b/internal/typedempty/typedempty.go
@@ -1,0 +1,203 @@
+// Package typedempty owns the metadata-to-DSL empty-value table.
+//
+// It deliberately does not know about interpreter.Ref. Callers that have a
+// registry provide a reference factory, keeping object-manager construction at
+// the boundary where the target entity and execution context are available.
+package typedempty
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+// Descriptor is the immutable part of field metadata needed to materialize an
+// empty DSL value. It is intentionally narrower than metadata.Field so the same
+// contract can describe entity fields, form attributes and ValueTable columns.
+type Descriptor struct {
+	Type      metadata.FieldType
+	RefEntity string
+	EnumName  string
+	Length    int
+	Scale     int
+}
+
+// FromField copies the type-bearing part of a metadata field.
+func FromField(field *metadata.Field) (Descriptor, bool) {
+	if field == nil {
+		return Descriptor{}, false
+	}
+	d := Descriptor{
+		Type:      field.Type,
+		RefEntity: field.RefEntity,
+		EnumName:  field.EnumName,
+		Length:    field.Length,
+		Scale:     field.Scale,
+	}
+	typeRef := string(field.Type)
+	lower := strings.ToLower(typeRef)
+	if d.RefEntity == "" && strings.HasPrefix(lower, "reference:") {
+		d.RefEntity = typeRef[len("reference:"):]
+	}
+	if d.EnumName == "" && strings.HasPrefix(lower, "enum:") {
+		d.EnumName = typeRef[len("enum:"):]
+	}
+	return d, d.Type != "" || d.RefEntity != "" || d.EnumName != ""
+}
+
+// FromFormType parses the compact type spelling used by managed-form
+// attributes (for example decimal(15,2), CatalogRef.Клиенты or string(40)).
+func FromFormType(typeRef string, length, scale int) (Descriptor, bool) {
+	typeRef = strings.TrimSpace(typeRef)
+	if typeRef == "" || strings.EqualFold(typeRef, "ValueTable") {
+		return Descriptor{}, false
+	}
+	lower := strings.ToLower(typeRef)
+	d := Descriptor{Length: length, Scale: scale}
+	switch {
+	case strings.HasPrefix(lower, "catalogref."):
+		d.RefEntity = strings.TrimSpace(typeRef[len("CatalogRef."):])
+		d.Type = metadata.FieldType("reference:" + d.RefEntity)
+	case strings.HasPrefix(lower, "documentref."):
+		d.RefEntity = strings.TrimSpace(typeRef[len("DocumentRef."):])
+		d.Type = metadata.FieldType("reference:" + d.RefEntity)
+	case strings.HasPrefix(lower, "reference:"):
+		d.RefEntity = strings.TrimSpace(typeRef[len("reference:"):])
+		d.Type = metadata.FieldType("reference:" + d.RefEntity)
+	case strings.HasPrefix(lower, "enumref."):
+		d.EnumName = strings.TrimSpace(typeRef[len("EnumRef."):])
+		d.Type = metadata.FieldType("enum:" + d.EnumName)
+	case strings.HasPrefix(lower, "enum:"):
+		d.EnumName = strings.TrimSpace(typeRef[len("enum:"):])
+		d.Type = metadata.FieldType("enum:" + d.EnumName)
+	case strings.HasPrefix(lower, "number"), strings.HasPrefix(lower, "decimal"):
+		d.Type = metadata.FieldTypeNumber
+		if parsedLength, parsedScale, ok := numberSpec(typeRef); ok {
+			d.Length, d.Scale = parsedLength, parsedScale
+		}
+	case strings.HasPrefix(lower, "string"):
+		d.Type = metadata.FieldTypeString
+	case strings.HasPrefix(lower, "richtext"):
+		d.Type = metadata.FieldTypeRichText
+	case strings.HasPrefix(lower, "date"):
+		d.Type = metadata.FieldTypeDate
+	case strings.HasPrefix(lower, "bool"):
+		d.Type = metadata.FieldTypeBool
+	case strings.HasPrefix(lower, "image"):
+		d.Type = metadata.FieldTypeImage
+	default:
+		return Descriptor{}, false
+	}
+	if d.RefEntity == "" && d.EnumName == "" && d.Type == "" {
+		return Descriptor{}, false
+	}
+	return d, true
+}
+
+// Field converts a form descriptor into the metadata shape used by the common
+// table-part row proxy. The returned value is a copy and is safe to retain.
+func (d Descriptor) Field(name string) metadata.Field {
+	return metadata.Field{
+		Name:      name,
+		Type:      d.Type,
+		RefEntity: d.RefEntity,
+		EnumName:  d.EnumName,
+		Length:    d.Length,
+		Scale:     d.Scale,
+	}
+}
+
+// Value materializes the canonical empty value for a declared field. The
+// factory is required only for references; it keeps this package independent
+// from the DSL interpreter and its object managers.
+func Value(d Descriptor, referenceFactory func(Descriptor) any) (any, bool) {
+	if d.RefEntity != "" {
+		if referenceFactory == nil {
+			return nil, false
+		}
+		return referenceFactory(d), true
+	}
+	if d.EnumName != "" {
+		return "", true
+	}
+	switch d.Type {
+	case metadata.FieldTypeNumber:
+		return decimal.Zero, true
+	case metadata.FieldTypeBool:
+		return false, true
+	case metadata.FieldTypeString, metadata.FieldTypeRichText:
+		return "", true
+	case metadata.FieldTypeDate:
+		return time.Time{}, true
+	default:
+		return nil, false
+	}
+}
+
+// Normalize returns a DSL value with the declared primitive type. In
+// particular, nil is materialized through Value without changing its owner.
+func Normalize(d Descriptor, raw any, referenceFactory func(Descriptor) any) any {
+	if text, ok := raw.(string); ok && strings.TrimSpace(text) == "" &&
+		d.Type != metadata.FieldTypeString && d.Type != metadata.FieldTypeRichText && d.EnumName == "" {
+		raw = nil
+	}
+	if raw == nil {
+		if value, ok := Value(d, referenceFactory); ok {
+			return value
+		}
+		return nil
+	}
+	switch d.Type {
+	case metadata.FieldTypeNumber:
+		switch value := raw.(type) {
+		case decimal.Decimal:
+			return value
+		case float64:
+			return decimal.NewFromFloat(value)
+		case int64:
+			return decimal.NewFromInt(value)
+		case int:
+			return decimal.NewFromInt(int64(value))
+		case string:
+			if parsed, err := decimal.NewFromString(strings.TrimSpace(value)); err == nil {
+				return parsed
+			}
+		}
+	case metadata.FieldTypeBool:
+		switch value := raw.(type) {
+		case bool:
+			return value
+		case int64:
+			return value != 0
+		case string:
+			return value == "true" || value == "1" || strings.EqualFold(value, "да")
+		}
+	}
+	return raw
+}
+
+func numberSpec(typeRef string) (length, scale int, ok bool) {
+	open := strings.IndexByte(typeRef, '(')
+	if open <= 0 || !strings.HasSuffix(typeRef, ")") {
+		return 0, 0, false
+	}
+	parts := strings.Split(typeRef[open+1:len(typeRef)-1], ",")
+	if len(parts) == 0 || len(parts) > 2 {
+		return 0, 0, false
+	}
+	length, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || length <= 0 {
+		return 0, 0, false
+	}
+	if len(parts) == 2 {
+		scale, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil || scale < 0 {
+			return 0, 0, false
+		}
+	}
+	return length, scale, true
+}

--- a/internal/typedempty/typedempty_test.go
+++ b/internal/typedempty/typedempty_test.go
@@ -1,0 +1,56 @@
+package typedempty
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+)
+
+func TestValue_CanonicalPrimitiveEmpties(t *testing.T) {
+	tests := []struct {
+		name string
+		desc Descriptor
+		ok   func(any) bool
+	}{
+		{"number", Descriptor{Type: metadata.FieldTypeNumber}, func(v any) bool { d, ok := v.(decimal.Decimal); return ok && d.IsZero() }},
+		{"bool", Descriptor{Type: metadata.FieldTypeBool}, func(v any) bool { b, ok := v.(bool); return ok && !b }},
+		{"string", Descriptor{Type: metadata.FieldTypeString}, func(v any) bool { s, ok := v.(string); return ok && s == "" }},
+		{"richtext", Descriptor{Type: metadata.FieldTypeRichText}, func(v any) bool { s, ok := v.(string); return ok && s == "" }},
+		{"enum", Descriptor{EnumName: "Статусы"}, func(v any) bool { s, ok := v.(string); return ok && s == "" }},
+		{"date", Descriptor{Type: metadata.FieldTypeDate}, func(v any) bool { d, ok := v.(time.Time); return ok && d.IsZero() }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Value(tc.desc, nil)
+			if !ok || !tc.ok(got) {
+				t.Fatalf("Value(%+v) = %T(%v), ok=%v", tc.desc, got, got, ok)
+			}
+		})
+	}
+}
+
+func TestFromFormType_PreservesFullDescriptor(t *testing.T) {
+	d, ok := FromFormType("decimal(15,2)", 0, 0)
+	if !ok || d.Type != metadata.FieldTypeNumber || d.Length != 15 || d.Scale != 2 {
+		t.Fatalf("decimal descriptor = %+v, ok=%v", d, ok)
+	}
+	d, ok = FromFormType("CatalogRef.Клиенты", 0, 0)
+	if !ok || d.RefEntity != "Клиенты" || d.Type != "reference:Клиенты" {
+		t.Fatalf("reference descriptor = %+v, ok=%v", d, ok)
+	}
+}
+
+func TestNormalize_EmptyInputUsesDeclaredType(t *testing.T) {
+	if got, ok := Normalize(Descriptor{Type: metadata.FieldTypeNumber}, "", nil).(decimal.Decimal); !ok || !got.IsZero() {
+		t.Fatalf("empty number = %T(%v)", Normalize(Descriptor{Type: metadata.FieldTypeNumber}, "", nil), Normalize(Descriptor{Type: metadata.FieldTypeNumber}, "", nil))
+	}
+	if got, ok := Normalize(Descriptor{Type: metadata.FieldTypeDate}, "", nil).(time.Time); !ok || !got.IsZero() {
+		t.Fatalf("empty date = %T(%v)", Normalize(Descriptor{Type: metadata.FieldTypeDate}, "", nil), Normalize(Descriptor{Type: metadata.FieldTypeDate}, "", nil))
+	}
+	if got := Normalize(Descriptor{Type: metadata.FieldTypeString}, "", nil); got != "" {
+		t.Fatalf("empty string = %T(%v)", got, got)
+	}
+}

--- a/internal/ui/dsl_catalogs.go
+++ b/internal/ui/dsl_catalogs.go
@@ -154,6 +154,7 @@ type catWriter struct {
 	// assigned — реквизиты, присвоенные модулем в этой сессии: их чтение не
 	// маскируется, значение принадлежит текущей операции (план 88E).
 	assigned map[string]bool
+	resolver *dslRefAttrResolver
 }
 
 func (w *catWriter) ctx() context.Context {
@@ -163,20 +164,35 @@ func (w *catWriter) ctx() context.Context {
 	return context.Background()
 }
 
+func (w *catWriter) refResolver() *dslRefAttrResolver {
+	if w.resolver == nil && w.s != nil {
+		w.resolver = w.s.newDSLRefAttrResolver(w.ctx())
+		w.resolver.ctxSrc = w.ctxSrc
+		w.resolver.attachObject(w.entity, w.obj)
+	}
+	return w.resolver
+}
+
 // Get: имя табличной части → tpProxy, иначе значение поля шапки. Реквизит
 // прочитанного из БД объекта отдаётся по полевой политике роли (план 88E) —
 // значение, присвоенное самим модулем, возвращается как есть.
 func (w *catWriter) Get(name string) any {
-	for _, tp := range w.entity.TableParts {
+	for i := range w.entity.TableParts {
+		tp := &w.entity.TableParts[i]
 		if strings.EqualFold(tp.Name, name) {
-			return &tpProxy{obj: w.obj, tpName: tp.Name}
+			return &tpProxy{obj: w.obj, tpName: tp.Name, tp: tp, resolver: w.refResolver()}
 		}
 	}
 	v := w.obj.Get(name)
-	if !w.loaded || w.assigned[strings.ToLower(strings.TrimSpace(name))] {
+	field := findObjectAttributeField(w.entity, name)
+	if field == nil {
 		return v
 	}
-	return w.s.maskDSLValue(w.ctx(), w.entity, name, v)
+	maskStored := w.loaded && !w.assigned[strings.ToLower(strings.TrimSpace(name))]
+	if maskStored && w.s.dslFieldMasked(w.ctx(), w.entity, field.Name) {
+		return w.s.maskDSLValue(w.ctx(), w.entity, field.Name, v)
+	}
+	return w.s.declaredEntityFieldValue(field, v, w.refResolver())
 }
 
 func (w *catWriter) Set(name string, v any) {

--- a/internal/ui/dsl_documents.go
+++ b/internal/ui/dsl_documents.go
@@ -120,6 +120,7 @@ func (s *Server) refManagerForSrc(entity *metadata.Entity, ctxSrc interpreter.Ct
 	switch entity.Kind {
 	case metadata.KindCatalog:
 		return interpreter.NewCatalogProxy(entity, s.store, ctxSrc).
+			WithEntityLookup(s.reg).
 			WithRowAccessChecker(s.dslRowAccessChecker()).
 			WithFieldSearchChecker(s.dslFieldSearchChecker()).
 			WithExchangeRegistrar(s.exchangeRegistrar()).
@@ -599,6 +600,7 @@ type docWriter struct {
 	// assigned — реквизиты, присвоенные модулем в этой сессии: их чтение не
 	// маскируется, значение принадлежит текущей операции (план 88E).
 	assigned map[string]bool
+	resolver *dslRefAttrResolver
 }
 
 func (w *docWriter) ctx() context.Context {
@@ -608,20 +610,35 @@ func (w *docWriter) ctx() context.Context {
 	return context.Background()
 }
 
+func (w *docWriter) refResolver() *dslRefAttrResolver {
+	if w.resolver == nil && w.s != nil {
+		w.resolver = w.s.newDSLRefAttrResolver(w.ctx())
+		w.resolver.ctxSrc = w.ctxSrc
+		w.resolver.attachObject(w.entity, w.obj)
+	}
+	return w.resolver
+}
+
 // Get: имя табличной части → tpProxy, иначе значение поля шапки. Реквизит
 // прочитанного из БД документа отдаётся по полевой политике роли (план 88E) —
 // значение, присвоенное самим модулем, возвращается как есть.
 func (w *docWriter) Get(name string) any {
-	for _, tp := range w.entity.TableParts {
+	for i := range w.entity.TableParts {
+		tp := &w.entity.TableParts[i]
 		if strings.EqualFold(tp.Name, name) {
-			return &tpProxy{obj: w.obj, tpName: tp.Name}
+			return &tpProxy{obj: w.obj, tpName: tp.Name, tp: tp, resolver: w.refResolver()}
 		}
 	}
 	v := w.obj.Get(name)
-	if !w.loaded || w.assigned[strings.ToLower(strings.TrimSpace(name))] {
+	field := findObjectAttributeField(w.entity, name)
+	if field == nil {
 		return v
 	}
-	return w.s.maskDSLValue(w.ctx(), w.entity, name, v)
+	maskStored := w.loaded && !w.assigned[strings.ToLower(strings.TrimSpace(name))]
+	if maskStored && w.s.dslFieldMasked(w.ctx(), w.entity, field.Name) {
+		return w.s.maskDSLValue(w.ctx(), w.entity, field.Name, v)
+	}
+	return w.s.declaredEntityFieldValue(field, v, w.refResolver())
 }
 
 func (w *docWriter) Set(name string, v any) {
@@ -1147,8 +1164,10 @@ func (w *docWriter) displayName() string {
 // tpProxy — табличная часть документа (Док.Товары).
 // tpProxy — табличная часть записываемого объекта (документа или справочника).
 type tpProxy struct {
-	obj    *runtime.Object
-	tpName string
+	obj      *runtime.Object
+	tpName   string
+	tp       *metadata.TablePart
+	resolver *dslRefAttrResolver
 }
 
 func (t *tpProxy) Get(_ string) any    { return nil }
@@ -1159,6 +1178,15 @@ func (t *tpProxy) Set(_ string, _ any) {}
 // (Ссылка.ПолучитьОбъект / НайтиПоНомеру), нельзя было прочитать в DSL.
 func (t *tpProxy) IterateRows() []map[string]any {
 	return t.obj.TablePartRows[t.tpName]
+}
+
+func (t *tpProxy) IterateThis() []interpreter.This {
+	rows := t.IterateRows()
+	out := make([]interpreter.This, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, newRefAwareMapThis(row, t.tp, t.resolver))
+	}
+	return out
 }
 
 // KnownMethods реализует interpreter.MethodLister: опечатка в имени метода
@@ -1175,7 +1203,7 @@ func (t *tpProxy) CallMethod(method string, args []any) any {
 	case "добавить", "add":
 		row := map[string]any{}
 		t.obj.TablePartRows[t.tpName] = append(rows, row)
-		return &interpreter.MapThis{M: row}
+		return newRefAwareMapThis(row, t.tp, t.resolver)
 	case "очистить", "clear":
 		t.obj.TablePartRows[t.tpName] = nil
 	case "количество", "count":
@@ -1183,7 +1211,7 @@ func (t *tpProxy) CallMethod(method string, args []any) any {
 	case "получить", "get":
 		if len(args) > 0 {
 			if idx := runtime.RowIndexArg(args[0]); idx >= 0 && idx < len(rows) {
-				return &interpreter.MapThis{M: rows[idx]}
+				return newRefAwareMapThis(rows[idx], t.tp, t.resolver)
 			}
 		}
 	case "удалить", "delete":

--- a/internal/ui/dsl_form_object.go
+++ b/internal/ui/dsl_form_object.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/ivantit66/onebase/internal/typedempty"
 )
 
 // formObjectThis — обёртка над *runtime.Object, используемая как this/Объект
@@ -204,10 +205,15 @@ func (f *formObjectThis) Get(name string) any {
 	}
 	// Дальше — обычные поля (через Object.Get который ищет в Fields).
 	v := f.obj.Get(name)
-	if ref, ok := v.(*interpreter.Ref); ok && f.refResolver != nil {
-		if fd := entityField(f.entity, name); fd != nil && fd.RefEntity != "" {
-			return f.refResolver.bindRefToContext(ref, fd.RefEntity)
+	if fd := entityField(f.entity, name); fd != nil {
+		return declaredDSLValue(v, mustFieldDescriptor(fd), f.refResolver)
+	}
+	if attr := findScalarFormAttribute(f.form, name); attr != nil {
+		if desc, ok := formAttributeDescriptor(attr); ok {
+			return declaredDSLValue(v, desc, f.refResolver)
 		}
+	}
+	if ref, ok := v.(*interpreter.Ref); ok && f.refResolver != nil {
 		if f.entity != nil && (strings.EqualFold(name, "Ссылка") || strings.EqualFold(name, "Reference")) {
 			return f.refResolver.bindRefToContext(ref, f.entity.Name)
 		}
@@ -218,25 +224,12 @@ func (f *formObjectThis) Get(name string) any {
 			return f.refResolver.bindRefToContext(ref, refName)
 		}
 	}
-	// Дефолты по типу: пустой numeric → 0, иначе `Объект.Сумма + 100` в DSL
-	// даст concat-строку «<nil>100» (DSL `+` для nil-операнда склеивает
-	// строкой), потом форма попытается записать её в PostgreSQL numeric →
-	// ERROR 22P02 invalid input syntax for type numeric.
-	if v == nil && f.entity != nil {
-		for _, fd := range f.entity.Fields {
-			if !strings.EqualFold(fd.Name, name) {
-				continue
-			}
-			switch fd.Type {
-			case metadata.FieldTypeNumber:
-				return float64(0)
-			case metadata.FieldTypeBool:
-				return false
-			}
-			break
-		}
-	}
 	return v
+}
+
+func mustFieldDescriptor(field *metadata.Field) typedempty.Descriptor {
+	desc, _ := typedempty.FromField(field)
+	return desc
 }
 
 // formAttributeTablePart даёт ValueTable тот же metadata-aware row proxy, что
@@ -251,10 +244,8 @@ func formAttributeTablePart(attr *metadata.FormAttribute) *metadata.TablePart {
 		if column == nil {
 			continue
 		}
-		tp.Fields = append(tp.Fields, metadata.Field{
-			Name:      column.Name,
-			RefEntity: attrRefEntityName(column.TypeRef),
-		})
+		desc, _ := typedempty.FromFormType(column.TypeRef, column.Length, column.Precision)
+		tp.Fields = append(tp.Fields, desc.Field(column.Name))
 	}
 	return tp
 }

--- a/internal/ui/dsl_form_object_test.go
+++ b/internal/ui/dsl_form_object_test.go
@@ -12,7 +12,94 @@ import (
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
+	"github.com/shopspring/decimal"
 )
+
+func TestFormObjectThis_DeclaredEmptyValuesAreTypedWithoutMutation(t *testing.T) {
+	target := &metadata.Entity{Name: "Контрагенты", Kind: metadata.KindCatalog}
+	entity := &metadata.Entity{
+		Name: "Заказ", Kind: metadata.KindDocument,
+		Fields: []metadata.Field{
+			{Name: "Сумма", Type: metadata.FieldTypeNumber},
+			{Name: "Флаг", Type: metadata.FieldTypeBool},
+			{Name: "Текст", Type: metadata.FieldTypeString},
+			{Name: "Дата", Type: metadata.FieldTypeDate},
+			{Name: "Статус", Type: "enum:Статусы", EnumName: "Статусы"},
+			{Name: "Контрагент", Type: "reference:Контрагенты", RefEntity: "Контрагенты"},
+			{Name: "Картинка", Type: metadata.FieldTypeImage},
+		},
+	}
+	form := &metadata.FormModule{Attributes: []*metadata.FormAttribute{
+		{Name: "Комментарий", TypeRef: "string(40)", Length: 40},
+		{Name: "ДатаФормы", TypeRef: "date"},
+		{Name: "Выбранный", TypeRef: "CatalogRef.Контрагенты"},
+	}}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{target, entity})
+	obj := runtime.NewObject(entity.Name, entity.Kind)
+	this := s.newFormObjectThis(ctx, obj, entity, form)
+
+	if got, ok := this.Get("Сумма").(decimal.Decimal); !ok || !got.IsZero() {
+		t.Fatalf("Сумма = %T(%v), ожидался decimal.Zero", this.Get("Сумма"), this.Get("Сумма"))
+	}
+	if got := this.Get("Флаг"); got != false {
+		t.Fatalf("Флаг = %T(%v)", got, got)
+	}
+	if got := this.Get("Текст"); got != "" {
+		t.Fatalf("Текст = %T(%v)", got, got)
+	}
+	if got := this.Get("Статус"); got != "" {
+		t.Fatalf("Статус = %T(%v)", got, got)
+	}
+	if got, ok := this.Get("Дата").(time.Time); !ok || !got.IsZero() {
+		t.Fatalf("Дата = %T(%v)", this.Get("Дата"), this.Get("Дата"))
+	}
+	ref, ok := this.Get("Контрагент").(*interpreter.Ref)
+	if !ok || ref.UUID != "" || ref.Type != target.Name || ref.Kind != metadata.KindCatalog {
+		t.Fatalf("Контрагент = %#v (%T), ожидалась типизированная пустая ссылка", ref, this.Get("Контрагент"))
+	}
+	if got := this.Get("Картинка"); got != nil {
+		t.Fatalf("Картинка = %T(%v), ожидалось Неопределено", got, got)
+	}
+	if got := this.Get("Комментарий"); got != "" {
+		t.Fatalf("Комментарий = %T(%v)", got, got)
+	}
+	if got, ok := this.Get("ДатаФормы").(time.Time); !ok || !got.IsZero() {
+		t.Fatalf("ДатаФормы = %T(%v)", this.Get("ДатаФормы"), this.Get("ДатаФормы"))
+	}
+	formRef, ok := this.Get("Выбранный").(*interpreter.Ref)
+	if !ok || formRef.Type != target.Name || formRef.Kind != metadata.KindCatalog || formRef.UUID != "" {
+		t.Fatalf("Выбранный = %#v (%T)", formRef, this.Get("Выбранный"))
+	}
+	if len(obj.Fields) != 0 {
+		t.Fatalf("чтение материализовало пустые значения в объекте: %#v", obj.Fields)
+	}
+}
+
+func TestFormObjectThis_ValueTableColumnsKeepTypeMetadata(t *testing.T) {
+	form := &metadata.FormModule{Attributes: []*metadata.FormAttribute{{
+		Name: "Подбор", TypeRef: "ValueTable",
+		Columns: []*metadata.FormAttributeColumn{
+			{Name: "Количество", TypeRef: "decimal(15,2)"},
+			{Name: "Дата", TypeRef: "date"},
+		},
+	}}}
+	obj := runtime.NewObject("Обработка", "")
+	this := &formObjectThis{obj: obj, form: form}
+	tp := this.Get("Подбор").(*formTpProxy)
+	if tp.tp.Fields[0].Type != metadata.FieldTypeNumber || tp.tp.Fields[0].Length != 15 || tp.tp.Fields[0].Scale != 2 {
+		t.Fatalf("metadata Количество = %+v", tp.tp.Fields[0])
+	}
+	row := tp.CallMethod("Добавить", nil).(*interpreter.MapThis)
+	if got, ok := row.Get("Количество").(decimal.Decimal); !ok || !got.IsZero() {
+		t.Fatalf("Количество = %T(%v)", row.Get("Количество"), row.Get("Количество"))
+	}
+	if got, ok := row.Get("Дата").(time.Time); !ok || !got.IsZero() {
+		t.Fatalf("Дата = %T(%v)", row.Get("Дата"), row.Get("Дата"))
+	}
+	if len(row.M) != 0 {
+		t.Fatalf("чтение создало значения в строке: %#v", row.M)
+	}
+}
 
 // План 37, этап 8: formObjectThis должен возвращать formTpProxy при Get
 // по имени ТЧ, чтобы DSL-выражение Объект.Товары.Добавить() реально

--- a/internal/ui/dsl_form_object_test.go
+++ b/internal/ui/dsl_form_object_test.go
@@ -239,6 +239,68 @@ func TestFormObjectThis_DirectValueWritesToRegister(t *testing.T) {
 	}
 }
 
+// Сквозная регрессия для типизированного пустого значения ссылки: чтение
+// незаполненного реквизита в posting-модуле возвращает *interpreter.Ref, но
+// граница storage обязана записать его как SQL NULL, а не передать драйверу
+// внутренний DSL-тип.
+func TestFormObjectThis_EmptyReferenceWritesNullToMovement(t *testing.T) {
+	contractors := &metadata.Entity{Name: "Контрагенты", Kind: metadata.KindCatalog}
+	doc := &metadata.Entity{
+		Name:    "Сделка",
+		Kind:    metadata.KindDocument,
+		Posting: true,
+		Fields: []metadata.Field{
+			{Name: "Номер", Type: metadata.FieldTypeString},
+			{Name: "Контрагент", Type: "reference:Контрагенты", RefEntity: "Контрагенты"},
+		},
+	}
+	reg := &metadata.Register{
+		Name:       "СделкиПоКонтрагентам",
+		Dimensions: []metadata.Field{{Name: "Контрагент", Type: "reference:Контрагенты", RefEntity: "Контрагенты"}},
+		Resources:  []metadata.Field{{Name: "Количество", Type: metadata.FieldTypeNumber}},
+	}
+	s, ctx := newSubmitTestServer(t, []*metadata.Entity{contractors, doc})
+	if err := s.store.MigrateRegisters(ctx, []*metadata.Register{reg}); err != nil {
+		t.Fatal(err)
+	}
+	posting := mustParse(t, `Процедура ОбработкаПроведения()
+	Дв = Движения.СделкиПоКонтрагентам.Добавить();
+	Дв.Контрагент = this.Контрагент;
+	Дв.Количество = 1;
+КонецПроцедуры`)
+	s.reg.Load(runtime.LoadOptions{
+		Entities:  []*metadata.Entity{contractors, doc},
+		Programs:  map[string]*ast.Program{doc.Name: posting},
+		Registers: []*metadata.Register{reg},
+	})
+
+	res, err := s.entitySvc.Save(ctx, entityservice.SaveRequest{
+		Entity: doc,
+		ID:     uuid.New(),
+		IsNew:  true,
+		Fields: map[string]any{"Номер": "СД-00001"},
+		Action: "post",
+	})
+	if err != nil {
+		t.Fatalf("проведение с пустой ссылкой вернуло техническую ошибку: %v", err)
+	}
+	if res.DSLError != "" {
+		t.Fatalf("проведение с пустой ссылкой вернуло DSL-ошибку: %s", res.DSLError)
+	}
+
+	rows, err := s.store.GetMovements(ctx, reg.Name, reg, storage.RegFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ожидалось одно движение, получено %d", len(rows))
+	}
+	contractor := rows[0]["Контрагент"]
+	if contractor != nil {
+		t.Fatalf("пустая ссылка записана как %T(%v), ожидался SQL NULL", contractor, contractor)
+	}
+}
+
 // formTpProxy.Добавить добавляет строку в obj.TablePartRows и возвращает
 // *interpreter.MapThis, в которую DSL присвоит .Количество и .Цена.
 func TestFormTpProxy_AddRowModifiesObject(t *testing.T) {

--- a/internal/ui/dsl_object_attr.go
+++ b/internal/ui/dsl_object_attr.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
 	"github.com/ivantit66/onebase/internal/metadata"
-	"github.com/shopspring/decimal"
+	"github.com/ivantit66/onebase/internal/typedempty"
 )
 
 // objectAttributeValue реализует DSL-функцию ЗначениеРеквизитаОбъекта(Ссылка,
@@ -431,31 +431,8 @@ func normalizeAttrValue(ft metadata.FieldType, v any) any {
 	if v == nil {
 		return nil
 	}
-	switch ft {
-	case metadata.FieldTypeNumber:
-		switch n := v.(type) {
-		case decimal.Decimal:
-			return n
-		case float64:
-			return decimal.NewFromFloat(n)
-		case int64:
-			return decimal.NewFromInt(n)
-		case int:
-			return decimal.NewFromInt(int64(n))
-		case string:
-			if d, err := decimal.NewFromString(strings.TrimSpace(n)); err == nil {
-				return d
-			}
-		}
-	case metadata.FieldTypeBool:
-		switch b := v.(type) {
-		case bool:
-			return b
-		case int64:
-			return b != 0
-		case string:
-			return b == "true" || b == "1" || strings.EqualFold(b, "да")
-		}
+	if text, ok := v.(string); ok && strings.TrimSpace(text) == "" {
+		return v
 	}
-	return v
+	return typedempty.Normalize(typedempty.Descriptor{Type: ft}, v, nil)
 }

--- a/internal/ui/dsl_ref_attr.go
+++ b/internal/ui/dsl_ref_attr.go
@@ -98,7 +98,13 @@ func (r *dslRefAttrResolver) ResolveRefAttr(ref *interpreter.Ref, field string) 
 	}
 	// План 88E: разыменование чужой записи (this.Клиент.Телефон) — такой же путь
 	// чтения, как форма или REST, и обязано подчиняться полевой политике роли.
-	return r.s.maskDSLValue(r.ctx, entity, fd.Name, row[fd.Name]), true
+	if r.s.dslFieldMasked(r.liveCtx(), entity, fd.Name) {
+		return r.s.maskDSLValue(r.liveCtx(), entity, fd.Name, row[fd.Name]), true
+	}
+	if value := row[fd.Name]; value != nil {
+		return value, true
+	}
+	return r.s.declaredEntityFieldValue(fd, nil, r), true
 }
 
 func (r *dslRefAttrResolver) attachObject(entity *metadata.Entity, obj *runtime.Object) {
@@ -280,7 +286,22 @@ func newRefAwareMapThis(row map[string]any, tp *metadata.TablePart, resolver *ds
 	if tp == nil {
 		return &interpreter.MapThis{M: row}
 	}
-	return &refAwareMapThis{row: row, tp: tp, resolver: resolver}
+	aware := &refAwareMapThis{row: row, tp: tp, resolver: resolver}
+	return &interpreter.MapThis{
+		M: row,
+		Read: func(name string) (any, bool) {
+			fd := tablePartField(tp, name)
+			if fd == nil {
+				return nil, false
+			}
+			_, value, _ := lookupMapCI(row, name)
+			return aware.wrapValue(fd, value), true
+		},
+		Write: func(name string, value any) bool {
+			aware.Set(name, value)
+			return true
+		},
+	}
 }
 
 func (m *refAwareMapThis) Get(name string) any {
@@ -288,10 +309,11 @@ func (m *refAwareMapThis) Get(name string) any {
 		return nil
 	}
 	_, v, ok := lookupMapCI(m.row, name)
-	if !ok {
+	fd := tablePartField(m.tp, name)
+	if !ok && fd == nil {
 		return nil
 	}
-	return m.wrapValue(name, v)
+	return m.wrapValue(fd, v)
 }
 
 func (m *refAwareMapThis) Set(name string, v any) {
@@ -314,28 +336,11 @@ func (m *refAwareMapThis) Set(name string, v any) {
 	m.row[name] = v
 }
 
-func (m *refAwareMapThis) wrapValue(name string, v any) any {
-	fd := tablePartField(m.tp, name)
-	if fd == nil || fd.RefEntity == "" {
+func (m *refAwareMapThis) wrapValue(fd *metadata.Field, v any) any {
+	if fd == nil {
 		return v
 	}
-	if m.resolver == nil {
-		return v
-	}
-	if ref, ok := v.(*interpreter.Ref); ok {
-		return m.resolver.bindRefToContext(ref, fd.RefEntity)
-	}
-	idStr, _, ok := uuidFromValue(v)
-	if !ok {
-		return v
-	}
-	return m.resolver.attachRef(&interpreter.Ref{
-		UUID:    idStr,
-		Name:    idStr,
-		Type:    fd.RefEntity,
-		Kind:    refKind(m.resolver.s.reg.GetEntity(fd.RefEntity)),
-		Manager: m.resolver.s.refManagerFor(m.resolver.s.reg.GetEntity(fd.RefEntity), m.resolver.ctx),
-	}, fd.RefEntity)
+	return declaredDSLValue(v, mustFieldDescriptor(fd), m.resolver)
 }
 
 func tablePartField(tp *metadata.TablePart, name string) *metadata.Field {

--- a/internal/ui/dsl_typed_empty.go
+++ b/internal/ui/dsl_typed_empty.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/dsl/interpreter"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/typedempty"
+)
+
+// declaredDSLValue is the single UI/runtime boundary for metadata-backed
+// values. It never mutates the stored object: a SQL NULL remains nil in the
+// runtime map and is materialized only for the current DSL read.
+func declaredDSLValue(raw any, desc typedempty.Descriptor, resolver *dslRefAttrResolver) any {
+	if text, ok := raw.(string); ok && strings.TrimSpace(text) == "" && desc.RefEntity != "" {
+		raw = nil
+	}
+	if raw == nil {
+		if value, ok := typedempty.Value(desc, func(d typedempty.Descriptor) any {
+			ref := &interpreter.Ref{Type: d.RefEntity}
+			if resolver != nil && resolver.s != nil {
+				entity := resolver.s.reg.GetEntity(d.RefEntity)
+				ref.Kind = refKind(entity)
+				return resolver.bindRefToContext(ref, d.RefEntity)
+			}
+			return ref
+		}); ok {
+			return value
+		}
+		return nil
+	}
+	if desc.RefEntity != "" {
+		if resolver != nil {
+			if ref, ok := raw.(*interpreter.Ref); ok {
+				return resolver.bindRefToContext(ref, desc.RefEntity)
+			}
+			if resolved := resolver.s.refFromValue(resolver.liveCtx(), desc.RefEntity, raw); resolved != nil {
+				if ref, ok := resolved.(*interpreter.Ref); ok {
+					return resolver.bindRefToContext(ref, desc.RefEntity)
+				}
+				return resolved
+			}
+		}
+		return raw
+	}
+	return typedempty.Normalize(desc, raw, nil)
+}
+
+func (s *Server) declaredEntityFieldValue(
+	field *metadata.Field,
+	raw any,
+	resolver *dslRefAttrResolver,
+) any {
+	if field == nil {
+		return raw
+	}
+	desc, ok := typedempty.FromField(field)
+	if !ok {
+		return raw
+	}
+	return declaredDSLValue(raw, desc, resolver)
+}
+
+func (s *Server) dslFieldMasked(ctx context.Context, entity *metadata.Entity, field string) bool {
+	decision, ok := s.fieldDecisions(ctx, entity)[canonicalDSLField(entity, field)]
+	return ok && decision.Masked()
+}
+
+func formAttributeDescriptor(attr *metadata.FormAttribute) (typedempty.Descriptor, bool) {
+	if attr == nil {
+		return typedempty.Descriptor{}, false
+	}
+	return typedempty.FromFormType(attr.TypeRef, attr.Length, attr.Precision)
+}
+
+func findScalarFormAttribute(form *metadata.FormModule, name string) *metadata.FormAttribute {
+	if form == nil {
+		return nil
+	}
+	for _, attr := range form.Attributes {
+		if formAttrIsScalar(attr) && strings.EqualFold(strings.TrimSpace(attr.Name), strings.TrimSpace(name)) {
+			return attr
+		}
+	}
+	return nil
+}

--- a/internal/ui/form_event_security_regression_test.go
+++ b/internal/ui/form_event_security_regression_test.go
@@ -204,7 +204,7 @@ func TestHandleManagedFormEventRejectsTablePartValueTableNameCollision(t *testin
 func TestHandleManagedFormEventUsesOnlyPOSTBrowserState(t *testing.T) {
 	srv, ent := setupManagedEventsServer(t, `
 Процедура Проверить()
-	Если Объект.Наименование = Неопределено Тогда
+	Если Объект.Наименование = "" Тогда
 		Сообщить("поле:нет");
 	Иначе
 		Сообщить("поле:" + Объект.Наименование);

--- a/internal/ui/handlers_dsl.go
+++ b/internal/ui/handlers_dsl.go
@@ -374,7 +374,26 @@ func (s *Server) buildDSLVarsWithMessagesTx(ctx context.Context, mc *runtime.Mov
 
 type entityHookThis struct {
 	*runtime.Object
-	entity *metadata.Entity
+	entity   *metadata.Entity
+	resolver *dslRefAttrResolver
+}
+
+func (o *entityHookThis) Get(name string) any {
+	if o == nil || o.Object == nil {
+		return nil
+	}
+	if o.entity != nil {
+		for i := range o.entity.TableParts {
+			tp := &o.entity.TableParts[i]
+			if strings.EqualFold(tp.Name, name) {
+				return &formTpProxy{obj: o.Object, tpName: tp.Name, tp: tp, refResolver: o.resolver}
+			}
+		}
+		if field := findObjectAttributeField(o.entity, name); field != nil {
+			return declaredDSLValue(o.Object.Get(name), mustFieldDescriptor(field), o.resolver)
+		}
+	}
+	return o.Object.Get(name)
 }
 
 func (o *entityHookThis) GetDynamicField(name string) (any, bool) {
@@ -422,7 +441,9 @@ func (s *Server) runEntityHook(ctx context.Context, proc *ast.ProcedureDecl, obj
 			// runtime.Object deliberately does not retain the metadata graph. Hooks
 			// still need it to distinguish an unset declared requisit from an unknown
 			// name when this["Field"] is used, so opt in only at this execution edge.
-			this = &entityHookThis{Object: obj, entity: entity}
+			resolver := s.newDSLRefAttrResolver(ctx)
+			resolver.attachObject(entity, obj)
+			this = &entityHookThis{Object: obj, entity: entity, resolver: resolver}
 		}
 	}
 	if wall := interpreter.ClampWallClock(ctx, s.operationTimeout(opEntitySave)); wall > 0 {

--- a/internal/ui/processor_formevent_execution_test.go
+++ b/internal/ui/processor_formevent_execution_test.go
@@ -559,7 +559,7 @@ func TestHandleProcessorFormEvent_BoundHandlerRejectsQueryParamInjection(t *test
 	formProgram := mustParse(t, `
 Процедура RunCheck()
 	Сообщить("видимое:" + Объект.Visible);
-	Если Параметры.Hidden = Неопределено Тогда
+	Если Параметры.Hidden = "" Тогда
 		Сообщить("скрытое:нет");
 	Иначе
 		Сообщить("скрытое:" + Параметры.Hidden);
@@ -611,12 +611,12 @@ func TestHandleProcessorFormEvent_BoundHandlerRejectsReadOnlyAndUnrenderedParams
 	formProgram := mustParse(t, `
 Процедура RunCheck()
 	Сообщить("видимое:" + Объект.Visible);
-	Если Объект.ReadOnlyParam = Неопределено Тогда
+	Если Объект.ReadOnlyParam = "" Тогда
 		Сообщить("толькочтение:нет");
 	Иначе
 		Сообщить("толькочтение:" + Объект.ReadOnlyParam);
 	КонецЕсли;
-	Если Параметры.Hidden = Неопределено Тогда
+	Если Параметры.Hidden = "" Тогда
 		Сообщить("скрытое:нет");
 	Иначе
 		Сообщить("скрытое:" + Параметры.Hidden);

--- a/internal/ui/tp_empty_number_zero_test.go
+++ b/internal/ui/tp_empty_number_zero_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/dsl/ast"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
 	"github.com/ivantit66/onebase/internal/dsl/lexer"
 	"github.com/ivantit66/onebase/internal/dsl/parser"
@@ -48,6 +49,7 @@ func tpz1136Doc() *metadata.Entity {
 			Fields: []metadata.Field{
 				{Name: "Цена", Type: metadata.FieldTypeNumber},
 				{Name: "Количество", Type: metadata.FieldTypeNumber},
+				{Name: "ДатаПоставки", Type: metadata.FieldTypeDate},
 			},
 		}},
 	}
@@ -118,7 +120,7 @@ func tpz1136Rows(t *testing.T, db *storage.DB, doc *metadata.Entity, id uuid.UUI
 	return rows
 }
 
-// tpz1136ReadFromDSL возвращает «Цена=0/Цена>0/ЗначениеЗаполнено» для каждой
+// tpz1136ReadFromDSL возвращает «Цена=0/Цена>0/ЗначениеЗаполнено/ТипЗнч» для каждой
 // строки прочитанного объекта. Путь публичный: тот же, которым прикладной
 // модуль перебирает ТЧ существующего документа.
 func tpz1136ReadFromDSL(t *testing.T, s *Server, id uuid.UUID) string {
@@ -127,7 +129,7 @@ func tpz1136ReadFromDSL(t *testing.T, s *Server, id uuid.UUID) string {
   Об = Документы.%s.НайтиПоИдентификатору(Ид).ПолучитьОбъект();
   Рез = "";
   Для Каждого Стр Из Об.Товары Цикл
-    Рез = Рез + Строка(Стр.Цена = 0) + "/" + Строка(Стр.Цена > 0) + "/" + Строка(ЗначениеЗаполнено(Стр.Цена));
+    Рез = Рез + Строка(Стр.Цена = 0) + "/" + Строка(Стр.Цена > 0) + "/" + Строка(ЗначениеЗаполнено(Стр.Цена)) + "/" + ТипЗнч(Стр.Цена) + "/" + ТипЗнч(Стр.ДатаПоставки);
   КонецЦикла;
   Возврат Рез;
 КонецФункции`, tpz1136DocName)
@@ -154,10 +156,21 @@ func TestTablePartEmptyNumber_СравниваетсяСНулём_1136(t *testi
 		}
 		doc := tpz1136Doc()
 		ts, s := tpz1136Server(t, db, []*metadata.Entity{doc})
+		hook, err := parser.New(lexer.New(`Процедура ПриЗаписи()
+  Для Каждого Стр Из this.Товары Цикл
+    Если ТипЗнч(Стр.Цена) <> "Число" Или ТипЗнч(Стр.ДатаПоставки) <> "Дата" Тогда
+      ВызватьИсключение("ПриЗаписи получил нетипизированное пустое поле");
+    КонецЕсли;
+  КонецЦикла;
+КонецПроцедуры`, "typed-empty-hook.os")).ParseProgram()
+		if err != nil {
+			t.Fatalf("parse hook: %v", err)
+		}
+		s.reg.Load(runtime.LoadOptions{Entities: []*metadata.Entity{doc}, Programs: map[string]*ast.Program{doc.Name: hook}})
 
 		// Цена не введена — ровно случай из заявки: в колонке NULL, а модуль
 		// обязан увидеть ноль.
-		empty := tpz1136Write(t, ts, doc, db, map[string]any{"Цена": "", "Количество": "2"})
+		empty := tpz1136Write(t, ts, doc, db, map[string]any{"Цена": "", "Количество": "2", "ДатаПоставки": ""})
 		rows := tpz1136Rows(t, db, doc, empty)
 		if len(rows) != 1 {
 			t.Fatalf("[%s] строк в базе %d, ожидалась 1: %#v", dialect, len(rows), rows)
@@ -166,22 +179,25 @@ func TestTablePartEmptyNumber_СравниваетсяСНулём_1136(t *testi
 		if rows[0]["Цена"] != nil {
 			t.Errorf("[%s] в колонке цены %#v, ожидался NULL", dialect, rows[0]["Цена"])
 		}
-		if got := tpz1136ReadFromDSL(t, s, empty); got != "true/false/false" {
-			t.Errorf("[%s] пустая цена: «=0/>0/Заполнено» = %q, ожидалось \"true/false/false\"", dialect, got)
+		if rows[0]["ДатаПоставки"] != nil {
+			t.Errorf("[%s] в колонке даты %#v, ожидался NULL", dialect, rows[0]["ДатаПоставки"])
+		}
+		if got := tpz1136ReadFromDSL(t, s, empty); got != "true/false/false/Число/Дата" {
+			t.Errorf("[%s] пустая цена: «=0/>0/Заполнено/ТипЗнч/ТипДаты» = %q", dialect, got)
 		}
 
 		// Введённая цена не должна стать нулём заодно.
 		filled := tpz1136Write(t, ts, doc, db, map[string]any{"Цена": "10", "Количество": "2"})
-		if got := tpz1136ReadFromDSL(t, s, filled); got != "false/true/true" {
-			t.Errorf("[%s] введённая цена: «=0/>0/Заполнено» = %q, ожидалось \"false/true/true\"", dialect, got)
+		if got := tpz1136ReadFromDSL(t, s, filled); got != "false/true/true/Число/Дата" {
+			t.Errorf("[%s] введённая цена: «=0/>0/Заполнено/ТипЗнч/ТипДаты» = %q", dialect, got)
 		}
 
 		// Введённый ноль неотличим от пустоты — и был неотличим до правки:
 		// ЗначениеЗаполнено(0) в 1С тоже Ложь. Закрепляем, чтобы правку не
 		// прочитали как утрату различия, которого не было.
 		zero := tpz1136Write(t, ts, doc, db, map[string]any{"Цена": "0", "Количество": "2"})
-		if got := tpz1136ReadFromDSL(t, s, zero); got != "true/false/false" {
-			t.Errorf("[%s] введённый ноль: «=0/>0/Заполнено» = %q, ожидалось \"true/false/false\"", dialect, got)
+		if got := tpz1136ReadFromDSL(t, s, zero); got != "true/false/false/Число/Дата" {
+			t.Errorf("[%s] введённый ноль: «=0/>0/Заполнено/ТипЗнч/ТипДаты» = %q", dialect, got)
 		}
 	})
 }
@@ -194,7 +210,7 @@ func TestFormEventEmptyNumber_НоваяСтрокаВидитНоль_1136(t *t
 Процедура ТоварыПриИзмененииСтроки()
 	Для Каждого Стр Из Объект.Товары Цикл
 		Если Стр.Цена = 0 Тогда
-			Сообщить("подставляем цену");
+			Сообщить("подставляем цену:" + ТипЗнч(Стр.Цена) + ":" + ТипЗнч(Стр.ДатаПоставки));
 		КонецЕсли;
 	КонецЦикла;
 КонецПроцедуры
@@ -211,6 +227,7 @@ func TestFormEventEmptyNumber_НоваяСтрокаВидитНоль_1136(t *t
 		Fields: []metadata.Field{
 			{Name: "Цена", Type: metadata.FieldTypeNumber},
 			{Name: "Количество", Type: metadata.FieldTypeNumber},
+			{Name: "ДатаПоставки", Type: metadata.FieldTypeDate},
 		},
 	}}
 
@@ -221,14 +238,47 @@ func TestFormEventEmptyNumber_НоваяСтрокаВидитНоль_1136(t *t
 	body.Set("_tp", "Товары")
 	body.Set("_tp_row", "0")
 	body.Set("_tp_row_number", "1")
-	body.Set("tp_json.Товары", `[{"Цена":"","Количество":"2"}]`)
+	body.Set("tp_json.Товары", `[{"Цена":"","Количество":"2","ДатаПоставки":""}]`)
 
 	resp := decodeFormEventResponse(t, executeFormEvent(t, srv, ent, body).Body.Bytes())
 	if !resp.OK {
 		t.Fatalf("ok=false, error=%q", resp.Error)
 	}
-	if len(resp.Messages) != 1 || resp.Messages[0] != "подставляем цену" {
-		t.Errorf("messages=%v, ожидалось [подставляем цену]", resp.Messages)
+	if len(resp.Messages) != 1 || resp.Messages[0] != "подставляем цену:Число:Дата" {
+		t.Errorf("messages=%v, ожидалось [подставляем цену:Число:Дата]", resp.Messages)
+	}
+}
+
+func TestFormEventTypedEmpty_FormAttributeAndValueTable_1274(t *testing.T) {
+	srv, ent := setupManagedEventsServer(t, `
+Процедура ПроверитьПустые()
+	Для Каждого Стр Из Объект.Подбор Цикл
+		Сообщить(ТипЗнч(Объект.Счетчик) + ":" + ТипЗнч(Стр.Количество) + ":" + Строка(Стр.Количество = 0));
+	КонецЦикла;
+КонецПроцедуры
+	`, nil, []*metadata.FormElement{
+		{Kind: metadata.FormElementField, Name: "ПолеСчетчик", DataPath: "Объект.Счетчик"},
+		{Kind: metadata.FormElementTablePart, Name: "ЭлементПодбор", DataPath: "Форма.Подбор"},
+		{Kind: metadata.FormElementButton, Name: "Проверить", Handlers: map[metadata.FormEventType]string{metadata.FormEventOnClick: "ПроверитьПустые"}},
+	})
+	ent.Forms[0].Attributes = []*metadata.FormAttribute{
+		{Name: "Счетчик", TypeRef: "number"},
+		{Name: "Подбор", TypeRef: "ValueTable", Columns: []*metadata.FormAttributeColumn{
+			{Name: "Метка", TypeRef: "string"},
+			{Name: "Количество", TypeRef: "number"},
+		}},
+	}
+	body := url.Values{
+		"_element":               {"Проверить"},
+		"_event":                 {string(metadata.FormEventOnClick)},
+		"_kind":                  {"object"},
+		"vt.Подбор.0.Метка":      {"строка"},
+		"vt.Подбор.0.Количество": {""},
+		"_ob_present_Счетчик":    {"1"},
+	}
+	resp := decodeFormEventResponse(t, executeFormEvent(t, srv, ent, body).Body.Bytes())
+	if !resp.OK || resp.Error != "" || len(resp.Messages) != 1 || resp.Messages[0] != "Число:Число:true" {
+		t.Fatalf("typed form empties: ok=%v error=%q messages=%v", resp.OK, resp.Error, resp.Messages)
 	}
 }
 


### PR DESCRIPTION
## Что сделано

- Добавлен единый metadata-контракт пустых DSL-значений для чисел, булевых, строк, дат, перечислений и ссылок.
- Формы, ValueTable, строки табличных частей, writers и lifecycle-хуки теперь материализуют типизированное пустое значение только при чтении, не меняя runtime-объект и SQL NULL.
- Для ссылок сохраняются Type/Kind и контекстный manager; masking по-прежнему выполняется до типизации.
- Полный TypeRef колонок ValueTable переносится во временные метаданные.

## Проверки

- `go build ./...`
- `go test ./...`
- Матричная приёмка SQLite/PostgreSQL: HTTP submit → SQL NULL без ghost-row → событие формы, ПриЗаписи и writer видят Число/Дата.

Вариант: 1 (рекомендация триажа)

Это срез A плана 159. Согласно нарезке плана, issue закрывает только финальный срез D, поэтому здесь намеренно нет `Fixes #1274`.

Part of #1274