### PR TITLE
fix(ui): не давать оболочке приложения стать выше экрана

### DIFF
--- a/internal/ui/app_shell_layout_test.go
+++ b/internal/ui/app_shell_layout_test.go
@@ -1,0 +1,52 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// Окно приложения не должно быть выше экрана. С одним min-height:100vh страницу
+// растягивало самое высокое содержимое (обычно длинное меню слева): тело
+// становилось 1283px при окне 908, вкладка-iframe получала ту же высоту, и любой
+// диалог с position:fixed внутри неё центрировался по фрейму — уезжал под нижний
+// край экрана. Правило легко потерять при следующей правке стилей, поэтому оно
+// зафиксировано тестом, а не только комментарием.
+func TestAppShellIsCappedToViewport(t *testing.T) {
+	src := templateSource()
+	body := cssRule(t, src, "body{font-family:system-ui")
+	for _, want := range []string{"height:100vh", "overflow:hidden"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("в правиле body нет %q: %s", want, body)
+		}
+	}
+	// min-height:auto у flex-элемента не даёт ему стать ниже содержимого —
+	// без явного нуля меню и рабочая область снова растянут страницу.
+	for _, rule := range []string{".app-body{", "aside{width:210px", "main{flex:1"} {
+		got := cssRule(t, src, rule)
+		if !strings.Contains(got, "min-height:0") {
+			t.Errorf("в правиле %q нет min-height:0: %s", rule, got)
+		}
+	}
+	// На узком экране страница прокручивается целиком: там ограничение снимается,
+	// иначе низ длинной формы стал бы недоступен.
+	mobile := src[strings.Index(src, "@media (max-width:820px){"):]
+	if !strings.Contains(mobile[:400], "body{height:auto;overflow:visible}") {
+		t.Errorf("мобильная раскладка не вернула странице высоту по содержимому: %s", mobile[:400])
+	}
+}
+
+// cssRule возвращает одно правило стилей целиком — от префикса до закрывающей
+// скобки. Тесту нужен именно текст правила: искать подстроку по всему шаблону
+// значило бы принять совпадение из соседнего селектора.
+func cssRule(t *testing.T, src, prefix string) string {
+	t.Helper()
+	i := strings.Index(src, prefix)
+	if i < 0 {
+		t.Fatalf("правило %q не найдено в шаблоне", prefix)
+	}
+	j := strings.Index(src[i:], "}")
+	if j < 0 {
+		t.Fatalf("правило %q не закрыто", prefix)
+	}
+	return src[i : i+j+1]
+}

--- a/internal/ui/templates.go
+++ b/internal/ui/templates.go
@@ -1176,7 +1176,15 @@ const tplHead = `
 <style>
 .ob-embedded .topbar,.ob-embedded .subsys-bar,.ob-embedded #ob-nav{display:none!important}
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:system-ui,sans-serif;display:flex;flex-direction:column;min-height:100vh;background:#f5f5f5}
+/* height:100vh + overflow:hidden — окно приложения ровно по экрану. С одним лишь
+   min-height:100vh страницу растягивало САМОЕ ВЫСОКОЕ содержимое (обычно длинное
+   меню слева): при окне 908px тело становилось 1283px, вместе с ним росла
+   вкладка-iframe (.ob-tabbody iframe — height:100% растянутой области), и
+   диалог с position:fixed внутри неё центрировался по ФРЕЙМУ, а не по экрану —
+   то есть уезжал под нижний край. Прокрутка никуда не делась: меню и рабочая
+   область прокручиваются каждая сама (overflow-y:auto). На узком экране правило
+   снимается — там страница прокручивается целиком, см. media-запрос ниже. */
+body{font-family:system-ui,sans-serif;display:flex;flex-direction:column;height:100vh;min-height:100vh;overflow:hidden;background:#f5f5f5}
 .topbar{background:#1e293b;color:#fff;padding:0 16px;display:flex;align-items:center;height:38px;flex-shrink:0;position:sticky;top:0;z-index:100}
 .topbar-title{font-size:14px;font-weight:600;color:#7dd3fc;flex:1}
 .sys-menu{position:relative}
@@ -1218,8 +1226,11 @@ body{font-family:system-ui,sans-serif;display:flex;flex-direction:column;min-hei
 .report-composed.rep-lines-both td:last-child,.report-composed.rep-lines-both th:last-child{border-right:none}
 .report-composed.rep-lines-none td,.report-composed.rep-lines-none th{border-bottom:none}
 .report-composed.rep-zebra tbody tr:nth-child(even){background:#fafbfc}
-.app-body{display:flex;flex:1;overflow:hidden}
-aside{width:210px;background:#1e293b;color:#fff;padding:16px 0;flex-shrink:0;overflow-y:auto}
+/* min-height:0 у строки и её колонок: у flex-элемента min-height по умолчанию
+   auto, поэтому он не может стать ниже своего содержимого — и длинное меню
+   растягивало всю страницу, несмотря на overflow:hidden выше. */
+.app-body{display:flex;flex:1;overflow:hidden;min-height:0}
+aside{width:210px;background:#1e293b;color:#fff;padding:16px 0;flex-shrink:0;overflow-y:auto;min-height:0}
 aside .sec{font-size:11px;text-transform:uppercase;color:#94a3b8;margin:14px 12px 4px;letter-spacing:.05em}
 aside a{display:block;padding:6px 14px;color:#cbd5e1;text-decoration:none;font-size:14px;margin:1px 6px;border-radius:5px;line-height:1.3;overflow-wrap:break-word}
 aside a:hover{background:#334155;color:#fff}
@@ -1229,7 +1240,7 @@ aside details.navsec>summary::-webkit-details-marker{display:none}
 aside details.navsec>summary::before{content:"\25B8";display:inline-block;width:1em;color:#64748b}
 aside details.navsec[open]>summary::before{content:"\25BE"}
 aside details.navsec>summary:hover{color:#cbd5e1}
-main{flex:1;padding:28px;overflow-y:auto}
+main{flex:1;padding:28px;overflow-y:auto;min-height:0;min-width:0}
 h2{font-size:22px;font-weight:600;margin-bottom:20px;color:#1e293b}
 h3{font-size:16px;font-weight:600;margin:24px 0 10px;color:#1e293b}
 .card{background:#fff;border-radius:10px;padding:24px;box-shadow:0 1px 3px rgba(0,0,0,.1);max-width:1400px}
@@ -1313,6 +1324,9 @@ body{padding-bottom:32px}
   html.nav-collapsed #ob-nav{display:none}
 }
 @media (max-width:820px){
+  /* Мобильная раскладка прокручивает страницу целиком — возвращаем ей высоту по
+     содержимому, иначе низ формы стал бы недоступен. */
+  body{height:auto;overflow:visible}
   .app-body{display:block;overflow:visible}
   aside{position:fixed;left:0;top:0;bottom:0;width:78vw;max-width:300px;z-index:401;transform:translateX(-100%);transition:transform .2s ease;box-shadow:2px 0 16px rgba(0,0,0,.3)}
   body.nav-open aside{transform:translateX(0)}


### PR DESCRIPTION
Fixes #1388

## Что было

Тело страницы растягивалось самым высоким содержимым — обычно длинным меню слева. Замер в оболочке с вкладками: окно 908px, `body` — 1283px, `.app-body` и вкладка-iframe (`height:100%` растянутой области) — 1145px.

Диалог с `position:fixed` внутри фрейма центрируется по ФРЕЙМУ, а не по экрану, поэтому форма выбора открывалась под нижним краем окна — видны были две-три строки списка. Снаружи растянутость не заметна (`overflow:hidden`), и дефект проявлялся только положением диалогов.

Причина — `min-height:auto` у flex-элементов: `.app-body`, `aside` и `main` не могут стать ниже своего содержимого, а у `body` задан только `min-height:100vh`.

## Что стало

Окно приложения ровно по экрану: `body{height:100vh;overflow:hidden}`, у строки и её колонок `min-height:0`. Прокрутка никуда не делась — меню и рабочая область прокручиваются каждая сама (`overflow-y:auto` у обеих был и раньше).

Цена: на десктопе страница больше не прокручивается целиком — это и есть штатная раскладка оболочки, все страницы уже прокручивались внутри `main`. На узком экране (`max-width:820px`) правило снимается: там раскладка блочная и страница прокручивается целиком, иначе низ длинной формы стал бы недоступен.

## Проверки

- `TestAppShellIsCappedToViewport` — краснеет без фикса: проверяет `height:100vh`/`overflow:hidden` у `body`, `min-height:0` у `.app-body`, `aside`, `main` и снятие ограничения в мобильном media-запросе.
- `go test ./internal/ui/` — зелёный.
- Ручная проверка через CDP в реальной оболочке (Edge, окно 1900×1000): до фикса вкладка-iframe 1145px при окне 908 и карточка диалога с `top=196` внутри фрейма; после — фрейм 770px, документ ровно по окну, карточка `top=106` по центру видимой области.

Не входит в область: поведение диалогов на мобильной раскладке (там страница прокручивается целиком и `position:fixed` работает по экрану).