### PR TITLE
fix(ui): load exchange plans in offline runtime

### DIFF
--- a/internal/ui/offline.go
+++ b/internal/ui/offline.go
@@ -46,6 +46,7 @@ func NewOfflineServer(proj *project.Project, db *storage.DB) (*Server, *runtime.
 	})
 	reg.LoadModules(proj.Modules)
 	reg.LoadProcessors(proj.Processors)
+	reg.LoadExchangePlans(proj.ExchangePlans)
 	// Регистры бухгалтерии нужны, чтобы запросы РегистрБухгалтерии.X.Остатки()/
 	// .Обороты() и проведение документов с проводками работали в offline-режиме
 	// (procrun), как и на полном сервере (run.go).

--- a/internal/ui/offline_exchange_test.go
+++ b/internal/ui/offline_exchange_test.go
@@ -1,0 +1,36 @@
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/project"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+func TestNewOfflineServerLoadsExchangePlans(t *testing.T) {
+	ctx := t.Context()
+	proj, err := project.Load(filepath.Join("..", "..", "examples", "cms"))
+	if err != nil {
+		t.Fatalf("load project: %v", err)
+	}
+	t.Cleanup(proj.Close)
+
+	plan := &metadata.ExchangePlan{Name: "Offline"}
+	proj.ExchangePlans = []*metadata.ExchangePlan{plan}
+
+	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "offline-exchange.db"))
+	if err != nil {
+		t.Fatalf("connect SQLite: %v", err)
+	}
+	t.Cleanup(db.Close)
+
+	_, reg, err := NewOfflineServer(proj, db)
+	if err != nil {
+		t.Fatalf("NewOfflineServer: %v", err)
+	}
+	if got := reg.GetExchangePlan("offline"); got != plan {
+		t.Fatalf("exchange plan was not loaded: got %p, want %p", got, plan)
+	}
+}


### PR DESCRIPTION
Fixes #1341

- Load exchange plans into the offline registry used by procrun and tests.
- Cover NewOfflineServer with a focused regression test.

Generated-with: Codex