### PR TITLE
fix(query): согласовать календарные функции с локальной зоной

### DIFF
--- a/internal/query/date_funcs_local_matrix_test.go
+++ b/internal/query/date_funcs_local_matrix_test.go
@@ -1,8 +1,13 @@
 package query_test
 
 import (
+	"archive/zip"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -20,15 +25,38 @@ import (
 // закрепляют зимнее/летнее смещение America/New_York. Тест идёт через публичные
 // Compile и Run и одним телом проверяет SQLite и PostgreSQL.
 func TestDateFunctionsUseApplicationLocalTime(t *testing.T) {
-	for _, zoneName := range []string{"Asia/Kolkata", "America/New_York"} {
-		zoneName := zoneName
-		t.Run(zoneName, func(t *testing.T) {
-			loc, err := time.LoadLocation(zoneName)
+	tests := []struct {
+		name      string
+		zoneName  string
+		localName string
+	}{
+		{name: "Asia/Kolkata", zoneName: "Asia/Kolkata"},
+		{name: "America/New_York", zoneName: "America/New_York"},
+		{name: "system Local without TZ", zoneName: "America/New_York", localName: "Local"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			loc, err := time.LoadLocation(tt.zoneName)
 			require.NoError(t, err, "загрузка часового пояса")
+			if tt.localName != "" {
+				loc = loadLocationNamed(t, tt.localName, tt.zoneName)
+			}
 
 			savedLocal := time.Local
 			time.Local = loc
 			t.Cleanup(func() { time.Local = savedLocal })
+			if tt.localName != "" {
+				savedTZ, hadTZ := os.LookupEnv("TZ")
+				require.NoError(t, os.Unsetenv("TZ"))
+				t.Cleanup(func() {
+					if hadTZ {
+						require.NoError(t, os.Setenv("TZ", savedTZ))
+					} else {
+						require.NoError(t, os.Unsetenv("TZ"))
+					}
+				})
+			}
 
 			dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
 				ctx := context.Background()
@@ -43,8 +71,8 @@ func TestDateFunctionsUseApplicationLocalTime(t *testing.T) {
 				require.NoError(t, db.Migrate(ctx, []*metadata.Entity{ent}), "миграция")
 
 				moments := map[string]time.Time{
-					"Зима": localBoundaryMoment(loc, zoneName, 2026, time.January),
-					"Лето": localBoundaryMoment(loc, zoneName, 2026, time.July),
+					"Зима": localBoundaryMoment(loc, tt.zoneName, 2026, time.January),
+					"Лето": localBoundaryMoment(loc, tt.zoneName, 2026, time.July),
 				}
 				for name, moment := range moments {
 					require.NoError(t, db.Upsert(ctx, ent.Name, uuid.New(), map[string]any{
@@ -95,6 +123,29 @@ func TestDateFunctionsUseApplicationLocalTime(t *testing.T) {
 			})
 		})
 	}
+}
+
+func loadLocationNamed(t *testing.T, name, zoneName string) *time.Location {
+	t.Helper()
+	zones, err := zip.OpenReader(filepath.Join(runtime.GOROOT(), "lib", "time", "zoneinfo.zip"))
+	require.NoError(t, err, "открытие Go zoneinfo.zip")
+	defer zones.Close()
+	for _, file := range zones.File {
+		if file.Name != zoneName {
+			continue
+		}
+		reader, err := file.Open()
+		require.NoError(t, err, "открытие зоны %s", zoneName)
+		data, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		require.NoError(t, readErr, "чтение зоны %s", zoneName)
+		require.NoError(t, closeErr, "закрытие зоны %s", zoneName)
+		loc, err := time.LoadLocationFromTZData(name, data)
+		require.NoError(t, err, "загрузка зоны %s с именем %s", zoneName, name)
+		return loc
+	}
+	t.Fatalf("зона %s не найдена в Go zoneinfo.zip", zoneName)
+	return nil
 }
 
 func localBoundaryMoment(loc *time.Location, zoneName string, year int, month time.Month) time.Time {

--- a/internal/query/date_funcs_local_matrix_test.go
+++ b/internal/query/date_funcs_local_matrix_test.go
@@ -1,0 +1,135 @@
+package query_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/query"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Календарные функции запроса обязаны видеть тот же местный день, что DSL и UI.
+// Два пояса ловят оба направления перехода через UTC-границу, а январь и июль
+// закрепляют зимнее/летнее смещение America/New_York. Тест идёт через публичные
+// Compile и Run и одним телом проверяет SQLite и PostgreSQL.
+func TestDateFunctionsUseApplicationLocalTime(t *testing.T) {
+	for _, zoneName := range []string{"Asia/Kolkata", "America/New_York"} {
+		zoneName := zoneName
+		t.Run(zoneName, func(t *testing.T) {
+			loc, err := time.LoadLocation(zoneName)
+			require.NoError(t, err, "загрузка часового пояса")
+
+			savedLocal := time.Local
+			time.Local = loc
+			t.Cleanup(func() { time.Local = savedLocal })
+
+			dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+				ctx := context.Background()
+				ent := &metadata.Entity{
+					Name: "КалендарныеФункции",
+					Kind: metadata.KindCatalog,
+					Fields: []metadata.Field{
+						{Name: "Наименование", Type: metadata.FieldTypeString},
+						{Name: "Момент", Type: metadata.FieldTypeDate},
+					},
+				}
+				require.NoError(t, db.Migrate(ctx, []*metadata.Entity{ent}), "миграция")
+
+				moments := map[string]time.Time{
+					"Зима": localBoundaryMoment(loc, zoneName, 2026, time.January),
+					"Лето": localBoundaryMoment(loc, zoneName, 2026, time.July),
+				}
+				for name, moment := range moments {
+					require.NoError(t, db.Upsert(ctx, ent.Name, uuid.New(), map[string]any{
+						"Наименование": name,
+						"Момент":       moment,
+					}, ent), "запись %s", name)
+				}
+
+				compiled, err := query.Compile(`
+					ВЫБРАТЬ
+						Наименование,
+						Момент,
+						Год(Момент) КАК ГодМомента,
+						Месяц(Момент) КАК МесяцМомента,
+						День(Момент) КАК ДеньМомента,
+						НачалоДня(Момент) КАК НачалоДняМомента,
+						КонецДня(Момент) КАК КонецДняМомента,
+						НачалоМесяца(Момент) КАК НачалоМесяцаМомента,
+						НачалоГода(Момент) КАК НачалоГодаМомента
+					ИЗ Справочник.КалендарныеФункции`, query.CompileOpts{
+					Entities: []*metadata.Entity{ent},
+					Dialect:  db.Dialect(),
+				})
+				require.NoError(t, err, "компиляция")
+
+				rows, _, err := query.Run(ctx, db, &compiled)
+				require.NoError(t, err, "выполнение")
+				require.Len(t, rows, len(moments), "строк результата")
+
+				for _, row := range rows {
+					name, ok := row["наименование"].(string)
+					require.True(t, ok, "Наименование: %#v", row["наименование"])
+					want, ok := moments[name]
+					require.True(t, ok, "неожиданная строка %q", name)
+
+					raw, ok := row["момент"].(time.Time)
+					require.True(t, ok, "сырой Момент должен быть датой, получено %T", row["момент"])
+					require.True(t, raw.Equal(want), "сырой Момент: %s != %s", raw, want)
+					require.Equal(t, want.Year(), intValue(t, row["годмомента"]))
+					require.Equal(t, int(want.Month()), intValue(t, row["месяцмомента"]))
+					require.Equal(t, want.Day(), intValue(t, row["деньмомента"]))
+
+					assertLocalClock(t, row["началоднямомента"], want.Year(), want.Month(), want.Day(), 0, 0, 0)
+					assertLocalClock(t, row["конецднямомента"], want.Year(), want.Month(), want.Day(), 23, 59, 59)
+					assertLocalClock(t, row["началомесяцамомента"], want.Year(), want.Month(), 1, 0, 0, 0)
+					assertLocalClock(t, row["началогодамомента"], want.Year(), time.January, 1, 0, 0, 0)
+				}
+			})
+		})
+	}
+}
+
+func localBoundaryMoment(loc *time.Location, zoneName string, year int, month time.Month) time.Time {
+	if zoneName == "Asia/Kolkata" {
+		// В положительной зоне местная полночь хранится предыдущим UTC-днём.
+		return time.Date(year, month, 15, 0, 30, 0, 0, loc)
+	}
+	// В отрицательной зоне поздний вечер хранится следующим UTC-днём.
+	return time.Date(year, month, 15, 23, 30, 0, 0, loc)
+}
+
+func intValue(t *testing.T, value any) int {
+	t.Helper()
+	switch v := value.(type) {
+	case int:
+		return v
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		t.Fatalf("ожидалось число, получено %T (%#v)", value, value)
+		return 0
+	}
+}
+
+func assertLocalClock(t *testing.T, value any, year int, month time.Month, day, hour, minute, second int) {
+	t.Helper()
+	got, ok := query.ToDateValue(value)
+	require.True(t, ok, "ожидалась дата, получено %T (%#v)", value, value)
+	got = got.In(time.Local)
+	require.Equal(t,
+		fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second),
+		got.Format("2006-01-02 15:04:05"),
+	)
+}

--- a/internal/query/date_funcs_local_matrix_test.go
+++ b/internal/query/date_funcs_local_matrix_test.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -125,11 +126,45 @@ func TestDateFunctionsUseApplicationLocalTime(t *testing.T) {
 	}
 }
 
+func TestDateFunctionUsesQualifiedSourceFieldType(t *testing.T) {
+	first := &metadata.Entity{
+		Name: "Первый",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Значение", Type: metadata.FieldTypeDate},
+		},
+	}
+	other := &metadata.Entity{
+		Name: "Другой",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Значение", Type: metadata.FieldTypeString},
+		},
+	}
+
+	compiled, err := query.Compile(`
+		ВЫБРАТЬ
+			День(Первый.Значение) КАК ДеньПервого,
+			День(Другой.Значение) КАК ДеньДругого
+		ИЗ Справочник.Первый КАК Первый
+			ЛЕВОЕ СОЕДИНЕНИЕ Справочник.Другой КАК Другой
+			ПО Первый.Ссылка = Другой.Ссылка`, query.CompileOpts{
+		Entities: []*metadata.Entity{first, other},
+		Dialect:  storage.SQLiteDialect{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(compiled.SQL, "ob_local_datetime("), compiled.SQL)
+	require.Contains(t, compiled.SQL, "ob_local_datetime(первый.значение)", compiled.SQL)
+	require.NotContains(t, compiled.SQL, "ob_local_datetime(другой.значение)", compiled.SQL)
+}
+
 func loadLocationNamed(t *testing.T, name, zoneName string) *time.Location {
 	t.Helper()
-	zones, err := zip.OpenReader(filepath.Join(runtime.GOROOT(), "lib", "time", "zoneinfo.zip"))
+	zones, err := zip.OpenReader(filepath.Join(zoneinfoRoot(t), "lib", "time", "zoneinfo.zip"))
 	require.NoError(t, err, "открытие Go zoneinfo.zip")
-	defer zones.Close()
+	defer func() {
+		require.NoError(t, zones.Close(), "закрытие Go zoneinfo.zip")
+	}()
 	for _, file := range zones.File {
 		if file.Name != zoneName {
 			continue
@@ -146,6 +181,15 @@ func loadLocationNamed(t *testing.T, name, zoneName string) *time.Location {
 	}
 	t.Fatalf("зона %s не найдена в Go zoneinfo.zip", zoneName)
 	return nil
+}
+
+func zoneinfoRoot(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", "GOROOT").Output()
+	require.NoError(t, err, "определение GOROOT")
+	root := strings.TrimSpace(string(out))
+	require.NotEmpty(t, root, "go env GOROOT")
+	return root
 }
 
 func localBoundaryMoment(loc *time.Location, zoneName string, year int, month time.Month) time.Time {

--- a/internal/query/date_funcs_local_matrix_test.go
+++ b/internal/query/date_funcs_local_matrix_test.go
@@ -158,6 +158,53 @@ func TestDateFunctionUsesQualifiedSourceFieldType(t *testing.T) {
 	require.NotContains(t, compiled.SQL, "ob_local_datetime(другой.значение)", compiled.SQL)
 }
 
+func TestDateFunctionScopesQualifiedSourceTypesInNestedSelect(t *testing.T) {
+	dateEntity, stringEntity := dateFunctionScopeEntities()
+	compiled, err := query.Compile(`
+		ВЫБРАТЬ
+			День(Т.Значение) КАК ДеньСтроки,
+			(ВЫБРАТЬ День(Т.Значение) ИЗ Справочник.Даты КАК Т) КАК ДеньДаты
+		ИЗ Справочник.Строки КАК Т`, query.CompileOpts{
+		Entities: []*metadata.Entity{dateEntity, stringEntity},
+		Dialect:  storage.SQLiteDialect{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(compiled.SQL, "ob_local_datetime("), compiled.SQL)
+	require.Contains(t, compiled.SQL, "ob_local_datetime(т.значение)", compiled.SQL)
+}
+
+func TestDateFunctionScopesQualifiedSourceTypesAcrossUnion(t *testing.T) {
+	dateEntity, stringEntity := dateFunctionScopeEntities()
+	compiled, err := query.Compile(`
+		ВЫБРАТЬ День(Т.Значение) ИЗ Справочник.Даты КАК Т
+		ОБЪЕДИНИТЬ ВСЕ
+		ВЫБРАТЬ День(Т.Значение) ИЗ Справочник.Строки КАК Т`, query.CompileOpts{
+		Entities: []*metadata.Entity{dateEntity, stringEntity},
+		Dialect:  storage.SQLiteDialect{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(compiled.SQL, "ob_local_datetime("), compiled.SQL)
+	require.Contains(t, compiled.SQL, "ob_local_datetime(т.значение)", compiled.SQL)
+}
+
+func dateFunctionScopeEntities() (*metadata.Entity, *metadata.Entity) {
+	dateEntity := &metadata.Entity{
+		Name: "Даты",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Значение", Type: metadata.FieldTypeDate},
+		},
+	}
+	stringEntity := &metadata.Entity{
+		Name: "Строки",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Значение", Type: metadata.FieldTypeString},
+		},
+	}
+	return dateEntity, stringEntity
+}
+
 func loadLocationNamed(t *testing.T, name, zoneName string) *time.Location {
 	t.Helper()
 	zones, err := zip.OpenReader(filepath.Join(zoneinfoRoot(t), "lib", "time", "zoneinfo.zip"))

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -3688,10 +3688,14 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 	}
 	projectionFields := projectionFieldNames(tokens)
 	projectionPlan := analyzeProjection(tokens)
+	// Типы нужно снять до раскрытия функций: после Год(Момент) → EXTRACT/strftime
+	// исходная граница аргумента теряется, а локализовать можно только date-момент,
+	// не произвольную строку и не будущий localdate (#1243).
+	colTypes := buildColTypes(tokens, opts)
 	tokens = rewriteGroupingReferenceAliases(tokens)
 	// расширяем НачалоДня/Год/Месяц/ОКР/АБС/ЦЕЛ/... в SQL-эквиваленты
 	// до основной трансляции, чтобы остальные шаги ничего не знали о них.
-	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect))
+	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect), colTypes, opts.Params)
 	tokens = rewriteStrftime(tokens, dialectName(opts.Dialect))
 	tr := &translator{
 		tokens:      tokens,
@@ -3699,7 +3703,7 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 		paramValues: opts.Params,
 		opts:        opts,
 		colMap:      buildColMap(tokens, opts),
-		colTypes:    buildColTypes(tokens, opts),
+		colTypes:    colTypes,
 		mainTable:   preScanMainTable(tokens),
 		refDims:     preScanRefDims(tokens, opts),
 		mainRef:     preScanMainRefSource(tokens, opts),
@@ -4337,7 +4341,7 @@ func scalarFuncRewrites(dialect string) map[string]funcRewrite {
 // т.п., чтобы основной транслятор обработал внутренний аргумент через обычные
 // правила (resolve ref dims, параметры и т.п.). Рекурсивно для вложенных
 // вызовов: Месяц(НачалоМесяца(x)) и ОКР(СУММА(x), 0) тоже разворачиваются.
-func rewriteScalarFuncs(tokens []tok, dialect string) []tok {
+func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metadata.FieldType, params map[string]any) []tok {
 	rewrites := scalarFuncRewrites(dialect)
 	var out []tok
 	for i := 0; i < len(tokens); i++ {
@@ -4367,8 +4371,18 @@ func rewriteScalarFuncs(tokens []tok, dialect string) []tok {
 					out = append(out, t)
 					continue
 				}
-				inner := tokens[i+2 : end]
-				inner = rewriteScalarFuncs(inner, dialect) // рекурсия
+				rawInner := tokens[i+2 : end]
+				inner := rewriteScalarFuncs(rawInner, dialect, colTypes, params) // рекурсия
+				// SQLite хранит date как UTC-текст. Переводим момент в стенные
+				// часы приложения до календарной операции, но только когда тип
+				// аргумента это доказывает. Поэтому будущий localdate останется
+				// «как записан», а строка с похожим содержимым не сменит смысл.
+				if dialect == "sqlite" && isCalendarDateFunc(key) && dateArgumentIsMoment(rawInner, colTypes, params) {
+					wrapped := tokenizeFragment("ob_local_datetime(")
+					wrapped = append(wrapped, inner...)
+					wrapped = append(wrapped, tokenizeFragment(")")...)
+					inner = wrapped
+				}
 				out = append(out, rw.prefix...)
 				out = append(out, inner...)
 				out = append(out, rw.suffix...)
@@ -4379,6 +4393,52 @@ func rewriteScalarFuncs(tokens []tok, dialect string) []tok {
 		out = append(out, t)
 	}
 	return out
+}
+
+func isCalendarDateFunc(name string) bool {
+	switch name {
+	case "началодня", "startofday", "конецдня", "endofday",
+		"началомесяца", "startofmonth", "началогода", "startofyear",
+		"год", "year", "месяц", "month", "день", "day":
+		return true
+	default:
+		return false
+	}
+}
+
+// dateArgumentIsMoment распознаёт только аргумент, чей моментный тип доказан
+// метаданными/параметром. Системный Период регистра тоже является моментом;
+// одноимённое прикладное поле сначала проверяется по метаданным. Сложные
+// выражения оставляем в прежней семантике fail-closed: угадывание их типа
+// локализовало бы будущий localdate или обычную строку.
+func dateArgumentIsMoment(tokens []tok, colTypes map[string]metadata.FieldType, params map[string]any) bool {
+	for len(tokens) >= 2 && tokens[0].kind == tLParen && tokens[len(tokens)-1].kind == tRParen {
+		tokens = tokens[1 : len(tokens)-1]
+	}
+	if len(tokens) == 1 {
+		switch tokens[0].kind {
+		case tIdent:
+			name := lowerFast(tokens[0].val)
+			if typ, ok := colTypes[name]; ok {
+				return typ == metadata.FieldTypeDate
+			}
+			return name == "период" || name == "period"
+		case tParam:
+			switch params[tokens[0].val].(type) {
+			case time.Time, *time.Time:
+				return true
+			}
+		}
+		return false
+	}
+	if len(tokens) == 3 && tokens[0].kind == tIdent && tokens[1].kind == tDot && tokens[2].kind == tIdent {
+		name := lowerFast(tokens[2].val)
+		if typ, ok := colTypes[name]; ok {
+			return typ == metadata.FieldTypeDate
+		}
+		return name == "период" || name == "period"
+	}
+	return false
 }
 
 // momentTimeValue — контракт для DSL-значения «момент времени».

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -2790,12 +2790,14 @@ func buildColTypes(tokens []tok, opts CompileOpts) map[string]metadata.FieldType
 }
 
 // buildQualifiedColTypes maps each unambiguous source qualifier to the field
-// types of that exact source. Scalar functions are rewritten before FROM is
-// emitted, so a qualified argument such as Other.Value cannot use colTypes:
-// that map intentionally describes only the first source of the query.
-func buildQualifiedColTypes(tokens []tok, opts CompileOpts) map[string]map[string]metadata.FieldType {
-	qualified := map[string]map[string]metadata.FieldType{}
-	ambiguous := map[string]bool{}
+// types of that exact source within its SELECT scope. Scalar functions are
+// rewritten before FROM is emitted, so a qualified argument such as Other.Value
+// cannot use colTypes: that map intentionally describes only the first source
+// of the query. Qualifiers must stay scoped because the same alias may denote
+// different sources in a nested SELECT or another UNION branch.
+func buildQualifiedColTypes(tokens []tok, opts CompileOpts, sourceCtx sourceContext) map[int]map[string]map[string]metadata.FieldType {
+	qualified := map[int]map[string]map[string]metadata.FieldType{}
+	ambiguous := map[int]map[string]bool{}
 
 	sameTypes := func(a, b map[string]metadata.FieldType) bool {
 		if len(a) != len(b) {
@@ -2808,19 +2810,28 @@ func buildQualifiedColTypes(tokens []tok, opts CompileOpts) map[string]map[strin
 		}
 		return true
 	}
-	addQualifier := func(name string, fields map[string]metadata.FieldType) {
+	addQualifier := func(scopeID int, name string, fields map[string]metadata.FieldType) {
 		name = lowerFast(name)
-		if name == "" || ambiguous[name] {
+		if name == "" {
 			return
 		}
-		if current, ok := qualified[name]; ok {
+		if qualified[scopeID] == nil {
+			qualified[scopeID] = map[string]map[string]metadata.FieldType{}
+		}
+		if ambiguous[scopeID] == nil {
+			ambiguous[scopeID] = map[string]bool{}
+		}
+		if ambiguous[scopeID][name] {
+			return
+		}
+		if current, ok := qualified[scopeID][name]; ok {
 			if !sameTypes(current, fields) {
-				delete(qualified, name)
-				ambiguous[name] = true
+				delete(qualified[scopeID], name)
+				ambiguous[scopeID][name] = true
 			}
 			return
 		}
-		qualified[name] = fields
+		qualified[scopeID][name] = fields
 	}
 
 	for i := 0; i+2 < len(tokens); i++ {
@@ -2831,20 +2842,24 @@ func buildQualifiedColTypes(tokens []tok, opts CompileOpts) map[string]map[strin
 		if !isSourceType(typeUpper) {
 			continue
 		}
+		scopeID, ok := sourceCtx.scopeIDAt(i)
+		if !ok {
+			continue
+		}
 		name := tokens[i+2].val
 		fields := sourceColTypes(typeUpper, name, opts)
 		if fields == nil {
 			continue
 		}
-		addQualifier(name, fields)
-		addQualifier(sourceToTable(typeUpper, name), fields)
+		addQualifier(scopeID, name, fields)
+		addQualifier(scopeID, sourceToTable(typeUpper, name), fields)
 
 		// A regular source has its optional alias directly after the entity name.
 		aliasPos := i + 3
 		if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
 			aliasUpper := upperFast(tokens[aliasPos].val)
 			if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
-				addQualifier(tokens[aliasPos+1].val, fields)
+				addQualifier(scopeID, tokens[aliasPos+1].val, fields)
 			}
 		}
 	}
@@ -3804,11 +3819,12 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 	// исходная граница аргумента теряется, а локализовать можно только date-момент,
 	// не произвольную строку и не будущий localdate (#1243).
 	colTypes := buildColTypes(tokens, opts)
-	qualifiedColTypes := buildQualifiedColTypes(tokens, opts)
+	scalarSourceCtx := preScanSourceContext(tokens)
+	qualifiedColTypes := buildQualifiedColTypes(tokens, opts, scalarSourceCtx)
 	tokens = rewriteGroupingReferenceAliases(tokens)
 	// расширяем НачалоДня/Год/Месяц/ОКР/АБС/ЦЕЛ/... в SQL-эквиваленты
 	// до основной трансляции, чтобы остальные шаги ничего не знали о них.
-	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect), colTypes, qualifiedColTypes, opts.Params)
+	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect), colTypes, qualifiedColTypes, scalarSourceCtx, 0, opts.Params)
 	tokens = rewriteStrftime(tokens, dialectName(opts.Dialect))
 	tr := &translator{
 		tokens:      tokens,
@@ -4454,7 +4470,7 @@ func scalarFuncRewrites(dialect string) map[string]funcRewrite {
 // т.п., чтобы основной транслятор обработал внутренний аргумент через обычные
 // правила (resolve ref dims, параметры и т.п.). Рекурсивно для вложенных
 // вызовов: Месяц(НачалоМесяца(x)) и ОКР(СУММА(x), 0) тоже разворачиваются.
-func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metadata.FieldType, qualifiedColTypes map[string]map[string]metadata.FieldType, params map[string]any) []tok {
+func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metadata.FieldType, qualifiedColTypes map[int]map[string]map[string]metadata.FieldType, sourceCtx sourceContext, tokenOffset int, params map[string]any) []tok {
 	rewrites := scalarFuncRewrites(dialect)
 	var out []tok
 	for i := 0; i < len(tokens); i++ {
@@ -4485,12 +4501,13 @@ func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metada
 					continue
 				}
 				rawInner := tokens[i+2 : end]
-				inner := rewriteScalarFuncs(rawInner, dialect, colTypes, qualifiedColTypes, params) // рекурсия
+				inner := rewriteScalarFuncs(rawInner, dialect, colTypes, qualifiedColTypes, sourceCtx, tokenOffset+i+2, params) // рекурсия
 				// SQLite хранит date как UTC-текст. Переводим момент в стенные
 				// часы приложения до календарной операции, но только когда тип
 				// аргумента это доказывает. Поэтому будущий localdate останется
 				// «как записан», а строка с похожим содержимым не сменит смысл.
-				if dialect == "sqlite" && isCalendarDateFunc(key) && dateArgumentIsMoment(rawInner, colTypes, qualifiedColTypes, params) {
+				scopeID, _ := sourceCtx.scopeIDAt(tokenOffset + i)
+				if dialect == "sqlite" && isCalendarDateFunc(key) && dateArgumentIsMoment(rawInner, colTypes, qualifiedColTypes[scopeID], params) {
 					wrapped := tokenizeFragment("ob_local_datetime(")
 					wrapped = append(wrapped, inner...)
 					wrapped = append(wrapped, tokenizeFragment(")")...)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -2789,6 +2789,118 @@ func buildColTypes(tokens []tok, opts CompileOpts) map[string]metadata.FieldType
 	return m
 }
 
+// buildQualifiedColTypes maps each unambiguous source qualifier to the field
+// types of that exact source. Scalar functions are rewritten before FROM is
+// emitted, so a qualified argument such as Other.Value cannot use colTypes:
+// that map intentionally describes only the first source of the query.
+func buildQualifiedColTypes(tokens []tok, opts CompileOpts) map[string]map[string]metadata.FieldType {
+	qualified := map[string]map[string]metadata.FieldType{}
+	ambiguous := map[string]bool{}
+
+	sameTypes := func(a, b map[string]metadata.FieldType) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for name, typ := range a {
+			if b[name] != typ {
+				return false
+			}
+		}
+		return true
+	}
+	addQualifier := func(name string, fields map[string]metadata.FieldType) {
+		name = lowerFast(name)
+		if name == "" || ambiguous[name] {
+			return
+		}
+		if current, ok := qualified[name]; ok {
+			if !sameTypes(current, fields) {
+				delete(qualified, name)
+				ambiguous[name] = true
+			}
+			return
+		}
+		qualified[name] = fields
+	}
+
+	for i := 0; i+2 < len(tokens); i++ {
+		if tokens[i].kind != tIdent || tokens[i+1].kind != tDot || tokens[i+2].kind != tIdent {
+			continue
+		}
+		typeUpper := upperFast(tokens[i].val)
+		if !isSourceType(typeUpper) {
+			continue
+		}
+		name := tokens[i+2].val
+		fields := sourceColTypes(typeUpper, name, opts)
+		if fields == nil {
+			continue
+		}
+		addQualifier(name, fields)
+		addQualifier(sourceToTable(typeUpper, name), fields)
+
+		// A regular source has its optional alias directly after the entity name.
+		aliasPos := i + 3
+		if aliasPos+1 < len(tokens) && tokens[aliasPos].kind == tIdent {
+			aliasUpper := upperFast(tokens[aliasPos].val)
+			if (aliasUpper == "КАК" || aliasUpper == "AS") && tokens[aliasPos+1].kind == tIdent {
+				addQualifier(tokens[aliasPos+1].val, fields)
+			}
+		}
+	}
+	return qualified
+}
+
+func sourceColTypes(typeUpper, name string, opts CompileOpts) map[string]metadata.FieldType {
+	fields := map[string]metadata.FieldType{}
+	add := func(items []metadata.Field) {
+		for _, field := range items {
+			fields[lowerFast(field.Name)] = field.Type
+		}
+	}
+	switch {
+	case isAccumRegType(typeUpper):
+		for _, reg := range opts.Registers {
+			if strings.EqualFold(reg.Name, name) {
+				add(reg.Dimensions)
+				add(reg.Resources)
+				add(reg.Attributes)
+				fields["period"] = metadata.FieldTypeDate
+				fields["период"] = metadata.FieldTypeDate
+				return fields
+			}
+		}
+	case isInfoRegType(typeUpper):
+		for _, reg := range opts.InfoRegs {
+			if strings.EqualFold(reg.Name, name) {
+				add(reg.Dimensions)
+				add(reg.Resources)
+				fields["period"] = metadata.FieldTypeDate
+				fields["период"] = metadata.FieldTypeDate
+				return fields
+			}
+		}
+	case isAccountRegType(typeUpper):
+		for _, reg := range opts.AccountRegs {
+			if strings.EqualFold(reg.Name, name) {
+				add(reg.Resources)
+				add(reg.Subconto)
+				fields["period"] = metadata.FieldTypeDate
+				fields["период"] = metadata.FieldTypeDate
+				return fields
+			}
+		}
+	default:
+		for _, entity := range opts.Entities {
+			if strings.EqualFold(entity.Name, name) {
+				add(entity.Fields)
+				return fields
+			}
+		}
+	}
+	return nil
+}
+
 // needsNumberCast — true, если колонку поля number нужно обернуть в
 // CAST(... AS NUMERIC): только на SQLite (там number хранится как TEXT) и только
 // в позициях сравнения/сортировки (WHERE/HAVING/ORDER BY). В ВЫБРАТЬ не кастим —
@@ -3692,10 +3804,11 @@ func translate(tokens []tok, opts CompileOpts) (Result, error) {
 	// исходная граница аргумента теряется, а локализовать можно только date-момент,
 	// не произвольную строку и не будущий localdate (#1243).
 	colTypes := buildColTypes(tokens, opts)
+	qualifiedColTypes := buildQualifiedColTypes(tokens, opts)
 	tokens = rewriteGroupingReferenceAliases(tokens)
 	// расширяем НачалоДня/Год/Месяц/ОКР/АБС/ЦЕЛ/... в SQL-эквиваленты
 	// до основной трансляции, чтобы остальные шаги ничего не знали о них.
-	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect), colTypes, opts.Params)
+	tokens = rewriteScalarFuncs(tokens, dialectName(opts.Dialect), colTypes, qualifiedColTypes, opts.Params)
 	tokens = rewriteStrftime(tokens, dialectName(opts.Dialect))
 	tr := &translator{
 		tokens:      tokens,
@@ -4341,7 +4454,7 @@ func scalarFuncRewrites(dialect string) map[string]funcRewrite {
 // т.п., чтобы основной транслятор обработал внутренний аргумент через обычные
 // правила (resolve ref dims, параметры и т.п.). Рекурсивно для вложенных
 // вызовов: Месяц(НачалоМесяца(x)) и ОКР(СУММА(x), 0) тоже разворачиваются.
-func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metadata.FieldType, params map[string]any) []tok {
+func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metadata.FieldType, qualifiedColTypes map[string]map[string]metadata.FieldType, params map[string]any) []tok {
 	rewrites := scalarFuncRewrites(dialect)
 	var out []tok
 	for i := 0; i < len(tokens); i++ {
@@ -4372,12 +4485,12 @@ func rewriteScalarFuncs(tokens []tok, dialect string, colTypes map[string]metada
 					continue
 				}
 				rawInner := tokens[i+2 : end]
-				inner := rewriteScalarFuncs(rawInner, dialect, colTypes, params) // рекурсия
+				inner := rewriteScalarFuncs(rawInner, dialect, colTypes, qualifiedColTypes, params) // рекурсия
 				// SQLite хранит date как UTC-текст. Переводим момент в стенные
 				// часы приложения до календарной операции, но только когда тип
 				// аргумента это доказывает. Поэтому будущий localdate останется
 				// «как записан», а строка с похожим содержимым не сменит смысл.
-				if dialect == "sqlite" && isCalendarDateFunc(key) && dateArgumentIsMoment(rawInner, colTypes, params) {
+				if dialect == "sqlite" && isCalendarDateFunc(key) && dateArgumentIsMoment(rawInner, colTypes, qualifiedColTypes, params) {
 					wrapped := tokenizeFragment("ob_local_datetime(")
 					wrapped = append(wrapped, inner...)
 					wrapped = append(wrapped, tokenizeFragment(")")...)
@@ -4411,7 +4524,7 @@ func isCalendarDateFunc(name string) bool {
 // одноимённое прикладное поле сначала проверяется по метаданным. Сложные
 // выражения оставляем в прежней семантике fail-closed: угадывание их типа
 // локализовало бы будущий localdate или обычную строку.
-func dateArgumentIsMoment(tokens []tok, colTypes map[string]metadata.FieldType, params map[string]any) bool {
+func dateArgumentIsMoment(tokens []tok, colTypes map[string]metadata.FieldType, qualifiedColTypes map[string]map[string]metadata.FieldType, params map[string]any) bool {
 	for len(tokens) >= 2 && tokens[0].kind == tLParen && tokens[len(tokens)-1].kind == tRParen {
 		tokens = tokens[1 : len(tokens)-1]
 	}
@@ -4432,11 +4545,14 @@ func dateArgumentIsMoment(tokens []tok, colTypes map[string]metadata.FieldType, 
 		return false
 	}
 	if len(tokens) == 3 && tokens[0].kind == tIdent && tokens[1].kind == tDot && tokens[2].kind == tIdent {
-		name := lowerFast(tokens[2].val)
-		if typ, ok := colTypes[name]; ok {
+		fields, ok := qualifiedColTypes[lowerFast(tokens[0].val)]
+		if !ok {
+			return false
+		}
+		if typ, ok := fields[lowerFast(tokens[2].val)]; ok {
 			return typ == metadata.FieldTypeDate
 		}
-		return name == "период" || name == "period"
+		return false
 	}
 	return false
 }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -443,11 +443,11 @@ func TestCompile_DateFuncs_SQLite(t *testing.T) {
 		src  string
 		want string
 	}{
-		{`ВЫБРАТЬ Год(Период) ИЗ РегистрНакопления.Х`, "cast(strftime('%Y', period) AS integer)"},
-		{`ВЫБРАТЬ Месяц(Период) ИЗ РегистрНакопления.Х`, "cast(strftime('%m', period) AS integer)"},
-		{`ВЫБРАТЬ День(Период) ИЗ РегистрНакопления.Х`, "cast(strftime('%d', period) AS integer)"},
-		{`ВЫБРАТЬ НачалоДня(Период) ИЗ РегистрНакопления.Х`, "date(period)"},
-		{`ВЫБРАТЬ НачалоМесяца(Период) ИЗ РегистрНакопления.Х`, "date(period, 'start of month')"},
+		{`ВЫБРАТЬ Год(Период) ИЗ РегистрНакопления.Х`, "cast(strftime('%Y', ob_local_datetime(period)) AS integer)"},
+		{`ВЫБРАТЬ Месяц(Период) ИЗ РегистрНакопления.Х`, "cast(strftime('%m', ob_local_datetime(period)) AS integer)"},
+		{`ВЫБРАТЬ День(Период) ИЗ РегистрНакопления.Х`, "cast(strftime('%d', ob_local_datetime(period)) AS integer)"},
+		{`ВЫБРАТЬ НачалоДня(Период) ИЗ РегистрНакопления.Х`, "date(ob_local_datetime(period))"},
+		{`ВЫБРАТЬ НачалоМесяца(Период) ИЗ РегистрНакопления.Х`, "date(ob_local_datetime(period), 'start of month')"},
 	}
 	for _, c := range cases {
 		r, err := query.Compile(c.src, query.CompileOpts{Dialect: storage.SQLiteDialect{}})
@@ -491,8 +491,34 @@ func TestCompile_DateFuncs_Nested(t *testing.T) {
 		t.Fatal(err)
 	}
 	// внутри Месяц(...) должно быть date(period, ...)
-	if !strings.Contains(r.SQL, "strftime('%m', date(period, 'start of month'))") {
+	if !strings.Contains(r.SQL, "strftime('%m', date(ob_local_datetime(period), 'start of month'))") {
 		t.Errorf("вложенность не развернулась: %s", r.SQL)
+	}
+}
+
+// Локализация привязана к типу date, а не к синтаксису функции. Это граница с
+// будущим localdate: значение без зоны должно остаться ровно как записано.
+func TestCompile_DateFuncs_LocalizeOnlyMomentType(t *testing.T) {
+	ent := &metadata.Entity{
+		Name: "Событие",
+		Kind: metadata.KindCatalog,
+		Fields: []metadata.Field{
+			{Name: "Момент", Type: metadata.FieldTypeDate},
+			{Name: "СтенныеЧасы", Type: metadata.FieldTypeString},
+		},
+	}
+	r, err := query.Compile(
+		`ВЫБРАТЬ День(Момент), День(СтенныеЧасы) ИЗ Справочник.Событие`,
+		query.CompileOpts{Entities: []*metadata.Entity{ent}, Dialect: storage.SQLiteDialect{}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.SQL, "strftime('%d', ob_local_datetime(момент))") {
+		t.Errorf("date-момент не локализован: %s", r.SQL)
+	}
+	if strings.Contains(r.SQL, "ob_local_datetime(стенныечасы)") {
+		t.Errorf("обычное строковое/будущее localdate поле ошибочно локализовано: %s", r.SQL)
 	}
 }
 

--- a/internal/storage/pg.go
+++ b/internal/storage/pg.go
@@ -168,31 +168,145 @@ func applyPostgresApplicationTimeZone(cfg *pgxpool.Config) {
 }
 
 func applicationTimeZoneName() string {
-	name := time.Local.String()
+	return applicationTimeZoneNameFor(time.Local, strings.TrimSpace(os.Getenv("TZ")), time.Now())
+}
+
+func applicationTimeZoneNameFor(loc *time.Location, envName string, now time.Time) string {
+	name := loc.String()
 	if name != "" && name != "Local" {
 		if _, err := time.LoadLocation(name); err == nil {
 			return name
 		}
 		// FixedZone и платформенные имена, которых нет в IANA PostgreSQL,
 		// безопасно сводим к текущему числовому смещению.
-		return applicationTimeZoneOffset()
+		return applicationTimeZoneOffsetAt(loc, now)
 	}
-	if envName := strings.TrimSpace(os.Getenv("TZ")); envName != "" {
+	if envName != "" {
 		if _, err := time.LoadLocation(envName); err == nil {
 			return envName
 		}
 	}
-	return applicationTimeZoneOffset()
+	if spec, ok := applicationTimeZonePOSIX(loc, now); ok {
+		return spec
+	}
+	return applicationTimeZoneOffsetAt(loc, now)
 }
 
-func applicationTimeZoneOffset() string {
-	_, offset := time.Now().In(time.Local).Zone()
+func applicationTimeZoneOffsetAt(loc *time.Location, at time.Time) string {
+	_, offset := at.In(loc).Zone()
 	sign := '+'
 	if offset < 0 {
 		sign = '-'
 		offset = -offset
 	}
 	return fmt.Sprintf("%c%02d:%02d", sign, offset/3600, (offset%3600)/60)
+}
+
+// applicationTimeZonePOSIX describes the recurring DST rules carried by an
+// unnamed system time.Local. Go uses that name on Windows even though the
+// Location contains standard/daylight transitions. PostgreSQL cannot resolve
+// "Local", while a numeric offset would freeze whichever side of DST is
+// active when the process starts.
+func applicationTimeZonePOSIX(loc *time.Location, at time.Time) (string, bool) {
+	type zoneTransition struct {
+		at           time.Time
+		beforeOffset int
+		afterOffset  int
+		toDST        bool
+	}
+
+	year := at.In(loc).Year()
+	start := time.Date(year, time.January, 1, 0, 0, 0, 0, loc)
+	end := time.Date(year+1, time.January, 1, 0, 0, 0, 0, loc)
+	var transitions []zoneTransition
+	for cursor := start; cursor.Before(end); {
+		_, boundary := cursor.ZoneBounds()
+		if boundary.IsZero() || !boundary.Before(end) {
+			break
+		}
+		if !boundary.After(cursor) {
+			return "", false
+		}
+		_, beforeOffset := boundary.Add(-time.Nanosecond).In(loc).Zone()
+		_, afterOffset := boundary.In(loc).Zone()
+		if beforeOffset != afterOffset {
+			transitions = append(transitions, zoneTransition{
+				at:           boundary,
+				beforeOffset: beforeOffset,
+				afterOffset:  afterOffset,
+				toDST:        boundary.In(loc).IsDST(),
+			})
+		}
+		cursor = boundary.Add(time.Nanosecond)
+	}
+	if len(transitions) != 2 {
+		return "", false
+	}
+
+	var dstStart, stdStart *zoneTransition
+	for i := range transitions {
+		transition := &transitions[i]
+		if transition.toDST {
+			if dstStart != nil {
+				return "", false
+			}
+			dstStart = transition
+		} else {
+			if stdStart != nil {
+				return "", false
+			}
+			stdStart = transition
+		}
+	}
+	if dstStart == nil || stdStart == nil ||
+		dstStart.beforeOffset != stdStart.afterOffset ||
+		dstStart.afterOffset != stdStart.beforeOffset {
+		return "", false
+	}
+
+	return fmt.Sprintf("<STD>%s<DST>%s,%s,%s",
+		postgresPOSIXOffset(dstStart.beforeOffset),
+		postgresPOSIXOffset(dstStart.afterOffset),
+		postgresPOSIXTransitionRule(dstStart.at, dstStart.beforeOffset),
+		postgresPOSIXTransitionRule(stdStart.at, stdStart.beforeOffset),
+	), true
+}
+
+func postgresPOSIXOffset(utcOffset int) string {
+	west := -utcOffset
+	sign := ""
+	if west < 0 {
+		sign = "-"
+		west = -west
+	}
+	hours := west / 3600
+	minutes := (west % 3600) / 60
+	seconds := west % 60
+	switch {
+	case seconds != 0:
+		return fmt.Sprintf("%s%d:%02d:%02d", sign, hours, minutes, seconds)
+	case minutes != 0:
+		return fmt.Sprintf("%s%d:%02d", sign, hours, minutes)
+	default:
+		return fmt.Sprintf("%s%d", sign, hours)
+	}
+}
+
+func postgresPOSIXTransitionRule(transition time.Time, offsetBefore int) string {
+	// POSIX records the local wall clock immediately before the transition.
+	wall := transition.UTC().Add(time.Duration(offsetBefore) * time.Second)
+	lastDay := time.Date(wall.Year(), wall.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
+	week := (wall.Day()-1)/7 + 1
+	if wall.Day()+7 > lastDay {
+		week = 5
+	}
+	clock := fmt.Sprintf("%d", wall.Hour())
+	if wall.Second() != 0 {
+		clock = fmt.Sprintf("%d:%02d:%02d", wall.Hour(), wall.Minute(), wall.Second())
+	} else if wall.Minute() != 0 {
+		clock = fmt.Sprintf("%d:%02d", wall.Hour(), wall.Minute())
+	}
+	return fmt.Sprintf("M%d.%d.%d/%s", wall.Month(), week, wall.Weekday(), clock)
 }
 
 // applyPoolDefaults sets pool sizing on cfg. ParseConfig has already applied

--- a/internal/storage/pg.go
+++ b/internal/storage/pg.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -133,6 +134,7 @@ func ConnectWithPool(ctx context.Context, dsn string, pc PoolConfig) (*DB, error
 		return nil, fmt.Errorf("storage: parse dsn: %w", err)
 	}
 	applyPoolDefaults(cfg, dsn, pc)
+	applyPostgresApplicationTimeZone(cfg)
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("storage: connect: %w", err)
@@ -150,6 +152,47 @@ func ConnectWithPool(ctx context.Context, dsn string, pc PoolConfig) (*DB, error
 
 	filesDir := defaultFilesDir(dsn)
 	return &DB{pool: pool, filesDir: filesDir, dialect: PgDialect{}}, nil
+}
+
+// applyPostgresApplicationTimeZone прибивает каждое соединение пула к зоне
+// приложения. TIMESTAMPTZ хранит момент в UTC, но EXTRACT/date_trunc считают
+// календарные части в session TimeZone; без этого PostgreSQL расходился с
+// SQLite и DSL в зависимости от настройки внешнего сервера (#1243).
+// TIMESTAMP WITHOUT TIME ZONE (будущий localdate) от session TimeZone не
+// преобразуется и сохраняет стенные часы как записаны.
+func applyPostgresApplicationTimeZone(cfg *pgxpool.Config) {
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["timezone"] = applicationTimeZoneName()
+}
+
+func applicationTimeZoneName() string {
+	name := time.Local.String()
+	if name != "" && name != "Local" {
+		if _, err := time.LoadLocation(name); err == nil {
+			return name
+		}
+		// FixedZone и платформенные имена, которых нет в IANA PostgreSQL,
+		// безопасно сводим к текущему числовому смещению.
+		return applicationTimeZoneOffset()
+	}
+	if envName := strings.TrimSpace(os.Getenv("TZ")); envName != "" {
+		if _, err := time.LoadLocation(envName); err == nil {
+			return envName
+		}
+	}
+	return applicationTimeZoneOffset()
+}
+
+func applicationTimeZoneOffset() string {
+	_, offset := time.Now().In(time.Local).Zone()
+	sign := '+'
+	if offset < 0 {
+		sign = '-'
+		offset = -offset
+	}
+	return fmt.Sprintf("%c%02d:%02d", sign, offset/3600, (offset%3600)/60)
 }
 
 // applyPoolDefaults sets pool sizing on cfg. ParseConfig has already applied

--- a/internal/storage/pg_timezone_test.go
+++ b/internal/storage/pg_timezone_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"archive/zip"
+	"io"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestApplicationTimeZoneNameKeepsUnnamedLocalDSTRules(t *testing.T) {
+	loc := loadTestLocationNamed(t, "Local", "America/New_York")
+	got := applicationTimeZoneNameFor(loc, "", time.Date(2026, time.July, 1, 0, 0, 0, 0, loc))
+	const want = "<STD>5<DST>4,M3.2.0/2,M11.1.0/2"
+	if got != want {
+		t.Fatalf("applicationTimeZoneNameFor() = %q, want %q", got, want)
+	}
+}
+
+func loadTestLocationNamed(t *testing.T, name, zoneName string) *time.Location {
+	t.Helper()
+	zones, err := zip.OpenReader(filepath.Join(runtime.GOROOT(), "lib", "time", "zoneinfo.zip"))
+	if err != nil {
+		t.Fatalf("open Go zoneinfo.zip: %v", err)
+	}
+	defer zones.Close()
+	for _, file := range zones.File {
+		if file.Name != zoneName {
+			continue
+		}
+		reader, err := file.Open()
+		if err != nil {
+			t.Fatalf("open zone %s: %v", zoneName, err)
+		}
+		data, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		if readErr != nil {
+			t.Fatalf("read zone %s: %v", zoneName, readErr)
+		}
+		if closeErr != nil {
+			t.Fatalf("close zone %s: %v", zoneName, closeErr)
+		}
+		loc, err := time.LoadLocationFromTZData(name, data)
+		if err != nil {
+			t.Fatalf("load zone %s as %s: %v", zoneName, name, err)
+		}
+		return loc
+	}
+	t.Fatalf("zone %s not found in Go zoneinfo.zip", zoneName)
+	return nil
+}

--- a/internal/storage/pg_timezone_test.go
+++ b/internal/storage/pg_timezone_test.go
@@ -3,8 +3,9 @@ package storage
 import (
 	"archive/zip"
 	"io"
+	"os/exec"
 	"path/filepath"
-	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -20,11 +21,15 @@ func TestApplicationTimeZoneNameKeepsUnnamedLocalDSTRules(t *testing.T) {
 
 func loadTestLocationNamed(t *testing.T, name, zoneName string) *time.Location {
 	t.Helper()
-	zones, err := zip.OpenReader(filepath.Join(runtime.GOROOT(), "lib", "time", "zoneinfo.zip"))
+	zones, err := zip.OpenReader(filepath.Join(testZoneinfoRoot(t), "lib", "time", "zoneinfo.zip"))
 	if err != nil {
 		t.Fatalf("open Go zoneinfo.zip: %v", err)
 	}
-	defer zones.Close()
+	defer func() {
+		if err := zones.Close(); err != nil {
+			t.Errorf("close Go zoneinfo.zip: %v", err)
+		}
+	}()
 	for _, file := range zones.File {
 		if file.Name != zoneName {
 			continue
@@ -49,4 +54,17 @@ func loadTestLocationNamed(t *testing.T, name, zoneName string) *time.Location {
 	}
 	t.Fatalf("zone %s not found in Go zoneinfo.zip", zoneName)
 	return nil
+}
+
+func testZoneinfoRoot(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "env", "GOROOT").Output()
+	if err != nil {
+		t.Fatalf("determine GOROOT: %v", err)
+	}
+	root := strings.TrimSpace(string(out))
+	if root == "" {
+		t.Fatal("go env GOROOT returned an empty path")
+	}
+	return root
 }

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -52,6 +52,7 @@ func ConnectWithSchema(ctx context.Context, dsn, schema string) (*DB, error) {
 	// search_path применяется на старте соединения; несуществующая схема в
 	// списке не ошибка — резолв идёт при запросе, к тому времени схема создана.
 	cfg.ConnConfig.RuntimeParams["search_path"] = schema + ",public"
+	applyPostgresApplicationTimeZone(cfg)
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ivantit66/onebase/internal/fsmode"
 	"github.com/ivantit66/onebase/internal/i18n/i18nerr"
@@ -33,6 +34,32 @@ func init() {
 		default:
 			return v, nil
 		}
+	})
+	// date хранится в SQLite как UTC с явным offset. Календарные функции
+	// прикладного запроса должны сначала увидеть те же локальные стенные часы,
+	// что DSL/UI. Функция намеренно не deterministic: time.Local — настройка
+	// процесса, и тесты проверяют несколько зон в одном запуске (#1243).
+	sqlite.MustRegisterScalarFunction("ob_local_datetime", 1, func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+		if len(args) != 1 || args[0] == nil {
+			return nil, nil
+		}
+		var value string
+		switch v := args[0].(type) {
+		case string:
+			value = v
+		case []byte:
+			value = string(v)
+		case time.Time:
+			return v.In(time.Local).Format("2006-01-02 15:04:05.999999999"), nil
+		default:
+			return nil, nil
+		}
+		for _, layout := range []string{sqliteTimeLayout, time.RFC3339Nano, time.RFC3339} {
+			if parsed, err := time.Parse(layout, strings.TrimSpace(value)); err == nil {
+				return parsed.In(time.Local).Format("2006-01-02 15:04:05.999999999"), nil
+			}
+		}
+		return nil, nil
 	})
 }
 


### PR DESCRIPTION
## Что исправлено

- SQLite переводит UTC-момент поля `date` в локальные стенные часы приложения до `Год`/`Месяц`/`День`, `Начало*` и `КонецДня`.
- Каждый PostgreSQL-коннект получает `TimeZone` приложения, поэтому `TIMESTAMPTZ` считает календарные части в той же зоне, что DSL и UI.
- Локализация применяется только к доказанному типу `date` и системному `Период`; обычная строка и будущий `localdate` остаются «как записаны».

Вариант: 1 (решение человека в комментарии к заявке).

## Проверки

- новый матричный тест `query.Compile` → `query.Run` для SQLite/PostgreSQL, `Asia/Kolkata` и `America/New_York`, зимнего и летнего смещений;
- `go test` для `internal/query`, `internal/storage`, `internal/dsl/interpreter`;
- зональные прогоны `internal/query` и `internal/storage` с `TZ=Asia/Kolkata` и `TZ=America/New_York`;
- `go test -race ./internal/query -run '^TestDateFunctionsUseApplicationLocalTime$' -count=1`;
- `go build ./...`;
- `go test ./...`.

Локально `TEST_DATABASE_URL` не задан, поэтому PostgreSQL-половину нового матричного теста исполнит обязательный `postgres-integration` job.

## Совместимость

Для существующих запросов календарный день `date` у границы UTC может измениться: теперь он совпадает с уже действующей семантикой DSL/UI. Сохранённые моменты не переписываются.

Fixes #1243