### PR TITLE
fix(check): запросы в модулях управляемых форм проверяются вместе с остальными

### DIFF
--- a/internal/configcheck/module_queries.go
+++ b/internal/configcheck/module_queries.go
@@ -28,17 +28,16 @@ type moduleQuery struct {
 }
 
 // CheckModuleQueries компилирует статические запросы вида `Запрос.Текст = "..."`
-// из .os-модулей (обработка проведения, заполнения и т.п.). CheckQueries
-// покрывает только виджеты/отчёты — запросы внутри модулей раньше не
-// проверялись вовсе (так в примере «закрытие месяца» прошёл незамеченным
+// из .os-модулей: src/*.os и модули управляемых форм forms/<сущность>/*.form.os.
+// CheckQueries покрывает только виджеты/отчёты — запросы внутри модулей раньше
+// не проверялись вовсе (так в примере «закрытие месяца» прошёл незамеченным
 // неподдерживаемый ПОДОБНО). Если validate != nil — дополнительно PREPARE
 // против in-memory схемы (как CheckQueriesExecutable). Динамически собранные
 // тексты (конкатенация с переменными) пропускаются — их статически не извлечь.
 func CheckModuleQueries(proj *project.Project, validate func(string) error) []Issue {
 	var issues []Issue
-	srcDir := filepath.Join(proj.Dir, "src")
-	entries, err := os.ReadDir(srcDir)
-	if err != nil {
+	files := moduleSourceFiles(proj.Dir)
+	if len(files) == 0 {
 		return nil
 	}
 	opts := query.CompileOpts{
@@ -50,12 +49,9 @@ func CheckModuleQueries(proj *project.Project, validate func(string) error) []Is
 	if validate != nil {
 		opts.Dialect = storage.SQLiteDialect{}
 	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".os") {
-			continue
-		}
-		label := "src/" + e.Name()
-		raw, rerr := os.ReadFile(filepath.Join(srcDir, e.Name()))
+	for _, f := range files {
+		label := f.label
+		raw, rerr := os.ReadFile(f.path)
 		if rerr != nil {
 			continue
 		}
@@ -99,6 +95,60 @@ func CheckModuleQueries(proj *project.Project, validate func(string) error) []Is
 		}
 	}
 	return issues
+}
+
+// moduleSource — файл модуля для проверки: путь на диске и метка для сообщения.
+type moduleSource struct{ label, path string }
+
+// moduleSourceFiles перечисляет .os-модули конфигурации: src/*.os и модули
+// управляемых форм forms/<сущность>/*.form.os.
+//
+// ФОРМЫ ДОБАВЛЕНЫ ОТДЕЛЬНО, потому что живут не в src/ и раньше не проверялись
+// вовсе: запрос в обработчике кнопки компилировался впервые уже при нажатии, у
+// пользователя. Это ровно тот класс, ради которого проверка и написана —
+// «no such column» на форме ничем не отличается от такой же ошибки в проведении,
+// кроме момента, когда её увидят.
+func moduleSourceFiles(dir string) []moduleSource {
+	var out []moduleSource
+	isModule := func(name string) bool {
+		return strings.HasSuffix(strings.ToLower(name), ".os")
+	}
+	srcDir := filepath.Join(dir, "src")
+	if entries, err := os.ReadDir(srcDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !isModule(e.Name()) {
+				continue
+			}
+			out = append(out, moduleSource{"src/" + e.Name(), filepath.Join(srcDir, e.Name())})
+		}
+	}
+	// forms/<сущность>/<форма>.form.os — на один уровень глубже; имена каталогов
+	// и файлов в нижнем регистре, но полагаться на это не нужно.
+	formsDir := filepath.Join(dir, "forms")
+	entityDirs, err := os.ReadDir(formsDir)
+	if err != nil {
+		return out
+	}
+	for _, d := range entityDirs {
+		if !d.IsDir() {
+			continue
+		}
+		sub := filepath.Join(formsDir, d.Name())
+		files, ferr := os.ReadDir(sub)
+		if ferr != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !isModule(f.Name()) {
+				continue
+			}
+			out = append(out, moduleSource{
+				label: "forms/" + d.Name() + "/" + f.Name(),
+				path:  filepath.Join(sub, f.Name()),
+			})
+		}
+	}
+	return out
 }
 
 // collectQueryVars собирает имена переменных, которым где-либо в теле присвоен

--- a/internal/configcheck/module_queries_test.go
+++ b/internal/configcheck/module_queries_test.go
@@ -86,30 +86,11 @@ elements:
   Плохой.Текст = "ВЫБРАТЬ НетТакогоПоля ИЗ Документ.Заказ";
 КонецПроцедуры`)
 
-	proj, err := project.Load(dir)
-	if err != nil {
-		t.Fatalf("project.Load: %v", err)
+	res := RunFull(dir)
+	if len(res.Issues) != 1 {
+		t.Fatalf("ожидалась 1 ошибка (только запрос с несуществующим полем), получено %d: %+v", len(res.Issues), res.Issues)
 	}
-	defer proj.Close()
-
-	ctx := context.Background()
-	dbPath := filepath.Join(dir, "schema.db")
-	db, err := storage.ConnectSQLite(ctx, dbPath)
-	if err != nil {
-		t.Fatalf("connect: %v", err)
-	}
-	defer func() { db.Close(); _ = os.Remove(dbPath) }()
-	if err := db.Migrate(ctx, proj.Entities); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-
-	issues := CheckModuleQueries(proj, func(sql string) error {
-		return db.ValidateQuery(ctx, sql)
-	})
-	if len(issues) != 1 {
-		t.Fatalf("ожидалась 1 ошибка (только запрос с несуществующим полем), получено %d: %+v", len(issues), issues)
-	}
-	got := issues[0]
+	got := res.Issues[0]
 	if !strings.Contains(got.File, "forms/заказ/формаобъекта.form.os") {
 		t.Errorf("ожидался файл модуля формы, получено %q", got.File)
 	}

--- a/internal/configcheck/module_queries_test.go
+++ b/internal/configcheck/module_queries_test.go
@@ -59,3 +59,61 @@ fields:
 		t.Errorf("ожидалась строка 5 (плохой запрос), получено %d", got.Line)
 	}
 }
+
+// Модуль управляемой формы живёт не в src/, а в forms/<сущность>/ — и до этой
+// правки не проверялся вовсе: запрос в обработчике кнопки компилировался
+// впервые уже при нажатии, у пользователя. Ошибка в нём ничем не отличается от
+// такой же в проведении, кроме момента, когда её увидят.
+func TestCheckModuleQueries_FormModules(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "documents", "заказ.yaml"), `name: Заказ
+fields:
+  - name: Наименование
+    type: string`)
+	mkFile(t, filepath.Join(dir, "forms", "заказ", "формаобъекта.form.yaml"), `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заказ
+elements:
+  - kind: ПолеВвода
+    name: ПолеНаименование
+    data_path: Объект.Наименование`)
+	mkFile(t, filepath.Join(dir, "forms", "заказ", "формаобъекта.form.os"), `Процедура КнопкаНажатие()
+  Хороший = Новый Запрос;
+  Хороший.Текст = "ВЫБРАТЬ Наименование ИЗ Документ.Заказ";
+  Плохой = Новый Запрос;
+  Плохой.Текст = "ВЫБРАТЬ НетТакогоПоля ИЗ Документ.Заказ";
+КонецПроцедуры`)
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(dir, "schema.db")
+	db, err := storage.ConnectSQLite(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { db.Close(); _ = os.Remove(dbPath) }()
+	if err := db.Migrate(ctx, proj.Entities); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	issues := CheckModuleQueries(proj, func(sql string) error {
+		return db.ValidateQuery(ctx, sql)
+	})
+	if len(issues) != 1 {
+		t.Fatalf("ожидалась 1 ошибка (только запрос с несуществующим полем), получено %d: %+v", len(issues), issues)
+	}
+	got := issues[0]
+	if !strings.Contains(got.File, "forms/заказ/формаобъекта.form.os") {
+		t.Errorf("ожидался файл модуля формы, получено %q", got.File)
+	}
+	if got.Line != 5 {
+		t.Errorf("ожидалась строка 5 (плохой запрос), получено %d", got.Line)
+	}
+}


### PR DESCRIPTION
## Дефект

`CheckModuleQueries` читал только `src/*.os`, поэтому запрос в обработчике управляемой формы (`forms/<сущность>/<форма>.form.os`) **не проверялся вообще** — он компилировался впервые уже при нажатии кнопки, у пользователя.

Ошибка там ничем не отличается от такой же в проведении: `no such column` одинаково ломает работу, разница только в том, когда её увидят. Именно ради этого класса проверка и написана — комментарий в самом файле объясняет, что запросы модулей раньше не проверялись вовсе и как из-за этого проехал неподдерживаемый `ПОДОБНО`.

Практический след: в прикладной конфигурации приходится сознательно держать запрос в общем модуле, а не в модуле формы, — только чтобы он попал под `check`.

## Что сделано

Перечисление файлов вынесено в `moduleSourceFiles`: `src/*.os` плюс `forms/*/*.os`. Остальной конвейер (сбор статических текстов, компиляция, PREPARE против in-memory схемы) не менялся, поэтому модули форм получают ровно ту же проверку, что и модули объектов, — с меткой файла `forms/<сущность>/<форма>.form.os` в сообщении.

## Проверено

- Новый `TestCheckModuleQueries_FormModules`: валидный запрос в модуле формы молчит, запрос с несуществующим полем даёт **одну** ошибку с верным файлом и строкой. Прежний `TestCheckModuleQueries` не менялся.
- `go test ./internal/configcheck/` — зелёный.
- Все девять конфигураций `examples/` (`accounting`, `archive`, `callcenter`, `cms`, `crm`, `finance`, `minimal`, `tasks`, `trade`) — `check` зелёный: ложных срабатываний новая ветка не добавила.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
