### PR TITLE
fix(check): линт предупреждает о нераспознанном типе реквизита формы

### DIFF
--- a/internal/configcheck/form_attr_type_check.go
+++ b/internal/configcheck/form_attr_type_check.go
@@ -1,0 +1,77 @@
+package configcheck
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ivantit66/onebase/internal/project"
+)
+
+// formAttrKnownTypes — типы реквизита управляемой формы, которые понимает
+// загрузчик (docs/forms.md, раздел «Типы реквизитов»). Список сравнивается по
+// ПРЕФИКСУ: «string(40)» и «decimal(15,2)» — те же типы с квалификаторами,
+// «CatalogRef.Контрагент» — ссылка на конкретный справочник.
+var formAttrKnownTypes = []string{
+	"string", "number", "decimal", "date", "datetime", "bool",
+	"catalogref.", "documentref.", "enumref.", "chartofaccountsref.", "anyref",
+	"valuetable",
+}
+
+// CheckLintFormAttrTypes предупреждает о типе реквизита формы, которого
+// загрузчик не знает.
+//
+// ПОЧЕМУ ЭТО ВООБЩЕ НУЖНО. Нераспознанный тип не ошибка и не пустое место:
+// значение приходит в обработчик СТРОКОЙ. Реквизит с типом «Дата» (по-русски,
+// как написано всё остальное в конфигурации) молча ведёт себя как строка —
+// сравнение с датой не срабатывает, арифметика дат не работает, а на форме поле
+// выглядит рабочим. Ссылочный тип в таком написании вдобавок теряет пикер:
+// варианты выбора собираются только для CatalogRef./DocumentRef.
+//
+// ПРЕДУПРЕЖДЕНИЕ, А НЕ ОШИБКА. Незнакомый тип сегодня работает как строка, и
+// конфигурации, где реквизит объявлен «Строка», этим пользуются — сломать их
+// сборкой значило бы наказать за то, что платформа сама разрешала. Ошибкой это
+// станет, если список типов когда-нибудь закроют.
+func CheckLintFormAttrTypes(proj *project.Project) []Issue {
+	if proj == nil {
+		return nil
+	}
+	var issues []Issue
+	for _, ent := range proj.Entities {
+		for _, form := range ent.Forms {
+			label := formFileLabel(ent, form)
+			for _, a := range form.Attributes {
+				if a == nil || strings.TrimSpace(a.TypeRef) == "" {
+					continue
+				}
+				if formAttrTypeKnown(a.TypeRef) {
+					continue
+				}
+				issues = append(issues, Issue{
+					File:   label,
+					Object: ent.Name,
+					Kind:   "Управляемая форма",
+					Code:   "form.attr-type",
+					Message: fmt.Sprintf(
+						"тип реквизита формы %q не распознан (%q): значение придёт в обработчик строкой",
+						a.Name, a.TypeRef),
+					SuggestedFix: "Названия типов латинские: string, string(N), number, decimal(P,S), date, dateTime, bool, " +
+						"CatalogRef.<Справочник>, DocumentRef.<Документ>, EnumRef.<Перечисление>, AnyRef, ValueTable. " +
+						"Русские написания («Строка», «Дата», «Число») загрузчик не понимает.",
+				})
+			}
+		}
+	}
+	return issues
+}
+
+// formAttrTypeKnown — распознаётся ли тип реквизита формы. Сравнение по
+// префиксу и без учёта регистра: «Date», «string(40)», «CatalogRef.Склад».
+func formAttrTypeKnown(typeRef string) bool {
+	t := strings.ToLower(strings.TrimSpace(typeRef))
+	for _, known := range formAttrKnownTypes {
+		if strings.HasPrefix(t, known) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/configcheck/form_attr_type_check.go
+++ b/internal/configcheck/form_attr_type_check.go
@@ -2,7 +2,6 @@ package configcheck
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/ivantit66/onebase/internal/metadata"
@@ -79,7 +78,7 @@ func formAttrTypeIssue(file, object, where, typeRef string) Issue {
 		Message: fmt.Sprintf(
 			"тип %s не распознан (%q): значение придёт в обработчик строкой",
 			where, typeRef),
-		SuggestedFix: "Названия типов латинские: string, string(N), number, decimal(P,S), date, dateTime, bool, " +
+		SuggestedFix: "Названия типов латинские: string, string(N), number, decimal(P), decimal(P,S), date, dateTime, bool, " +
 			"CatalogRef.<Справочник>, DocumentRef.<Документ>, EnumRef.<Перечисление>, " +
 			"ChartOfAccountsRef.<ПланСчетов>, AnyRef, ValueTable. " +
 			"Русские написания («Строка», «Дата», «Число») загрузчик не понимает.",
@@ -94,7 +93,7 @@ func formAttrFileLabel(owner string, form *metadata.FormModule) string {
 	return "forms/" + strings.ToLower(owner) + "/" + name + ".form.yaml"
 }
 
-// formAttrTypeKnown повторяет документированную грамматику реквизита формы.
+// formAttrTypeKnown повторяет фактическую грамматику реквизита формы.
 // ValueTable проверяется отдельно и только в точном написании: часть runtime
 // использует EqualFold, но formAttrIsScalar различает его регистрозависимо.
 func formAttrTypeKnown(typeRef string) bool {
@@ -102,23 +101,20 @@ func formAttrTypeKnown(typeRef string) bool {
 	return t == "ValueTable" || formValueTypeKnown(t)
 }
 
-// formValueTypeKnown проверяет скалярные реквизиты и колонки ValueTable.
-// Примитивы регистронезависимы, как typeFormAttrValue; ссылочные префиксы
-// регистрозависимы, как attrRefEntityName. Голый HasPrefix здесь намеренно не
-// используется: ValueTableExtra и numberish — это строки, а не объявленные
-// типы.
+// formValueTypeKnown повторяет фактическое распознавание типов формы.
+// Примитивы регистронезависимы и распознаются по префиксу, как
+// typeFormAttrValue и typedempty.FromFormType: в частности, decimal(15) из
+// канонического импорта 1С остаётся числом, а dateTime — датой. Ссылочные
+// префиксы регистрозависимы, как attrRefEntityName.
 func formValueTypeKnown(typeRef string) bool {
 	t := strings.TrimSpace(typeRef)
-	switch {
-	case strings.EqualFold(t, "string"),
-		strings.EqualFold(t, "number"),
-		strings.EqualFold(t, "date"),
-		strings.EqualFold(t, "datetime"),
-		strings.EqualFold(t, "bool"),
-		t == "AnyRef":
-		return true
-	case qualifiedPositiveInt(t, "string", 1),
-		qualifiedPositiveInt(t, "decimal", 2):
+	lower := strings.ToLower(t)
+	for _, prefix := range []string{"string", "number", "decimal", "date", "bool"} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	if t == "AnyRef" {
 		return true
 	}
 	for _, prefix := range []string{"CatalogRef.", "DocumentRef.", "EnumRef.", "ChartOfAccountsRef."} {
@@ -128,23 +124,4 @@ func formValueTypeKnown(typeRef string) bool {
 		}
 	}
 	return false
-}
-
-func qualifiedPositiveInt(typeRef, name string, count int) bool {
-	lower := strings.ToLower(typeRef)
-	prefix := name + "("
-	if !strings.HasPrefix(lower, prefix) || !strings.HasSuffix(typeRef, ")") {
-		return false
-	}
-	parts := strings.Split(typeRef[len(prefix):len(typeRef)-1], ",")
-	if len(parts) != count {
-		return false
-	}
-	for i, part := range parts {
-		value, err := strconv.Atoi(strings.TrimSpace(part))
-		if err != nil || value < 0 || (i == 0 && value == 0) {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/configcheck/form_attr_type_check.go
+++ b/internal/configcheck/form_attr_type_check.go
@@ -2,20 +2,12 @@ package configcheck
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/project"
 )
-
-// formAttrKnownTypes — типы реквизита управляемой формы, которые понимает
-// загрузчик (docs/forms.md, раздел «Типы реквизитов»). Список сравнивается по
-// ПРЕФИКСУ: «string(40)» и «decimal(15,2)» — те же типы с квалификаторами,
-// «CatalogRef.Контрагент» — ссылка на конкретный справочник.
-var formAttrKnownTypes = []string{
-	"string", "number", "decimal", "date", "datetime", "bool",
-	"catalogref.", "documentref.", "enumref.", "chartofaccountsref.", "anyref",
-	"valuetable",
-}
 
 // CheckLintFormAttrTypes предупреждает о типе реквизита формы, которого
 // загрузчик не знает.
@@ -37,41 +29,122 @@ func CheckLintFormAttrTypes(proj *project.Project) []Issue {
 	}
 	var issues []Issue
 	for _, ent := range proj.Entities {
-		for _, form := range ent.Forms {
-			label := formFileLabel(ent, form)
-			for _, a := range form.Attributes {
-				if a == nil || strings.TrimSpace(a.TypeRef) == "" {
+		if ent != nil {
+			issues = append(issues, checkFormAttrTypes(ent.Name, ent.Forms)...)
+		}
+	}
+	for _, proc := range proj.Processors {
+		if proc != nil {
+			issues = append(issues, checkFormAttrTypes(proc.Name, proc.Forms)...)
+		}
+	}
+	return issues
+}
+
+func checkFormAttrTypes(owner string, forms []*metadata.FormModule) []Issue {
+	var issues []Issue
+	for _, form := range forms {
+		if form == nil {
+			continue
+		}
+		label := formAttrFileLabel(owner, form)
+		for _, attr := range form.Attributes {
+			if attr == nil || strings.TrimSpace(attr.TypeRef) == "" {
+				continue
+			}
+			if !formAttrTypeKnown(attr.TypeRef) {
+				issues = append(issues, formAttrTypeIssue(label, owner, fmt.Sprintf("реквизита формы %q", attr.Name), attr.TypeRef))
+			}
+			if attr.TypeRef != "ValueTable" {
+				continue
+			}
+			for _, column := range attr.Columns {
+				if column == nil || strings.TrimSpace(column.TypeRef) == "" || formValueTypeKnown(column.TypeRef) {
 					continue
 				}
-				if formAttrTypeKnown(a.TypeRef) {
-					continue
-				}
-				issues = append(issues, Issue{
-					File:   label,
-					Object: ent.Name,
-					Kind:   "Управляемая форма",
-					Code:   "form.attr-type",
-					Message: fmt.Sprintf(
-						"тип реквизита формы %q не распознан (%q): значение придёт в обработчик строкой",
-						a.Name, a.TypeRef),
-					SuggestedFix: "Названия типов латинские: string, string(N), number, decimal(P,S), date, dateTime, bool, " +
-						"CatalogRef.<Справочник>, DocumentRef.<Документ>, EnumRef.<Перечисление>, AnyRef, ValueTable. " +
-						"Русские написания («Строка», «Дата», «Число») загрузчик не понимает.",
-				})
+				where := fmt.Sprintf("колонки %q реквизита формы %q", column.Name, attr.Name)
+				issues = append(issues, formAttrTypeIssue(label, owner, where, column.TypeRef))
 			}
 		}
 	}
 	return issues
 }
 
-// formAttrTypeKnown — распознаётся ли тип реквизита формы. Сравнение по
-// префиксу и без учёта регистра: «Date», «string(40)», «CatalogRef.Склад».
+func formAttrTypeIssue(file, object, where, typeRef string) Issue {
+	return Issue{
+		File:   file,
+		Object: object,
+		Kind:   "Управляемая форма",
+		Code:   "form.attr-type",
+		Message: fmt.Sprintf(
+			"тип %s не распознан (%q): значение придёт в обработчик строкой",
+			where, typeRef),
+		SuggestedFix: "Названия типов латинские: string, string(N), number, decimal(P,S), date, dateTime, bool, " +
+			"CatalogRef.<Справочник>, DocumentRef.<Документ>, EnumRef.<Перечисление>, " +
+			"ChartOfAccountsRef.<ПланСчетов>, AnyRef, ValueTable. " +
+			"Русские написания («Строка», «Дата», «Число») загрузчик не понимает.",
+	}
+}
+
+func formAttrFileLabel(owner string, form *metadata.FormModule) string {
+	name := form.Name
+	if name == "" {
+		name = "объекта"
+	}
+	return "forms/" + strings.ToLower(owner) + "/" + name + ".form.yaml"
+}
+
+// formAttrTypeKnown повторяет документированную грамматику реквизита формы.
+// ValueTable проверяется отдельно и только в точном написании: часть runtime
+// использует EqualFold, но formAttrIsScalar различает его регистрозависимо.
 func formAttrTypeKnown(typeRef string) bool {
-	t := strings.ToLower(strings.TrimSpace(typeRef))
-	for _, known := range formAttrKnownTypes {
-		if strings.HasPrefix(t, known) {
-			return true
+	t := strings.TrimSpace(typeRef)
+	return t == "ValueTable" || formValueTypeKnown(t)
+}
+
+// formValueTypeKnown проверяет скалярные реквизиты и колонки ValueTable.
+// Примитивы регистронезависимы, как typeFormAttrValue; ссылочные префиксы
+// регистрозависимы, как attrRefEntityName. Голый HasPrefix здесь намеренно не
+// используется: ValueTableExtra и numberish — это строки, а не объявленные
+// типы.
+func formValueTypeKnown(typeRef string) bool {
+	t := strings.TrimSpace(typeRef)
+	switch {
+	case strings.EqualFold(t, "string"),
+		strings.EqualFold(t, "number"),
+		strings.EqualFold(t, "date"),
+		strings.EqualFold(t, "datetime"),
+		strings.EqualFold(t, "bool"),
+		t == "AnyRef":
+		return true
+	case qualifiedPositiveInt(t, "string", 1),
+		qualifiedPositiveInt(t, "decimal", 2):
+		return true
+	}
+	for _, prefix := range []string{"CatalogRef.", "DocumentRef.", "EnumRef.", "ChartOfAccountsRef."} {
+		if strings.HasPrefix(t, prefix) {
+			name := t[len(prefix):]
+			return name != "" && name == strings.TrimSpace(name)
 		}
 	}
 	return false
+}
+
+func qualifiedPositiveInt(typeRef, name string, count int) bool {
+	lower := strings.ToLower(typeRef)
+	prefix := name + "("
+	if !strings.HasPrefix(lower, prefix) || !strings.HasSuffix(typeRef, ")") {
+		return false
+	}
+	parts := strings.Split(typeRef[len(prefix):len(typeRef)-1], ",")
+	if len(parts) != count {
+		return false
+	}
+	for i, part := range parts {
+		value, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || value < 0 || (i == 0 && value == 0) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/configcheck/form_attr_type_check_test.go
+++ b/internal/configcheck/form_attr_type_check_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ivantit66/onebase/internal/onec_forms"
 	"github.com/ivantit66/onebase/internal/project"
 )
 
@@ -96,7 +97,7 @@ attributes:
       - { name: Количество, type: number }
       - { name: Цена, type: "decimal(15,2)" }
       - { name: Ссылка, type: CatalogRef.Товары }
-      - { name: Ошибка, type: numberExtra }
+      - { name: Ошибка, type: numericExtra }
 elements: []`)
 
 	proj, err := project.Load(dir)
@@ -106,22 +107,48 @@ elements: []`)
 	defer proj.Close()
 
 	issues := formAttrTypeIssues(CheckLintProject(dir, proj, nil))
-	if len(issues) != 2 {
-		t.Fatalf("ожидалось 2 предупреждения формы обработки, получено %d: %+v", len(issues), issues)
+	if len(issues) != 1 {
+		t.Fatalf("ожидалось 1 предупреждение формы обработки, получено %d: %+v", len(issues), issues)
 	}
-	for _, want := range []string{"Период", "Ошибка"} {
-		found := false
-		for _, got := range issues {
-			if strings.Contains(got.Message, want) {
-				found = true
-				if !strings.Contains(got.File, "forms/проверка/") {
-					t.Errorf("файл = %q, ожидался путь формы обработки", got.File)
-				}
-			}
-		}
-		if !found {
-			t.Errorf("нет предупреждения для %s: %+v", want, issues)
-		}
+	if !strings.Contains(issues[0].Message, "Ошибка") {
+		t.Errorf("предупреждение не относится к неизвестному типу: %+v", issues)
+	}
+	if !strings.Contains(issues[0].File, "forms/проверка/") {
+		t.Errorf("файл = %q, ожидался путь формы обработки", issues[0].File)
+	}
+	if strings.Contains(issues[0].Message, "Период") {
+		t.Errorf("dateSuffix типизируется runtime как дата и не должен считаться строкой: %+v", issues)
+	}
+}
+
+func TestCheckLintFormAttrTypes_AcceptsCanonicalImportedDecimal(t *testing.T) {
+	importedType := onec_forms.Type1CToOneBase("xs:decimal", 15, 0, "")
+	if importedType != "decimal(15)" {
+		t.Fatalf("канонический импорт xs:decimal = %q, ожидался decimal(15)", importedType)
+	}
+
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "processors", "проверка.yaml"), `name: Проверка
+params: []`)
+	mkFile(t, filepath.Join(dir, "forms", "проверка", "основная.form.yaml"), `schema: onebase.form/v1
+form:
+  name: Основная
+  kind: object
+  entity: Проверка
+attributes:
+  - name: Сумма
+    type: "`+importedType+`"
+    save: false
+elements: []`)
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	if issues := formAttrTypeIssues(CheckLintProject(dir, proj, nil)); len(issues) != 0 {
+		t.Fatalf("канонический decimal(15) импорта ошибочно признан строкой: %+v", issues)
 	}
 }
 

--- a/internal/configcheck/form_attr_type_check_test.go
+++ b/internal/configcheck/form_attr_type_check_test.go
@@ -32,11 +32,17 @@ attributes:
   - name: ПоискСклад
     type: CatalogRef.Заявка
     save: false
+  - name: ОпечаткаСсылки
+    type: catalogref.Заявка
+    save: false
   - name: ПоискЧисло
     type: decimal(15,2)
     save: false
   - name: Строки
     type: ValueTable
+    save: false
+  - name: ПочтиТаблица
+    type: ValueTableExtra
     save: false
 elements:
   - kind: ПолеВвода
@@ -49,19 +55,73 @@ elements:
 	}
 	defer proj.Close()
 
-	issues := CheckLintFormAttrTypes(proj)
-	if len(issues) != 1 {
-		t.Fatalf("ожидалось 1 предупреждение (только «Дата»), получено %d: %+v", len(issues), issues)
+	issues := formAttrTypeIssues(CheckLintProject(dir, proj, nil))
+	if len(issues) != 3 {
+		t.Fatalf("ожидалось 3 предупреждения, получено %d: %+v", len(issues), issues)
 	}
-	got := issues[0]
-	if !strings.Contains(got.Message, "ПоискДатаС") || !strings.Contains(got.Message, "Дата") {
-		t.Errorf("сообщение должно называть реквизит и его тип, получено %q", got.Message)
+	for _, want := range []string{"ПоискДатаС", "ОпечаткаСсылки", "ПочтиТаблица"} {
+		found := false
+		for _, got := range issues {
+			if strings.Contains(got.Message, want) {
+				found = true
+				if !strings.Contains(got.File, "forms/заявка/") {
+					t.Errorf("файл = %q, ожидался путь формы", got.File)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("нет предупреждения для %s: %+v", want, issues)
+		}
 	}
-	if got.Code != "form.attr-type" {
-		t.Errorf("код = %q, ожидался form.attr-type", got.Code)
+}
+
+func TestCheckLintFormAttrTypes_ProcessorAndValueTableColumns(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "processors", "проверка.yaml"), `name: Проверка
+params: []`)
+	mkFile(t, filepath.Join(dir, "forms", "проверка", "основная.form.yaml"), `schema: onebase.form/v1
+form:
+  name: Основная
+  kind: object
+  entity: Проверка
+attributes:
+  - name: Период
+    type: dateSuffix
+    save: false
+  - name: Строки
+    type: ValueTable
+    save: false
+    columns:
+      - { name: Текст, type: string }
+      - { name: Количество, type: number }
+      - { name: Цена, type: "decimal(15,2)" }
+      - { name: Ссылка, type: CatalogRef.Товары }
+      - { name: Ошибка, type: numberExtra }
+elements: []`)
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
 	}
-	if !strings.Contains(got.File, "forms/заявка/") {
-		t.Errorf("файл = %q, ожидался путь формы", got.File)
+	defer proj.Close()
+
+	issues := formAttrTypeIssues(CheckLintProject(dir, proj, nil))
+	if len(issues) != 2 {
+		t.Fatalf("ожидалось 2 предупреждения формы обработки, получено %d: %+v", len(issues), issues)
+	}
+	for _, want := range []string{"Период", "Ошибка"} {
+		found := false
+		for _, got := range issues {
+			if strings.Contains(got.Message, want) {
+				found = true
+				if !strings.Contains(got.File, "forms/проверка/") {
+					t.Errorf("файл = %q, ожидался путь формы обработки", got.File)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("нет предупреждения для %s: %+v", want, issues)
+		}
 	}
 }
 
@@ -92,7 +152,17 @@ elements:
 	}
 	defer proj.Close()
 
-	if issues := CheckLintFormAttrTypes(proj); len(issues) != 0 {
+	if issues := formAttrTypeIssues(CheckLintProject(dir, proj, nil)); len(issues) != 0 {
 		t.Fatalf("ожидалось 0 предупреждений, получено %d: %+v", len(issues), issues)
 	}
+}
+
+func formAttrTypeIssues(issues []Issue) []Issue {
+	var result []Issue
+	for _, issue := range issues {
+		if issue.Code == "form.attr-type" {
+			result = append(result, issue)
+		}
+	}
+	return result
 }

--- a/internal/configcheck/form_attr_type_check_test.go
+++ b/internal/configcheck/form_attr_type_check_test.go
@@ -1,0 +1,98 @@
+package configcheck
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ivantit66/onebase/internal/project"
+)
+
+// Нераспознанный тип реквизита формы не ошибка и не пустое место: значение
+// приходит в обработчик СТРОКОЙ. «Дата» по-русски выглядит рабочей, а ведёт
+// себя как строка — предупреждение делает это видимым.
+func TestCheckLintFormAttrTypes(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "documents", "заявка.yaml"), `name: Заявка
+fields:
+  - name: Улица
+    type: string`)
+	mkFile(t, filepath.Join(dir, "forms", "заявка", "формаобъекта.form.yaml"), `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заявка
+attributes:
+  - name: ПоискУлица
+    type: string
+    save: false
+  - name: ПоискДатаС
+    type: Дата
+    save: false
+  - name: ПоискСклад
+    type: CatalogRef.Заявка
+    save: false
+  - name: ПоискЧисло
+    type: decimal(15,2)
+    save: false
+  - name: Строки
+    type: ValueTable
+    save: false
+elements:
+  - kind: ПолеВвода
+    name: ПолеУлица
+    data_path: Объект.Улица`)
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	issues := CheckLintFormAttrTypes(proj)
+	if len(issues) != 1 {
+		t.Fatalf("ожидалось 1 предупреждение (только «Дата»), получено %d: %+v", len(issues), issues)
+	}
+	got := issues[0]
+	if !strings.Contains(got.Message, "ПоискДатаС") || !strings.Contains(got.Message, "Дата") {
+		t.Errorf("сообщение должно называть реквизит и его тип, получено %q", got.Message)
+	}
+	if got.Code != "form.attr-type" {
+		t.Errorf("код = %q, ожидался form.attr-type", got.Code)
+	}
+	if !strings.Contains(got.File, "forms/заявка/") {
+		t.Errorf("файл = %q, ожидался путь формы", got.File)
+	}
+}
+
+// Пустой тип пропускаем: его отдельно разбирает импорт форм 1С, и дублировать
+// то же предупреждение из линта незачем.
+func TestCheckLintFormAttrTypes_EmptyTypeSilent(t *testing.T) {
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "documents", "заявка.yaml"), `name: Заявка
+fields:
+  - name: Улица
+    type: string`)
+	mkFile(t, filepath.Join(dir, "forms", "заявка", "формаобъекта.form.yaml"), `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заявка
+attributes:
+  - name: БезТипа
+    save: false
+elements:
+  - kind: ПолеВвода
+    name: ПолеУлица
+    data_path: Объект.Улица`)
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	defer proj.Close()
+
+	if issues := CheckLintFormAttrTypes(proj); len(issues) != 0 {
+		t.Fatalf("ожидалось 0 предупреждений, получено %d: %+v", len(issues), issues)
+	}
+}

--- a/internal/configcheck/lint.go
+++ b/internal/configcheck/lint.go
@@ -67,6 +67,7 @@ func CheckLintProject(dir string, proj *project.Project, roles []*auth.Role) []I
 	issues = append(issues, CheckLintRoles(dir, proj, roles)...)
 	issues = append(issues, CheckLintIndexes(proj)...)
 	issues = append(issues, CheckLintReports(proj)...)
+	issues = append(issues, CheckLintFormAttrTypes(proj)...)
 	return issues
 }
 

--- a/internal/ui/form_attr_values_test.go
+++ b/internal/ui/form_attr_values_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/onec_forms"
 	"github.com/ivantit66/onebase/internal/runtime"
 )
 
@@ -114,6 +115,41 @@ func TestFormEvent_StringAttrRoundTrip(t *testing.T) {
 	}
 	if got != "привет!" {
 		t.Fatalf("мутация обработчика не вернулась: %v", got)
+	}
+}
+
+// Канонический decimal(15) из импорта 1С и дата с runtime-префиксом проходят
+// через настоящий form-event и видны DSL типизированными, а не строками.
+func TestFormEvent_ImportedDecimalAndDatePrefixKeepRuntimeTypes(t *testing.T) {
+	s, ent, _ := attrEventServer(t, `
+Процедура ПолеТипыПриИзменении()
+	Сообщить(ТипЗнч(Объект.Сумма) + "/" + ТипЗнч(Объект.Период));
+КонецПроцедуры
+`)
+	importedType := onec_forms.Type1CToOneBase("xs:decimal", 15, 0, "")
+	if importedType != "decimal(15)" {
+		t.Fatalf("канонический импорт xs:decimal = %q, ожидался decimal(15)", importedType)
+	}
+	form := ent.Forms[0]
+	form.Attributes = append(form.Attributes,
+		&metadata.FormAttribute{Name: "Сумма", TypeRef: importedType, Save: false},
+		&metadata.FormAttribute{Name: "Период", TypeRef: "dateSuffix", Save: false},
+	)
+	form.Elements = append(form.Elements, &metadata.FormElement{
+		Kind: metadata.FormElementField, Name: "ПолеТипы", DataPath: "Сумма",
+		Handlers: map[metadata.FormEventType]string{metadata.FormEventOnChange: "ПолеТипыПриИзменении"},
+	})
+
+	rec := executeFormEvent(t, s, ent, url.Values{
+		"_element":     {"ПолеТипы"},
+		"_event":       {"ПриИзменении"},
+		"Наименование": {"Тест"},
+		"Сумма":        {"12,50"},
+		"Период":       {"2026-09-09"},
+	})
+	resp := decodeFormEventResponse(t, rec.Body.Bytes())
+	if len(resp.Messages) != 1 || resp.Messages[0] != "Число/Дата" {
+		t.Fatalf("runtime-типы реквизитов формы = %v, ожидались [Число/Дата]", resp.Messages)
 	}
 }
 


### PR DESCRIPTION
## Дефект

Тип реквизита управляемой формы, которого загрузчик не знает, — не ошибка и не пустое место: значение приходит в обработчик **строкой**.

Реквизит с типом `Дата` (по-русски, как написано всё остальное в конфигурации) молча ведёт себя как строка: сравнение с датой не срабатывает, арифметика дат не работает, а поле на форме выглядит рабочим. Ссылочный тип в русском написании вдобавок теряет пикер — варианты выбора собираются только для `CatalogRef.`/`DocumentRef.`.

Поймано на прикладной конфигурации: реквизиты формы объявлены `Строка`, и это работает **по случайности** (нераспознанный тип и есть строка), а рядом `Дата` уже не работает. Разницы при этом не видно ниоткуда: ни ошибки, ни предупреждения, ни пустого поля.

## Что сделано

Линт-проверка `form.attr-type`: тип реквизита формы сверяется со списком из `docs/forms.md` («Типы реквизитов»), сравнение по префиксу и без учёта регистра — `string(40)`, `decimal(15,2)`, `CatalogRef.Склад` распознаются. Подсказка перечисляет допустимые написания и прямо говорит, что русские названия загрузчик не понимает.

**Предупреждение, а не ошибка.** Незнакомый тип сегодня работает как строка, и конфигурации этим пользуются; ломать их сборкой значило бы наказать за то, что платформа сама разрешала. Ошибкой это стоит делать отдельно, если список типов когда-нибудь закроют.

## Проверено

- `TestCheckLintFormAttrTypes` — `Дата` даёт ровно одно предупреждение с именем реквизита, кодом и путём формы; `string`, `decimal(15,2)`, `CatalogRef.X`, `ValueTable` молчат.
- `TestCheckLintFormAttrTypes_EmptyTypeSilent` — пустой тип не дублирует предупреждение импорта форм 1С.
- `go test ./internal/configcheck/` — зелёный.
- Все девять конфигураций `examples/` — **ноль** срабатываний: шума линт не добавил.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
