### PR TITLE
fix(dsl): у ссылки одно представление, каким бы поиском её ни получили

### DIFF
--- a/internal/storage/match_field_test.go
+++ b/internal/storage/match_field_test.go
@@ -70,8 +70,8 @@ func TestMatchCatalogByField(t *testing.T) {
 		if id == "" {
 			t.Error("ожидался id найденной записи")
 		}
-		if display != "7701234567" {
-			t.Errorf("display=%q, want значение реквизита", display)
+		if display != "ООО Ромашка" {
+			t.Errorf("display=%q, want представление записи", display)
 		}
 	})
 

--- a/internal/storage/predefined.go
+++ b/internal/storage/predefined.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -511,24 +512,17 @@ func (db *DB) GetPredefinedIDStr(ctx context.Context, entityName, predefinedName
 
 // FindCatalogByField looks up a single catalog row by exact match of fieldName.
 // Returns (id, displayValue, true) on hit; ("", "", false, nil) when not found.
-// displayValue is the matched field's value — handy for building a *Ref.
-// fieldName lookup is case-insensitive against entity.Fields names.
+// displayValue is the row's PRESENTATION (metadata.RowLabel) — not the matched
+// field's value. fieldName lookup is case-insensitive against entity.Fields names.
 func (db *DB) FindCatalogByField(ctx context.Context, entity *metadata.Entity, fieldName, value string) (string, string, bool, error) {
-	var field *metadata.Field
-	for i := range entity.Fields {
-		if strings.EqualFold(entity.Fields[i].Name, fieldName) {
-			field = &entity.Fields[i]
-			break
-		}
+	sel, err := newLabelSelect(entity, fieldName)
+	if err != nil {
+		return "", "", false, err
 	}
-	if field == nil {
-		return "", "", false, fmt.Errorf("entity %s has no field %q", entity.Name, fieldName)
-	}
-	col := metadata.ColumnName(*field)
-	table := metadata.TableName(entity.Name)
 	d := db.dialect
 	rows, err := db.Query(ctx,
-		fmt.Sprintf(`SELECT id, %s FROM %s WHERE %s = %s LIMIT 1`, col, table, col, d.Placeholder(1)),
+		fmt.Sprintf(`SELECT id, %s FROM %s WHERE %s = %s LIMIT 1`,
+			strings.Join(sel.columns, ", "), metadata.TableName(entity.Name), sel.searchColumn, d.Placeholder(1)),
 		value,
 	)
 	if err != nil {
@@ -538,19 +532,30 @@ func (db *DB) FindCatalogByField(ctx context.Context, entity *metadata.Entity, f
 	if !rows.Next() {
 		return "", "", false, nil
 	}
-	var idStr, display string
-	if err := rows.Scan(&idStr, &display); err != nil {
-		return "", "", false, fmt.Errorf("find %s.%s scan: %w", entity.Name, fieldName, err)
+	idStr, display, serr := sel.scan(rows)
+	if serr != nil {
+		return "", "", false, fmt.Errorf("find %s.%s scan: %w", entity.Name, fieldName, serr)
 	}
 	return idStr, display, true, nil
 }
 
-// ListCatalogMatchesByField returns every matching row in deterministic order.
-// It is used when row-level access is active: callers must check each row
-// before deciding whether the result is absent, unique, or ambiguous. Returning
-// only LIMIT 1 or COUNT(*) would either hide a later visible row or disclose the
-// number of rows that the current user cannot read.
-func (db *DB) ListCatalogMatchesByField(ctx context.Context, entity *metadata.Entity, fieldName, value string) ([]string, []string, error) {
+// labelSelect — выборка «идентификатор + представление» для поиска по реквизиту.
+//
+// ПРЕДСТАВЛЕНИЕ, А НЕ НАЙДЕННОЕ ЗНАЧЕНИЕ. Раньше сюда подставлялась колонка, по
+// которой искали, и ссылка от НайтиПоРеквизиту("Код", …) печаталась КОДОМ, а та
+// же самая ссылка, прочитанная реквизитом объекта, — НАИМЕНОВАНИЕМ. Строка() от
+// одной и той же ссылки давала разное в зависимости от того, как её получили:
+// сравнение Строка(А) = Строка(Б) молча не сходилось, а сообщение оператору
+// печатало «TG-FRIDGE» вместо «Холодильники». Представление у ссылки одно, и
+// считает его metadata.RowLabel — тот же, что у списков и подбора.
+type labelSelect struct {
+	columns      []string         // колонки после id: кандидаты представления
+	fields       []metadata.Field // им соответствующие реквизиты (по порядку)
+	searchColumn string           // колонка условия поиска
+	entity       *metadata.Entity // для RowLabel
+}
+
+func newLabelSelect(entity *metadata.Entity, fieldName string) (*labelSelect, error) {
 	var field *metadata.Field
 	for i := range entity.Fields {
 		if strings.EqualFold(entity.Fields[i].Name, fieldName) {
@@ -559,12 +564,70 @@ func (db *DB) ListCatalogMatchesByField(ctx context.Context, entity *metadata.En
 		}
 	}
 	if field == nil {
-		return nil, nil, fmt.Errorf("entity %s has no field %q", entity.Name, fieldName)
+		return nil, fmt.Errorf("entity %s has no field %q", entity.Name, fieldName)
 	}
-	col := metadata.ColumnName(*field)
-	table := metadata.TableName(entity.Name)
+	sel := &labelSelect{searchColumn: metadata.ColumnName(*field), entity: entity}
+	seen := map[string]bool{}
+	add := func(f metadata.Field) {
+		col := metadata.ColumnName(f)
+		if seen[col] {
+			return
+		}
+		seen[col] = true
+		sel.columns = append(sel.columns, col)
+		sel.fields = append(sel.fields, f)
+	}
+	for _, f := range metadata.LabelFields(entity) {
+		add(f)
+	}
+	// Запасной вариант — найденное поле: у справочника может не быть ни одного
+	// строкового реквизита, и тогда без него ссылка осталась бы вовсе безымянной.
+	add(*field)
+	return sel, nil
+}
+
+// scan читает строку выборки и собирает представление правилом RowLabel.
+func (s *labelSelect) scan(rows Rows) (string, string, error) {
+	values := make([]any, 0, len(s.columns)+1)
+	var idStr string
+	values = append(values, &idStr)
+	cells := make([]sql.NullString, len(s.columns))
+	for i := range cells {
+		values = append(values, &cells[i])
+	}
+	if err := rows.Scan(values...); err != nil {
+		return "", "", err
+	}
+	row := map[string]any{"id": idStr}
+	for i, f := range s.fields {
+		if cells[i].Valid {
+			row[f.Name] = cells[i].String
+		}
+	}
+	display := metadata.RowLabel(row, s.entity)
+	if strings.TrimSpace(display) == "" || display == idStr {
+		// RowLabel уходит в идентификатор, когда представлять нечем; для ссылки
+		// понятнее найденное значение, чем UUID.
+		if last := len(cells) - 1; last >= 0 && cells[last].Valid && strings.TrimSpace(cells[last].String) != "" {
+			display = cells[last].String
+		}
+	}
+	return idStr, display, nil
+}
+
+// ListCatalogMatchesByField returns every matching row in deterministic order.
+// It is used when row-level access is active: callers must check each row
+// before deciding whether the result is absent, unique, or ambiguous. Returning
+// only LIMIT 1 or COUNT(*) would either hide a later visible row or disclose the
+// number of rows that the current user cannot read.
+func (db *DB) ListCatalogMatchesByField(ctx context.Context, entity *metadata.Entity, fieldName, value string) ([]string, []string, error) {
+	sel, err := newLabelSelect(entity, fieldName)
+	if err != nil {
+		return nil, nil, err
+	}
 	rows, err := db.Query(ctx,
-		fmt.Sprintf(`SELECT id, %s FROM %s WHERE %s = %s ORDER BY id`, col, table, col, db.dialect.Placeholder(1)),
+		fmt.Sprintf(`SELECT id, %s FROM %s WHERE %s = %s ORDER BY id`,
+			strings.Join(sel.columns, ", "), metadata.TableName(entity.Name), sel.searchColumn, db.dialect.Placeholder(1)),
 		value,
 	)
 	if err != nil {
@@ -573,9 +636,9 @@ func (db *DB) ListCatalogMatchesByField(ctx context.Context, entity *metadata.En
 	defer rows.Close()
 	var ids, displays []string
 	for rows.Next() {
-		var id, display string
-		if err := rows.Scan(&id, &display); err != nil {
-			return nil, nil, fmt.Errorf("list matches %s.%s scan: %w", entity.Name, fieldName, err)
+		id, display, serr := sel.scan(rows)
+		if serr != nil {
+			return nil, nil, fmt.Errorf("list matches %s.%s scan: %w", entity.Name, fieldName, serr)
 		}
 		ids = append(ids, id)
 		displays = append(displays, display)

--- a/internal/storage/predefined.go
+++ b/internal/storage/predefined.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -521,8 +520,8 @@ func (db *DB) FindCatalogByField(ctx context.Context, entity *metadata.Entity, f
 	}
 	d := db.dialect
 	rows, err := db.Query(ctx,
-		fmt.Sprintf(`SELECT id, %s FROM %s WHERE %s = %s LIMIT 1`,
-			strings.Join(sel.columns, ", "), metadata.TableName(entity.Name), sel.searchColumn, d.Placeholder(1)),
+		fmt.Sprintf(`SELECT %s FROM %s WHERE %s = %s LIMIT 1`,
+			sel.selectList(), metadata.TableName(entity.Name), sel.searchColumn, d.Placeholder(1)),
 		value,
 	)
 	if err != nil {
@@ -580,39 +579,53 @@ func newLabelSelect(entity *metadata.Entity, fieldName string) (*labelSelect, er
 	for _, f := range metadata.LabelFields(entity) {
 		add(f)
 	}
-	// Запасной вариант — найденное поле: у справочника может не быть ни одного
-	// строкового реквизита, и тогда без него ссылка осталась бы вовсе безымянной.
-	add(*field)
+	// RowLabel строит синтетическую подпись документа из дат и чисел, если
+	// строкового представления нет. Выборка обязана дать ей те же данные, что
+	// полная строка в списках и пикерах; искомое ссылочное поле таким кандидатом
+	// не является.
+	if entity.Kind == metadata.KindDocument && len(entity.Presentation) == 0 {
+		for _, f := range entity.Fields {
+			if f.Type == metadata.FieldTypeDate || f.Type == metadata.FieldTypeNumber {
+				add(f)
+			}
+		}
+	}
 	return sel, nil
+}
+
+func (s *labelSelect) selectList() string {
+	if len(s.columns) == 0 {
+		return "id"
+	}
+	return "id, " + strings.Join(s.columns, ", ")
 }
 
 // scan читает строку выборки и собирает представление правилом RowLabel.
 func (s *labelSelect) scan(rows Rows) (string, string, error) {
+	return s.scanWithTail(rows)
+}
+
+// scanWithTail дополнительно читает служебные колонки после полей
+// представления (например, COUNT(*) в safe-match).
+func (s *labelSelect) scanWithTail(rows Rows, tail ...any) (string, string, error) {
 	values := make([]any, 0, len(s.columns)+1)
 	var idStr string
 	values = append(values, &idStr)
-	cells := make([]sql.NullString, len(s.columns))
+	cells := make([]any, len(s.columns))
 	for i := range cells {
 		values = append(values, &cells[i])
 	}
+	values = append(values, tail...)
 	if err := rows.Scan(values...); err != nil {
 		return "", "", err
 	}
 	row := map[string]any{"id": idStr}
 	for i, f := range s.fields {
-		if cells[i].Valid {
-			row[f.Name] = cells[i].String
+		if cells[i] != nil {
+			row[f.Name] = normalizeFieldValue(f, cells[i])
 		}
 	}
-	display := metadata.RowLabel(row, s.entity)
-	if strings.TrimSpace(display) == "" || display == idStr {
-		// RowLabel уходит в идентификатор, когда представлять нечем; для ссылки
-		// понятнее найденное значение, чем UUID.
-		if last := len(cells) - 1; last >= 0 && cells[last].Valid && strings.TrimSpace(cells[last].String) != "" {
-			display = cells[last].String
-		}
-	}
-	return idStr, display, nil
+	return idStr, metadata.RowLabel(row, s.entity), nil
 }
 
 // ListCatalogMatchesByField returns every matching row in deterministic order.
@@ -626,8 +639,8 @@ func (db *DB) ListCatalogMatchesByField(ctx context.Context, entity *metadata.En
 		return nil, nil, err
 	}
 	rows, err := db.Query(ctx,
-		fmt.Sprintf(`SELECT id, %s FROM %s WHERE %s = %s ORDER BY id`,
-			strings.Join(sel.columns, ", "), metadata.TableName(entity.Name), sel.searchColumn, db.dialect.Placeholder(1)),
+		fmt.Sprintf(`SELECT %s FROM %s WHERE %s = %s ORDER BY id`,
+			sel.selectList(), metadata.TableName(entity.Name), sel.searchColumn, db.dialect.Placeholder(1)),
 		value,
 	)
 	if err != nil {
@@ -657,17 +670,11 @@ func (db *DB) ListCatalogMatchesByField(ctx context.Context, entity *metadata.En
 // все совпадения (1 round-trip и 1 сканирование вместо прежних двух).
 // fieldName сопоставляется без учёта регистра.
 func (db *DB) MatchCatalogByField(ctx context.Context, entity *metadata.Entity, fieldName, value string) (string, string, int, error) {
-	var field *metadata.Field
-	for i := range entity.Fields {
-		if strings.EqualFold(entity.Fields[i].Name, fieldName) {
-			field = &entity.Fields[i]
-			break
-		}
+	sel, err := newLabelSelect(entity, fieldName)
+	if err != nil {
+		return "", "", 0, err
 	}
-	if field == nil {
-		return "", "", 0, fmt.Errorf("entity %s has no field %q", entity.Name, fieldName)
-	}
-	return db.matchCatalogByExpression(ctx, entity, metadata.ColumnName(*field), fieldName, value)
+	return db.matchCatalogByExpression(ctx, entity, sel, fieldName, value)
 }
 
 // MatchCatalogByPresentation ищет по фактическому явно заданному
@@ -738,7 +745,7 @@ func (db *DB) MatchCatalogByPresentation(ctx context.Context, entity *metadata.E
 	return "", "", count, nil
 }
 
-func (db *DB) matchCatalogByExpression(ctx context.Context, entity *metadata.Entity, expression, fieldLabel, value string) (string, string, int, error) {
+func (db *DB) matchCatalogByExpression(ctx context.Context, entity *metadata.Entity, sel *labelSelect, fieldLabel, value string) (string, string, int, error) {
 	table := metadata.TableName(entity.Name)
 	d := db.dialect
 	// Один запрос: LIMIT 1 берёт id/представление первой записи, а вложенный
@@ -747,8 +754,8 @@ func (db *DB) matchCatalogByExpression(ctx context.Context, entity *metadata.Ent
 	// Два плейсхолдера (а не повтор одного) — универсально для PostgreSQL ($1/$2)
 	// и SQLite (?, ?).
 	rows, err := db.Query(ctx,
-		fmt.Sprintf(`SELECT id, %s, (SELECT COUNT(*) FROM %s WHERE %s = %s) FROM %s WHERE %s = %s LIMIT 1`,
-			expression, table, expression, d.Placeholder(1), table, expression, d.Placeholder(2)),
+		fmt.Sprintf(`SELECT %s, (SELECT COUNT(*) FROM %s WHERE %s = %s) FROM %s WHERE %s = %s LIMIT 1`,
+			sel.selectList(), table, sel.searchColumn, d.Placeholder(1), table, sel.searchColumn, d.Placeholder(2)),
 		value, value,
 	)
 	if err != nil {
@@ -758,9 +765,9 @@ func (db *DB) matchCatalogByExpression(ctx context.Context, entity *metadata.Ent
 		rows.Close()
 		return "", "", 0, nil // 0 совпадений
 	}
-	var idStr, display string
 	cnt := 0
-	if err := rows.Scan(&idStr, &display, &cnt); err != nil {
+	idStr, display, err := sel.scanWithTail(rows, &cnt)
+	if err != nil {
 		rows.Close()
 		return "", "", 0, fmt.Errorf("match %s.%s scan: %w", entity.Name, fieldLabel, err)
 	}

--- a/internal/storage/ref_presentation_matrix_test.go
+++ b/internal/storage/ref_presentation_matrix_test.go
@@ -1,0 +1,95 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dbtest"
+	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/storage"
+)
+
+// Поиск по реквизиту обязан строить ту же подпись, что списки и пикеры, на
+// обоих диалектах. В частности, поле поиска не становится скрытым fallback, а
+// синтетическая подпись документа получает нужные ей даты и числа.
+func TestFieldLookupPresentationMatrix(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		ctx := context.Background()
+
+		t.Run("explicit presentation does not fall back to search field", func(t *testing.T) {
+			entity := &metadata.Entity{
+				Name:         "LookupPresentation" + uuid.NewString()[:8],
+				Kind:         metadata.KindCatalog,
+				Presentation: []string{"Артикул"},
+				Fields: []metadata.Field{
+					{Name: "Артикул", Type: metadata.FieldTypeString},
+					{Name: "Код", Type: metadata.FieldTypeString},
+				},
+			}
+			if err := db.Migrate(ctx, []*metadata.Entity{entity}); err != nil {
+				t.Fatalf("Migrate: %v", err)
+			}
+			id, err := db.WriteCatalogRecord(ctx, entity, "", map[string]any{"Артикул": "", "Код": "K-1"})
+			if err != nil {
+				t.Fatalf("WriteCatalogRecord: %v", err)
+			}
+
+			assertFieldLookupLabels(t, db, entity, "Код", "K-1", id)
+		})
+
+		t.Run("document uses date and number fallback", func(t *testing.T) {
+			owners := &metadata.Entity{
+				Name: "LookupOwners" + uuid.NewString()[:8], Kind: metadata.KindCatalog,
+				Fields: []metadata.Field{{Name: "Наименование", Type: metadata.FieldTypeString}},
+			}
+			doc := &metadata.Entity{
+				Name: "LookupDocument" + uuid.NewString()[:8], Kind: metadata.KindDocument,
+				Fields: []metadata.Field{
+					{Name: "Владелец", Type: metadata.FieldType("reference:" + owners.Name), RefEntity: owners.Name},
+					{Name: "Дата", Type: metadata.FieldTypeDate},
+					{Name: "Сумма", Type: metadata.FieldTypeNumber},
+				},
+			}
+			if err := db.Migrate(ctx, []*metadata.Entity{owners, doc}); err != nil {
+				t.Fatalf("Migrate: %v", err)
+			}
+			ownerID := uuid.New()
+			if err := db.Upsert(ctx, owners.Name, ownerID, map[string]any{"Наименование": "Владелец"}, owners); err != nil {
+				t.Fatalf("Upsert owner: %v", err)
+			}
+			docID := uuid.New()
+			if err := db.Upsert(ctx, doc.Name, docID, map[string]any{
+				"Владелец": ownerID,
+				"Дата":     time.Date(2026, time.September, 9, 12, 30, 0, 0, time.UTC),
+				"Сумма":    125,
+			}, doc); err != nil {
+				t.Fatalf("Upsert document: %v", err)
+			}
+
+			assertFieldLookupLabels(t, db, doc, "Владелец", ownerID.String(), "09.09.2026 · 125")
+		})
+	})
+}
+
+func assertFieldLookupLabels(t *testing.T, db *storage.DB, entity *metadata.Entity, field, value, want string) {
+	t.Helper()
+	ctx := context.Background()
+
+	id, display, found, err := db.FindCatalogByField(ctx, entity, field, value)
+	if err != nil {
+		t.Fatalf("FindCatalogByField: %v", err)
+	}
+	if !found || id == "" || display != want {
+		t.Fatalf("FindCatalogByField = (%q, %q, %v), want nonempty id and %q", id, display, found, want)
+	}
+
+	ids, displays, err := db.ListCatalogMatchesByField(ctx, entity, field, value)
+	if err != nil {
+		t.Fatalf("ListCatalogMatchesByField: %v", err)
+	}
+	if len(ids) != 1 || len(displays) != 1 || ids[0] != id || displays[0] != want {
+		t.Fatalf("ListCatalogMatchesByField = (%v, %v), want ([%s], [%s])", ids, displays, id, want)
+	}
+}

--- a/internal/ui/dsl_findbycode_test.go
+++ b/internal/ui/dsl_findbycode_test.go
@@ -185,4 +185,8 @@ func TestFindByField_RefPresentationIsEntityLabel(t *testing.T) {
 	if byName != byCode {
 		t.Errorf("НайтиПоНаименованию дал %q, а НайтиПоКоду %q", byName, byCode)
 	}
+	safeMatch := call(`Справочники.Контрагенты.ПроверитьСовпадениеПоРеквизиту("Код", "К-000042").Ссылка`)
+	if safeMatch != byCode {
+		t.Errorf("ПроверитьСовпадениеПоРеквизиту дал %q, а НайтиПоКоду %q", safeMatch, byCode)
+	}
 }

--- a/internal/ui/dsl_findbycode_test.go
+++ b/internal/ui/dsl_findbycode_test.go
@@ -9,6 +9,7 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -153,5 +154,35 @@ func TestFindByCode_NoArgumentIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "не указано значение") {
 		t.Errorf("невнятное сообщение: %v", err)
+	}
+}
+
+// Представление ссылки ОДНО, каким бы поиском её ни получили. Раньше сюда
+// подставлялось найденное значение, и Строка() от ссылки печатала то, по чему
+// искали: НайтиПоКоду давал «К-000042», а та же ссылка из реквизита объекта —
+// «Альфа». Сравнение Строка(А) = Строка(Б) на этом молча не сходилось, а
+// сообщение оператору показывало код вместо наименования.
+func TestFindByField_RefPresentationIsEntityLabel(t *testing.T) {
+	s, ctx, _ := findByCodeServer(t)
+	call := func(expr string) string {
+		t.Helper()
+		got, err := runFindDSL(t, s, ctx, "Функция Тест()\n  Возврат Строка("+expr+");\nКонецФункции")
+		if err != nil {
+			t.Fatalf("%s: %v", expr, err)
+		}
+		return strings.TrimSpace(fmt.Sprintf("%v", got))
+	}
+
+	byCode := call(`Справочники.Контрагенты.НайтиПоКоду("К-000042")`)
+	if byCode != "Альфа" {
+		t.Errorf("НайтиПоКоду → Строка() = %q, ожидалось представление «Альфа»", byCode)
+	}
+	byField := call(`Справочники.Контрагенты.НайтиПоРеквизиту("Код", "К-000042")`)
+	if byField != byCode {
+		t.Errorf("НайтиПоРеквизиту дал %q, а НайтиПоКоду %q — представление у ссылки должно быть одно", byField, byCode)
+	}
+	byName := call(`Справочники.Контрагенты.НайтиПоНаименованию("Альфа")`)
+	if byName != byCode {
+		t.Errorf("НайтиПоНаименованию дал %q, а НайтиПоКоду %q", byName, byCode)
 	}
 }


### PR DESCRIPTION
## Дефект

`Строка()` от ссылки печатает **разное** в зависимости от того, как ссылку добыли:

```bsl
Гр = Справочники.ТоварнаяГруппа.НайтиПоРеквизиту("Код", "TG-FRIDGE");
Сообщить(Строка(Гр));                       // TG-FRIDGE
Сообщить(Строка(Объект.ТоварнаяГруппа));    // Холодильники   ← та же ссылка
```

Тип у обеих один (`СправочникСсылка.ТоварнаяГруппа`), и по коду разница не видна ниоткуда.

Цена — не косметика. Сравнение `Строка(А) = Строка(Б)` на таких ссылках молча не сходится: поймано на тесте прикладной конфигурации, где тест обвинял **рабочий** код в том, что подстановка не сработала. А сообщение оператору показывает код вместо наименования.

## Причина

`FindCatalogByField` выбирал `id, <колонка поиска>` и клал найденное значение в `Ref.Name` — в комментарии это прямо названо «displayValue is the matched field's value — handy for building a *Ref». То есть представлением становилось то, **по чему** искали.

## Что сделано

Обе функции поиска — `FindCatalogByField` и `ListCatalogMatchesByField` (вторая — путь с построчным доступом) — выбирают кандидатов представления и считают его тем же `metadata.RowLabel`, что списки, подбор и формы: явный `presentation`, иначе правило по именам. Зависимость представления от поля поиска полностью убрана. Если у справочника нет строковых кандидатов представления, используется штатный крайний fallback `metadata.RowLabel` — `id`.

## Что изменится у конфигураций

`Строка(НайтиПоКоду(…))` и `Строка(НайтиПоРеквизиту(…))` теперь дают наименование, а не искомое значение. Это и есть 1С-поведение (представление ссылки), и оно совпадает с тем, что уже показывают списки и подбор. Полагаться на прежнее мог только код, печатавший ссылку вместо самого значения, которое у него и так на руках.

## Проверено

- `TestFindByField_RefPresentationIsEntityLabel` — три способа найти одну запись (по коду, по реквизиту, по наименованию) дают **одно** представление «Альфа». Тест идёт через ту же точку, что модуль конфигурации: разбор текста и исполнение интерпретатором с реальными объектами доступа.
- Зелёные: `internal/storage`, `internal/ui`, `internal/dsl/...`, `internal/configcheck`, `internal/entityservice`, `internal/query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
