### PR TITLE
fix(ui): сохранять раскладку условно скрытых элементов

### DIFF
--- a/internal/ui/managed_dynamic_anchor_test.go
+++ b/internal/ui/managed_dynamic_anchor_test.go
@@ -18,7 +18,10 @@ import (
 func managedDynamicAnchorEntity() *metadata.Entity {
 	entity := &metadata.Entity{
 		Name: "ЗаявкаСДинамическимОформлением", Kind: metadata.KindCatalog,
-		Fields: []metadata.Field{{Name: "Стадия", Type: metadata.FieldTypeString}},
+		Fields: []metadata.Field{
+			{Name: "Стадия", Type: metadata.FieldTypeString},
+			{Name: "Срочно", Type: metadata.FieldTypeBool},
+		},
 	}
 	whenAccepted := `Стадия = "Принята"`
 	form := &metadata.FormModule{
@@ -31,6 +34,7 @@ func managedDynamicAnchorEntity() *metadata.Entity {
 			{Kind: metadata.FormElementLabel, Name: "НадписьСтатуса", TitleMap: map[string]string{"ru": "Черновик"}, HiddenWhen: whenAccepted},
 			{Kind: metadata.FormElementPicture, Name: "КартинкаСФайлом", Picture: "logo.png", HiddenWhen: whenAccepted},
 			{Kind: metadata.FormElementPicture, Name: "КартинкаБезФайла", HiddenWhen: whenAccepted},
+			{Kind: metadata.FormElementCheckbox, Name: "ФлажокСрочно", DataPath: "Объект.Срочно", HiddenWhen: whenAccepted},
 			{Kind: metadata.FormElementCommandBar, Name: "ПанельКоманд", ReadOnlyWhen: whenAccepted},
 			{Kind: metadata.FormElementField, Name: "ПолеСтадии", DataPath: "Объект.Стадия"},
 		},
@@ -101,7 +105,7 @@ func managedDescendantButton(root *html.Node) *html.Node {
 
 func TestManagedDynamicAnchorsRenderThroughPublicForm(t *testing.T) {
 	draft := renderManagedDynamicAnchorPage(t, "Черновик")
-	for _, name := range []string{"НадписьСтатуса", "КартинкаСФайлом", "КартинкаБезФайла", "ПанельКоманд"} {
+	for _, name := range []string{"НадписьСтатуса", "КартинкаСФайлом", "КартинкаБезФайла", "ФлажокСрочно", "ПанельКоманд"} {
 		if managedAnchorNode(t, draft, name) == nil {
 			t.Errorf("draft form has no dynamic-state anchor %q", name)
 		}
@@ -115,7 +119,7 @@ func TestManagedDynamicAnchorsRenderThroughPublicForm(t *testing.T) {
 	}
 
 	accepted := renderManagedDynamicAnchorPage(t, "Принята")
-	for _, name := range []string{"НадписьСтатуса", "КартинкаСФайлом", "КартинкаБезФайла"} {
+	for _, name := range []string{"НадписьСтатуса", "КартинкаСФайлом", "КартинкаБезФайла", "ФлажокСрочно"} {
 		if managedAnchorNode(t, accepted, name) != nil {
 			t.Errorf("server render did not hide %q", name)
 		}

--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -439,7 +439,12 @@ window.obManagedApplyTablePartRefOptions = obManagedApplyTablePartRefOptions;
     var hidden = st.hidden || {};
     Object.keys(hidden).forEach(function (name) {
       var el = byName(name);
-      if (el) el.style.display = hidden[name] ? 'none' : '';
+      if (!el) return;
+      // Some managed elements keep their layout only in an inline display
+      // declaration (checkbox and command bar use flex). Remember that value
+      // before the first state update instead of erasing it on hidden=false.
+      if (!Object.prototype.hasOwnProperty.call(el, '_obDisplay')) el._obDisplay = el.style.display || '';
+      el.style.display = hidden[name] ? 'none' : el._obDisplay;
     });
     var ro = st.readonly || {};
     Object.keys(ro).forEach(function (name) {

--- a/internal/ui/static/managed_dynamic_anchor_behavior_test.js
+++ b/internal/ui/static/managed_dynamic_anchor_behavior_test.js
@@ -99,23 +99,38 @@ function anchor(app, name) {
 test('event state hides decorations and locks the real command bar', () => {
   const app = boot();
   const decorations = ['НадписьСтатуса', 'КартинкаСФайлом', 'КартинкаБезФайла'];
+  const dynamic = decorations.concat('ФлажокСрочно', 'ПанельКоманд');
+  const checkbox = anchor(app, 'ФлажокСрочно');
   const panel = anchor(app, 'ПанельКоманд');
   const buttons = panel.querySelectorAll('button');
   assert.ok(buttons.length > 0, 'fixture has no real command-bar buttons');
+  assert.equal(checkbox.style.display, 'flex');
+  assert.equal(panel.style.display, 'flex');
+
+  // The first event includes false values for every declared hidden_when.
+  // Applying that response must not erase an inline layout declaration.
+  app.applyElementStates({
+    hidden: Object.fromEntries(dynamic.map((name) => [name, false]))
+  });
+  for (const name of decorations) assert.equal(anchor(app, name).style.display, '');
+  assert.equal(checkbox.style.display, 'flex');
+  assert.equal(panel.style.display, 'flex');
 
   app.applyElementStates({
-    hidden: Object.fromEntries(decorations.concat('ПанельКоманд').map((name) => [name, true])),
+    hidden: Object.fromEntries(dynamic.map((name) => [name, true])),
     readonly: {ПанельКоманд: true}
   });
   for (const name of decorations) assert.equal(anchor(app, name).style.display, 'none');
+  assert.equal(checkbox.style.display, 'none');
   assert.equal(panel.style.display, 'none');
   for (const button of buttons) assert.equal(button.disabled, true);
 
   app.applyElementStates({
-    hidden: Object.fromEntries(decorations.concat('ПанельКоманд').map((name) => [name, false])),
+    hidden: Object.fromEntries(dynamic.map((name) => [name, false])),
     readonly: {ПанельКоманд: false}
   });
   for (const name of decorations) assert.equal(anchor(app, name).style.display, '');
-  assert.equal(panel.style.display, '');
+  assert.equal(checkbox.style.display, 'flex');
+  assert.equal(panel.style.display, 'flex');
   for (const button of buttons) assert.equal(button.disabled, false);
 });


### PR DESCRIPTION
## Что сделано

- `applyElementStates` запоминает исходный inline-`display` элемента до первого обновления и восстанавливает его при `hidden=false`.
- Регрессионный тест через production-рендер управляемой формы проверяет командную панель и флажок с `display:flex`, включая первый ответ события с ложным условием.
- Элементы без inline-`display` сохраняют прежнее поведение.

## Почему

Пустая строка удаляла inline-объявление и переводила флажок и командную панель из flex-раскладки в `display:block` даже при ложном `hidden_when`.

## Проверки

- `go build ./...`
- `go test -count=1 ./internal/ui`
- `go test -count=1 ./...`
- `git diff --check`

Fixes #1344