### PR TITLE
fix(pipeline): не терять PR с ship без доказательств

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -442,6 +442,10 @@ func analyze(prs []apiPull, owner string) report {
 			case currentCompletions > 0:
 				item.Stage = "merge"
 				result.MergeCandidates = append(result.MergeCandidates, item)
+			default:
+				result.HumanWaiting = append(result.HumanWaiting, item)
+				result.add("yellow", "ship_without_current_review_proof", pr.Number,
+					"ship есть, но доказательств ревью текущего HEAD нет при существующей истории протокола; нужен человек")
 			}
 			continue
 		}

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -402,6 +402,20 @@ func TestShipOnUnmarkedAuthorPushIsNotCarriedIntoReview(t *testing.T) {
 	}
 }
 
+func TestShipWithProtocolHistoryButNoCompletionsIsVisible(t *testing.T) {
+	item := testPR(7, headA, "ship")
+	item = addComment(item, 40, syncIntent(headB, 20, 25, 30))
+	item = addComment(item, 41, syncDone(40, headB, headB))
+
+	got := analyze([]apiPull{item}, "ivanarama")
+	if len(got.HumanWaiting) != 1 || got.HumanWaiting[0].Number != 7 {
+		t.Fatalf("ship PR disappeared from every queue: %+v", got)
+	}
+	if !hasFinding(got, "ship_without_current_review_proof") {
+		t.Fatalf("ship PR disappeared without a finding: %+v", got)
+	}
+}
+
 func testIssue(number int, comments ...apiComment) apiIssue {
 	return apiIssue{Number: number, Title: "Issue", HTMLURL: "https://example.test/issue", CreatedAt: "2026-09-01T00:00:00Z", UpdatedAt: "2026-09-02T00:00:00Z", State: "open", Thread: comments}
 }


### PR DESCRIPTION
## Что исправлено

- `pipelinehealth` направляет PR с `ship`, историей протокола и без доказательств ревью текущего HEAD в `human_waiting`.
- Для состояния добавлен yellow finding `ship_without_current_review_proof`, чтобы зелёный отчёт не скрывал остановившийся PR.
- Регрессионный тест воспроизводит старую base-sync историю без completion и проверяет очередь и finding.

## Почему

Раньше непокрытая комбинация проходила `switch` без единого `case`, после чего `continue` исключал PR из всех очередей. Явный fallback делает неизвестное состояние видимым человеку и не выдаёт его автоматически REVIEW или MERGE.

## Проверки

- `go build ./...`
- `go test ./tools/pipelinehealth ./internal/pipelinecontract`
- `go test ./...`

Fixes #1345