### PR TITLE
fix(ui): синхронизировать адрес вкладки после записи

### DIFF
--- a/internal/ui/static/managed.js
+++ b/internal/ui/static/managed.js
@@ -953,7 +953,13 @@ window.obManagedApplyTablePartRefOptions = obManagedApplyTablePartRefOptions;
         var idInput = document.querySelector('#main-form [name="_id"]');
         if (idInput) idInput.value = DOC_ID;
         if (window.history && history.replaceState) {
-          history.replaceState(null, '', location.pathname.replace(/\/new$/, '/' + DOC_ID));
+          var savedURL = location.pathname.replace(/\/new$/, '/' + DOC_ID);
+          history.replaceState(null, '', savedURL);
+          try {
+            if (window.parent && window.parent !== window) {
+              window.parent.postMessage({source: 'obFrameURLChanged', url: savedURL}, location.origin);
+            }
+          } catch (_) {}
         }
         window._obFormDirty = false;
       }

--- a/internal/ui/static/managed_file_reader_behavior_test.js
+++ b/internal/ui/static/managed_file_reader_behavior_test.js
@@ -287,6 +287,44 @@ test('immediate click waits for the current file read', async () => {
   assert.equal(new URLSearchParams(fetchBodies[0]).get('Upload'), 'instant contents');
 });
 
+test('saving a new managed form notifies the tab shell after history replacement', async () => {
+  resetDOM();
+  const originalFetch = global.fetch;
+  const originalHistory = global.history;
+  const originalLocation = global.location;
+  const originalParent = global.parent;
+  const messages = [];
+  const replacements = [];
+  global.location = {origin: 'http://127.0.0.1:8080', pathname: '/ui/document/purchase/new'};
+  global.history = {
+    replaceState(_state, _title, url) {
+      replacements.push(url);
+      global.location.pathname = url;
+    }
+  };
+  global.parent = {
+    postMessage(data, targetOrigin) { messages.push({data, targetOrigin}); }
+  };
+  global.fetch = async (_url, options) => {
+    fetchBodies.push(options.body.toString());
+    return {json: async () => ({savedId: '42', messages: []})};
+  };
+  try {
+    await window.obFire('Save', 'Нажатие');
+    assert.deepEqual(replacements, ['/ui/document/purchase/42']);
+    assert.deepEqual(messages, [{
+      data: {source: 'obFrameURLChanged', url: '/ui/document/purchase/42'},
+      targetOrigin: 'http://127.0.0.1:8080'
+    }]);
+  } finally {
+    global.fetch = originalFetch;
+    global.history = originalHistory;
+    global.location = originalLocation;
+    if (originalParent === undefined) delete global.parent;
+    else global.parent = originalParent;
+  }
+});
+
 test('obFire re-syncs grid state after waiting for FileReader', async () => {
   resetDOM();
   FakeFileReader.instances = [];

--- a/internal/ui/static/tabs_behavior_test.js
+++ b/internal/ui/static/tabs_behavior_test.js
@@ -178,6 +178,17 @@ function shell(storage, search = '') {
       frame.contentWindow.location = {href};
       frame.dispatch('load');
     },
+    replaceWithoutLoad(index, href) {
+      const frame = frames()[index];
+      frame.contentWindow.location = {href};
+      for (const listener of windowListeners.get('message') || []) {
+        listener({
+          origin: context.location.origin,
+          source: frame.contentWindow,
+          data: {source: 'obFrameURLChanged', url: href}
+        });
+      }
+    },
     denyLocation(index) {
       const frame = frames()[index];
       Object.defineProperty(frame.contentWindow, 'location', {
@@ -260,6 +271,27 @@ test('same-origin iframe navigation refreshes persistence, restore and URL dedup
   app.open(createURL, 'Purchase again');
   assert.equal(app.count(), 2);
   assert.deepEqual(savedTabs(storage).map(tab => tab.url), [listURL, createURL]);
+});
+
+test('history replacement refreshes persistence, restore and URL deduplication without iframe load', () => {
+  const storage = new FakeStorage();
+  const createURL = '/ui/document/purchase/new';
+  const cardURL = '/ui/document/purchase/42';
+  let app = shell(storage);
+  app.open(createURL, 'Purchase');
+
+  app.replaceWithoutLoad(0, cardURL);
+  assert.equal(savedTabs(storage)[0].url, cardURL);
+  assert.equal(savedActive(storage).url, cardURL);
+
+  app = shell(storage);
+  assert.equal(app.count(), 1);
+  assert.equal(app.activeIndex(), 0);
+  assert.equal(savedTabs(storage)[0].url, cardURL);
+
+  app.open(createURL, 'Purchase again');
+  assert.equal(app.count(), 2);
+  assert.deepEqual(savedTabs(storage).map(tab => tab.url), [cardURL, createURL]);
 });
 
 test('duplicate uses the refreshed URL and unsafe frame locations are ignored', () => {

--- a/internal/ui/tabs.go
+++ b/internal/ui/tabs.go
@@ -137,10 +137,10 @@ const tplAppShell = `{{define "page-app-shell"}}
     document.body.appendChild(m);
     setTimeout(function(){ document.addEventListener('click',function rm(){ m.remove(); document.removeEventListener('click',rm); }); },0);
   }
-  function syncFrameURL(t){
+  function syncFrameURL(t,href){
     var next='';
     try{
-      var current=new URL(String(t.frame.contentWindow.location.href||''),location.origin);
+      var current=new URL(String(href||t.frame.contentWindow.location.href||''),location.origin);
       if(current.origin!==location.origin)return;
       next=current.pathname+current.search+current.hash;
     }catch(e){return;}
@@ -180,6 +180,7 @@ const tplAppShell = `{{define "page-app-shell"}}
     var d=ev.data; if(!d||typeof d!=='object')return;
     if(d.source==='obOpenTab' && d.url){ var ou=String(d.url); if(!openable(ou))return; openTab(ou, d.title?String(d.title):'Форма', {allowDup:!!d.allowDup}); }
     else if(d.source==='obCloseTab'){ var ct=tabByWindow(ev.source); if(ct)closeTab(ct); }
+    else if(d.source==='obFrameURLChanged' && d.url){ var ut=tabByWindow(ev.source); if(ut)syncFrameURL(ut,String(d.url)); }
     else if(d.source==='obSetTitle' && active && d.title){ active.title=String(d.title); active.label.textContent=active.title; active.btn.title=active.title; persist(); }
     else if(d.source==='obDirty'){ var dt=tabByWindow(ev.source); if(dt){ dt.dirty=!!d.dirty; dt.btn.classList.toggle('dirty',dt.dirty); } } // фаза 3
   });


### PR DESCRIPTION
## Что сделано

- Управляемая форма после `history.replaceState` сообщает оболочке вкладок новый адрес.
- Оболочка принимает обновление только от своего origin и окна известного iframe, затем применяет существующие проверки `syncFrameURL` и `openable`.
- Поведенческие тесты проверяют отправку события настоящим `obFire`, восстановление после F5 и дедупликацию без события `load`.

## Почему

Запись новой формы меняла адрес внутри iframe без перезагрузки. Оболочка продолжала хранить `/new`, поэтому F5 восстанавливал пустую форму, а повторное открытие ошибочно дедуплицировалось со старой вкладкой.

Вариант: 1 (комментарий человека #5576426018)

## Проверки

- `go test -count=1 ./internal/ui -run 'Test(TabsBehaviorInNode|ManagedFileReaderBehaviorInNode)$'`
- `go test -count=1 ./internal/ui`
- `go build ./...`
- `go test -count=1 ./...`
- `git diff --check`

Fixes #1347