### PR TITLE
fix(pipeline): сверять маршрут триажа с метками

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"crypto/sha256"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -31,6 +32,7 @@ var (
 	baseSyncIntent    = regexp.MustCompile(`(?m)^<!-- pp:base-sync-intent from=([0-9a-f]{40}) base=([0-9a-f]{40}) review-comment=([0-9]+) claim=([0-9]+) completion=([0-9]+) ship-event=([A-Za-z0-9_=-]+) previous=([0-9]+|none) -->$`)
 	baseSyncDone      = regexp.MustCompile(`(?m)^<!-- pp:base-sync-done intent=([0-9]+) from=([0-9a-f]{40}) to=([0-9a-f]{40}) base=([0-9a-f]{40}) previous=([0-9]+|none) ship-event=([A-Za-z0-9_=-]+) -->$`)
 	triageRouteClaim  = regexp.MustCompile(`(?m)^<!-- pp:triage-route-claim fingerprint-sha256=([0-9a-f]{64}) owner=[0-9a-fA-F-]{36} -->$`)
+	triageRouteRecord = regexp.MustCompile(`(?m)(^pp-triage-route-v1\nissue=([0-9]+)\nissue-updated=[^\n]+\ntitle-sha256=[0-9a-f]{64}\nbody-sha256=[0-9a-f]{64}\nanalysis-sha256=[0-9a-f]{64}\ncomments-sha256=[0-9a-f]{64}\nlabels-sha256=[0-9a-f]{64}\nevents-watermark=(?:[0-9]+|none)\nclass=(?:bug|enhancement|question|documentation)\nroute=(ready-fix|needs-decision)\nmanual=(?:true|false)\nreply=(required|none)\n)`)
 	triageRouteLabels = regexp.MustCompile(`(?m)^<!-- pp:triage-route-labels claim=([0-9]+) fingerprint-sha256=([0-9a-f]{64}) .+ -->$`)
 	triageAuthorReply = regexp.MustCompile(`(?m)^<!-- pp:triage-author-reply claim=([0-9]+) fingerprint-sha256=([0-9a-f]{64}) -->$`)
 	triageRouteDone   = regexp.MustCompile(`(?m)^<!-- pp:triage-route-done claim=([0-9]+) fingerprint-sha256=([0-9a-f]{64}) -->$`)
@@ -510,6 +512,25 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 		}
 
 		labels := labelSet(issue.Labels)
+		route := inspectTriageRoute(issue, owner)
+		routeFinding := false
+		routeMismatch := false
+		if route.hasClaim && !route.ready {
+			result.addIssue("yellow", "fix_issue_not_executable", issue.Number, route.reason)
+			routeFinding = true
+		}
+		if route.hasClaim && route.ready {
+			switch {
+			case route.route == "ready-fix" && labels["needs-decision"] && !labels["approved"]:
+				routeMismatch = true
+				result.addIssue("yellow", "triage_route_label_mismatch", issue.Number,
+					"TRIAGE route=ready-fix, но issue помечена needs-decision без последующего approved")
+			case route.route == "needs-decision" && labels["ready-fix"] && !labels["approved"]:
+				routeMismatch = true
+				result.addIssue("yellow", "triage_route_label_mismatch", issue.Number,
+					"TRIAGE route=needs-decision, но issue помечена ready-fix без следов решения человека")
+			}
+		}
 		priority, prioritySource := queuePriority(labels, issue.CreatedAt, now)
 		item := candidate{
 			Number: issue.Number, Title: issue.Title, URL: issue.HTMLURL,
@@ -517,6 +538,11 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 			UpdatedAt: issue.UpdatedAt,
 		}
 		if labels["hold"] || labels["manual"] {
+			continue
+		}
+		if routeMismatch {
+			item.Stage = "human-decision"
+			result.HumanWaiting = append(result.HumanWaiting, item)
 			continue
 		}
 		switch {
@@ -532,9 +558,10 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 			if labels["in-work"] || issueReferencedByOpenPull(issue.Number, prs) {
 				continue
 			}
-			ready, reason := triageHandoffReady(issue, owner)
-			if !ready {
-				result.addIssue("yellow", "fix_issue_not_executable", issue.Number, reason)
+			if !route.ready {
+				if !routeFinding {
+					result.addIssue("yellow", "fix_issue_not_executable", issue.Number, route.reason)
+				}
 				continue
 			}
 			result.FixCandidates = append(result.FixCandidates, item)
@@ -558,10 +585,24 @@ func issueReferencedByOpenPull(number int, prs []apiPull) bool {
 	return false
 }
 
-func triageHandoffReady(issue apiIssue, owner string) (bool, string) {
+type triageRouteState struct {
+	hasClaim bool
+	ready    bool
+	route    string
+	reason   string
+}
+
+func inspectTriageRoute(issue apiIssue, owner string) triageRouteState {
+	thread := append([]apiComment(nil), issue.Thread...)
+	sort.SliceStable(thread, func(i, j int) bool {
+		if thread[i].CreatedAt == thread[j].CreatedAt {
+			return thread[i].ID < thread[j].ID
+		}
+		return thread[i].CreatedAt < thread[j].CreatedAt
+	})
 	var root *apiComment
-	for index := range issue.Thread {
-		comment := &issue.Thread[index]
+	for index := range thread {
+		comment := &thread[index]
 		if !trustedUnedited(*comment, owner) || !hasExactLine(comment.Body, "<!-- pp:triage -->") {
 			continue
 		}
@@ -571,20 +612,34 @@ func triageHandoffReady(issue apiIssue, owner string) (bool, string) {
 		}
 	}
 	if root == nil {
-		return false, "eligible FIX issue has no canonical trusted triage"
+		return triageRouteState{reason: "eligible FIX issue has no canonical trusted triage"}
 	}
 	if !strings.Contains(root.Body, "pp:triage-route-claim") {
-		return true, ""
+		return triageRouteState{ready: true}
 	}
+	state := triageRouteState{hasClaim: true}
+	normalized := strings.ReplaceAll(root.Body, "\r\n", "\n")
 	claims := triageRouteClaim.FindAllStringSubmatch(root.Body, -1)
 	if len(claims) != 1 {
-		return false, "canonical triage has a malformed route claim"
+		state.reason = "canonical triage has a malformed route claim"
+		return state
 	}
 	fingerprint := claims[0][1]
+	records := triageRouteRecord.FindAllStringSubmatch(normalized, -1)
+	if len(records) != 1 || fmt.Sprintf("%x", sha256.Sum256([]byte(records[0][1]))) != fingerprint {
+		state.reason = "canonical triage route record is malformed or its fingerprint does not match"
+		return state
+	}
+	recordIssue, err := strconv.Atoi(records[0][2])
+	if err != nil || recordIssue != issue.Number {
+		state.reason = "canonical triage route record names another issue"
+		return state
+	}
+	state.route = records[0][3]
 	claimID := strconv.FormatInt(root.ID, 10)
 	labelsCommitted, replyCommitted, done := false, false, false
-	replyRequired := hasExactLine(root.Body, "reply=required")
-	for _, comment := range issue.Thread {
+	replyRequired := records[0][4] == "required"
+	for _, comment := range thread {
 		if !trustedUnedited(comment, owner) || comment.CreatedAt < root.CreatedAt ||
 			(comment.CreatedAt == root.CreatedAt && comment.ID <= root.ID) {
 			continue
@@ -606,9 +661,11 @@ func triageHandoffReady(issue apiIssue, owner string) (bool, string) {
 		}
 	}
 	if !done {
-		return false, "TRIAGE route claim is unfinished; FIX must wait for matching labels/reply/done markers"
+		state.reason = "TRIAGE route claim is unfinished; FIX must wait for matching labels/reply/done markers"
+		return state
 	}
-	return true, ""
+	state.ready = true
+	return state
 }
 
 func hasExactLine(body, line string) bool {

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -594,6 +594,7 @@ func TestPublicCommandReportsRouteMismatchesAndUnfinishedHumanRoute(t *testing.T
 		t.Fatal(err)
 	}
 
+	//nolint:gosec // The executable and flags are fixed; variable arguments are test-owned temporary paths.
 	command := exec.Command("go", "run", ".", "-json", "-prs", prsPath, "-issues", issuesPath,
 		"-contract", filepath.Join("..", "..", ".claude", "skills", "review-queue", "SKILL.md"))
 	output, err := command.CombinedOutput()

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -420,6 +425,23 @@ func issueComment(id int64, body string) apiComment {
 		User: apiUser{Login: "ivanarama"}, Body: body}
 }
 
+func triageRouteRoot(issue int, id int64, route string) (apiComment, string) {
+	record := fmt.Sprintf("pp-triage-route-v1\nissue=%d\nissue-updated=2026-09-01T00:00:00Z\ntitle-sha256=%s\nbody-sha256=%s\nanalysis-sha256=%s\ncomments-sha256=%s\nlabels-sha256=%s\nevents-watermark=1\nclass=bug\nroute=%s\nmanual=false\nreply=none\n",
+		issue, epoch, epoch, epoch, epoch, epoch, route)
+	fingerprint := fmt.Sprintf("%x", sha256.Sum256([]byte(record)))
+	body := fmt.Sprintf("<!-- pp:triage -->\n%s<!-- pp:triage-route-claim fingerprint-sha256=%s owner=11111111-1111-1111-1111-111111111111 -->", record, fingerprint)
+	return issueComment(id, body), fingerprint
+}
+
+func completedTriageRoute(issue int, route string) []apiComment {
+	root, fingerprint := triageRouteRoot(issue, 10, route)
+	return []apiComment{
+		root,
+		issueComment(11, "<!-- pp:triage-route-labels claim=10 fingerprint-sha256="+fingerprint+" events-through=1 labels-sha256="+epoch+" -->"),
+		issueComment(12, "<!-- pp:triage-route-done claim=10 fingerprint-sha256="+fingerprint+" -->"),
+	}
+}
+
 func TestMojibakeInTriageVisibleTextIsRed(t *testing.T) {
 	broken := issueComment(10, "**РўСЂРёР°Р¶.**\nРљРѕСЂРµРЅСЊ РЅР°Р№РґРµРЅ.\n<!-- pp:triage -->\npp-triage-route-v1")
 	result := analyze(nil, "ivanarama")
@@ -490,13 +512,13 @@ func TestFixQueueExcludesInWorkAndOpenPullReferences(t *testing.T) {
 }
 
 func TestFixQueueRequiresCompletedTriageRoute(t *testing.T) {
-	fingerprint := strings.Repeat("a", 64)
-	root := issueComment(10, "<!-- pp:triage -->\nreply=none\n<!-- pp:triage-route-claim fingerprint-sha256="+fingerprint+" owner=11111111-1111-1111-1111-111111111111 -->")
+	root, fingerprint := triageRouteRoot(30, 10, "ready-fix")
 	unfinished := testIssue(30, root)
 	unfinished.Labels = []apiLabel{{Name: "approved"}}
-	complete := testIssue(31, root,
-		issueComment(11, "<!-- pp:triage-route-labels claim=10 fingerprint-sha256="+fingerprint+" events-through=1 labels-sha256="+fingerprint+" -->"),
-		issueComment(12, "<!-- pp:triage-route-done claim=10 fingerprint-sha256="+fingerprint+" -->"))
+	completeRoot, completeFingerprint := triageRouteRoot(31, 10, "ready-fix")
+	complete := testIssue(31, completeRoot,
+		issueComment(11, "<!-- pp:triage-route-labels claim=10 fingerprint-sha256="+completeFingerprint+" events-through=1 labels-sha256="+fingerprint+" -->"),
+		issueComment(12, "<!-- pp:triage-route-done claim=10 fingerprint-sha256="+completeFingerprint+" -->"))
 	complete.Labels = []apiLabel{{Name: "approved"}}
 	result := analyze(nil, "ivanarama")
 	analyzeIssues(&result, []apiIssue{unfinished, complete}, nil, "ivanarama")
@@ -507,4 +529,93 @@ func TestFixQueueRequiresCompletedTriageRoute(t *testing.T) {
 	if !hasFinding(result, "fix_issue_not_executable") {
 		t.Fatalf("unfinished TRIAGE handoff was not diagnosed: %+v", result.Findings)
 	}
+}
+
+func TestIssueRouteDiagnosticsUseCommittedTriageForAllLabels(t *testing.T) {
+	readyRoute := testIssue(40, completedTriageRoute(40, "ready-fix")...)
+	readyRoute.Labels = []apiLabel{{Name: "needs-decision"}}
+	humanRoute := testIssue(41, completedTriageRoute(41, "needs-decision")...)
+	humanRoute.Labels = []apiLabel{{Name: "ready-fix"}}
+	unfinishedRoot, _ := triageRouteRoot(42, 10, "ready-fix")
+	unfinished := testIssue(42, unfinishedRoot)
+	unfinished.Labels = []apiLabel{{Name: "needs-decision"}}
+
+	result := analyze(nil, "ivanarama")
+	analyzeIssues(&result, []apiIssue{readyRoute, humanRoute, unfinished}, nil, "ivanarama")
+
+	for _, number := range []int{40, 41} {
+		if !hasIssueFinding(result, "triage_route_label_mismatch", number) {
+			t.Fatalf("route mismatch for issue #%d was not diagnosed: %+v", number, result.Findings)
+		}
+	}
+	if !hasIssueFinding(result, "fix_issue_not_executable", 42) {
+		t.Fatalf("unfinished route under needs-decision was hidden: %+v", result.Findings)
+	}
+	if len(result.FixCandidates) != 0 {
+		t.Fatalf("route mismatch leaked into the executable FIX allowlist: %+v", result.FixCandidates)
+	}
+	if len(result.HumanWaiting) != 3 {
+		t.Fatalf("route diagnostics did not preserve human-visible work: %+v", result.HumanWaiting)
+	}
+}
+
+func TestApprovedOverridesCompletedTriageRouteMismatch(t *testing.T) {
+	issue := testIssue(43, completedTriageRoute(43, "needs-decision")...)
+	issue.Labels = []apiLabel{{Name: "ready-fix"}, {Name: "approved"}}
+	result := analyze(nil, "ivanarama")
+	analyzeIssues(&result, []apiIssue{issue}, nil, "ivanarama")
+
+	if hasIssueFinding(result, "triage_route_label_mismatch", 43) ||
+		len(result.FixCandidates) != 1 || result.FixCandidates[0].Number != 43 {
+		t.Fatalf("approved did not override the triage route: %+v", result)
+	}
+}
+
+func TestPublicCommandReportsRouteMismatchesAndUnfinishedHumanRoute(t *testing.T) {
+	readyRoute := testIssue(50, completedTriageRoute(50, "ready-fix")...)
+	readyRoute.Labels = []apiLabel{{Name: "needs-decision"}}
+	humanRoute := testIssue(51, completedTriageRoute(51, "needs-decision")...)
+	humanRoute.Labels = []apiLabel{{Name: "ready-fix"}}
+	unfinishedRoot, _ := triageRouteRoot(52, 10, "ready-fix")
+	unfinished := testIssue(52, unfinishedRoot)
+	unfinished.Labels = []apiLabel{{Name: "needs-decision"}}
+
+	temp := t.TempDir()
+	issuesPath := filepath.Join(temp, "issues.json")
+	prsPath := filepath.Join(temp, "prs.json")
+	issuesJSON, err := json.Marshal([]apiIssue{readyRoute, humanRoute, unfinished})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(issuesPath, issuesJSON, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(prsPath, []byte("[]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command("go", "run", ".", "-json", "-prs", prsPath, "-issues", issuesPath,
+		"-contract", filepath.Join("..", "..", ".claude", "skills", "review-queue", "SKILL.md"))
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pipelinehealth failed: %v\n%s", err, output)
+	}
+	var got report
+	if err := json.Unmarshal(output, &got); err != nil {
+		t.Fatalf("decode pipelinehealth output: %v\n%s", err, output)
+	}
+	if !hasIssueFinding(got, "triage_route_label_mismatch", 50) ||
+		!hasIssueFinding(got, "triage_route_label_mismatch", 51) ||
+		!hasIssueFinding(got, "fix_issue_not_executable", 52) {
+		t.Fatalf("public command hid route diagnostics: %+v", got.Findings)
+	}
+}
+
+func hasIssueFinding(result report, code string, issue int) bool {
+	for _, item := range result.Findings {
+		if item.Code == code && item.Issue == issue {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Что сделано

- `pipelinehealth` проверяет завершённый `pp-triage-route-v1` и сообщает о расхождении `route=` с фактическими метками.
- Незавершённый route-claim теперь виден независимо от того, попала issue в FIX или уже помечена `needs-decision`.
- Несогласованный маршрут не попадает в исполняемый FIX allowlist, а остаётся в очереди человека.
- Публичный регрессионный тест запускает настоящий CLI на fixtures и проверяет оба расхождения и незавершённый handoff.

## Почему

Раньше проверка route-claim выполнялась только внутри ветки FIX, поэтому `needs-decision` могла скрыть незавершённую транзакцию. Само поле `route=` не разбиралось, и завершённый маршрут мог противоречить текущим меткам без сигнала.

## Проверки

- `go test -count=1 ./tools/pipelinehealth`
- `go vet ./tools/pipelinehealth`
- `go build ./...`
- `go test -count=1 ./...`
- `go run ./tools/pipelinehealth -json`
- `git diff --check`

Fixes #1349