### PR TITLE
fix(report): скрыть внутренний тип конструкции формулы

### DIFF
--- a/internal/report/expreval/expreval_test.go
+++ b/internal/report/expreval/expreval_test.go
@@ -221,6 +221,30 @@ func TestEvaluator_ОпасныеКонструкцииОтклоняютсяД�
 	}
 }
 
+func TestEvaluator_ПропущенныйАргументНазванНаЯзыкеПользователя(t *testing.T) {
+	ev := New(interpreter.New(), DefaultProfile())
+	_, _, err := ev.EvalNum(`Строка(1,,2)`, compose.Row{})
+	if err == nil {
+		t.Fatal("формула с пропущенным аргументом принята")
+	}
+	if !strings.Contains(err.Error(), "пропущенный аргумент") {
+		t.Fatalf("ошибка не называет конструкцию языка: %v", err)
+	}
+	if strings.Contains(err.Error(), "MissingArg") || strings.Contains(err.Error(), "*ast.") {
+		t.Fatalf("ошибка раскрывает внутренний тип AST: %v", err)
+	}
+}
+
+func TestForbiddenFormulaExprDescription_НеРаскрываетНеизвестныйТип(t *testing.T) {
+	got := forbiddenFormulaExprDescription(&ast.Ident{})
+	if got != "неподдерживаемое выражение" {
+		t.Fatalf("fallback = %q", got)
+	}
+	if strings.Contains(got, "Ident") || strings.Contains(got, "*ast.") {
+		t.Fatalf("fallback раскрывает внутренний тип AST: %q", got)
+	}
+}
+
 func TestEvaluator_ОшибкаПравилаНеМеняетПорядокСледующихПравил(t *testing.T) {
 	ev := New(interpreter.New(), DefaultProfile())
 	row := compose.Row{"Сумма": float64(150)}

--- a/internal/report/expreval/formula_policy.go
+++ b/internal/report/expreval/formula_policy.go
@@ -156,7 +156,19 @@ func validateFormulaExprN(expr ast.Expr, nodes *int) error {
 	case nil:
 		return fmt.Errorf("пустое выражение формулы отчёта")
 	default:
-		return fmt.Errorf("конструкция %T не разрешена в формуле отчёта", expr)
+		return fmt.Errorf("формула отчёта содержит недопустимую конструкцию: %s", forbiddenFormulaExprDescription(expr))
+	}
+}
+
+// forbiddenFormulaExprDescription keeps implementation type names out of
+// diagnostics shown to report users. The fallback deliberately stays generic:
+// a newly added AST node must remain forbidden without exposing its Go type.
+func forbiddenFormulaExprDescription(expr ast.Expr) string {
+	switch expr.(type) {
+	case *ast.MissingArg:
+		return "пропущенный аргумент"
+	default:
+		return "неподдерживаемое выражение"
 	}
 }
 


### PR DESCRIPTION
## Что исправлено

- запрещённый пропущенный аргумент в формуле отчёта теперь называется пользовательским термином «пропущенный аргумент»;
- fallback для будущих неизвестных AST-конструкций остаётся fail-closed, но больше не раскрывает имя внутреннего Go-типа;
- добавлены регрессионные тесты публичного пути `Evaluator.EvalNum(Строка(1,,2))` и безопасного fallback.

Политика выполнения не менялась: недопустимые конструкции по-прежнему отклоняются до исполнения.

## Проверки

- `go test -count=1 ./internal/report/expreval`;
- `go build ./...`;
- `go test -count=1 ./...`;
- `git diff --check`.

Fixes #1357