### PR TITLE
fix(ui): локализовать подписи меню подсистемы

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -740,7 +740,7 @@ func (s *Server) buildNavFromContents(r *http.Request, contents *metadata.Subsys
 			if !s.can(r, "inforeg", ir.Name, "read") {
 				continue
 			}
-			label := ir.Name
+			label := ir.DisplayName(lang)
 			if ir.Periodic {
 				label += " (" + s.tr(lang, "периодический") + ")"
 			}
@@ -763,10 +763,7 @@ func (s *Server) buildNavFromContents(r *http.Request, contents *metadata.Subsys
 			if !s.can(r, "report", rep.Name, "run") {
 				continue
 			}
-			label := rep.Title
-			if label == "" {
-				label = rep.Name
-			}
+			label := rep.DisplayName(lang)
 			repItems = append(repItems, navItem{Label: label, URL: "/ui/report/" + strings.ToLower(rep.Name) + q})
 		}
 		if len(repItems) > 0 {
@@ -786,10 +783,7 @@ func (s *Server) buildNavFromContents(r *http.Request, contents *metadata.Subsys
 			if !s.can(r, "processor", proc.Name, "run") {
 				continue
 			}
-			label := proc.Title
-			if label == "" {
-				label = proc.Name
-			}
+			label := proc.DisplayName(lang)
 			procItems = append(procItems, navItem{Label: label, URL: "/ui/processor/" + strings.ToLower(proc.Name) + q})
 		}
 		if len(procItems) > 0 {

--- a/internal/ui/subsys_access_test.go
+++ b/internal/ui/subsys_access_test.go
@@ -8,10 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/ivantit66/onebase/internal/auth"
 	"github.com/ivantit66/onebase/internal/metadata"
+	"github.com/ivantit66/onebase/internal/processor"
+	"github.com/ivantit66/onebase/internal/report"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/widget"
 )
@@ -161,6 +164,63 @@ func TestAppShell_HiddenSubsystem_Forbidden(t *testing.T) {
 	s.appShell(rec, reqWithUser("/ui/app?subsystem=Продажи", storekeeperUser()))
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("оболочка вкладок тоже должна гейтить скрытый раздел, получено %d", rec.Code)
+	}
+}
+
+func TestIndex_SubsystemUsesSameLocalizedObjectTitlesAsGlobalHome(t *testing.T) {
+	s := newServerForFormMode(t)
+	s.cfg.Bundle = mustBundle(t, `"Save"`)
+	infoReg := &metadata.InfoRegister{
+		Name: "StockState", Title: "Состояние запасов",
+		Titles: map[string]string{"en": "Stock state"},
+	}
+	rep := &report.Report{
+		Name: "SalesReport", Title: "Отчёт о продажах",
+		Titles: map[string]string{"en": "Sales report"},
+	}
+	proc := &processor.Processor{
+		Name: "Reconcile", Title: "Сверка остатков",
+		Titles: map[string]string{"en": "Reconcile stock"},
+	}
+	s.reg.Load(runtime.LoadOptions{
+		InfoRegs: []*metadata.InfoRegister{infoReg},
+		Reports:  []*report.Report{rep},
+	})
+	s.reg.LoadProcessors([]*processor.Processor{proc})
+	s.reg.LoadSubsystems([]*metadata.Subsystem{{
+		Name: "Operations",
+		Contents: metadata.SubsystemContents{
+			InfoRegs:   []string{infoReg.Name},
+			Reports:    []string{rep.Name},
+			Processors: []string{proc.Name},
+		},
+	}})
+
+	tests := []struct {
+		name string
+		lang string
+		want []string
+	}{
+		{name: "base titles", lang: "ru", want: []string{"Состояние запасов", "Отчёт о продажах", "Сверка остатков"}},
+		{name: "localized titles", lang: "en", want: []string{"Stock state", "Sales report", "Reconcile stock"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s.cfg.Lang = tc.lang
+			for _, target := range []string{"/ui/", "/ui/?subsystem=Operations"} {
+				rec := httptest.NewRecorder()
+				s.index(rec, httptest.NewRequest(http.MethodGet, target, nil))
+				if rec.Code != http.StatusOK {
+					t.Fatalf("GET %s: status = %d, want 200", target, rec.Code)
+				}
+				body := rec.Body.String()
+				for _, label := range tc.want {
+					if !strings.Contains(body, `title="`+label+`"`) {
+						t.Errorf("GET %s: menu does not contain title %q", target, label)
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Что сделано

- Подписи регистра сведений, отчёта и обработки в меню подсистемы теперь используют единый `DisplayName(lang)` с языковым переводом и штатным fallback.
- Добавлен регрессионный тест через HTTP-обработчик главной страницы: базовые и английские подписи сверяются в глобальном и подсистемном меню.

## Проверка

- `go build ./...`
- `go test -count=1 ./internal/ui`
- `go test -count=1 ./...`: все остальные пакеты прошли; `internal/selfupdate` не смог создать намеренно слишком большой тестовый файл из-за нехватки места на системном диске `C:`.

Fixes #1368