### PR TITLE
fix(launcher): ограничить проверку баз таймаутом

### DIFF
--- a/internal/launcher/base_status_cache_test.go
+++ b/internal/launcher/base_status_cache_test.go
@@ -1,7 +1,13 @@
 package launcher
 
 import (
+	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -50,5 +56,78 @@ func TestBaseStatusesCacheAndInvalidate(t *testing.T) {
 	h.baseStatuses([]*Base{b})
 	if t2 := fetched(); t2.Equal(t0) {
 		t.Fatal("после инвалидации статус не перепробован")
+	}
+}
+
+// HTTP-список не должен ждать сетевого таймаута PostgreSQL: медленная база
+// получает короткий UI-deadline, не мешая параллельно проверить остальные
+// строки. Повторный рендер берёт оба результата из кэша.
+func TestIndex_DatabaseStatusProbeRespectsDeadline(t *testing.T) {
+	store := &Store{path: filepath.Join(t.TempDir(), "ibases.yaml")}
+	for _, b := range []*Base{
+		{ID: "slow", Name: "Недоступная", ConfigSource: "database", Port: freePort(t)},
+		{ID: "fast", Name: "Доступная", ConfigSource: "database", Port: freePort(t)},
+	} {
+		if err := store.Add(b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fastDone := make(chan struct{})
+	var calls atomic.Int32
+	var ranInParallel atomic.Bool
+	h := &handler{
+		store:         store,
+		runner:        NewRunner(),
+		statusTimeout: 40 * time.Millisecond,
+		statusReadAppYAML: func(ctx context.Context, b *Base, _ any) error {
+			calls.Add(1)
+			if b.ID == "fast" {
+				close(fastDone)
+				return nil
+			}
+			select {
+			case <-fastDone:
+				ranInParallel.Store(true)
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	render := func() (time.Duration, *httptest.ResponseRecorder) {
+		t.Helper()
+		start := time.Now()
+		rec := httptest.NewRecorder()
+		h.index(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		return time.Since(start), rec
+	}
+
+	elapsed, rec := render()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("index status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("список ждал недоступную базу %s", elapsed)
+	}
+	if !ranInParallel.Load() {
+		t.Fatal("быстрая база не проверилась параллельно с зависшей")
+	}
+	for _, want := range []string{"Недоступная", "Доступная"} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Errorf("в списке нет %q", want)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("первый рендер выполнил %d проб вместо 2", got)
+	}
+
+	if elapsed, rec = render(); rec.Code != http.StatusOK || elapsed > 500*time.Millisecond {
+		t.Fatalf("повторный index: status=%d elapsed=%s", rec.Code, elapsed)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("кэш не сработал: проб=%d, ожидалось 2", got)
 	}
 }

--- a/internal/launcher/handlers.go
+++ b/internal/launcher/handlers.go
@@ -110,8 +110,11 @@ type handler struct {
 	// (`/?sel=`) синхронно и последовательно било по всем базам, и список
 	// заметно тормозил (issue #596, регрессия c434500a). Мутирующие обработчики
 	// (start/stop/…) сбрасывают запись базы, чтобы статус обновился сразу.
-	statusMu    sync.Mutex
-	statusCache map[string]baseStatus
+	statusMu      sync.Mutex
+	statusCache   map[string]baseStatus
+	statusTimeout time.Duration
+	// statusReadAppYAML синхронизирует тест таймаута; в production всегда nil.
+	statusReadAppYAML func(context.Context, *Base, any) error
 	// updateMu serializes every selfupdate state mutation, including the quiet
 	// watcher, so a stale network result cannot erase restart recovery state.
 	updateMu sync.Mutex
@@ -138,7 +141,10 @@ type baseStatus struct {
 // быстрое переключение `/?sel=` укладывается в окно и не перепробует, а лаг
 // индикатора «запущена/остановлена» при этом незаметен (плюс мутирующие действия
 // сбрасывают кэш сразу).
-const baseStatusTTL = 3 * time.Second
+const (
+	baseStatusTTL          = 3 * time.Second
+	baseStatusProbeTimeout = 2 * time.Second
+)
 
 // baseVM — view-модель информационной базы для списка лаунчера: встраивает
 // *Base и дополняет рантайм-полями (запущена ли база, URL, данные из app.yaml).
@@ -202,15 +208,26 @@ func (h *handler) probeBase(b *Base) baseStatus {
 	gate := cfgAuthDBGate(b.ID)
 	gate.RLock()
 	defer gate.RUnlock()
+	timeout := h.statusTimeout
+	if timeout <= 0 {
+		timeout = baseStatusProbeTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	st := baseStatus{running: h.baseRunning(b), fetched: time.Now()}
 	var cfg struct {
 		Name    string `yaml:"name"`
 		Version string `yaml:"version"`
 		Logo    string `yaml:"logo"`
 	}
+	read := readAppYAML
+	if h.statusReadAppYAML != nil {
+		read = h.statusReadAppYAML
+	}
 	// Одна сломанная конфигурация не должна ломать весь список: строка остаётся
 	// пустой, причина уходит в журнал внутри readAppYAML.
-	if err := readAppYAML(context.Background(), b, &cfg); err == nil {
+	if err := read(ctx, b, &cfg); err == nil {
 		st.appName = cfg.Name
 		st.appVersion = cfg.Version
 		st.hasLogo = cfg.Logo != ""


### PR DESCRIPTION
## Что исправлено

- Фоновая проверка каждой базы в списке лаунчера теперь получает двухсекундный UI-deadline.
- Недоступный PostgreSQL больше не держит весь список до сетевого таймаута: строка остаётся доступной с пустыми данными конфигурации.
- HTTP-регрессия проверяет deadline, параллельное завершение доступной базы и повторное использование кэша.

## Почему

`probeBase` вызывал `readAppYAML` с `context.Background()`, и PostgreSQL `Ping` мог ждать сеть без ограничения. Deadline действует только на фоновую пробу списка; запуск и открытие выбранной базы не менялись.

## Проверки

- `go test -race -count=1 ./internal/launcher -run TestIndex_DatabaseStatusProbeRespectsDeadline$`
- `go test -count=1 ./internal/launcher`
- `go build ./...`
- `git diff --check`
- `go test -count=1 ./...` — затронутый `internal/launcher` и остальные пакеты прошли; `internal/selfupdate` ожидаемо отклонил перенесённый на `D:` temp как каталог вне профиля, а `internal/ui` достиг 10-минутного Windows `FlushFileBuffers` timeout.

Fixes #1370