### PR TITLE
fix(ui): вернуть фокус и каретку в поиск после автосабмита списка

### DIFF
--- a/internal/ui/list_search_focus_node_test.go
+++ b/internal/ui/list_search_focus_node_test.go
@@ -1,0 +1,18 @@
+package ui
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestListSearchFocusBehaviorInNode(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is not installed")
+	}
+	cmd := exec.Command(node, "--test", "static/list_search_focus_behavior_test.js") //nolint:gosec // test-only executable resolved by exec.LookPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node list search focus behavior test: %v\n%s", err, output)
+	}
+}

--- a/internal/ui/static/list_search_focus_behavior_test.js
+++ b/internal/ui/static/list_search_focus_behavior_test.js
@@ -1,0 +1,222 @@
+// Фокус и каретка строки поиска после отложенного автосабмита — поведение
+// боевого кода из ui.js.
+//
+// Разметочный тест доказал бы только наличие атрибута `data-ob-auto-submit`, а
+// он был на месте и в сломанном виде: страница перезагружалась, поле теряло
+// фокус, и следующие буквы уходили в горячие клавиши списка. Поэтому здесь
+// исполняется тот же кусок ui.js в поддельном DOM: сначала пользовательский
+// путь «ввод → debounce → отправка», затем загрузка новой страницы.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const uiSource = fs.readFileSync(path.join(__dirname, 'ui.js'), 'utf8');
+
+function slice(from, to) {
+  const start = uiSource.indexOf(from);
+  const end = uiSource.indexOf(to, start);
+  if (start < 0 || end < 0) {
+    throw new Error(`slice not found in ui.js: ${from}`);
+  }
+  return uiSource.slice(start, end);
+}
+
+const restoreSource = slice('// BEGIN onebase-list-search-restore', '// END onebase-list-search-restore');
+const delegatesSource = slice('function obInitListDelegates() {', '\nfunction listSubmit');
+const interactiveSource = slice('function obIsInteractiveTarget', '\nfunction obHasBlockingModal');
+
+function storage() {
+  const data = new Map();
+  const log = [];
+  return {
+    log,
+    getItem(key) { return data.has(key) ? data.get(key) : null; },
+    setItem(key, value) { log.push('set'); data.set(String(key), String(value)); },
+    removeItem(key) { log.push('remove'); data.delete(String(key)); },
+  };
+}
+
+function input(attrs = {}, props = {}) {
+  const attributes = new Map(Object.entries(attrs).map(([k, v]) => [k, String(v)]));
+  const el = {
+    nodeType: 1,
+    tagName: 'INPUT',
+    id: props.id || '',
+    value: props.value === undefined ? '' : props.value,
+    selectionStart: props.selectionStart,
+    selectionEnd: props.selectionEnd,
+    focused: false,
+    range: null,
+    getAttribute(name) { return attributes.has(name) ? attributes.get(name) : null; },
+    focus() { el.focused = true; },
+    setSelectionRange(start, end) { el.range = [start, end]; },
+    closest(selector) {
+      if (selector.includes('[data-ob-auto-submit]') && attributes.has('data-ob-auto-submit')) return el;
+      if (selector.includes('input')) return el;
+      return null;
+    },
+  };
+  el.form = props.form === undefined ? { name: 'list-search-form' } : props.form;
+  return el;
+}
+
+// Одна страница приложения: свой DOM, своя история вызовов, общее на вкладку
+// хранилище передаётся снаружи — ровно так живёт sessionStorage в браузере.
+function page(opts) {
+  const listeners = new Map();
+  const timers = new Map();
+  const calls = [];
+  let nextTimer = 1;
+  const doc = {
+    readyState: 'complete',
+    addEventListener(type, fn) { listeners.set(type, fn); },
+    getElementById(id) { return opts.search && opts.search.id === id ? opts.search : null; },
+  };
+  const sandbox = {
+    document: doc,
+    location: { pathname: opts.pathname },
+    setTimeout(fn) { const id = nextTimer++; timers.set(id, fn); return id; },
+    clearTimeout(id) { timers.delete(id); },
+  };
+  sandbox.window = {
+    document: doc,
+    HTMLFormElement: { prototype: { submit() { calls.push('submit'); } } },
+  };
+  Object.defineProperty(sandbox.window, 'sessionStorage', {
+    get() {
+      if (opts.storageThrows) throw new Error('доступ к данным запрещён');
+      return opts.storage;
+    },
+  });
+  vm.createContext(sandbox);
+  vm.runInContext(restoreSource, sandbox, { filename: 'ui-list-search-restore.js' });
+  vm.runInContext(delegatesSource, sandbox, { filename: 'ui-list-delegates.js' });
+  vm.runInContext(interactiveSource, sandbox, { filename: 'ui-interactive-target.js' });
+  sandbox.obInitListDelegates();
+  return {
+    sandbox,
+    calls,
+    type(target) {
+      listeners.get('input')({ target });
+      for (const [id, fn] of [...timers]) { timers.delete(id); fn(); }
+    },
+    restore() { return sandbox.obRestoreListSearchFocus(); },
+  };
+}
+
+test('каретка запоминается ровно перед отправкой формы', () => {
+  const store = storage();
+  const search = input({ 'data-ob-auto-submit': '320', 'data-ob-list-search': '' },
+    { id: 'ob-list-search', value: 'Иванов', selectionStart: 6, selectionEnd: 6 });
+  const app = page({ pathname: '/ui/catalog/контрагенты', storage: store, search });
+
+  app.type(search);
+
+  assert.deepEqual(app.calls, ['submit'], 'форма не отправилась');
+  // Порядок важен: после submit страница уже уничтожается, сохранять поздно.
+  assert.deepEqual(store.log, ['set'], 'каретка сохранена не одной записью до отправки');
+  assert.deepEqual(JSON.parse(store.getItem('ob-list-search-focus')),
+    { path: '/ui/catalog/контрагенты', start: 6, end: 6 });
+});
+
+test('после перезагрузки той же страницы фокус и каретка возвращаются в поиск', () => {
+  const store = storage();
+  const before = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-list-search', value: 'Ива', selectionStart: 3, selectionEnd: 3 });
+  page({ pathname: '/ui/catalog/контрагенты', storage: store, search: before }).type(before);
+
+  // Новая страница: значение пришло с сервера, фокуса нет.
+  const after = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: 'Ива' });
+  const reloaded = page({ pathname: '/ui/catalog/контрагенты', storage: store, search: after });
+
+  assert.equal(reloaded.restore(), after, 'поиск не найден на новой странице');
+  assert.equal(after.focused, true, 'фокус не вернулся в строку поиска');
+  assert.deepEqual(after.range, [3, 3], 'каретка не восстановлена');
+});
+
+test('отметка одноразовая: повторный показ страницы фокус уже не забирает', () => {
+  const store = storage();
+  const before = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-list-search', value: 'Ива', selectionStart: 3, selectionEnd: 3 });
+  page({ pathname: '/ui/catalog/контрагенты', storage: store, search: before }).type(before);
+
+  const after = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: 'Ива' });
+  const first = page({ pathname: '/ui/catalog/контрагенты', storage: store, search: after });
+  first.restore();
+  after.focused = false;
+  after.range = null;
+
+  const again = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: 'Ива' });
+  const second = page({ pathname: '/ui/catalog/контрагенты', storage: store, search: again });
+  assert.equal(second.restore(), null, 'отметка пережила одну загрузку');
+  assert.equal(again.focused, false, 'фокус забран повторно');
+});
+
+test('другая страница чужой фокус не забирает', () => {
+  const store = storage();
+  const before = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-list-search', value: 'Ива', selectionStart: 3, selectionEnd: 3 });
+  page({ pathname: '/ui/catalog/контрагенты', storage: store, search: before }).type(before);
+
+  const other = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: '' });
+  const elsewhere = page({ pathname: '/ui/document/расходнаянакладная', storage: store, search: other });
+  assert.equal(elsewhere.restore(), null, 'фокус восстановлен на чужой странице');
+  assert.equal(other.focused, false, 'поиск другой страницы получил фокус');
+});
+
+test('обычный переход по ссылке фокус в поиск не переводит', () => {
+  const store = storage();
+  const search = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: '' });
+  const fresh = page({ pathname: '/ui/catalog/контрагенты', storage: store, search });
+  assert.equal(fresh.restore(), null, 'фокус восстановлен без сохранённой отметки');
+  assert.equal(search.focused, false, 'поиск забрал фокус на обычной загрузке');
+});
+
+test('пока фокус в поиске, списковые горячие клавиши молчат', () => {
+  const store = storage();
+  const before = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-list-search', value: 'Ива', selectionStart: 3, selectionEnd: 3 });
+  page({ pathname: '/ui/catalog/контрагенты', storage: store, search: before }).type(before);
+
+  const after = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: 'Ива' });
+  const reloaded = page({ pathname: '/ui/catalog/контрагенты', storage: store, search: after });
+  const restored = reloaded.restore();
+
+  // Тем же предикатом обработчик keydown отсекает Insert и клавиши списка.
+  assert.equal(reloaded.sandbox.obIsInteractiveTarget(restored), true,
+    'продолжение ввода снова уйдёт в горячие клавиши списка');
+});
+
+test('каретка не выходит за пределы значения, пришедшего с сервера', () => {
+  const store = storage();
+  const before = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-list-search', value: 'Иванов', selectionStart: 6, selectionEnd: 6 });
+  page({ pathname: '/ui/catalog/контрагенты', storage: store, search: before }).type(before);
+
+  const after = input({ 'data-ob-auto-submit': '320' }, { id: 'ob-list-search', value: 'Ив' });
+  const reloaded = page({ pathname: '/ui/catalog/контрагенты', storage: store, search: after });
+  reloaded.restore();
+  assert.deepEqual(after.range, [2, 2], 'каретка встала за концом строки');
+});
+
+test('поле автосабмита вне списка каретку не запоминает', () => {
+  const store = storage();
+  const other = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-filter-search', value: 'Ива', selectionStart: 3, selectionEnd: 3 });
+  const app = page({ pathname: '/ui/catalog/контрагенты', storage: store, search: other });
+  app.type(other);
+  assert.deepEqual(app.calls, ['submit'], 'форма не отправилась');
+  assert.deepEqual(store.log, [], 'сохранена каретка чужого поля');
+});
+
+test('запрещённое хранилище не ломает ни отправку, ни загрузку', () => {
+  const search = input({ 'data-ob-auto-submit': '320' },
+    { id: 'ob-list-search', value: 'Ива', selectionStart: 3, selectionEnd: 3 });
+  const app = page({ pathname: '/ui/catalog/контрагенты', storageThrows: true, search });
+  app.type(search);
+  assert.deepEqual(app.calls, ['submit'], 'поиск перестал работать без sessionStorage');
+  assert.equal(app.restore(), null, 'восстановление не пережило отказ хранилища');
+});

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -1639,6 +1639,86 @@ function listActionsBtnClick(e, btn) {
   showListMenu(sel ? listMenuItems(sel) : listMenuNoSel(), r.left, r.bottom);
 }
 
+// BEGIN onebase-list-search-restore
+// Отложенный автосабмит строки поиска — полная навигация: старый документ
+// уничтожается вместе с фокусом и кареткой, поэтому на новой странице поиск
+// ничем не выделен, и следующие набранные буквы уходят уже не в поле, а в
+// горячие клавиши списка (Insert открывал форму создания). Перед самой
+// отправкой запоминаем каретку для текущего адреса, а на загрузке той же
+// страницы возвращаем её. Отметка одноразовая и привязана к pathname: обычный
+// переход по ссылке и возврат назад не должны сами забирать фокус в поиск.
+var OB_LIST_SEARCH_FOCUS = 'ob-list-search-focus';
+
+function obListSearchStorage() {
+  // В приватном режиме и при запрещённых сайту данных бросает сам доступ к
+  // свойству — потерянный фокус не повод ронять поиск целиком.
+  try {
+    return window.sessionStorage || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function obListSearchCaret(raw, max) {
+  var n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return max;
+  return Math.min(Math.floor(n), max);
+}
+
+function obSaveListSearchFocus(input) {
+  if (!input || input.id !== 'ob-list-search') return;
+  var store = obListSearchStorage();
+  if (!store) return;
+  var value = typeof input.value === 'string' ? input.value : '';
+  var start = obListSearchCaret(input.selectionStart, value.length);
+  var end = obListSearchCaret(input.selectionEnd, value.length);
+  try {
+    store.setItem(OB_LIST_SEARCH_FOCUS, JSON.stringify({
+      path: location.pathname,
+      start: start,
+      end: end < start ? start : end,
+    }));
+  } catch (e) {
+    // Переполненное хранилище не должно мешать самому поиску.
+  }
+}
+
+function obRestoreListSearchFocus() {
+  var store = obListSearchStorage();
+  if (!store) return null;
+  var raw = null;
+  try {
+    raw = store.getItem(OB_LIST_SEARCH_FOCUS);
+    // Снимаем отметку сразу: она действует ровно на одну загрузку страницы.
+    if (raw !== null) store.removeItem(OB_LIST_SEARCH_FOCUS);
+  } catch (e) {
+    return null;
+  }
+  if (!raw) return null;
+  var state = null;
+  try {
+    state = JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+  if (!state || state.path !== location.pathname) return null;
+  var input = document.getElementById('ob-list-search');
+  if (!input) return null;
+  var value = typeof input.value === 'string' ? input.value : '';
+  var start = obListSearchCaret(state.start, value.length);
+  var end = obListSearchCaret(state.end, value.length);
+  if (typeof input.focus === 'function') input.focus();
+  if (typeof input.setSelectionRange === 'function') {
+    try {
+      input.setSelectionRange(start, end < start ? start : end);
+    } catch (e) {
+      // Не всякий тип поля умеет каретку; фокус уже возвращён, и этого хватает.
+    }
+  }
+  return input;
+}
+// END onebase-list-search-restore
+
 function obInitListDelegates() {
   if (window.__obListDelegates) return;
   window.__obListDelegates = true;
@@ -1683,6 +1763,8 @@ function obInitListDelegates() {
       // cannot disable the debounced search submission.
       var proto = window.HTMLFormElement && window.HTMLFormElement.prototype;
       var nativeSubmit = proto && typeof proto.submit === 'function' ? proto.submit : null;
+      // Строго до отправки: дальше страница уже уничтожается вместе с кареткой.
+      obSaveListSearchFocus(input);
       if (nativeSubmit) nativeSubmit.call(form);
       else if (typeof form.submit === 'function') form.submit();
     }, delay);
@@ -1767,6 +1849,7 @@ function obInitFeed() {
 
 obReady(function () {
   obInitListDelegates();
+  obRestoreListSearchFocus();
   obInitDOMTables();
   obInitKeyboardShortcuts();
   var firstListRow = obListRows()[0];


### PR DESCRIPTION
## Что сделано

Строка поиска списка помечена `data-ob-auto-submit="320"`, и обработчик в
`internal/ui/static/ui.js` после debounce вызывает нативный `form.submit()` —
это полная навигация. Старый документ уничтожается вместе с фокусом и кареткой,
на новой странице `#ob-list-search` ничем не выделен: дальнейший ввод уходит в
глобальные горячие клавиши списка (Insert открывал форму создания), а запрос
обрывается на первых буквах.

Перед самой отправкой сохраняем каретку для текущего `pathname`
(`obSaveListSearchFocus`), на загрузке той же страницы возвращаем фокус и
позицию в `#ob-list-search` и сразу снимаем отметку (`obRestoreListSearchFocus`).

## Почему так

Реализован вариант Б из заявки (восстановление после навигации), как и написано
в разборе триажа: вариант А (fetch + замена tbody) переписывает весь путь
отрисовки списка вместе с деревом, плиткой, отбором и пагинацией — это отдельная
работа, а не починка потерянного фокуса.

Отметка **одноразовая** и **привязана к адресу** — это и есть ответ на риски из
разбора: обычный переход по ссылке и возврат назад не должны сами забирать фокус
в поиск. Ключ снимается сразу при чтении, а `pathname` сверяется до фокуса.

Сохранение ограничено `#ob-list-search`: другие поля с `data-ob-auto-submit`
(например, фильтры) каретку не запоминают. Доступ к `sessionStorage` обёрнут в
try/catch — в приватном режиме бросает сам доступ к свойству, и поиск не должен
из-за этого ломаться.

## Проверка

`internal/ui/static/list_search_focus_behavior_test.js` (9 тестов, запускается из
Go — `TestListSearchFocusBehaviorInNode`) исполняет **боевые** куски `ui.js` в
поддельном DOM пользовательским путём «ввод → debounce → отправка → загрузка
новой страницы»: порядок «сохранили строго до submit», восстановление фокуса и
каретки, одноразовость отметки, чужой адрес, обычный переход по ссылке, кламп
каретки по значению с сервера, чужое поле автосабмита, отказ хранилища.
Проверка горячих клавиш идёт через тот же предикат `obIsInteractiveTarget`,
которым их отсекает боевой обработчик `keydown`.

Убрал вызов `obSaveListSearchFocus` — падает 4 теста из 9: тест не зелёный на
мёртвом коде.

`gofmt`, `go build ./...`, `go test ./internal/ui/` — зелёные.

Fixes #1371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193qqYBwLbZNGpCBroQks84