### PR TITLE
test(entityservice): матричный тест перевода дублей на обоих диалектах

### DIFF
--- a/internal/entityservice/unique_violation_test.go
+++ b/internal/entityservice/unique_violation_test.go
@@ -3,18 +3,32 @@ package entityservice
 import (
 	"context"
 	"errors"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/ivantit66/onebase/internal/dbtest"
 	"github.com/ivantit66/onebase/internal/dsl/interpreter"
 	"github.com/ivantit66/onebase/internal/metadata"
 	"github.com/ivantit66/onebase/internal/runtime"
 	"github.com/ivantit66/onebase/internal/storage"
 )
 
+// Перевод дубля в человеческий текст обязан работать одинаково на обоих
+// диалектах: распознавание идёт РАЗНЫМИ ветками — SQLite читает текст «UNIQUE
+// constraint failed: таблица.колонка», PostgreSQL сверяет имя ограничения из
+// SQLSTATE 23505 с вычисленным stableIndexName (`internal/storage/code_unique.go`).
+// Пока тест гонялся только на SQLite, PG-ветка оставалась непокрытой, хотя
+// разойтись эти пути могут молча: пользователь вместо своего значения увидел бы
+// текст драйвера (#1448).
 func TestSaveExplainsUniqueViolationOnCreateAndVersionedUpdate(t *testing.T) {
+	dbtest.ForEachDialect(t, func(t *testing.T, db *storage.DB) {
+		testSaveExplainsUniqueViolation(t, db)
+	})
+}
+
+func testSaveExplainsUniqueViolation(t *testing.T, db *storage.DB) {
+	t.Helper()
 	t.Run("declared index", func(t *testing.T) {
 		entity := &metadata.Entity{
 			Name: "Контрагенты",
@@ -25,7 +39,7 @@ func TestSaveExplainsUniqueViolationOnCreateAndVersionedUpdate(t *testing.T) {
 			},
 			Indexes: []metadata.IndexSpec{{Fields: []string{"ИНН"}, Unique: true}},
 		}
-		ctx, svc := uniqueViolationFixture(t, entity)
+		ctx, svc := uniqueViolationFixture(t, db, entity)
 
 		saveEntity(t, ctx, svc, entity, uuid.New(), true, nil, map[string]any{
 			"ИНН": "77", "Наименование": "Первый",
@@ -64,7 +78,7 @@ func TestSaveExplainsUniqueViolationOnCreateAndVersionedUpdate(t *testing.T) {
 			},
 			Numerator: &metadata.Numerator{Prefix: "С-", Length: 6, Period: "none", Unique: true},
 		}
-		ctx, svc := uniqueViolationFixture(t, entity)
+		ctx, svc := uniqueViolationFixture(t, db, entity)
 
 		saveEntity(t, ctx, svc, entity, uuid.New(), true, nil, map[string]any{
 			metadata.StandardCodeField: "С-000001", "Наименование": "Первый",
@@ -87,14 +101,11 @@ func TestSaveExplainsUniqueViolationOnCreateAndVersionedUpdate(t *testing.T) {
 	})
 }
 
-func uniqueViolationFixture(t *testing.T, entity *metadata.Entity) (context.Context, *Service) {
+// uniqueViolationFixture готовит сервис на уже открытой базе: соединение и его
+// закрытие ведёт dbtest.ForEachDialect, а на PostgreSQL — ещё и эфемерная схема.
+func uniqueViolationFixture(t *testing.T, db *storage.DB, entity *metadata.Entity) (context.Context, *Service) {
 	t.Helper()
 	ctx := context.Background()
-	db, err := storage.ConnectSQLite(ctx, filepath.Join(t.TempDir(), "unique.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { db.Close() })
 	if err := db.Migrate(ctx, []*metadata.Entity{entity}); err != nil {
 		t.Fatalf("Migrate: %v", err)
 	}


### PR DESCRIPTION
## Что сделано

`TestSaveExplainsUniqueViolationOnCreateAndVersionedUpdate` поднимал базу через
`storage.ConnectSQLite` напрямую и исполнялся только на SQLite. Распознавание
уникального нарушения при этом идёт **разными ветками**
(`internal/storage/code_unique.go:261-305`):

- SQLite — разбор текста `UNIQUE constraint failed: таблица.колонка`;
- PostgreSQL — сверка `pgErr.ConstraintName` из SQLSTATE 23505 с вычисленным
  `stableIndexName(table, cols, true)`.

Разойтись они могут молча: пользователь вместо «значение ИНН «77» уже занято»
увидел бы текст драйвера. Конвенция CLAUDE.md на такой случай прямая — «трогаешь
семантику SQL, пиши матричный тест».

Тело теста вынесено в `testSaveExplainsUniqueViolation` и обёрнуто в
`dbtest.ForEachDialect`; соединение, закрытие и эфемерная схема PostgreSQL — на
хелпере. Сами проверки не менялись: оба случая (объявленный `indexes:` и
`numerator.unique`), создание и версионная правка, отсутствие утечки деталей
драйвера.

## Что стоит знать ревью

PG-ветку **локально прогнать было нечем**: в этом окружении нет ни `psql`, ни
docker, `TEST_DATABASE_URL` не задан — подтест `postgres` пропускается. Она
отработает в джобе `postgres-integration`, и это ровно то, ради чего заявка
заводилась.

Статически PG-путь выглядит сходящимся: индекс создаётся тем же
`stableIndexName` (`internal/storage/ddl.go:81`), которым потом сверяется имя
ограничения, и колонки в обоих местах берутся одним `entityIndexColumns`. Но
если джоб всё-таки покраснеет — это находка, а не поломка теста: чинить тогда
надо распознавание в `code_unique.go`, и делать это следует в этом же PR.

`go build ./...`, `go test ./internal/entityservice/ ./internal/storage/`,
`gofmt` — зелёные.

Fixes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193qqYBwLbZNGpCBroQks84