### PR TITLE
fix(check): ref_card_button в корне формы больше не проходит молча

### DIFF
--- a/internal/configcheck/form_ref_card_button_lint_test.go
+++ b/internal/configcheck/form_ref_card_button_lint_test.go
@@ -1,0 +1,103 @@
+package configcheck
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `ref_card_button` в корне документа формы (issue #1450).
+//
+// Ключ читается загрузчиком только внутри блока `form:`
+// (`internal/dsl/loader/managed_form_loader.go`, поле RefCardButton у тега
+// yaml:"form"), но в белом списке линта он стоял ДВАЖДЫ — и в блоке, и в корне.
+// Конфигурация с ключом в корне проходила проверку зелёной, а кнопка молча
+// оставалась на месте: ровно та «тихая потеря», от которой линт и заведён.
+//
+// Тест идёт через RunFullWithOptions — тот самый вызов, которым `onebase check
+// --lint` проверяет проект (`internal/cli/check.go:56,70`), а не через разбор
+// схемы напрямую.
+
+func refCardButtonProject(t *testing.T, formYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	mkFile(t, filepath.Join(dir, "documents", "заказ.yaml"), `name: Заказ
+fields:
+  - name: Номер
+    type: string
+`)
+	mkFile(t, filepath.Join(dir, "forms", "заказ", "объекта.form.yaml"), formYAML)
+	return dir
+}
+
+// unvalidatedKeyMentions ищет находку линта про неизвестный ключ с этим именем.
+// Смотрим и Issues, и Warnings: класс находки — деталь реализации, а тест
+// говорит о том, названа ли проблема вообще.
+func unvalidatedKeyMentions(res Result, key string) bool {
+	for _, list := range [][]Issue{res.Issues, res.Warnings} {
+		for _, is := range list {
+			if is.Code == "metadata.unvalidated-key" && strings.Contains(is.Message, key) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestLint_RefCardButtonInFormRootReported(t *testing.T) {
+	dir := refCardButtonProject(t, `schema: onebase.form/v1
+ref_card_button: false
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заказ
+elements:
+  - kind: ПолеВвода
+    name: Номер
+    data_path: Объект.Номер
+`)
+	res := RunFullWithOptions(dir, Options{Lint: true})
+	if !unvalidatedKeyMentions(res, "ref_card_button") {
+		t.Errorf("ключ в корне формы не назван линтом; находки: %+v %+v", res.Issues, res.Warnings)
+	}
+}
+
+func TestLint_RefCardButtonInsideFormAccepted(t *testing.T) {
+	// Правильное место ключа обязано остаться зелёным: иначе починка «тихой
+	// потери» превратилась бы в ложную тревогу на рабочих конфигурациях.
+	dir := refCardButtonProject(t, `schema: onebase.form/v1
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заказ
+  ref_card_button: false
+elements:
+  - kind: ПолеВвода
+    name: Номер
+    data_path: Объект.Номер
+`)
+	res := RunFullWithOptions(dir, Options{Lint: true})
+	if unvalidatedKeyMentions(res, "ref_card_button") {
+		t.Errorf("ключ внутри form: назван неизвестным; находки: %+v %+v", res.Issues, res.Warnings)
+	}
+}
+
+func TestLint_RefCardButtonInRootSilentWithoutLint(t *testing.T) {
+	// Обычный `onebase check` без --lint поведения не меняет: находка
+	// рекомендательная и приходит только с флагом.
+	dir := refCardButtonProject(t, `schema: onebase.form/v1
+ref_card_button: false
+form:
+  name: ФормаОбъекта
+  kind: object
+  entity: Заказ
+elements:
+  - kind: ПолеВвода
+    name: Номер
+    data_path: Объект.Номер
+`)
+	res := RunFull(dir)
+	if unvalidatedKeyMentions(res, "ref_card_button") {
+		t.Errorf("lint-находка попала в обычный check; находки: %+v %+v", res.Issues, res.Warnings)
+	}
+}

--- a/internal/configcheck/lint.go
+++ b/internal/configcheck/lint.go
@@ -651,7 +651,12 @@ func formModuleYAMLSchema() *yamlLintSchema {
 		"then":  style,
 	})
 
-	return with(obj("schema", "entity", "name", "kind", "layout_kind", "original_id", "auto_save_settings", "auto_save_data_in_settings", "vertical_scroll", "ref_card_button"), map[string]*yamlLintSchema{
+	// `ref_card_button` в этом списке НЕТ намеренно: загрузчик читает его только
+	// внутри блока `form:` (`internal/dsl/loader/managed_form_loader.go`, поле
+	// RefCardButton у тега yaml:"form"). Пока ключ был разрешён и в корне,
+	// конфигурация с ним проходила линт зелёно, а кнопка молча оставалась на
+	// месте — ровно та «тихая потеря», от которой этот линт и заведён (#1450).
+	return with(obj("schema", "entity", "name", "kind", "layout_kind", "original_id", "auto_save_settings", "auto_save_data_in_settings", "vertical_scroll"), map[string]*yamlLintSchema{
 		"form":                   formHeader,
 		"title":                  freeMap(),
 		"events":                 freeMap(),


### PR DESCRIPTION
## Что сделано

`ref_card_button` стоял в белом списке линта **дважды**: и в блоке `form:`
(`internal/configcheck/lint.go:645`), и в корне документа (там же, `:654`).
Загрузчик читает его только внутри `form:` — поле `RefCardButton` объявлено у
тега `yaml:"form"` в `internal/dsl/loader/managed_form_loader.go:160`. Значит
конфигурация с ключом в корне проходила проверку зелёной, а кнопка молча
оставалась на месте — та самая «тихая потеря», от которой линт и заведён.

Убран лишний элемент из корневого списка. Дальше срабатывает уже существующая
диагностика `metadata.unvalidated-key` («неизвестный YAML-ключ …: загрузчик его
игнорирует»), нового кода не потребовалось; на месте ключа оставлен комментарий,
объясняющий, почему его тут нет.

## Уточнение к разбору

В разборе триажа сказано, что находку «гейт CI трактует как ошибку». По коду это
не так: `metadata.unvalidated-key` — рекомендательная находка, и приходит она
только с флагом (`onebase check --lint` / `onebase lint`,
`internal/cli/check.go:46,56`). Обычный `onebase check` поведения не меняет
вовсе. Так что цена правки ещё ниже, чем оценивалась: ни одна существующая
конфигурация от неё не краснеет на обычной проверке.

## Проверка

`internal/configcheck/form_ref_card_button_lint_test.go` идёт через
`RunFullWithOptions(dir, Options{Lint: true})` — тот самый вызов, которым
`onebase check --lint` проверяет проект (`internal/cli/check.go:56,70`), а не
через разбор схемы напрямую:

- ключ в корне формы — находка есть;
- тот же ключ внутри `form:` — находки нет (правильное место осталось зелёным);
- обычный `RunFull` без `--lint` молчит, как и раньше.

Откат правки роняет первый тест. `go build ./...`,
`go test ./internal/configcheck/ ./internal/cli/`, `gofmt`, а также
`onebase check --project examples/trade` и он же с `--lint` — зелёные.

Fixes #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193qqYBwLbZNGpCBroQks84