### PR TITLE
fix(loader): искать модули форм по каталогу, а не по нижнему регистру

### DIFF
--- a/internal/dsl/loader/form_loader.go
+++ b/internal/dsl/loader/form_loader.go
@@ -21,38 +21,69 @@ func NewFormLoader() *FormLoader {
 	return &FormLoader{}
 }
 
-// LoadEntityForms loads all form modules for an entity from src/ directory
+// LoadEntityForms loads all form modules for an entity from src/ directory.
+//
+// Имена файлов ИЩУТСЯ в каталоге, а не вычисляются: раньше модуль формы
+// собирался как strings.ToLower(entityName)+".form.os" и сразу открывался, и на
+// регистрозависимой файловой системе файл `Заказы.form.os` молча не
+// подхватывался — форма оставалась без модуля, а обработчики просто не
+// срабатывали (#1452). #1317 тем же способом починил поиск каталога управляемых
+// форм: сопоставление по факту, а не по вычисленному имени.
 func (fl *FormLoader) LoadEntityForms(srcDir, entityName string) ([]*metadata.FormModule, error) {
 	var forms []*metadata.FormModule
 
-	// Try to load object form (entity.form.os)
-	objectFormFile := filepath.Join(srcDir, metadata.ObjectFormFileName(entityName))
-	if form, err := fl.loadFormModule(objectFormFile, entityName, "ФормаОбъекта", "object"); err == nil {
-		forms = append(forms, form)
-	}
-
-	// Try to load list form
-	listFormFile := filepath.Join(srcDir, strings.ToLower(entityName)+"_list.form.os")
-	if _, err := os.Stat(listFormFile); err == nil {
-		if form, err := fl.loadFormModule(listFormFile, entityName, "ФормаСписка", "list"); err == nil {
-			forms = append(forms, form)
-		}
-	}
-
-	// Try to load choice form
-	choiceFormFile := filepath.Join(srcDir, strings.ToLower(entityName)+"_choice.form.os")
-	if _, err := os.Stat(choiceFormFile); err == nil {
-		if form, err := fl.loadFormModule(choiceFormFile, entityName, "ФормаВыбора", "choice"); err == nil {
-			forms = append(forms, form)
-		}
-	}
-
-	// Load custom forms (pattern: entity_formname.form.os)
 	files, err := os.ReadDir(srcDir)
 	if err != nil {
 		return forms, nil
 	}
 
+	// Два файла, различающиеся только регистром, на такой ФС — РАЗНЫЕ файлы.
+	// Точное имя в нижнем регистре старше любого другого: проект, который
+	// грузился до этой правки, обязан продолжать грузить тот же самый файл, а
+	// новое поведение получают только те, у кого канонического имени нет.
+	// Среди остальных берём первый по порядку каталога (os.ReadDir отдаёт
+	// записи отсортированными), чтобы выбор не зависел от файловой системы.
+	actualByLower := make(map[string]string, len(files))
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		name := file.Name()
+		lower := strings.ToLower(name)
+		if prev, seen := actualByLower[lower]; !seen || (prev != lower && name == lower) {
+			actualByLower[lower] = name
+		}
+	}
+	resolve := func(want string) (string, bool) {
+		actual, ok := actualByLower[strings.ToLower(want)]
+		if !ok {
+			return "", false
+		}
+		return filepath.Join(srcDir, actual), true
+	}
+
+	// Object form (entity.form.os)
+	if path, ok := resolve(metadata.ObjectFormFileName(entityName)); ok {
+		if form, err := fl.loadFormModule(path, entityName, "ФормаОбъекта", "object"); err == nil {
+			forms = append(forms, form)
+		}
+	}
+
+	// List form
+	if path, ok := resolve(strings.ToLower(entityName) + "_list.form.os"); ok {
+		if form, err := fl.loadFormModule(path, entityName, "ФормаСписка", "list"); err == nil {
+			forms = append(forms, form)
+		}
+	}
+
+	// Choice form
+	if path, ok := resolve(strings.ToLower(entityName) + "_choice.form.os"); ok {
+		if form, err := fl.loadFormModule(path, entityName, "ФормаВыбора", "choice"); err == nil {
+			forms = append(forms, form)
+		}
+	}
+
+	// Custom forms (pattern: entity_formname.form.os)
 	prefix := strings.ToLower(entityName) + "_"
 	suffix := ".form.os"
 
@@ -61,21 +92,40 @@ func (fl *FormLoader) LoadEntityForms(srcDir, entityName string) ([]*metadata.Fo
 			continue
 		}
 		name := file.Name()
-		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) {
-			formName := strings.TrimPrefix(name, prefix)
-			formName = strings.TrimSuffix(formName, suffix)
-			formName = upperFirst(formName)
+		if !hasPrefixFold(name, prefix) || !hasSuffixFold(name, suffix) {
+			continue
+		}
+		// Тот же выбор представителя, что и у стандартных форм: иначе пара
+		// файлов, различающихся регистром, дала бы две формы с одним именем.
+		if actualByLower[strings.ToLower(name)] != name {
+			continue
+		}
+		// Имя формы берём из ФАКТИЧЕСКОГО имени файла, а не из приведённого к
+		// нижнему регистру: `заказ_ПечатьСчёта.form.os` обязан остаться формой
+		// «ПечатьСчёта», а не «Печатьсчёта».
+		formName := upperFirst(name[len(prefix) : len(name)-len(suffix)])
 
-			if !metadata.IsStandardForm(formName) {
-				fullPath := filepath.Join(srcDir, name)
-				if form, err := fl.loadFormModule(fullPath, entityName, formName, "custom"); err == nil {
-					forms = append(forms, form)
-				}
+		if !metadata.IsStandardForm(formName) {
+			fullPath := filepath.Join(srcDir, name)
+			if form, err := fl.loadFormModule(fullPath, entityName, formName, "custom"); err == nil {
+				forms = append(forms, form)
 			}
 		}
 	}
 
 	return forms, nil
+}
+
+// hasPrefixFold и hasSuffixFold сравнивают края имени файла без учёта регистра.
+// Срез берётся по длине образца: если граница не попала на границу руны,
+// strings.EqualFold просто вернёт false, и файл не совпадёт — молчаливой ошибки
+// это не даёт.
+func hasPrefixFold(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+func hasSuffixFold(s, suffix string) bool {
+	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
 }
 
 func upperFirst(s string) string {

--- a/internal/project/form_module_case_test.go
+++ b/internal/project/form_module_case_test.go
@@ -1,0 +1,144 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Регистр в имени файла модуля формы (issue #1452).
+//
+// Имя строилось как strings.ToLower(entityName)+".form.os" и сразу открывалось,
+// поэтому на регистрозависимой файловой системе `Заказы.form.os` молча не
+// подхватывался: форма оставалась без модуля, а обработчики просто не
+// срабатывали. #1317 чинил ровно ту же переносимость для каталога управляемых
+// форм — сопоставлением по факту вместо вычисленного имени.
+//
+// Тест идёт через project.Load — тот же путь, которым проект читают `onebase
+// check`, `run` и `procrun`, а не через сам загрузчик форм.
+
+func writeFormCaseProject(t *testing.T, moduleFile string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{"catalogs", "src"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "catalogs", "заказы.yaml"),
+		[]byte("name: Заказы\nfields:\n  - name: Наименование\n    type: string\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mod := "Процедура ПриОткрытииФормы()\n  Сообщить(\"открыто\");\nКонецПроцедуры\n"
+	if err := os.WriteFile(filepath.Join(dir, "src", moduleFile), []byte(mod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// entityForm возвращает единственный модуль формы справочника Заказы.
+func entityForm(t *testing.T, dir string) (string, []string) {
+	t.Helper()
+	proj, err := Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	t.Cleanup(proj.Close)
+	for _, ent := range proj.Entities {
+		if !strings.EqualFold(ent.Name, "Заказы") {
+			continue
+		}
+		if len(ent.Forms) != 1 {
+			t.Fatalf("ожидалась одна форма, получено %d", len(ent.Forms))
+		}
+		var procs []string
+		for name := range ent.Forms[0].Procedures {
+			procs = append(procs, name)
+		}
+		sort.Strings(procs)
+		return ent.Forms[0].Name, procs
+	}
+	t.Fatalf("справочник Заказы не загрузился")
+	return "", nil
+}
+
+func entityFormNames(t *testing.T, dir string) []string {
+	t.Helper()
+	proj, err := Load(dir)
+	if err != nil {
+		t.Fatalf("project.Load: %v", err)
+	}
+	t.Cleanup(proj.Close)
+	for _, ent := range proj.Entities {
+		if !strings.EqualFold(ent.Name, "Заказы") {
+			continue
+		}
+		var names []string
+		for _, f := range ent.Forms {
+			names = append(names, f.Name)
+		}
+		return names
+	}
+	t.Fatalf("справочник Заказы не загрузился")
+	return nil
+}
+
+func TestLoad_FormModuleFileNotLowercase(t *testing.T) {
+	// Имя файла не в нижнем регистре: до правки модуль молча терялся.
+	dir := writeFormCaseProject(t, "Заказы.form.os")
+	names := entityFormNames(t, dir)
+	if len(names) != 1 || names[0] != "ФормаОбъекта" {
+		t.Errorf("модуль формы не подхватился: %v", names)
+	}
+}
+
+func TestLoad_FormModuleLowercaseStillWorks(t *testing.T) {
+	// Канонический регистр обязан работать как раньше.
+	dir := writeFormCaseProject(t, "заказы.form.os")
+	names := entityFormNames(t, dir)
+	if len(names) != 1 || names[0] != "ФормаОбъекта" {
+		t.Errorf("модуль формы в нижнем регистре потерялся: %v", names)
+	}
+}
+
+func TestLoad_FormModuleCustomFormKeepsNameCase(t *testing.T) {
+	// Произвольная форма: регистр имени формы берётся из файла, а не из
+	// приведённого к нижнему регистру имени, иначе «ПечатьСчёта» стала бы
+	// «Печатьсчёта».
+	dir := writeFormCaseProject(t, "Заказы_ПечатьСчёта.form.os")
+	names := entityFormNames(t, dir)
+	if len(names) != 1 || names[0] != "ПечатьСчёта" {
+		t.Errorf("имя произвольной формы искажено: %v", names)
+	}
+}
+
+func TestLoad_FormModuleCaseCollisionPrefersLowercase(t *testing.T) {
+	// Два файла, различающихся только регистром, — разные файлы. Побеждает
+	// каноническое нижнее имя: проект, который грузился до правки, обязан
+	// грузить тот же самый модуль.
+	dir := writeFormCaseProject(t, "заказы.form.os")
+	upper := filepath.Join(dir, "src", "Заказы.form.os")
+	if err := os.WriteFile(upper, []byte("Процедура ПередЗаписью()\n  Сообщить(\"не тот файл\");\nКонецПроцедуры\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(upper); err != nil {
+		t.Skip("файловая система не различает регистр в именах файлов")
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "src"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 2 {
+		t.Skip("файловая система не различает регистр в именах файлов")
+	}
+	// Файлы различаются процедурой, поэтому видно, какой из них прочитан.
+	name, procs := entityForm(t, dir)
+	if name != "ФормаОбъекта" {
+		t.Fatalf("форма загрузилась как %q", name)
+	}
+	if len(procs) != 1 || procs[0] != "ПриОткрытииФормы" {
+		t.Errorf("прочитан не канонический файл: процедуры %v", procs)
+	}
+}


### PR DESCRIPTION
## Что сделано

`LoadEntityForms` строил имя файла как `strings.ToLower(entityName)+".form.os"`
и сразу его открывал (`internal/dsl/loader/form_loader.go:29,35,43,56`,
`internal/metadata/form_module.go:658`). На регистрозависимой файловой системе
`Заказы.form.os` поэтому молча не подхватывался: форма оставалась без модуля,
обработчики не срабатывали, ошибки при этом не было. #1317 чинил ровно ту же
переносимость для каталога управляемых форм — сопоставлением по факту вместо
вычисленного имени (`managed_form_loader.go:91`).

Теперь каталог `src` читается один раз, а имена модулей — формы объекта, списка,
выбора и произвольных — сопоставляются без учёта регистра.

## Спорные решения

**Коллизия регистра решается в пользу канонического имени, а не «первый по
порядку каталога».** Два файла, различающихся регистром, на такой ФС — разные
файлы, и правило нужно детерминированное. Порядок каталога здесь плох тем, что
`Заказы.form.os` сортируется раньше `заказы.form.os`: проект, который сегодня
грузит нижний регистр, после правки начал бы грузить другой файл. Поэтому точное
имя в нижнем регистре старше любого другого — правка получается строго
добавляющей, а новое поведение достаётся только тем, у кого канонического имени
нет.

**Имя произвольной формы берётся из фактического имени файла.** Если выводить
его из приведённого к нижнему регистру, `заказ_ПечатьСчёта.form.os` стал бы
формой «Печатьсчёта» вместо «ПечатьСчёта» — это была бы регрессия для уже
работающих проектов. Закреплено тестом.

**Коллизия не отклоняется ошибкой**, в отличие от управляемых форм (#1317, там
`LoadEntityForms` возвращает ошибку с обоими именами). Здесь ошибка сломала бы
загрузку проекта, который сегодня работает; а `LoadEntityForms` легаси-форм и
так молча пропускает файлы, которые не разобрались.

## Проверка

`internal/project/form_module_case_test.go` идёт через `project.Load` — тот путь,
которым проект читают `onebase check`, `run` и `procrun`, а не через сам
загрузчик форм:

- `Заказы.form.os` (не нижний регистр) — модуль подхватывается;
- `заказы.form.os` — работает как раньше;
- `Заказы_ПечатьСчёта.form.os` — форма называется «ПечатьСчёта», регистр не съеден;
- оба файла сразу — читается канонический нижний, и это доказано разными
  процедурами в файлах, а не только числом форм (на ФС без различения регистра
  подтест пропускается).

Откат правки роняет первый и третий случаи. `go build ./...`,
`go test ./internal/project/ ./internal/dsl/loader/ ./internal/ui/`, `gofmt` и
`onebase check --project examples/trade` — зелёные.

Fixes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193qqYBwLbZNGpCBroQks84