### PR TITLE
test(pipeline): сторож расхождения списка обязательных проверок

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,14 @@ onebase describe --project <dir>                # вся структура ко
   расходиться им нельзя. Аварийное снятие — `gh api -X DELETE
   …/branches/main/protection`, возврат — `-X PUT … --input
   .github/branch-protection.json`.
+  - Машиночитаемую пару сторожит тест: `required_status_checks.contexts` из
+    `.github/branch-protection.json` обязан совпадать с `required_checks` в
+    `pipelinectl.json` (`internal/pipelinecontract`). Меняешь список — правь оба
+    файла, иначе `pipelinectl` ждёт не тот набор проверок, чем требует GitHub.
+    Три текстовые копии (этот файл, `docs/maintenance-pipeline.md`, скил
+    пастуха) остаются на честном слове намеренно: проверка «имя упомянуто» не
+    поймала бы #1192 — там имя было на месте, неверным было утверждение вокруг
+    него (#1346).
   - `test-windows` стал обязательным 20.08.2026 (#962, Р2): Windows — основная
     платформа продукта (лаунчер, WebView2, переименование запущенного `.exe` при
     самообновлении), а красный джоб на ней мёрж не останавливал. На критический

--- a/internal/pipelinecontract/required_checks_test.go
+++ b/internal/pipelinecontract/required_checks_test.go
@@ -1,0 +1,96 @@
+package pipelinecontract
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+)
+
+// Список обязательных проверок ветки `main` живёт в репозитории пятью копиями
+// (issue #1346). Авторитет — `.github/branch-protection.json`: этот же JSON
+// лежит в живой защите ветки. Копия, которую читает не человек, а инструмент
+// конвейера, ровно одна — `required_checks` в `pipelinectl.json`, и её
+// расхождение с авторитетом означает не «неточную памятку», а неверное
+// поведение: `pipelinectl` ждёт другой набор проверок, чем требует GitHub.
+//
+// Цена расхождения известна: после того как `launcher-webview-build` стал
+// обязательным 22.08.2026, три текста продолжали называть его необязательным
+// (#1192) — агент по инструкции считал красный джоб неблокирующим и упирался в
+// отказ GitHub, которого в его картине мира не бывает. #1194 синхронизировал
+// тексты, но сторожа не поставил.
+//
+// Здесь сторожится именно машиночитаемая пара. Текстовые копии (CLAUDE.md,
+// docs/maintenance-pipeline.md, скил пастуха) намеренно оставлены вне теста:
+// проверка «имя проверки упомянуто в тексте» не поймала бы #1192 — имя там
+// присутствовало, неверным было утверждение вокруг него, — зато сделала бы
+// красной сборкой любую переформулировку абзаца. Ощущение гарантии без самой
+// гарантии дороже честного отсутствия проверки.
+//
+// Вариант 1 из разбора триажа (#1346).
+
+func branchProtectionContexts(t *testing.T) []string {
+	t.Helper()
+	var protection struct {
+		RequiredStatusChecks struct {
+			Contexts []string `json:"contexts"`
+		} `json:"required_status_checks"`
+	}
+	raw := repositoryFile(t, ".github", "branch-protection.json")
+	if err := json.Unmarshal([]byte(raw), &protection); err != nil {
+		t.Fatalf(".github/branch-protection.json: %v", err)
+	}
+	return protection.RequiredStatusChecks.Contexts
+}
+
+func pipelinectlRequiredChecks(t *testing.T) []string {
+	t.Helper()
+	var config struct {
+		RequiredChecks []string `json:"required_checks"`
+	}
+	raw := repositoryFile(t, "pipelinectl.json")
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("pipelinectl.json: %v", err)
+	}
+	return config.RequiredChecks
+}
+
+func TestPipelinectlRequiredChecksMatchBranchProtection(t *testing.T) {
+	authority := branchProtectionContexts(t)
+	tool := pipelinectlRequiredChecks(t)
+
+	// Пустой список означал бы, что ключ переименовали или структура файла
+	// изменилась: тогда сравнение двух пустых множеств прошло бы молча и
+	// сторож перестал бы сторожить.
+	if len(authority) == 0 {
+		t.Fatal(".github/branch-protection.json: required_status_checks.contexts пуст — сторож сравнивал бы пустоту")
+	}
+	if len(tool) == 0 {
+		t.Fatal("pipelinectl.json: required_checks пуст — сторож сравнивал бы пустоту")
+	}
+
+	missing := difference(authority, tool)
+	extra := difference(tool, authority)
+	if len(missing) > 0 {
+		t.Errorf("pipelinectl.json не знает обязательные проверки %v: конвейер вольёт PR, который GitHub не пропустит", missing)
+	}
+	if len(extra) > 0 {
+		t.Errorf("pipelinectl.json ждёт проверки %v, которых нет в защите ветки: конвейер будет ждать вечно", extra)
+	}
+}
+
+// difference возвращает элементы want, которых нет в have, — отсортированными,
+// чтобы сообщение об ошибке не зависело от порядка ключей в файлах.
+func difference(want, have []string) []string {
+	present := make(map[string]bool, len(have))
+	for _, name := range have {
+		present[name] = true
+	}
+	var out []string
+	for _, name := range want {
+		if !present[name] {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
## Что сделано

`internal/pipelinecontract/required_checks_test.go` сравнивает как множества:

- `required_status_checks.contexts` из `.github/branch-protection.json` —
  авторитет, этот же JSON лежит в живой защите ветки;
- `required_checks` из `pipelinectl.json` — единственная копия, которую читает
  не человек, а инструмент конвейера.

Недостающие и лишние проверки называются отдельно, потому что это разные
поломки: «`pipelinectl.json` не знает обязательные проверки X» означает, что
конвейер вольёт PR, который GitHub не пропустит, а «ждёт проверки Y, которых нет
в защите» — что он будет ждать вечно.

Пустой список любой из сторон — тоже отказ. Без этого переименование ключа или
смена структуры файла превратили бы сторожа в сравнение двух пустот, и он бы
молча перестал сторожить — ровно тот класс отказа, от которого заявка и заведена.

Вариант: 1 (рекомендация триажа) — только машиночитаемая пара.

## Что осознанно НЕ сделано

Три текстовые копии (`CLAUDE.md`, `docs/maintenance-pipeline.md`, скил пастуха)
остались вне теста. Мягкая проверка «каждое имя упомянуто в тексте» **не
поймала бы #1192**: имя `launcher-webview-build` во всех трёх текстах
присутствовало, неверным было утверждение вокруг него («необязательный»). Зато
такая проверка сделала бы красной сборкой любую переформулировку абзаца и
создала бы ощущение гарантии, которой у неё нет. Это зафиксировано и в разборе
триажа, и в комментарии теста.

## Проверка

Тест зелёный на текущем `main` (все пять копий совпадают). Что он ловит —
проверено обеими сторонами:

- убрал `launcher-webview-build` из `pipelinectl.json` (сценарий #1192) →
  `pipelinectl.json не знает обязательные проверки [launcher-webview-build]`;
- добавил несуществующую `fuzz` → `pipelinectl.json ждёт проверки [fuzz],
  которых нет в защите ветки`.

`go build ./...`, `go test ./internal/pipelinecontract/ ./tools/...`, `gofmt` —
зелёные.

В `CLAUDE.md` рядом со списком проверок добавлена строка о том, что пара теперь
сторожится и править надо оба файла: без неё следующий редактор узнаёт об этом
только от красного теста.

Fixes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193qqYBwLbZNGpCBroQks84