### PR TITLE
fix(ui): подтверждать закрытие формы встроенным модалом

### DIFF
--- a/internal/ui/static/ref_create_modal_behavior_test.js
+++ b/internal/ui/static/ref_create_modal_behavior_test.js
@@ -74,7 +74,7 @@ function setup(options) {
     getElementById(id) { return walk(body, (candidate) => candidate.id === id); },
     querySelector(selector) { return selector === 'a.btn-cancel' ? parentCancel : null; },
   });
-  const window = eventTarget({confirm() { return true; }});
+  const window = eventTarget({confirm() { throw new Error('window.confirm must not be used'); }});
   global.document = document;
   global.window = window;
   if (options.managedEscape) new Function(managedEscapeSource)();
@@ -91,7 +91,15 @@ function escapeEvent() {
   };
 }
 
-test('external Cancel and close button safely release the modal', () => {
+function closeConfirmation(document) {
+  return document.getElementById('_ref-create-close-confirm');
+}
+
+function confirmationButtons(confirm) {
+  return confirm.children[0].children[1].children;
+}
+
+test('external Cancel and close button use an in-page confirmation', () => {
   const env = setup();
   const select = {options: [], value: '', appendChild() {}, dispatchEvent() {}};
   env.openRefCreate(select, 'Город');
@@ -103,21 +111,37 @@ test('external Cancel and close button safely release the modal', () => {
   assert.equal(cancel.textContent, 'Отмена');
   assert.equal(close.textContent, '×');
 
-  env.window.confirm = () => false;
   cancel.dispatch('click', {});
-  assert.equal(env.document.getElementById('_ref-create-modal'), modal, 'cancel bypassed the unsaved-data confirmation');
+  let confirm = closeConfirmation(env.document);
+  assert.ok(confirm, 'external Cancel did not open the in-page confirmation');
+  assert.equal(env.document.getElementById('_ref-create-modal'), modal);
+  assert.equal(confirm.children[0].children[0].textContent, 'Данные были изменены и не записаны. Закрыть форму?');
 
-  env.window.confirm = () => true;
+  let [closeWithoutSave, stay] = confirmationButtons(confirm);
+  assert.equal(closeWithoutSave.textContent, 'Закрыть');
+  assert.equal(stay.textContent, 'Отмена');
+  stay.dispatch('click', {});
+  assert.equal(closeConfirmation(env.document), null);
+  assert.equal(env.document.getElementById('_ref-create-modal'), modal, 'confirmation cancellation closed the create form');
+
   close.dispatch('click', {});
+  confirm = closeConfirmation(env.document);
+  assert.ok(confirm, 'close button bypassed the in-page confirmation');
+  [closeWithoutSave] = confirmationButtons(confirm);
+  closeWithoutSave.dispatch('click', {});
   assert.equal(env.document.getElementById('_ref-create-modal'), null);
+  assert.equal(closeConfirmation(env.document), null);
   assert.equal(env.window.listenerCount('message'), 0, 'closed modal leaked its message handler');
 });
 
-test('Escape closes from both parent document and same-origin error iframe', () => {
+test('Escape asks before closing from both parent document and same-origin error iframe', () => {
   const env = setup();
   const select = {options: [], value: '', appendChild() {}, dispatchEvent() {}};
   env.openRefCreate(select, 'Город');
   env.document.dispatch('keydown', escapeEvent());
+  let confirm = closeConfirmation(env.document);
+  assert.ok(confirm);
+  confirmationButtons(confirm)[0].dispatch('click', {});
   assert.equal(env.document.getElementById('_ref-create-modal'), null);
 
   env.openRefCreate(select, 'Город');
@@ -125,18 +149,28 @@ test('Escape closes from both parent document and same-origin error iframe', () 
   const iframe = modal.children[0].children[1];
   iframe.dispatch('load', {});
   iframe.contentDocument.dispatch('keydown', escapeEvent());
+  confirm = closeConfirmation(env.document);
+  assert.ok(confirm);
+  confirmationButtons(confirm)[0].dispatch('click', {});
   assert.equal(env.document.getElementById('_ref-create-modal'), null);
 });
 
-test('managed capture handler closes inline modal before the parent form', () => {
+test('managed capture handler opens confirmation before the parent form', () => {
   const env = setup({managedEscape: true});
   const select = {options: [], value: '', appendChild() {}, dispatchEvent() {}};
   env.openRefCreate(select, 'Город');
 
   env.document.dispatch('keydown', escapeEvent());
 
-  assert.equal(env.document.getElementById('_ref-create-modal'), null);
+  assert.ok(closeConfirmation(env.document));
+  assert.ok(env.document.getElementById('_ref-create-modal'));
   assert.equal(env.parentCancel.clicks, 0, 'Escape closed the managed parent form');
+  env.document.dispatch('keydown', escapeEvent());
+  assert.equal(closeConfirmation(env.document), null, 'second Escape did not cancel the confirmation');
+  assert.ok(env.document.getElementById('_ref-create-modal'), 'cancelling the confirmation closed the create form');
+  env.document.dispatch('keydown', escapeEvent());
+  confirmationButtons(closeConfirmation(env.document))[0].dispatch('click', {});
+  assert.equal(env.document.getElementById('_ref-create-modal'), null);
   assert.equal(env.window.listenerCount('message'), 0, 'managed Escape bypassed modal cleanup');
 });
 
@@ -145,9 +179,12 @@ test('reopening cleans the previous modal before installing a new handler', () =
   const select = {options: [], value: '', appendChild() {}, dispatchEvent() {}};
   env.openRefCreate(select, 'Город');
   const first = env.document.getElementById('_ref-create-modal');
+  first._obClose();
+  assert.ok(closeConfirmation(env.document));
   env.openRefCreate(select, 'Город');
   const second = env.document.getElementById('_ref-create-modal');
   assert.notEqual(second, first);
   assert.equal(first.parentElement, null);
+  assert.equal(closeConfirmation(env.document), null, 'reopening leaked the old confirmation');
   assert.equal(env.window.listenerCount('message'), 1);
 });

--- a/internal/ui/static/ui.js
+++ b/internal/ui/static/ui.js
@@ -3215,10 +3215,55 @@ function openRefCreate(targetSelect, refEntity) {
       cleanup();
     }
   }
+  var closeConfirm = null;
+  function dismissCloseConfirm() {
+    if (!closeConfirm) return;
+    closeConfirm.remove();
+    closeConfirm = null;
+  }
   function confirmClose() {
-    if (typeof window.confirm === 'function' &&
-        !window.confirm('Данные были изменены и не записаны. Закрыть форму?')) return;
-    cleanup();
+    if (closeConfirm) return;
+    var overlay = document.createElement('div');
+    overlay.id = '_ref-create-close-confirm';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', '_ref-create-close-confirm-message');
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.35);z-index:10001;display:flex;align-items:center;justify-content:center';
+    var confirmBox = document.createElement('div');
+    confirmBox.style.cssText = 'background:#fff;padding:18px 22px;border-radius:8px;box-shadow:0 6px 28px rgba(0,0,0,.2);min-width:280px;font-size:13px';
+    var message = document.createElement('div');
+    message.id = '_ref-create-close-confirm-message';
+    message.textContent = 'Данные были изменены и не записаны. Закрыть форму?';
+    message.style.cssText = 'margin-bottom:14px';
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex;gap:8px;justify-content:flex-end';
+    var closeWithoutSave = document.createElement('button');
+    closeWithoutSave.type = 'button';
+    closeWithoutSave.textContent = 'Закрыть';
+    closeWithoutSave.style.cssText = 'background:#c00;color:#fff;border:none;padding:5px 14px;border-radius:4px;cursor:pointer';
+    var stay = document.createElement('button');
+    stay.type = 'button';
+    stay.textContent = 'Отмена';
+    stay.style.cssText = 'background:#e2e8f0;color:#333;border:none;padding:5px 12px;border-radius:4px;cursor:pointer';
+    closeWithoutSave.addEventListener('click', function () {
+      dismissCloseConfirm();
+      cleanup();
+    });
+    stay.addEventListener('click', dismissCloseConfirm);
+    overlay.addEventListener('keydown', function (ev) {
+      if (ev.key !== 'Escape' && ev.keyCode !== 27) return;
+      dismissCloseConfirm();
+      ev.preventDefault();
+      ev.stopPropagation();
+    });
+    row.appendChild(closeWithoutSave);
+    row.appendChild(stay);
+    confirmBox.appendChild(message);
+    confirmBox.appendChild(row);
+    overlay.appendChild(confirmBox);
+    document.body.appendChild(overlay);
+    closeConfirm = overlay;
+    if (typeof stay.focus === 'function') stay.focus();
   }
   function closeOnEscape(ev) {
     if (ev.key !== 'Escape' && ev.keyCode !== 27) return;
@@ -3236,10 +3281,14 @@ function openRefCreate(targetSelect, refEntity) {
   function cleanup() {
     window.removeEventListener('message', handler);
     if (frameDocument) frameDocument.removeEventListener('keydown', closeOnEscape, true);
+    dismissCloseConfirm();
     modal.remove();
   }
   modal._obCleanup = cleanup;
-  modal._obClose = confirmClose;
+  modal._obClose = function () {
+    if (closeConfirm) dismissCloseConfirm();
+    else confirmClose();
+  };
   cancelBtn.addEventListener('click', confirmClose);
   closeBtn.addEventListener('click', confirmClose);
   iframe.addEventListener('load', bindFrameEscape);


### PR DESCRIPTION
## Что сделано

- `openRefCreate` больше не вызывает `window.confirm`: подтверждение закрытия показывает встроенный HTML-модал, одинаковый для браузера и WebView2.
- Наружные «Отмена», «×» и Esc сохраняют форму открытой до явного подтверждения; повторное открытие формы очищает и основной модал, и диалог подтверждения.
- Поведенческий тест проходит через публичные клики и события Esc, проверяет отмену, подтверждение и отсутствие утечки обработчика.

Вариант: 1 (рекомендация триажа)

## Проверки

- `node --test static/ref_create_modal_behavior_test.js`
- `go test -count=1 ./internal/ui`
- `go build ./...`
- `go run ./tools/i18ncheck`
- `go test -count=1 ./...`: полный параллельный прогон упёрся в известный Windows timeout `FlushFileBuffers` в `internal/ui` и системный `GOTMPDIR`; затронутый пакет прошёл отдельно, `internal/selfupdate` прошёл при `GOTMPDIR` внутри профиля, тест из timeout-стека прошёл изолированно.

Fixes #1447