### PR TITLE
fix(pipeline): показывать причину исключения заявки

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -529,7 +529,16 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 		case labels["plan-in-review"]:
 			// The plan PR is visible in REVIEW; product FIX must wait for its merge.
 		case labels["approved"] || labels["ready-fix"] && !labels["needs-decision"]:
-			if labels["in-work"] || issueReferencedByOpenPull(issue.Number, prs) {
+			if labels["in-work"] {
+				continue
+			}
+			if references := openPullsReferencingIssue(issue.Number, prs); len(references) > 0 {
+				items := make([]string, 0, len(references))
+				for _, number := range references {
+					items = append(items, fmt.Sprintf("#%d", number))
+				}
+				result.addIssue("yellow", "fix_issue_referenced_by_open_pull", issue.Number,
+					"заявка исключена из FIX-очереди: её номер упомянут в открытых PR "+strings.Join(items, ", "))
 				continue
 			}
 			ready, reason := triageHandoffReady(issue, owner)
@@ -548,14 +557,16 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 	sortCandidates(result.HumanWaiting)
 }
 
-func issueReferencedByOpenPull(number int, prs []apiPull) bool {
+func openPullsReferencingIssue(number int, prs []apiPull) []int {
 	pattern := regexp.MustCompile(fmt.Sprintf(`(^|[^0-9])#%d([^0-9]|$)`, number))
+	references := []int{}
 	for _, pr := range prs {
 		if pr.State == "open" && pattern.MatchString(pr.Title+"\n"+pr.Body) {
-			return true
+			references = append(references, pr.Number)
 		}
 	}
-	return false
+	sort.Ints(references)
+	return references
 }
 
 func triageHandoffReady(issue apiIssue, owner string) (bool, string) {

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -481,11 +485,70 @@ func TestFixQueueExcludesInWorkAndOpenPullReferences(t *testing.T) {
 		issueWithLabels(21, "approved"),
 		issueWithLabels(22, "approved"),
 	}
-	prs := []apiPull{{Number: 100, State: "open", Title: "fix: issue #21", Body: "Fixes #21"}}
+	prs := []apiPull{
+		{Number: 101, State: "open", Title: "related work", Body: "See #21 for context"},
+		{Number: 100, State: "open", Title: "fix: issue #21", Body: "Fixes #21"},
+		{Number: 99, State: "closed", Title: "old fix #21"},
+	}
 	analyzeIssues(&result, issues, prs, "ivanarama")
 
 	if len(result.FixCandidates) != 1 || result.FixCandidates[0].Number != 22 {
 		t.Fatalf("FIX queue included work already owned by a PR: %+v", result.FixCandidates)
+	}
+	var diagnostic *finding
+	for index := range result.Findings {
+		if result.Findings[index].Code == "fix_issue_referenced_by_open_pull" {
+			diagnostic = &result.Findings[index]
+			break
+		}
+	}
+	if diagnostic == nil || diagnostic.Severity != "yellow" || diagnostic.Issue != 21 ||
+		!strings.Contains(diagnostic.Message, "#100, #101") {
+		t.Fatalf("open PR references were not diagnosed deterministically: %+v", result.Findings)
+	}
+}
+
+func TestCLIReportsWhyOpenPullReferenceExcludesFixIssue(t *testing.T) {
+	directory := t.TempDir()
+	writeFixture := func(name string, value any) string {
+		t.Helper()
+		path := filepath.Join(directory, name)
+		data, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return path
+	}
+
+	issuePath := writeFixture("issues.json", []apiIssue{issueWithLabels(21, "approved")})
+	pullPath := writeFixture("pulls.json", []apiPull{
+		{Number: 101, State: "open", Title: "related work", Body: "See #21 for context"},
+		{Number: 100, State: "open", Title: "fix: issue #21", Body: "Fixes #21"},
+	})
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	command := exec.Command("go", "run", "./tools/pipelinehealth", "-prs", pullPath, "-issues", issuePath, "-json")
+	command.Dir = repositoryRoot
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pipelinehealth CLI failed: %v\n%s", err, output)
+	}
+	var result report
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode pipelinehealth output: %v\n%s", err, output)
+	}
+	if len(result.FixCandidates) != 0 {
+		t.Fatalf("referenced issue remained executable: %+v", result.FixCandidates)
+	}
+	if len(result.Findings) != 1 || result.Findings[0].Severity != "yellow" ||
+		result.Findings[0].Code != "fix_issue_referenced_by_open_pull" || result.Findings[0].Issue != 21 ||
+		!strings.Contains(result.Findings[0].Message, "#100, #101") {
+		t.Fatalf("CLI did not explain the exclusion: %+v", result.Findings)
 	}
 }
 

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -532,6 +532,7 @@ func TestCLIReportsWhyOpenPullReferenceExcludesFixIssue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve repository root: %v", err)
 	}
+	// #nosec G204 -- executable and flags are fixed; variable arguments are test-owned paths from t.TempDir.
 	command := exec.Command("go", "run", "./tools/pipelinehealth", "-prs", pullPath, "-issues", issuePath, "-json")
 	command.Dir = repositoryRoot
 	output, err := command.CombinedOutput()


### PR DESCRIPTION
## Что сделано

- `pipelinehealth` сохраняет широкий критерий исключения: заявка по-прежнему не попадает в FIX, если её номер упомянут в title/body любого открытого PR.
- Вместо молчаливого `continue` добавляется жёлтый finding `fix_issue_referenced_by_open_pull` с отсортированным перечнем всех совпавших PR.
- Regression-тест проверяет результат через публичный CLI и JSON-вывод, включая обычное упоминание без `Fixes`.

Вариант: 1 (рекомендация триажа)

## Проверки

- `go test -count=1 ./tools/pipelinehealth`
- `go build ./...`
- `go test -count=1 ./...` дошёл до известных Windows-сбоев среды: package timeout в `modernc/sqlite` на `FlushFileBuffers` (`launcher`, `storage`, `ui`) и системный `GOTMPDIR` вне профиля для `selfupdate`.
- Изолированно с `GOTMPDIR` внутри профиля прошли весь `internal/selfupdate` и конкретные тесты из timeout-стеков `launcher`, `storage`, `ui`.

Fixes #1451