### PR TITLE
fix(cli): показывать SQL до ошибки запроса

### DIFF
--- a/internal/cli/query.go
+++ b/internal/cli/query.go
@@ -74,6 +74,8 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	showSQL, _ := cmd.Flags().GetBool("sql")
 
 	ctx := context.Background()
 	db, err := bc.OpenDB(ctx)
@@ -97,6 +99,9 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		Dialect:     db.Dialect(),
 	})
 	if err != nil {
+		if showSQL {
+			return fmt.Errorf("compile query: SQL ещё не построен: %w", err)
+		}
 		return fmt.Errorf("compile query: %w", err)
 	}
 
@@ -105,9 +110,15 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	if limit > 0 {
 		sqlText = "SELECT * FROM (" + sqlText + ") _onebase_q LIMIT " + fmt.Sprint(limit)
 	}
+	if showSQL && !jsonOut {
+		outf("SQL:\n%s\nARGS: %v\n\n", sqlText, compiled.Args)
+	}
 	start := time.Now()
 	rows, cols, err := querylang.Run(ctx, db, &compiled)
 	if err != nil {
+		if showSQL && jsonOut {
+			return fmt.Errorf("SQL:\n%s\nARGS: %v\n\n%w", sqlText, compiled.Args, err)
+		}
 		return err
 	}
 	if rows == nil {
@@ -118,8 +129,6 @@ func runQuery(cmd *cobra.Command, args []string) error {
 	}
 	elapsed := time.Since(start).Round(time.Millisecond)
 
-	jsonOut, _ := cmd.Flags().GetBool("json")
-	showSQL, _ := cmd.Flags().GetBool("sql")
 	out := queryOutput{
 		Columns: cols,
 		Rows:    rows,
@@ -135,9 +144,6 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(out)
-	}
-	if showSQL {
-		outf("SQL:\n%s\nARGS: %v\n\n", sqlText, compiled.Args)
 	}
 	printRowsText(cols, rows)
 	outf("\n%d строк, %s\n", len(rows), elapsed)

--- a/internal/cli/query_test.go
+++ b/internal/cli/query_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func queryCommandFixture(t *testing.T) (string, string) {
+	t.Helper()
+	projectDir := t.TempDir()
+	configDir := filepath.Join(projectDir, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(configDir, "app.yaml"),
+		[]byte("name: query-test\nversion: \"1.0\"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	return projectDir, filepath.Join(t.TempDir(), "query.db")
+}
+
+func executeQueryCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	resetQueryCommandFlags(t)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetQueryCommandFlags(t)
+	})
+	return captureStdout(t, rootCmd.Execute)
+}
+
+func resetQueryCommandFlags(t *testing.T) {
+	t.Helper()
+	queryCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if err := flag.Value.Set(flag.DefValue); err != nil {
+			t.Fatalf("сбросить флаг query --%s: %v", flag.Name, err)
+		}
+		flag.Changed = false
+	})
+}
+
+func TestQuerySQLIsPrintedBeforeExecutionError(t *testing.T) {
+	projectDir, dbPath := queryCommandFixture(t)
+	out, err := executeQueryCommand(t,
+		"query", "--project", projectDir, "--sqlite", dbPath, "--sql",
+		"SELECT * FROM missing_query_table",
+	)
+	if err == nil {
+		t.Fatal("запрос к отсутствующей таблице обязан завершиться ошибкой")
+	}
+	if !strings.Contains(out, "SQL:\n") || !strings.Contains(out, "missing_query_table") {
+		t.Fatalf("--sql не показал скомпилированный SQL до ошибки:\n%s", out)
+	}
+	if !strings.Contains(out, "ARGS: []") {
+		t.Fatalf("--sql не показал аргументы до ошибки:\n%s", out)
+	}
+}
+
+func TestQueryExecutionErrorWithoutSQLFlagHasNoDiagnostic(t *testing.T) {
+	projectDir, dbPath := queryCommandFixture(t)
+	out, err := executeQueryCommand(t,
+		"query", "--project", projectDir, "--sqlite", dbPath,
+		"SELECT * FROM missing_query_table",
+	)
+	if err == nil {
+		t.Fatal("запрос к отсутствующей таблице обязан завершиться ошибкой")
+	}
+	if strings.Contains(out, "SQL:") || strings.Contains(out, "ARGS:") {
+		t.Fatalf("диагностика SQL появилась без --sql:\n%s", out)
+	}
+}
+
+func TestQuerySQLFlagExplainsCompileError(t *testing.T) {
+	projectDir, dbPath := queryCommandFixture(t)
+	out, err := executeQueryCommand(t,
+		"query", "--project", projectDir, "--sqlite", dbPath, "--sql",
+		"ВЫБРАТЬ Ном ИЗ РегистрНакопления.Неизвестный.Остатки()",
+	)
+	if err == nil {
+		t.Fatal("незавершённый запрос обязан завершиться ошибкой компиляции")
+	}
+	if !strings.Contains(err.Error(), "SQL ещё не построен") {
+		t.Fatalf("ошибка не объясняет отсутствие SQL: %v", err)
+	}
+	if strings.Contains(out, "SQL:\n") || strings.Contains(out, "ARGS:") {
+		t.Fatalf("при ошибке компиляции напечатан несуществующий SQL:\n%s", out)
+	}
+}
+
+func TestQueryJSONWithSQLRemainsSingleJSONDocument(t *testing.T) {
+	projectDir, dbPath := queryCommandFixture(t)
+	out, err := executeQueryCommand(t,
+		"query", "--project", projectDir, "--sqlite", dbPath, "--json", "--sql",
+		"SELECT 1 AS value",
+	)
+	if err != nil {
+		t.Fatalf("успешный JSON-запрос вернул ошибку: %v", err)
+	}
+	var got queryOutput
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("--json --sql должен вернуть один JSON-документ: %v\n%s", err, out)
+	}
+	if got.SQL == "" || len(got.Rows) != 1 {
+		t.Fatalf("JSON-ответ потерял SQL или результат: %+v", got)
+	}
+}
+
+func TestQueryJSONExecutionErrorKeepsDiagnosticOutOfStdout(t *testing.T) {
+	projectDir, dbPath := queryCommandFixture(t)
+	out, err := executeQueryCommand(t,
+		"query", "--project", projectDir, "--sqlite", dbPath, "--json", "--sql",
+		"SELECT * FROM missing_query_table",
+	)
+	if err == nil {
+		t.Fatal("запрос к отсутствующей таблице обязан завершиться ошибкой")
+	}
+	if out != "" {
+		t.Fatalf("ошибка не должна загрязнять JSON-канал stdout:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "SQL:\n") || !strings.Contains(err.Error(), "ARGS: []") {
+		t.Fatalf("ошибка --json --sql потеряла SQL-диагностику: %v", err)
+	}
+}


### PR DESCRIPTION
## Что исправлено

- `onebase query --sql` теперь печатает скомпилированный SQL и `ARGS` до исполнения, поэтому они остаются видны при ошибке СУБД.
- При ошибке компиляции команда явно сообщает, что SQL ещё не построен.
- Сочетание `--json --sql` сохраняет чистый JSON в stdout; при ошибке диагностика остаётся в возвращаемой ошибке.
- Добавлены сквозные тесты через публичную CLI-команду для ошибок исполнения/компиляции, режима без `--sql` и JSON-контракта.

## Проверки

- `go test -count=1 ./internal/cli -run '^TestQuery'`
- `go test -count=1 ./internal/cli`
- `go vet ./internal/cli`
- `go build ./...`
- `go test -count=1 ./...` — изменённые пакеты зелёные; общий параллельный прогон встретил известные Windows I/O timeout в неизменённых пакетах, все точные timeout-тесты затем прошли последовательно.
- `go test -count=1 ./internal/selfupdate` — успешно с `GOTMPDIR` внутри пользовательского профиля (системный `D:\GoTemp` корректно отвергается политикой пакета).

Fixes #1472