### PR TITLE
feat(pipeline): показывать конфликты маршрутных меток

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -512,6 +512,14 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 		}
 
 		labels := labelSet(issue.Labels)
+		if labels["ready-fix"] && labels["needs-decision"] {
+			result.addIssue("yellow", "issue_route_conflict", issue.Number,
+				"ready-fix конфликтует с needs-decision: автоматический FIX остановлен до явного решения")
+		}
+		if labels["manual"] && (labels["approved"] || labels["ready-fix"] || labels["plan-needed"] || labels["in-work"]) {
+			result.addIssue("yellow", "manual_route_conflict", issue.Number,
+				"manual сочетается с автоматической маршрутной меткой, которая не будет исполнена")
+		}
 		priority, prioritySource := queuePriority(labels, issue.CreatedAt, now)
 		item := candidate{
 			Number: issue.Number, Title: issue.Title, URL: issue.HTMLURL,

--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -512,7 +512,7 @@ func analyzeIssues(result *report, issues []apiIssue, prs []apiPull, owner strin
 		}
 
 		labels := labelSet(issue.Labels)
-		if labels["ready-fix"] && labels["needs-decision"] {
+		if labels["ready-fix"] && labels["needs-decision"] && !labels["approved"] {
 			result.addIssue("yellow", "issue_route_conflict", issue.Number,
 				"ready-fix конфликтует с needs-decision: автоматический FIX остановлен до явного решения")
 		}

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -516,6 +516,25 @@ func TestIssueQueuesSeparatePlanFixAndHumanWork(t *testing.T) {
 	}
 }
 
+func TestIssueRouteConflictsAreReportedWithoutChangingRouting(t *testing.T) {
+	result := analyze(nil, "ivanarama")
+	analyzeIssues(&result, []apiIssue{
+		issueWithLabels(15, "ready-fix", "needs-decision"),
+		issueWithLabels(16, "manual", "approved"),
+		issueWithLabels(17, "approved", "needs-decision"),
+	}, nil, "ivanarama")
+
+	if !hasFinding(result, "issue_route_conflict") {
+		t.Fatalf("ready-fix/needs-decision conflict was not diagnosed: %+v", result.Findings)
+	}
+	if !hasFinding(result, "manual_route_conflict") {
+		t.Fatalf("manual/automatic route conflict was not diagnosed: %+v", result.Findings)
+	}
+	if len(result.FixCandidates) != 1 || result.FixCandidates[0].Number != 17 {
+		t.Fatalf("approved did not override needs-decision as specified: %+v", result.FixCandidates)
+	}
+}
+
 func TestFixQueueExcludesInWorkAndOpenPullReferences(t *testing.T) {
 	result := analyze(nil, "ivanarama")
 	issues := []apiIssue{

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -522,6 +522,7 @@ func TestIssueRouteConflictsAreReportedWithoutChangingRouting(t *testing.T) {
 		issueWithLabels(15, "ready-fix", "needs-decision"),
 		issueWithLabels(16, "manual", "approved"),
 		issueWithLabels(17, "approved", "needs-decision"),
+		issueWithLabels(18, "ready-fix", "needs-decision", "approved"),
 	}, nil, "ivanarama")
 
 	if !hasFinding(result, "issue_route_conflict") {
@@ -530,7 +531,12 @@ func TestIssueRouteConflictsAreReportedWithoutChangingRouting(t *testing.T) {
 	if !hasFinding(result, "manual_route_conflict") {
 		t.Fatalf("manual/automatic route conflict was not diagnosed: %+v", result.Findings)
 	}
-	if len(result.FixCandidates) != 1 || result.FixCandidates[0].Number != 17 {
+	for _, item := range result.Findings {
+		if item.Code == "issue_route_conflict" && item.Issue == 18 {
+			t.Fatalf("approved ready-fix issue was falsely diagnosed as stopped: %+v", result.Findings)
+		}
+	}
+	if len(result.FixCandidates) != 2 || result.FixCandidates[0].Number != 17 || result.FixCandidates[1].Number != 18 {
 		t.Fatalf("approved did not override needs-decision as specified: %+v", result.FixCandidates)
 	}
 }


### PR DESCRIPTION
## Что изменилось
- pipelinehealth предупреждает о ready-fix + needs-decision
- pipelinehealth предупреждает о manual вместе с автоматическим маршрутом
- approved + needs-decision остаётся допустимым override по контракту
- инструмент только сообщает, но не меняет метки

## Проверка
- go test ./tools/pipelinehealth