### PR TITLE
fix(pipeline): сохранять владельца между sync-звеньями

### DIFF
--- a/tools/pipelinehealth/main.go
+++ b/tools/pipelinehealth/main.go
@@ -855,12 +855,18 @@ type baseSyncIntentShape struct {
 	from, base, previous, shipEvent, createdAt string
 }
 
+type baseSyncDoneShape struct {
+	intentID                      int64
+	from, to, previous, shipEvent string
+}
+
 // baseSyncRESTState is deliberately only an operational hint. The mutation
 // contracts still prove comment nodes, timeline edges and commit parents with
 // two stable GraphQL snapshots before changing GitHub state.
 func baseSyncRESTState(comments []apiComment, owner, head string, headParents []string) (doneCurrent, intentOpen, baseAdvanced, protocolHistory bool, integrationAt string) {
 	intents := map[int64]baseSyncIntentShape{}
 	doneIntents := map[int64]bool{}
+	dones := map[int64]baseSyncDoneShape{}
 	for _, comment := range comments {
 		if !trustedUnedited(comment, owner) {
 			continue
@@ -878,11 +884,16 @@ func baseSyncRESTState(comments []apiComment, owner, head string, headParents []
 				continue
 			}
 			doneIntents[intentID] = true
+			dones[comment.ID] = baseSyncDoneShape{
+				intentID: intentID, from: match[2], to: match[3],
+				previous: match[5], shipEvent: match[6],
+			}
 			if match[3] == head {
 				doneCurrent = true
 				baseAdvanced = intent.base != match[4]
-				if integrationAt == "" || intent.createdAt < integrationAt {
-					integrationAt = intent.createdAt
+				startedAt := baseSyncIntegrationStart(intent, intents, dones)
+				if integrationAt == "" || startedAt < integrationAt {
+					integrationAt = startedAt
 				}
 			}
 		}
@@ -898,11 +909,41 @@ func baseSyncRESTState(comments []apiComment, owner, head string, headParents []
 			continue
 		}
 		intentOpen = true
-		if integrationAt == "" || intent.createdAt < integrationAt {
-			integrationAt = intent.createdAt
+		startedAt := baseSyncIntegrationStart(intent, intents, dones)
+		if integrationAt == "" || startedAt < integrationAt {
+			integrationAt = startedAt
 		}
 	}
 	return doneCurrent, intentOpen, baseAdvanced, protocolHistory, integrationAt
+}
+
+// baseSyncIntegrationStart preserves ownership across a multi-hop carry chain.
+// An updated PR may need another base-sync while it waits for merge. Its new
+// intent points at the previous done comment; using only the new comment time
+// would let a later PR overtake an already active single-flight owner.
+func baseSyncIntegrationStart(intent baseSyncIntentShape, intents map[int64]baseSyncIntentShape, dones map[int64]baseSyncDoneShape) string {
+	startedAt := intent.createdAt
+	seen := map[int64]bool{}
+	current := intent
+	for current.previous != "none" {
+		doneID, err := strconv.ParseInt(current.previous, 10, 64)
+		if err != nil || seen[doneID] {
+			break
+		}
+		seen[doneID] = true
+		done, ok := dones[doneID]
+		previous, previousOK := intents[done.intentID]
+		if !ok || !previousOK || done.to != current.from ||
+			done.from != previous.from || done.previous != previous.previous ||
+			done.shipEvent != current.shipEvent || previous.shipEvent != current.shipEvent {
+			break
+		}
+		if previous.createdAt < startedAt {
+			startedAt = previous.createdAt
+		}
+		current = previous
+	}
+	return startedAt
 }
 
 // intentCanDescribeCurrentHead limits recovery to a transaction that can still

--- a/tools/pipelinehealth/main_test.go
+++ b/tools/pipelinehealth/main_test.go
@@ -182,6 +182,29 @@ func TestNewIntentFromCurrentCompletedHeadStillRequiresRecovery(t *testing.T) {
 	}
 }
 
+func TestMultiHopRecoveryKeepsOriginalSingleFlightOwnership(t *testing.T) {
+	owner := testPR(1218, headC, "ship", "reviewed")
+	owner.HeadParents = []string{headB, headA}
+	owner = addComment(owner, 10,
+		fmt.Sprintf("<!-- pp:base-sync-intent from=%s base=%s review-comment=1 claim=2 completion=3 ship-event=LE_test previous=none -->", headA, headB))
+	owner = addComment(owner, 11,
+		fmt.Sprintf("<!-- pp:base-sync-done intent=10 from=%s to=%s base=%s previous=none ship-event=LE_test -->", headA, headB, headB))
+	owner = addComment(owner, 50,
+		fmt.Sprintf("<!-- pp:base-sync-intent from=%s base=%s review-comment=4 claim=5 completion=6 ship-event=LE_test previous=11 -->", headB, headA))
+
+	later := testPR(1220, headB, "ship", "reviewed")
+	later.HeadParents = []string{headA, headB}
+	later = addComment(later, 20, syncIntent(headA, 7, 8, 9))
+	later = addComment(later, 21, syncDone(20, headA, headB))
+
+	got := analyze([]apiPull{later, owner}, "ivanarama")
+	if got.IntegrationOwner == nil || got.IntegrationOwner.Number != 1218 ||
+		got.IntegrationOwner.Stage != "integration-merge-recovery" ||
+		len(got.MergeExecutable) != 1 || got.MergeExecutable[0].Number != 1218 {
+		t.Fatalf("multi-hop owner was overtaken by a later chain: %+v", got)
+	}
+}
+
 func TestCompletedIntegrationReviewKeepsBarrierUntilMerge(t *testing.T) {
 	owner := addComment(testPR(20, headB, "ship", "reviewed"), 30, syncIntent(headA, 10, 20, 25))
 	owner = addComment(owner, 31, syncDone(30, headA, headB))


### PR DESCRIPTION
Исправляет повторную потерю single-flight-владельца в многошаговой base-sync цепочке.

После каждого нового intent поле `integration_at` раньше начиналось заново. Поэтому уже активный PR уступал очередь более поздней цепочке: на живом состоянии recovery #1218 оказался видимым, но владельцем ошибочно стал #1220. Через `previous=<done id>` теперь восстанавливается время первого intent всей непрерывной цепочки.

Что изменено:
- валидные done-звенья индексируются по id комментария;
- время владения проходит назад по согласованной `previous`-цепочке;
- разорванная или несогласованная цепочка не наследует чужой приоритет;
- добавлен регрессионный тест на обгон многошагового recovery более поздним PR.

Проверки:
- `go test -count=1 -v ./tools/pipelinehealth`
- `go test -count=1 ./tools/...`
- `git diff --check`
- live health: выявляет настоящего старейшего владельца #1178 и сохраняет recovery #1218 в очереди.